### PR TITLE
feat(ui): use full-width course grid

### DIFF
--- a/packages/ui/src/components/container.tsx
+++ b/packages/ui/src/components/container.tsx
@@ -1,7 +1,6 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { buttonVariants } from "@zoonk/ui/components/button";
-import { WIDE_CONTENT_MAX_WIDTH_CLASS } from "@zoonk/ui/components/layout";
 import { cn } from "@zoonk/ui/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
 import { type LucideIcon } from "lucide-react";
@@ -14,10 +13,7 @@ const containerVariants = cva("flex w-full flex-col gap-4 antialiased", {
       centered:
         "bg-background mx-auto min-h-dvh max-w-sm items-center justify-center py-4 lg:gap-8",
       default: "",
-      grid: cn(
-        "mx-auto gap-5 px-4 pb-8 **:data-[slot=container-description]:text-base **:data-[slot=container-header]:px-0 **:data-[slot=container-title]:text-2xl **:data-[slot=container-title]:md:text-3xl lg:py-8",
-        WIDE_CONTENT_MAX_WIDTH_CLASS,
-      ),
+      grid: "gap-5 px-4 pb-8 **:data-[slot=container-description]:text-base **:data-[slot=container-header]:px-0 **:data-[slot=container-title]:text-2xl **:data-[slot=container-title]:md:text-3xl",
       list: "mx-auto pb-8 lg:max-w-xl lg:py-8",
       narrow: "mx-auto py-4 lg:max-w-xl lg:gap-8 lg:py-16",
     },

--- a/packages/ui/src/components/grid.tsx
+++ b/packages/ui/src/components/grid.tsx
@@ -90,7 +90,7 @@ const gridGroupVariants = cva("grid grid-cols-1 gap-4", {
   defaultVariants: { variant: "default" },
   variants: {
     variant: {
-      default: "sm:grid-cols-2 lg:grid-cols-3",
+      default: "sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5",
       pane: "sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4",
     },
   },


### PR DESCRIPTION
## Summary

- remove the max-width cap from grid containers
- increase default catalog grid columns on larger screens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the course grid full-width and show more courses on wide screens. Removes the grid container max-width cap and increases default grid columns to xl:4 and 2xl:5.

<sup>Written for commit 45c4ce8b67898c9311665477089a8ddd1663e419. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1543?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

