### PR TITLE
fix(player): bound word audio preloading

### DIFF
--- a/packages/player/src/_utils/audio-blob-cache.test.ts
+++ b/packages/player/src/_utils/audio-blob-cache.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type AudioBlobCache,
+  clearAudioObjectUrlCache,
+  getCachedAudioSourceUrl,
+  storeAudioObjectUrl,
+} from "./audio-blob-cache";
+
+describe("audio blob cache", () => {
+  it("falls back to the source URL when audio was not prefetched", () => {
+    const cache: AudioBlobCache = new Map();
+
+    expect(getCachedAudioSourceUrl({ cache, sourceUrl: "/audio/one.mp3" })).toBe("/audio/one.mp3");
+  });
+
+  it("promotes cached audio when it is used", () => {
+    const cache: AudioBlobCache = new Map([
+      ["/audio/one.mp3", "blob:one"],
+      ["/audio/two.mp3", "blob:two"],
+    ]);
+
+    expect(getCachedAudioSourceUrl({ cache, sourceUrl: "/audio/one.mp3" })).toBe("blob:one");
+    expect([...cache.keys()]).toStrictEqual(["/audio/two.mp3", "/audio/one.mp3"]);
+  });
+
+  it("evicts and revokes the least recently used object URL", () => {
+    const cache: AudioBlobCache = new Map([
+      ["/audio/one.mp3", "blob:one"],
+      ["/audio/two.mp3", "blob:two"],
+    ]);
+
+    const revokeObjectUrl = vi.fn();
+
+    storeAudioObjectUrl({
+      cache,
+      maxEntries: 2,
+      objectUrl: "blob:three",
+      revokeObjectUrl,
+      sourceUrl: "/audio/three.mp3",
+    });
+
+    expect([...cache.entries()]).toStrictEqual([
+      ["/audio/two.mp3", "blob:two"],
+      ["/audio/three.mp3", "blob:three"],
+    ]);
+
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:one");
+  });
+
+  it("revokes the previous object URL when replacing a cached source", () => {
+    const cache: AudioBlobCache = new Map([["/audio/one.mp3", "blob:one"]]);
+    const revokeObjectUrl = vi.fn();
+
+    storeAudioObjectUrl({
+      cache,
+      objectUrl: "blob:one-new",
+      revokeObjectUrl,
+      sourceUrl: "/audio/one.mp3",
+    });
+
+    expect([...cache.entries()]).toStrictEqual([["/audio/one.mp3", "blob:one-new"]]);
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:one");
+  });
+
+  it("clears every cached object URL", () => {
+    const cache: AudioBlobCache = new Map([
+      ["/audio/one.mp3", "blob:one"],
+      ["/audio/two.mp3", "blob:two"],
+    ]);
+
+    const revokeObjectUrl = vi.fn();
+
+    clearAudioObjectUrlCache({ cache, revokeObjectUrl });
+
+    expect(cache.size).toBe(0);
+    expect(revokeObjectUrl).toHaveBeenCalledTimes(2);
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:one");
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:two");
+  });
+});

--- a/packages/player/src/_utils/audio-blob-cache.ts
+++ b/packages/player/src/_utils/audio-blob-cache.ts
@@ -1,0 +1,89 @@
+const MAX_AUDIO_BLOB_CACHE_ENTRIES = 16;
+
+export type AudioBlobCache = Map<string, string>;
+
+type RevokeObjectUrl = (objectUrl: string) => void;
+
+/**
+ * Promotes a cached audio blob URL when it is used so the bounded cache evicts
+ * the least recently used audio instead of removing the clip the learner just
+ * tapped. If a URL was not prefetched, playback should fall back to the
+ * original source URL rather than blocking on a fetch.
+ */
+export function getCachedAudioSourceUrl({
+  cache,
+  sourceUrl,
+}: {
+  cache: AudioBlobCache;
+  sourceUrl: string;
+}): string {
+  const objectUrl = cache.get(sourceUrl);
+
+  if (!objectUrl) {
+    return sourceUrl;
+  }
+
+  cache.delete(sourceUrl);
+  cache.set(sourceUrl, objectUrl);
+
+  return objectUrl;
+}
+
+/**
+ * Stores one prefetched audio blob URL and keeps the cache bounded. iOS Safari
+ * is sensitive to media resource pressure, so preloading must not grow with
+ * every word bank or every step in a lesson.
+ */
+export function storeAudioObjectUrl({
+  cache,
+  maxEntries = MAX_AUDIO_BLOB_CACHE_ENTRIES,
+  objectUrl,
+  revokeObjectUrl,
+  sourceUrl,
+}: {
+  cache: AudioBlobCache;
+  maxEntries?: number;
+  objectUrl: string;
+  revokeObjectUrl: RevokeObjectUrl;
+  sourceUrl: string;
+}): void {
+  const existingObjectUrl = cache.get(sourceUrl);
+
+  if (existingObjectUrl) {
+    revokeObjectUrl(existingObjectUrl);
+    cache.delete(sourceUrl);
+  }
+
+  cache.set(sourceUrl, objectUrl);
+
+  while (cache.size > maxEntries) {
+    const oldestSourceUrl = cache.keys().next().value;
+
+    if (!oldestSourceUrl) {
+      return;
+    }
+
+    const oldestObjectUrl = cache.get(oldestSourceUrl);
+
+    if (oldestObjectUrl) {
+      revokeObjectUrl(oldestObjectUrl);
+    }
+
+    cache.delete(oldestSourceUrl);
+  }
+}
+
+/**
+ * Revokes every object URL before the hook unmounts so prefetched audio bytes
+ * are released when the player moves to a new step or leaves the lesson.
+ */
+export function clearAudioObjectUrlCache({
+  cache,
+  revokeObjectUrl,
+}: {
+  cache: AudioBlobCache;
+  revokeObjectUrl: RevokeObjectUrl;
+}): void {
+  cache.forEach((objectUrl) => revokeObjectUrl(objectUrl));
+  cache.clear();
+}

--- a/packages/player/src/use-word-audio.ts
+++ b/packages/player/src/use-word-audio.ts
@@ -1,8 +1,16 @@
 "use client";
 
 import { useCallback, useEffect, useEffectEvent, useRef } from "react";
+import {
+  type AudioBlobCache,
+  clearAudioObjectUrlCache,
+  getCachedAudioSourceUrl,
+  storeAudioObjectUrl,
+} from "./_utils/audio-blob-cache";
 
 type UseWordAudioOptions = { onEnded?: () => void; preloadUrls?: (string | null)[] };
+
+const AUDIO_PRELOAD_CONCURRENCY = 2;
 
 /**
  * Word banks can repeat the same audio URL or include empty entries. Normalizing the list in one
@@ -17,76 +25,173 @@ function getUniqueAudioUrls(urls?: (string | null)[]): string[] {
 }
 
 /**
- * Reusing one audio element per URL avoids paying the fetch and decode cost on every tap. The
- * element is also configured for eager loading so short vocabulary clips are warm before playback.
+ * The blob preloader works in small waves so a word bank can warm its clips
+ * without asking mobile Safari to start every media request at once.
  */
-function createAudioElement(url: string, onEnded: () => void): HTMLAudioElement {
+function getPreloadBatches(urls: string[]): string[][] {
+  return Array.from({ length: Math.ceil(urls.length / AUDIO_PRELOAD_CONCURRENCY) }, (_, index) =>
+    urls.slice(
+      index * AUDIO_PRELOAD_CONCURRENCY,
+      index * AUDIO_PRELOAD_CONCURRENCY + AUDIO_PRELOAD_CONCURRENCY,
+    ),
+  );
+}
+
+/**
+ * Fetches audio bytes into a blob URL instead of creating a permanent media
+ * element for each word. If fetch fails because a remote asset does not allow
+ * CORS, playback still falls back to the original URL when the learner taps.
+ */
+async function preloadAudioBlob({
+  cache,
+  signal,
+  sourceUrl,
+}: {
+  cache: AudioBlobCache;
+  signal: AbortSignal;
+  sourceUrl: string;
+}): Promise<void> {
+  if (cache.has(sourceUrl)) {
+    return;
+  }
+
+  try {
+    const response = await fetch(sourceUrl, { signal });
+
+    if (!response.ok) {
+      return;
+    }
+
+    const blob = await response.blob();
+
+    if (signal.aborted) {
+      return;
+    }
+
+    storeAudioObjectUrl({
+      cache,
+      objectUrl: URL.createObjectURL(blob),
+      revokeObjectUrl: (objectUrl) => URL.revokeObjectURL(objectUrl),
+      sourceUrl,
+    });
+  } catch {
+    // Fetch preloading is opportunistic. Playback can still use the original URL.
+  }
+}
+
+/**
+ * Runs one bounded preload wave. Keeping this separate makes the reducer below
+ * read as a sequence of small concurrent batches instead of hiding fetch logic
+ * inside promise chaining.
+ */
+function preloadAudioBatch({
+  batch,
+  cache,
+  signal,
+}: {
+  batch: string[];
+  cache: AudioBlobCache;
+  signal: AbortSignal;
+}): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+
+  return Promise.all(batch.map((sourceUrl) => preloadAudioBlob({ cache, signal, sourceUrl }))).then(
+    () => {
+      // The ordered preloader only cares that the batch finished.
+    },
+  );
+}
+
+/**
+ * Preloads a bounded set of audio blobs with limited concurrency. The hook
+ * deliberately waits for each small wave before starting the next one so the
+ * player warms audio without competing with step rendering and taps.
+ */
+async function preloadAudioBlobs({
+  cache,
+  signal,
+  urls,
+}: {
+  cache: AudioBlobCache;
+  signal: AbortSignal;
+  urls: string[];
+}): Promise<void> {
+  return getPreloadBatches(urls).reduce(
+    (pendingBatch, batch) => pendingBatch.then(() => preloadAudioBatch({ batch, cache, signal })),
+    Promise.resolve(),
+  );
+}
+
+/**
+ * Reusing one playback element keeps Safari from holding a media element per
+ * word-bank option. The preloader warms bytes separately; this element only
+ * owns the clip the learner is actively playing.
+ */
+function createAudioElement(onEnded: () => void): HTMLAudioElement {
   const audio = new Audio();
-  audio.preload = "auto";
-  audio.src = url;
+  audio.preload = "none";
   audio.addEventListener("ended", onEnded);
   return audio;
 }
 
 /**
- * Resetting playback to the beginning ensures rapid reselection always restarts the same word from
- * the start instead of resuming from a partially played clip.
+ * Starts a source from the beginning on the reusable playback element.
+ * Reassigning the source on every tap avoids Safari's ended-element replay
+ * bug while still keeping only one media element alive.
  */
-function resetAudio(audio: HTMLAudioElement): void {
+function startAudioFromSource(audio: HTMLAudioElement, sourceUrl: string): void {
   audio.pause();
+  audio.src = sourceUrl;
   audio.currentTime = 0;
 }
 
 /**
- * Short language clips need to start as close to instantly as possible. This hook keeps a warm
- * audio element per URL, optionally preloads likely clips on mount, and exposes simple play/pause
- * helpers for interaction components.
+ * Short language clips need to start as close to instantly as possible. This
+ * hook warms audio bytes in a bounded blob cache, then plays those bytes through
+ * one reusable media element so mobile Safari does not retain a media element
+ * for every word-bank option.
  */
 export function useWordAudio(options?: UseWordAudioOptions): {
   pause: () => void;
   play: (url: string | null) => void;
 } {
-  const activeAudioRef = useRef<HTMLAudioElement | null>(null);
-  const audioCacheRef = useRef<Map<string, HTMLAudioElement>>(new Map());
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const audioBlobCacheRef = useRef<AudioBlobCache>(new Map());
   const preloadKey = getUniqueAudioUrls(options?.preloadUrls).join("\n");
 
-  const handleEnded = useEffectEvent((audio: HTMLAudioElement, url: string) => {
-    // Ignore events from stale audio elements that were already replaced in the
-    // cache — Safari can re-fire `ended` on elements it previously marked as ended.
-    if (activeAudioRef.current !== audio) {
-      return;
-    }
-
-    activeAudioRef.current = null;
-
-    // Safari doesn't reliably replay an audio element after it ends — it re-fires
-    // `ended` instead of restarting playback. Replace the cache entry with a fresh
-    // element (which starts loading from browser cache immediately) so the next
-    // play() call works on all browsers.
-    const fresh = createAudioElement(url, () => handleEnded(fresh, url));
-    fresh.load();
-    audioCacheRef.current.set(url, fresh);
-
-    // Force Safari to release the old element's audio resource. Without this,
-    // Safari can hold onto stale internal state and re-fire events on the old
-    // element. This follows the same pattern howler.js uses for cleanup.
+  const releaseAudioSource = useCallback((audio: HTMLAudioElement) => {
     audio.pause();
     audio.removeAttribute("src");
     audio.load();
+  }, []);
+
+  const handleEnded = useEffectEvent(() => {
+    const audio = audioRef.current;
+
+    if (!audio) {
+      return;
+    }
+
+    // Safari can get stuck when replaying an element that naturally ended.
+    // Clearing the source leaves the reusable element alive but resets the
+    // browser media state before the next tap assigns a fresh source.
+    releaseAudioSource(audio);
 
     options?.onEnded?.();
   });
 
-  const getAudio = useCallback((url: string) => {
-    const cachedAudio = audioCacheRef.current.get(url);
+  const getAudio = useCallback(() => {
+    const existingAudio = audioRef.current;
 
-    if (cachedAudio) {
-      return cachedAudio;
+    if (existingAudio) {
+      return existingAudio;
     }
 
-    const audio = createAudioElement(url, () => handleEnded(audio, url));
+    const audio = createAudioElement(handleEnded);
 
-    audioCacheRef.current.set(url, audio);
+    audioRef.current = audio;
 
     return audio;
   }, []);
@@ -97,58 +202,59 @@ export function useWordAudio(options?: UseWordAudioOptions): {
         return;
       }
 
-      const nextAudio = getAudio(url);
-      const currentAudio = activeAudioRef.current;
+      const audio = getAudio();
 
-      if (currentAudio && currentAudio !== nextAudio) {
-        resetAudio(currentAudio);
-      }
+      const sourceUrl = getCachedAudioSourceUrl({
+        cache: audioBlobCacheRef.current,
+        sourceUrl: url,
+      });
 
-      activeAudioRef.current = nextAudio;
-      nextAudio.currentTime = 0;
-
+      startAudioFromSource(audio, sourceUrl);
       // Browser rejects play() when rapid clicks lose the user-gesture association.
       // oxlint-disable-next-line no-empty-function -- intentional no-op for rejected play()
-      nextAudio.play().catch(() => {});
+      audio.play().catch(() => {});
     },
     [getAudio],
   );
 
   const pause = useCallback(() => {
-    const activeAudio = activeAudioRef.current;
+    const audio = audioRef.current;
 
-    if (!activeAudio) {
+    if (!audio) {
       return;
     }
 
-    resetAudio(activeAudio);
-    activeAudioRef.current = null;
-  }, []);
+    releaseAudioSource(audio);
+  }, [releaseAudioSource]);
 
   useEffect(() => {
     const preloadUrls = preloadKey ? preloadKey.split("\n") : [];
+    const abortController = new AbortController();
 
-    preloadUrls.forEach((url) => {
-      const audio = getAudio(url);
-
-      if (audio.readyState === 0) {
-        audio.load();
-      }
+    void preloadAudioBlobs({
+      cache: audioBlobCacheRef.current,
+      signal: abortController.signal,
+      urls: preloadUrls,
     });
-  }, [getAudio, preloadKey]);
+
+    return () => abortController.abort();
+  }, [preloadKey]);
 
   useEffect(
     () => () => {
-      audioCacheRef.current.forEach((audio) => {
-        audio.pause();
-        audio.removeAttribute("src");
-        audio.load();
-      });
+      const audio = audioRef.current;
 
-      audioCacheRef.current.clear();
-      activeAudioRef.current = null;
+      if (audio) {
+        releaseAudioSource(audio);
+        audioRef.current = null;
+      }
+
+      clearAudioObjectUrlCache({
+        cache: audioBlobCacheRef.current,
+        revokeObjectUrl: (objectUrl) => URL.revokeObjectURL(objectUrl),
+      });
     },
-    [],
+    [releaseAudioSource],
   );
 
   return { pause, play };


### PR DESCRIPTION
## Summary
- replace per-word `Audio` caching with a bounded blob preloader plus one reusable playback element
- keep tap playback fast while avoiding Safari media-resource pressure on the reading word bank
- add unit coverage for cache promotion, eviction, and cleanup behavior

## Testing
- formatting and lint checks passed on the updated player files
- `@zoonk/player` typecheck passed
- player unit tests passed for the new audio cache coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches word audio preloading to a bounded blob cache with a single reusable playback element to fix Safari media-resource pressure and reduce tap-to-play lag. Keeps playback instant while preventing runaway preloads in word banks.

- **Bug Fixes**
  - Bounded LRU blob cache for audio (max 16) with 2-at-a-time prefetch; one reusable `Audio` element for playback.
  - Falls back to the source URL if prefetch fails; promotes recent entries to keep taps fast.
  - Cleans up on unmount by revoking object URLs and resetting the element.
  - Adds unit tests for cache promotion, eviction, and cleanup in `@zoonk/player`.

<sup>Written for commit fb1baf9fe059c5517b35994be6ea7bfde2fee30c. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1540?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

