### PR TITLE
fix(api): handle course generation slug races

### DIFF
--- a/apps/api/src/workflows/course-generation/_internal/course-slug.ts
+++ b/apps/api/src/workflows/course-generation/_internal/course-slug.ts
@@ -1,0 +1,17 @@
+import { ensureLocaleSuffix, toSlug } from "@zoonk/utils/string";
+
+/**
+ * Course suggestions store the plain URL slug, while generated course rows use
+ * the locale-aware slug that is protected by the organization unique index.
+ * Deriving that value in one place keeps duplicate detection aligned with the
+ * database write that can fail under concurrent workflow starts.
+ */
+export function getCourseSlugForTitle({
+  language,
+  title,
+}: {
+  language: string;
+  title: string;
+}): string {
+  return ensureLocaleSuffix(toSlug(title), language);
+}

--- a/apps/api/src/workflows/course-generation/_internal/existing-course-content.ts
+++ b/apps/api/src/workflows/course-generation/_internal/existing-course-content.ts
@@ -1,0 +1,36 @@
+import { type CourseGetPayload } from "@zoonk/db";
+
+export const courseContentInclude = {
+  _count: { select: { categories: true, chapters: true } },
+} as const;
+
+export type CourseWithContentCounts = CourseGetPayload<{ include: typeof courseContentInclude }>;
+
+export type ExistingCourseContent = {
+  description: string | null;
+  imageUrl: string | null;
+  hasCategories: boolean;
+  hasChapters: boolean;
+};
+
+export const EMPTY_EXISTING_CONTENT: ExistingCourseContent = {
+  description: null,
+  hasCategories: false,
+  hasChapters: false,
+  imageUrl: null,
+};
+
+/**
+ * Course setup only needs to know which persisted content already exists.
+ * Keeping that shape small prevents duplicate-run recovery from passing full
+ * Prisma rows through workflow branches that only decide what generation to
+ * skip.
+ */
+export function getExistingCourseContent(course: CourseWithContentCounts): ExistingCourseContent {
+  return {
+    description: course.description,
+    hasCategories: course._count.categories > 0,
+    hasChapters: course._count.chapters > 0,
+    imageUrl: course.imageUrl,
+  };
+}

--- a/apps/api/src/workflows/course-generation/_internal/generate-missing-content.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/generate-missing-content.test.ts
@@ -1,8 +1,8 @@
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { type CourseContext } from "../steps/initialize-course-step";
+import { type ExistingCourseContent } from "./existing-course-content";
 import { generateMissingContent } from "./generate-missing-content";
-import { type ExistingCourseContent } from "./get-or-create-course";
 
 const {
   generateCourseDescriptionMock,

--- a/apps/api/src/workflows/course-generation/_internal/generate-missing-content.ts
+++ b/apps/api/src/workflows/course-generation/_internal/generate-missing-content.ts
@@ -5,7 +5,7 @@ import { generateChaptersStep } from "../steps/generate-chapters-step";
 import { generateDescriptionStep } from "../steps/generate-description-step";
 import { generateImageStep } from "../steps/generate-image-step";
 import { type CourseContext } from "../steps/initialize-course-step";
-import { type ExistingCourseContent } from "./get-or-create-course";
+import { type ExistingCourseContent } from "./existing-course-content";
 
 export type GeneratedContent = {
   description: string;

--- a/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
@@ -5,6 +5,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { type ExistingCourse } from "../steps/resolve-course-identity-step";
+import { getCourseSlugForTitle } from "./course-slug";
 import { getOrCreateCourse } from "./get-or-create-course";
 
 describe(getOrCreateCourse, () => {
@@ -26,6 +27,7 @@ describe(getOrCreateCourse, () => {
 
     const result = await getOrCreateCourse(null, suggestion, suggestion.id, workflowRunId);
 
+    expect(result.status).toBe("ready");
     expect(result.course.courseTitle).toBe(suggestion.title);
     expect(result.course.courseId).toStrictEqual(expect.any(String));
 
@@ -48,9 +50,42 @@ describe(getOrCreateCourse, () => {
     expect(updatedSuggestion.courseId).toBe(createdCourse.id);
   });
 
+  it("returns the running course when creation loses an org slug race", async () => {
+    const title = `Concurrent Course ${randomUUID()}`;
+    const language = "en";
+    const slug = getCourseSlugForTitle({ language, title });
+
+    const existingCourse = await courseFixture({
+      generationStatus: "running",
+      language,
+      organizationId,
+      slug,
+      title,
+    });
+
+    const suggestion = await courseSuggestionFixture({ language, title });
+    const workflowRunId = `run-${randomUUID()}`;
+
+    const result = await getOrCreateCourse(null, suggestion, suggestion.id, workflowRunId);
+
+    expect(result.status).toBe("running");
+    expect(result.course.courseId).toBe(existingCourse.id);
+
+    const [courses, updatedSuggestion] = await Promise.all([
+      prisma.course.findMany({ where: { organizationId, slug } }),
+      prisma.courseSuggestion.findUniqueOrThrow({ where: { id: suggestion.id } }),
+    ]);
+
+    expect(courses).toHaveLength(1);
+    expect(updatedSuggestion.courseId).toBe(existingCourse.id);
+    expect(updatedSuggestion.generationStatus).toBe("running");
+    expect(updatedSuggestion.generationRunId).toBe(workflowRunId);
+  });
+
   it("reuses existing course and marks it as running", async () => {
     const course = await courseFixture({
       description: "Existing description",
+      generationStatus: "failed",
       imageUrl: "https://example.com/img.webp",
       organizationId,
       title: `Existing Course ${randomUUID()}`,
@@ -69,6 +104,7 @@ describe(getOrCreateCourse, () => {
       workflowRunId,
     );
 
+    expect(result.status).toBe("ready");
     expect(result.course.courseId).toBe(course.id);
 
     expect(result.existing).toStrictEqual({

--- a/apps/api/src/workflows/course-generation/_internal/get-or-create-course.ts
+++ b/apps/api/src/workflows/course-generation/_internal/get-or-create-course.ts
@@ -1,57 +1,126 @@
 import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
-import { type CourseSuggestion } from "@zoonk/db";
+import { type Course, type CourseSuggestion } from "@zoonk/db";
 import { getAIOrganizationStep } from "../steps/get-ai-organization-step";
-import { type CourseContext, initializeCourseStep } from "../steps/initialize-course-step";
+import {
+  type CourseContext,
+  type InitializedCourse,
+  getCourseContext,
+  initializeCourseStep,
+} from "../steps/initialize-course-step";
 import { type ExistingCourse } from "../steps/resolve-course-identity-step";
 import { setCourseAsRunningStep } from "../steps/set-course-as-running-step";
+import {
+  EMPTY_EXISTING_CONTENT,
+  type ExistingCourseContent,
+  getExistingCourseContent,
+} from "./existing-course-content";
 
-export type ExistingCourseContent = {
-  description: string | null;
-  imageUrl: string | null;
-  hasCategories: boolean;
-  hasChapters: boolean;
+type CourseSetupStatus = "completed" | "ready" | "running";
+
+export type GetOrCreateCourseResult = {
+  course: CourseContext;
+  existing: ExistingCourseContent;
+  status: CourseSetupStatus;
 };
 
-const DEFAULT_EXISTING_CONTENT: ExistingCourseContent = {
-  description: null,
-  hasCategories: false,
-  hasChapters: false,
-  imageUrl: null,
-};
+/**
+ * Only failed or pending existing courses need this workflow to continue setup.
+ * Running and completed courses already have another run or a finished result,
+ * so the caller should stop after linking the suggestion.
+ */
+function getCourseSetupStatus(generationStatus: Course["generationStatus"]): CourseSetupStatus {
+  if (generationStatus === "running") {
+    return "running";
+  }
 
+  if (generationStatus === "completed") {
+    return "completed";
+  }
+
+  return "ready";
+}
+
+/**
+ * Starts generation for reusable existing courses, or reports that setup should
+ * stop because a concurrent run is already responsible for this course.
+ */
+async function prepareExistingCourse({
+  course,
+  courseSuggestionId,
+  existing,
+  generationStatus,
+  workflowRunId,
+}: {
+  course: CourseContext;
+  courseSuggestionId: string;
+  existing: ExistingCourseContent;
+  generationStatus: Course["generationStatus"];
+  workflowRunId: string;
+}): Promise<GetOrCreateCourseResult> {
+  const status = getCourseSetupStatus(generationStatus);
+
+  if (status !== "ready") {
+    await streamSkipStep("setCourseAsRunning");
+    return { course, existing, status };
+  }
+
+  await setCourseAsRunningStep({ courseId: course.courseId, courseSuggestionId, workflowRunId });
+
+  return { course, existing, status: "ready" };
+}
+
+/**
+ * Converts the initialize step result into the caller's setup plan. A recovered
+ * existing course can be running or completed, so creation recovery must go
+ * through the same status gate as a resolver-found existing course.
+ */
+async function prepareInitializedCourse({
+  courseSuggestionId,
+  initialized,
+  workflowRunId,
+}: {
+  courseSuggestionId: string;
+  initialized: InitializedCourse;
+  workflowRunId: string;
+}): Promise<GetOrCreateCourseResult> {
+  if (!initialized.existing) {
+    await streamSkipStep("setCourseAsRunning");
+    return { course: initialized.course, existing: EMPTY_EXISTING_CONTENT, status: "ready" };
+  }
+
+  return prepareExistingCourse({
+    course: initialized.course,
+    courseSuggestionId,
+    existing: initialized.existing,
+    generationStatus: initialized.generationStatus,
+    workflowRunId,
+  });
+}
+
+/**
+ * Produces the course setup plan after identity resolution. It creates a new
+ * course when possible, recovers from concurrent unique-key inserts, and tells
+ * the workflow to stop when another run already owns the same course.
+ */
 export async function getOrCreateCourse(
   existingCourse: ExistingCourse | null,
   suggestion: CourseSuggestion,
   courseSuggestionId: string,
   workflowRunId: string,
-): Promise<{ course: CourseContext; existing: ExistingCourseContent }> {
+): Promise<GetOrCreateCourseResult> {
   if (!existingCourse) {
-    const course = await initializeCourseStep({ suggestion, workflowRunId });
-    await streamSkipStep("setCourseAsRunning");
-    return { course, existing: DEFAULT_EXISTING_CONTENT };
+    const initialized = await initializeCourseStep({ suggestion, workflowRunId });
+    return prepareInitializedCourse({ courseSuggestionId, initialized, workflowRunId });
   }
 
   await streamSkipStep("initializeCourse");
   const aiOrg = await getAIOrganizationStep();
 
-  const course: CourseContext = {
-    courseId: existingCourse.id,
-    courseSlug: existingCourse.slug,
-    courseTitle: suggestion.title,
-    language: suggestion.language,
-    organizationId: aiOrg.id,
-    targetLanguage: suggestion.targetLanguage,
-  };
-
-  await setCourseAsRunningStep({ courseId: existingCourse.id, courseSuggestionId, workflowRunId });
-
-  return {
-    course,
-    existing: {
-      description: existingCourse.description,
-      hasCategories: existingCourse._count.categories > 0,
-      hasChapters: existingCourse._count.chapters > 0,
-      imageUrl: existingCourse.imageUrl,
-    },
-  };
+  return prepareExistingCourse({
+    course: getCourseContext({ course: existingCourse, organizationId: aiOrg.id, suggestion }),
+    courseSuggestionId,
+    existing: getExistingCourseContent(existingCourse),
+    generationStatus: existingCourse.generationStatus,
+    workflowRunId,
+  });
 }

--- a/apps/api/src/workflows/course-generation/_internal/persist-generated-content.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/persist-generated-content.test.ts
@@ -5,8 +5,8 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { type CourseContext } from "../steps/initialize-course-step";
+import { type ExistingCourseContent } from "./existing-course-content";
 import { type GeneratedContent } from "./generate-missing-content";
-import { type ExistingCourseContent } from "./get-or-create-course";
 import { persistGeneratedContent } from "./persist-generated-content";
 
 describe(persistGeneratedContent, () => {

--- a/apps/api/src/workflows/course-generation/_internal/persist-generated-content.ts
+++ b/apps/api/src/workflows/course-generation/_internal/persist-generated-content.ts
@@ -4,8 +4,8 @@ import { addCategoriesStep } from "../steps/add-categories-step";
 import { addChaptersStep } from "../steps/add-chapters-step";
 import { type CourseContext } from "../steps/initialize-course-step";
 import { updateCourseStep } from "../steps/update-course-step";
+import { type ExistingCourseContent } from "./existing-course-content";
 import { type GeneratedContent } from "./generate-missing-content";
-import { type ExistingCourseContent } from "./get-or-create-course";
 
 async function emitSkippedPersistSteps(
   needsCourseUpdate: boolean,

--- a/apps/api/src/workflows/course-generation/_internal/setup-course.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/setup-course.test.ts
@@ -4,7 +4,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { type CourseContext } from "../steps/initialize-course-step";
-import { type ExistingCourseContent } from "./get-or-create-course";
+import { type ExistingCourseContent } from "./existing-course-content";
 import { setupCourse } from "./setup-course";
 
 const {

--- a/apps/api/src/workflows/course-generation/_internal/setup-course.ts
+++ b/apps/api/src/workflows/course-generation/_internal/setup-course.ts
@@ -2,8 +2,8 @@ import { streamSkipStep } from "@/workflows/_shared/stream-skip-step";
 import { type Chapter } from "@zoonk/db";
 import { getCourseChaptersStep } from "../steps/get-course-chapters-step";
 import { type CourseContext } from "../steps/initialize-course-step";
+import { type ExistingCourseContent } from "./existing-course-content";
 import { generateMissingContent } from "./generate-missing-content";
-import { type ExistingCourseContent } from "./get-or-create-course";
 import { persistGeneratedContent } from "./persist-generated-content";
 
 async function getChapters(

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -122,7 +122,7 @@ export async function courseGenerationWorkflow(courseSuggestionId: string): Prom
     return;
   }
 
-  const { course, existing } = await getOrCreateCourse(
+  const courseSetup = await getOrCreateCourse(
     existingCourse,
     suggestion,
     courseSuggestionId,
@@ -139,14 +139,28 @@ export async function courseGenerationWorkflow(courseSuggestionId: string): Prom
     throw error;
   });
 
+  if (courseSetup.status === "running") {
+    return;
+  }
+
+  if (courseSetup.status === "completed") {
+    await completeCourseSetupStep({
+      courseId: courseSetup.course.courseId,
+      courseSlug: courseSetup.course.courseSlug,
+      courseSuggestionId,
+    });
+
+    return;
+  }
+
   const chapters = await setupCourseContent({
-    course,
+    course: courseSetup.course,
     courseSuggestionId,
     description: suggestion.description,
-    existing,
+    existing: courseSetup.existing,
   }).catch(async (error: unknown) => {
     await handleCourseFailureStep({
-      courseId: course.courseId,
+      courseId: courseSetup.course.courseId,
       courseSuggestionId,
       error: serializeWorkflowError(error),
     });

--- a/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.test.ts
@@ -80,4 +80,38 @@ describe(completeCourseSetupStep, () => {
       }),
     );
   });
+
+  it("marks linked suggestions as completed when another run finishes the course", async () => {
+    const course = await courseFixture({
+      generationStatus: "running",
+      organizationId,
+      title: `Linked Complete Setup ${randomUUID()}`,
+    });
+
+    const [primarySuggestion, linkedSuggestion] = await Promise.all([
+      courseSuggestionFixture({
+        courseId: course.id,
+        generationStatus: "running",
+        title: `Primary Complete Suggestion ${randomUUID()}`,
+      }),
+      courseSuggestionFixture({
+        courseId: course.id,
+        generationRunId: "other-run",
+        generationStatus: "running",
+        title: `Linked Complete Suggestion ${randomUUID()}`,
+      }),
+    ]);
+
+    await completeCourseSetupStep({
+      courseId: course.id,
+      courseSlug: course.slug,
+      courseSuggestionId: primarySuggestion.id,
+    });
+
+    const updatedLinkedSuggestion = await prisma.courseSuggestion.findUniqueOrThrow({
+      where: { id: linkedSuggestion.id },
+    });
+
+    expect(updatedLinkedSuggestion.generationStatus).toBe("completed");
+  });
 });

--- a/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/complete-course-setup-step.ts
@@ -3,6 +3,12 @@ import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { throwSettledFailures } from "@zoonk/utils/settled";
 
+/**
+ * Marks the course and every suggestion already linked to it as completed.
+ * Duplicate workflow starts can link more than one suggestion to the same
+ * in-progress course, and they should all resolve when the winning run
+ * finishes the shared course.
+ */
 export async function completeCourseSetupStep(input: {
   courseSuggestionId: string;
   courseId: string;
@@ -22,6 +28,10 @@ export async function completeCourseSetupStep(input: {
     prisma.courseSuggestion.update({
       data: { courseId: input.courseId, generationStatus: "completed" },
       where: { id: input.courseSuggestionId },
+    }),
+    prisma.courseSuggestion.updateMany({
+      data: { generationStatus: "completed" },
+      where: { courseId: input.courseId },
     }),
   ]);
 

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.test.ts
@@ -55,6 +55,42 @@ describe(handleCourseFailureStep, () => {
     );
   });
 
+  it("marks linked running suggestions as failed when the course run fails", async () => {
+    const course = await courseFixture({
+      generationRunId: "old-run",
+      generationStatus: "running",
+      organizationId,
+      title: `Linked Fail Course ${randomUUID()}`,
+    });
+
+    const [primarySuggestion, linkedSuggestion] = await Promise.all([
+      courseSuggestionFixture({
+        courseId: course.id,
+        generationRunId: "old-run",
+        generationStatus: "running",
+        title: `Primary Fail Suggestion ${randomUUID()}`,
+      }),
+      courseSuggestionFixture({
+        courseId: course.id,
+        generationRunId: "other-run",
+        generationStatus: "running",
+        title: `Linked Fail Suggestion ${randomUUID()}`,
+      }),
+    ]);
+
+    await handleCourseFailureStep({
+      courseId: course.id,
+      courseSuggestionId: primarySuggestion.id,
+    });
+
+    const updatedLinkedSuggestion = await prisma.courseSuggestion.findUniqueOrThrow({
+      where: { id: linkedSuggestion.id },
+    });
+
+    expect(updatedLinkedSuggestion.generationStatus).toBe("failed");
+    expect(updatedLinkedSuggestion.generationRunId).toBeNull();
+  });
+
   it("throws all status update failures", async () => {
     const promise = handleCourseFailureStep({
       courseId: randomUUID(),

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
@@ -7,9 +7,9 @@ import { getSettledFailureError, settledFailures } from "@zoonk/utils/settled";
 
 /**
  * Marks a course-generation run as permanently failed after the workflow has
- * stopped retrying the step that threw. The original error is logged here so
- * Workflow can keep retryable steps clean while final failure diagnostics still
- * show the provider or database error that caused the run to fail.
+ * stopped retrying the step that threw. Suggestions linked by duplicate starts
+ * fail with the shared course so no request stays stuck in a running state
+ * after the winning workflow gives up.
  */
 export async function handleCourseFailureStep(input: {
   courseId: string | null;
@@ -31,6 +31,10 @@ export async function handleCourseFailureStep(input: {
       prisma.courseSuggestion.update({
         data: { generationRunId: null, generationStatus: "failed" },
         where: { id: courseSuggestionId },
+      }),
+      prisma.courseSuggestion.updateMany({
+        data: { generationRunId: null, generationStatus: "failed" },
+        where: { courseId, generationStatus: { not: "completed" } },
       }),
     ]);
 

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.test.ts
@@ -45,18 +45,20 @@ describe(initializeCourseStep, () => {
 
     const result = await initializeCourseStep({ suggestion, workflowRunId });
 
-    expect(result.courseTitle).toBe(suggestion.title);
-    expect(result.language).toBe(suggestion.language);
-    expect(result.courseId).toStrictEqual(expect.any(String));
+    expect(result.course.courseTitle).toBe(suggestion.title);
+    expect(result.course.language).toBe(suggestion.language);
+    expect(result.course.courseId).toStrictEqual(expect.any(String));
+    expect(result.existing).toBeNull();
+    expect(result.generationStatus).toBe("running");
 
     const [updatedSuggestion, createdCourse] = await Promise.all([
       prisma.courseSuggestion.findUniqueOrThrow({ where: { id: suggestion.id } }),
-      prisma.course.findUniqueOrThrow({ where: { id: result.courseId } }),
+      prisma.course.findUniqueOrThrow({ where: { id: result.course.courseId } }),
     ]);
 
     expect(updatedSuggestion.generationStatus).toBe("running");
     expect(updatedSuggestion.generationRunId).toBe(workflowRunId);
-    expect(updatedSuggestion.courseId).toBe(result.courseId);
+    expect(updatedSuggestion.courseId).toBe(result.course.courseId);
     expect(createdCourse.generationStatus).toBe("running");
     expect(createdCourse.isPublished).toBe(true);
     expect(createdCourse.title).toBe(suggestion.title);
@@ -80,9 +82,9 @@ describe(initializeCourseStep, () => {
 
     const result = await initializeCourseStep({ suggestion, workflowRunId: `run-${randomUUID()}` });
 
-    expect(result.targetLanguage).toBe("es");
+    expect(result.course.targetLanguage).toBe("es");
 
-    const course = await prisma.course.findUniqueOrThrow({ where: { id: result.courseId } });
+    const course = await prisma.course.findUniqueOrThrow({ where: { id: result.course.courseId } });
 
     expect(course.targetLanguage).toBe("es");
   });

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
@@ -1,8 +1,19 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
-import { type CourseSuggestion, prisma } from "@zoonk/db";
+import {
+  type Course,
+  type CourseSuggestion,
+  isPrismaUniqueConstraintError,
+  prisma,
+} from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
-import { ensureLocaleSuffix, normalizeString, toSlug } from "@zoonk/utils/string";
+import { normalizeString } from "@zoonk/utils/string";
+import { getCourseSlugForTitle } from "../_internal/course-slug";
+import {
+  type ExistingCourseContent,
+  courseContentInclude,
+  getExistingCourseContent,
+} from "../_internal/existing-course-content";
 
 export type CourseContext = {
   courseId: string;
@@ -11,6 +22,12 @@ export type CourseContext = {
   language: string;
   organizationId: string;
   targetLanguage: string | null;
+};
+
+export type InitializedCourse = {
+  course: CourseContext;
+  existing: ExistingCourseContent | null;
+  generationStatus: Course["generationStatus"];
 };
 
 /**
@@ -34,6 +51,56 @@ async function updateCourseSuggestionToRunning({
 }
 
 /**
+ * Links a suggestion to a course discovered after a unique-key race. Completed
+ * courses can satisfy the suggestion immediately; every other state means this
+ * workflow or the already-running workflow should keep the suggestion in a
+ * running state until the course finishes or fails.
+ */
+async function updateCourseSuggestionForRecoveredCourse({
+  courseId,
+  generationStatus,
+  suggestionId,
+  workflowRunId,
+}: {
+  courseId: string;
+  generationStatus: Course["generationStatus"];
+  suggestionId: string;
+  workflowRunId: string;
+}): Promise<void> {
+  await prisma.courseSuggestion.update({
+    data:
+      generationStatus === "completed"
+        ? { courseId, generationStatus: "completed" }
+        : { courseId, generationRunId: workflowRunId, generationStatus: "running" },
+    where: { id: suggestionId },
+  });
+}
+
+/**
+ * Converts a persisted course row into the stable workflow context shape.
+ * The workflow keeps the suggestion title/language as the learner-facing
+ * request while using the database course id and slug as the durable target.
+ */
+export function getCourseContext({
+  course,
+  organizationId,
+  suggestion,
+}: {
+  course: Pick<Course, "id" | "slug">;
+  organizationId: string;
+  suggestion: CourseSuggestion;
+}): CourseContext {
+  return {
+    courseId: course.id,
+    courseSlug: course.slug,
+    courseTitle: suggestion.title,
+    language: suggestion.language,
+    organizationId,
+    targetLanguage: suggestion.targetLanguage,
+  };
+}
+
+/**
  * Creates the course entity in the database.
  * This is a pure save step — one DB operation.
  */
@@ -45,11 +112,11 @@ async function createCourseEntity({
   organizationId: string;
   suggestion: CourseSuggestion;
   workflowRunId: string;
-}): Promise<CourseContext> {
-  const slug = ensureLocaleSuffix(toSlug(suggestion.title), suggestion.language);
+}): Promise<Course> {
+  const slug = getCourseSlugForTitle({ language: suggestion.language, title: suggestion.title });
   const normalizedTitle = normalizeString(suggestion.title);
 
-  const course = await prisma.course.create({
+  return prisma.course.create({
     data: {
       generationRunId: workflowRunId,
       generationStatus: "running",
@@ -62,30 +129,97 @@ async function createCourseEntity({
       title: suggestion.title,
     },
   });
-
-  return {
-    courseId: course.id,
-    courseSlug: course.slug,
-    courseTitle: suggestion.title,
-    language: suggestion.language,
-    organizationId,
-    targetLanguage: suggestion.targetLanguage,
-  };
 }
 
 /**
- * Initializes a new course from a suggestion.
- * Split into two DB operations:
- * 1. Create the course entity
- * 2. Link the suggestion to the course and mark it as "running"
- *
- * This avoids a redundant pre-create update while keeping failures attributable
- * to a specific action.
+ * Loads the course that won a concurrent insert for the same organization slug.
+ * If the unique error was for a different constraint or the winning row is not
+ * visible yet, rethrow the original error so Workflow can retry the step.
+ */
+async function getRecoveredCourse({
+  error,
+  organizationId,
+  slug,
+}: {
+  error: unknown;
+  organizationId: string;
+  slug: string;
+}) {
+  if (!isPrismaUniqueConstraintError(error)) {
+    throw error;
+  }
+
+  const course = await prisma.course.findUnique({
+    include: courseContentInclude,
+    where: { orgSlug: { organizationId, slug } },
+  });
+
+  if (!course) {
+    throw error;
+  }
+
+  return course;
+}
+
+/**
+ * Creates the course when this workflow wins the insert race, or returns the
+ * existing course that another workflow already created for the same unique
+ * organization slug. This keeps duplicate starts idempotent at the database
+ * boundary instead of treating a valid race as a terminal failure.
+ */
+async function createOrRecoverCourse({
+  organizationId,
+  suggestion,
+  workflowRunId,
+}: {
+  organizationId: string;
+  suggestion: CourseSuggestion;
+  workflowRunId: string;
+}): Promise<InitializedCourse> {
+  const slug = getCourseSlugForTitle({ language: suggestion.language, title: suggestion.title });
+
+  try {
+    const course = await createCourseEntity({ organizationId, suggestion, workflowRunId });
+
+    await updateCourseSuggestionToRunning({
+      courseId: course.id,
+      suggestionId: suggestion.id,
+      workflowRunId,
+    });
+
+    return {
+      course: getCourseContext({ course, organizationId, suggestion }),
+      existing: null,
+      generationStatus: course.generationStatus,
+    };
+  } catch (error) {
+    const course = await getRecoveredCourse({ error, organizationId, slug });
+
+    await updateCourseSuggestionForRecoveredCourse({
+      courseId: course.id,
+      generationStatus: course.generationStatus,
+      suggestionId: suggestion.id,
+      workflowRunId,
+    });
+
+    return {
+      course: getCourseContext({ course, organizationId, suggestion }),
+      existing: getExistingCourseContent(course),
+      generationStatus: course.generationStatus,
+    };
+  }
+}
+
+/**
+ * Initializes the course target for a suggestion. The normal path creates the
+ * course and links the suggestion; the duplicate-start path links to the row
+ * that won the unique slug race so the workflow can stop or resume based on
+ * that course's current generation status.
  */
 export async function initializeCourseStep(input: {
   suggestion: CourseSuggestion;
   workflowRunId: string;
-}): Promise<CourseContext> {
+}): Promise<InitializedCourse> {
   "use step";
 
   await using stream = createStepStream<CourseWorkflowStepName>();
@@ -96,11 +230,9 @@ export async function initializeCourseStep(input: {
 
   const aiOrg = await prisma.organization.findUniqueOrThrow({ where: { slug: AI_ORG_SLUG } });
 
-  const course = await createCourseEntity({ organizationId: aiOrg.id, suggestion, workflowRunId });
-
-  await updateCourseSuggestionToRunning({
-    courseId: course.courseId,
-    suggestionId: suggestion.id,
+  const course = await createOrRecoverCourse({
+    organizationId: aiOrg.id,
+    suggestion,
     workflowRunId,
   });
 

--- a/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.ts
@@ -12,14 +12,14 @@ import {
   getAiGenerationCourseWhere,
   prisma,
 } from "@zoonk/db";
-import { ensureLocaleSuffix, normalizeString, toSlug } from "@zoonk/utils/string";
+import { normalizeString, toSlug } from "@zoonk/utils/string";
+import { getCourseSlugForTitle } from "../_internal/course-slug";
+import { courseContentInclude } from "../_internal/existing-course-content";
 
 const IDENTITY_SEARCH_STEP = "generateCourseIdentitySearchQueries";
 const IDENTITY_CLASSIFICATION_STEP = "resolveCourseIdentity";
 
-const courseInclude = { _count: { select: { categories: true, chapters: true } } } as const;
-
-export type ExistingCourse = CourseGetPayload<{ include: typeof courseInclude }>;
+export type ExistingCourse = CourseGetPayload<{ include: typeof courseContentInclude }>;
 
 type CourseWhereInput = NonNullable<Parameters<typeof getAiGenerationCourseWhere>[0]>;
 type CourseIdentityStream = ReturnType<typeof createStepStream<CourseWorkflowStepName>>;
@@ -77,7 +77,7 @@ function getSearchTextWhereClauses({
 }): CourseWhereInput[] {
   const normalizedText = normalizeString(text);
   const normalizedSlug = toSlug(text);
-  const suffixedSlug = ensureLocaleSuffix(normalizedSlug, language);
+  const suffixedSlug = getCourseSlugForTitle({ language, title: text });
 
   const clauses: (CourseWhereInput | null)[] = [
     normalizedText ? { normalizedTitle: normalizedText } : null,
@@ -137,7 +137,7 @@ async function findCandidateCourses({
   }
 
   return prisma.course.findMany({
-    include: courseInclude,
+    include: courseContentInclude,
     where: getAiGenerationCourseWhere({ OR: whereClauses, language: suggestion.language }),
   });
 }
@@ -154,7 +154,7 @@ function getDirectMatch({
   candidates: ExistingCourse[];
   suggestion: CourseSuggestion;
 }): ExistingCourse | null {
-  const slug = ensureLocaleSuffix(toSlug(suggestion.slug), suggestion.language);
+  const slug = getCourseSlugForTitle({ language: suggestion.language, title: suggestion.title });
   const normalizedTitle = normalizeString(suggestion.title);
 
   return (
@@ -179,7 +179,7 @@ async function getCachedCourse(courseId: string | null): Promise<ExistingCourse 
   }
 
   return prisma.course.findFirst({
-    include: courseInclude,
+    include: courseContentInclude,
     where: getAiGenerationCourseWhere({ id: courseId }),
   });
 }


### PR DESCRIPTION
## Summary
- recover course initialization when another workflow wins the organization slug insert race
- stop duplicate workflow runs when the recovered course is already running or completed
- propagate shared course completion/failure to linked suggestions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes race conditions in course generation when multiple runs try to create the same course. We now recover the losing run, stop duplicates, and keep linked suggestions in sync with the shared course state.

- **Bug Fixes**
  - Recover on org+slug unique conflicts by loading the winning course and linking the suggestion.
  - Short‑circuit duplicate runs when the recovered course is already running or completed.
  - Propagate completion/failure to all suggestions linked to the same course to avoid stuck “running” states.

- **Refactors**
  - Centralized locale-aware slug logic in `getCourseSlugForTitle` to match the DB unique key.
  - Introduced `ExistingCourseContent` to pass minimal content flags instead of full rows.
  - `initializeCourseStep` now returns a structured `InitializedCourse` via `getCourseContext`, unifying created vs. recovered paths.

<sup>Written for commit d45ad5504ccee31ce9bfa8604d7704f357e3eb1d. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1545?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

