### PR TITLE
feat(main): add generation exit links

### DIFF
--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -370,7 +370,7 @@ test.describe("Generate Chapter Page - With Subscription", () => {
 
 test.describe("Generate Chapter Page - First Chapter Free", () => {
   test("unauthenticated user sees generation UI for first chapter", async ({ page }) => {
-    const { chapter } = await createPendingChapter(0);
+    const { chapter, course } = await createPendingChapter(0);
 
     await setupMockApis(page, {
       statusDelayMs: 2500,
@@ -381,6 +381,10 @@ test.describe("Generate Chapter Page - First Chapter Free", () => {
 
     await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toHaveCount(0);
     await expect(page.getByRole("heading", { name: chapter.title })).toBeVisible();
+
+    const exitLink = page.getByRole("link", { name: /back to course/iu });
+    await expect(exitLink).toBeVisible();
+    await expect(exitLink).toHaveAttribute("href", `/b/${AI_ORG_SLUG}/c/${course.slug}`);
   });
 
   test("authenticated user without subscription sees generation UI for first chapter", async ({

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -181,6 +181,10 @@ test.describe("Generate Course Page", () => {
       await expect(page.getByText(/creating your course/iu)).toBeVisible({ timeout: 10_000 });
 
       await expect(page.getByText(/this usually takes about 2 minutes/iu)).toBeVisible();
+
+      const exitLink = page.getByRole("link", { name: /back home/iu });
+      await expect(exitLink).toBeVisible();
+      await expect(exitLink).toHaveAttribute("href", "/");
     });
   });
 

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -262,7 +262,7 @@ test.describe("Generate Lesson Page - No Subscription", () => {
 
 test.describe("Generate Lesson Page - First Chapter Free", () => {
   test("unauthenticated user sees generation UI for first chapter lesson", async ({ page }) => {
-    const { lesson } = await createPendingLesson(0);
+    const { chapter, course, lesson } = await createPendingLesson(0);
 
     await setupMockApis(page, {
       statusDelayMs: 2500,
@@ -274,6 +274,14 @@ test.describe("Generate Lesson Page - First Chapter Free", () => {
     await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toHaveCount(0);
     await expect(page.getByText(/upgrade to create/iu)).toHaveCount(0);
     await expect(page.getByRole("heading", { name: lesson.title ?? "" })).toBeVisible();
+
+    const exitLink = page.getByRole("link", { name: /back to chapter/iu });
+    await expect(exitLink).toBeVisible();
+
+    await expect(exitLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`,
+    );
   });
 
   test("authenticated user without subscription sees generation UI for first chapter lesson", async ({

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -460,6 +460,11 @@ test.describe("Lesson Player Page", () => {
     await expect(generateLink).toBeVisible();
     await expect(generateLink).toHaveAttribute("href", new RegExp(`/generate/l/${lesson.id}`, "u"));
     await expect(generateLink).toHaveAttribute("rel", "nofollow");
+
+    const chapterLink = page.getByRole("link", { name: /back to chapter/iu });
+    await expect(chapterLink).toBeVisible();
+
+    await expect(chapterLink).toHaveAttribute("href", `/b/ai/c/${course.slug}/ch/${chapter.slug}`);
   });
 
   test("blocked practice lessons link to the required explanation generation page", async ({

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -963,6 +963,11 @@ msgstr "Open required lesson"
 msgid "ZzznjM"
 msgstr "Create lesson"
 
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+#: src/app/generate/l/[id]/generate-lesson-content.tsx
+msgid "/N8rYN"
+msgstr "Back to chapter"
+
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "mA7vCW"
 msgstr "Review locked"
@@ -1088,6 +1093,10 @@ msgstr "Saving your progress..."
 msgid "XxZuJi"
 msgstr "Putting it all together..."
 
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "rPgekg"
+msgstr "Back home"
+
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"
 msgstr "Creating your course"
@@ -1207,10 +1216,6 @@ msgstr "Summarizing what you'll learn..."
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgid "9r/4zz"
 msgstr "Writing the overview..."
-
-#: src/app/generate/l/[id]/generate-lesson-content.tsx
-msgid "/N8rYN"
-msgstr "Back to chapter"
 
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgid "kXZ7ZI"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -963,6 +963,11 @@ msgstr "Abrir la lección requerida"
 msgid "ZzznjM"
 msgstr "Crear lección"
 
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+#: src/app/generate/l/[id]/generate-lesson-content.tsx
+msgid "/N8rYN"
+msgstr "Volver al capítulo"
+
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "mA7vCW"
 msgstr "Revisión bloqueada"
@@ -1088,6 +1093,10 @@ msgstr "Guardando tu progreso..."
 msgid "XxZuJi"
 msgstr "Juntando todo..."
 
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "rPgekg"
+msgstr "Volver al inicio"
+
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"
 msgstr "Creando tu curso"
@@ -1207,10 +1216,6 @@ msgstr "Resumiendo lo que aprenderás..."
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgid "9r/4zz"
 msgstr "Escribiendo la descripción general..."
-
-#: src/app/generate/l/[id]/generate-lesson-content.tsx
-msgid "/N8rYN"
-msgstr "Volver al capítulo"
 
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgid "kXZ7ZI"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -963,6 +963,11 @@ msgstr "Abra a aula necessária"
 msgid "ZzznjM"
 msgstr "Criar aula"
 
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+#: src/app/generate/l/[id]/generate-lesson-content.tsx
+msgid "/N8rYN"
+msgstr "Voltar para o capítulo"
+
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "mA7vCW"
 msgstr "Revisão bloqueada"
@@ -1088,6 +1093,10 @@ msgstr "Salvando seu progresso..."
 msgid "XxZuJi"
 msgstr "Juntando tudo..."
 
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "rPgekg"
+msgstr "Voltar para o início"
+
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"
 msgstr "Criando seu curso"
@@ -1207,10 +1216,6 @@ msgstr "Resumindo o que você vai aprender..."
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgid "9r/4zz"
 msgstr "Escrevendo a visão geral..."
-
-#: src/app/generate/l/[id]/generate-lesson-content.tsx
-msgid "/N8rYN"
-msgstr "Voltar para o capítulo"
 
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgid "kXZ7ZI"

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
@@ -1,3 +1,4 @@
+import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import { buttonVariants } from "@zoonk/ui/components/button";
 import {
   Empty,
@@ -13,18 +14,23 @@ import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 
 export async function LessonNotGenerated({
-  lessonId,
   brandSlug,
+  chapterSlug,
+  courseSlug,
+  lessonId,
   prerequisiteLessonId,
 }: {
-  lessonId: string;
   brandSlug: string;
+  chapterSlug: string;
+  courseSlug: string;
+  lessonId: string;
   prerequisiteLessonId?: string | null;
 }) {
   const t = await getExtracted();
   const canGenerateLesson = brandSlug === AI_ORG_SLUG;
   const generationLessonId = prerequisiteLessonId ?? lessonId;
   const isBlockedByPrerequisite = Boolean(prerequisiteLessonId);
+  const chapterHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}` as const;
 
   return (
     <Empty className="border-0">
@@ -44,8 +50,8 @@ export async function LessonNotGenerated({
         </EmptyDescription>
       </EmptyHeader>
 
-      {canGenerateLesson && (
-        <EmptyContent>
+      <EmptyContent>
+        {canGenerateLesson && (
           <Link
             className={buttonVariants({ variant: "outline" })}
             href={`/generate/l/${generationLessonId}`}
@@ -55,8 +61,9 @@ export async function LessonNotGenerated({
             <SparklesIcon data-icon="inline-start" />
             {isBlockedByPrerequisite ? t("Open required lesson") : t("Create lesson")}
           </Link>
-        </EmptyContent>
-      )}
+        )}
+        <GenerationExitLink href={chapterHref}>{t("Back to chapter")}</GenerationExitLink>
+      </EmptyContent>
     </Empty>
   );
 }

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -73,8 +73,10 @@ export default async function LessonPage({ params }: Props) {
     return (
       <main className="flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center p-4">
         <LessonNotGenerated
-          lessonId={lesson.id}
           brandSlug={brandSlug}
+          chapterSlug={chapterSlug}
+          courseSlug={courseSlug}
+          lessonId={lesson.id}
           prerequisiteLessonId={blockingPrerequisite?.lessonId ?? null}
         />
       </main>

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -1,4 +1,5 @@
 import { LoginRequired } from "@/components/auth/login-required";
+import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import { SubscriptionGate } from "@/components/subscription/subscription-gate";
 import { getChapterForGeneration } from "@/data/chapters/get-chapter-for-generation";
 import { getInitialGenerationPageStatus } from "@/lib/workflow/get-initial-generation-page-status";
@@ -62,6 +63,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
             generationRunId={chapter.generationRunId}
             initialStatus={initialStatus}
           />
+          <GenerationExitLink href={backHref}>{backLabel}</GenerationExitLink>
         </SubscriptionGate>
       </ContainerBody>
     </Container>

--- a/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
@@ -1,3 +1,4 @@
+import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import {
   getCourseSuggestionById,
   getLinkedCourseForSuggestion,
@@ -14,6 +15,7 @@ import { Empty, EmptyContent, EmptyHeader } from "@zoonk/ui/components/empty";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { ensureLocaleSuffix } from "@zoonk/utils/string";
+import { getExtracted } from "next-intl/server";
 import { notFound, redirect } from "next/navigation";
 import { GenerationClient } from "./generation-client";
 
@@ -35,6 +37,8 @@ export async function GenerateCourseSuggestionContent({
     redirect(`/b/${AI_ORG_SLUG}/c/${linkedCourse.slug}`);
   }
 
+  const t = await getExtracted();
+
   return (
     <Container variant="narrow">
       <ContainerHeader>
@@ -52,6 +56,7 @@ export async function GenerateCourseSuggestionContent({
           generationStatus={suggestion.generationStatus}
           suggestionId={id}
         />
+        <GenerationExitLink href="/">{t("Back home")}</GenerationExitLink>
       </ContainerBody>
     </Container>
   );

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -1,4 +1,5 @@
 import { LoginRequired } from "@/components/auth/login-required";
+import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import { SubscriptionGate } from "@/components/subscription/subscription-gate";
 import { getLessonForGeneration } from "@/data/lessons/get-lesson-for-generation";
 import { getLessonDisplayMeta } from "@/lib/lessons";
@@ -107,6 +108,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
                 <SparklesIcon data-icon="inline-start" />
                 {t("Open required lesson")}
               </Link>
+              <GenerationExitLink href={backHref}>{backLabel}</GenerationExitLink>
             </EmptyContent>
           </Empty>
         </ContainerBody>
@@ -138,6 +140,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
             lessonKind={lesson.kind}
             lessonSlug={lesson.slug}
           />
+          <GenerationExitLink href={backHref}>{backLabel}</GenerationExitLink>
         </SubscriptionGate>
       </ContainerBody>
     </Container>

--- a/apps/main/src/components/generation/generation-exit-link.tsx
+++ b/apps/main/src/components/generation/generation-exit-link.tsx
@@ -1,0 +1,23 @@
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { type Route } from "next";
+import Link from "next/link";
+
+/**
+ * Gives learners a quiet way out of generated-content waiting states. Keeping
+ * this as a plain server-rendered link means streaming components can keep one
+ * job: start, display, and clean up the workflow stream.
+ */
+export function GenerationExitLink<Href extends string>({
+  children,
+  href,
+}: {
+  children: React.ReactNode;
+  href: Route<Href>;
+}) {
+  return (
+    <Link className={cn(buttonVariants(), "w-max")} href={href} prefetch>
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- Add primary back links to generation waiting pages for courses, chapters, and lessons
- Add a back-to-chapter link to the lesson unavailable state
- Cover the new links with focused e2e assertions and translations


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clear “back” links to course, chapter, and lesson generation pages, plus the lesson-not-generated view, so learners can quickly return to the right place. Includes i18n and e2e coverage, using a new server-rendered `GenerationExitLink` component.

- **New Features**
  - Course suggestion generation: “Back home”.
  - Chapter generation: “Back to course”.
  - Lesson generation: “Back to chapter”.
  - Lesson not generated: added “Back to chapter”.
  - New `GenerationExitLink` button-style link for simple, server-rendered navigation.
  - Updated translations (en/es/pt) and added focused e2e assertions for visibility and hrefs.

<sup>Written for commit 702d9c541e2725c7164eaf66e6a330cc9633ec7b. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1546?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

