### PR TITLE
fix(ai): tighten language lesson descriptions

### DIFF
--- a/apps/evals/src/tasks/language-chapter-lessons/test-cases.ts
+++ b/apps/evals/src/tasks/language-chapter-lessons/test-cases.ts
@@ -39,6 +39,8 @@ const SHARED_EXPECTATIONS = `
   ## Evaluating copy and progression
 
   - Lesson descriptions should be concise — no filler words like "introduces", "presents", "teaches"
+  - Lesson descriptions should use direct learner-facing wording, not third-person or future boilerplate such as "O aluno vai...", "The learner will...", or "El estudiante va a..."
+  - Prefer direct action phrasing such as "Reconheça...", "Use...", "Compare...", "Choose...", or the natural equivalent in the user's language
   - Logical progression from foundational to advanced
   - No summary, review, or assessment lessons
   - No duplicate lesson scope across lessons
@@ -71,6 +73,24 @@ export const TEST_CASES = [
       chapterTitle: "Present Tense",
       targetLanguage: "es",
       userLanguage: "en",
+    },
+  },
+  {
+    expectations: `
+      USER LANGUAGE: Brazilian Portuguese
+      TARGET LANGUAGE: English
+
+      Lesson descriptions should be direct and concise. A description like "Reconheça e use cumprimentos comuns como hello, hi, good morning e good evening" is better than "O aluno vai reconhecer e usar cumprimentos...". Repeated "O aluno vai..." phrasing is a copy issue even when the lesson scope is correct.
+
+      ${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-english-greetings-direct-descriptions",
+    userInput: {
+      chapterDescription:
+        "Cumprimentos, despedidas, apresentações simples, perguntas sobre nome e origem, e expressões básicas de cortesia.",
+      chapterTitle: "Saudações e Apresentações",
+      targetLanguage: "en",
+      userLanguage: "pt",
     },
   },
   {

--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.prompt.md
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.prompt.md
@@ -67,6 +67,9 @@ Only pure language acquisition content is allowed:
 - Write 1-2 plain sentences in `USER_LANGUAGE`.
 - Say what the learner will recognize, say, compare, build, or choose.
 - Do not start with "introduces", "presents", "shows", "teaches", "covers", or "explains".
+- Prefer direct learner-facing wording: "Recognize and use common greetings like hello, hi, good morning, and good evening."
+- Do not describe the learner from the outside. Avoid phrasing like "O aluno vai...", "The learner will...", or "El estudiante va a...".
+- Do not default to future framing like "You will..." when a direct verb is clearer. Prefer "Recognize", "Use", "Compare", "Choose", "Build", "Distinguish", or the natural equivalent in `USER_LANGUAGE`.
 
 # Final Check
 


### PR DESCRIPTION
Updates the language chapter lessons prompt to prefer direct learner-facing descriptions instead of third-person or future boilerplate.

Adds an eval case and rubric expectations for the greetings description copy issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened language lesson descriptions to use direct learner-facing phrasing and avoid third-person/future boilerplate. Adds eval coverage to prevent regressions, focusing on the greetings chapter.

- **Bug Fixes**
  - Updated `packages/ai` prompt to prefer direct verbs (e.g., “Recognize”, “Use”) and avoid “The learner will…”/“O aluno vai…” phrasing.
  - Added `apps/evals` test case and rubric expectations for greetings descriptions to enforce concise, direct copy.

<sup>Written for commit 73cdeb94a61b0ac285956f345276350d6babf10a. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1542?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

