### PR TITLE
fix(main): simplify generation status copy

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1032,8 +1032,9 @@ msgstr "Choosing lesson types"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgid "aJev/w"
-msgstr "Getting things ready"
+#: src/app/generate/l/[id]/use-phase-labels.ts
+msgid "EKtClK"
+msgstr "Getting started"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "SF9AtA"
@@ -1058,14 +1059,8 @@ msgstr "Reviewing the lesson mix..."
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "xrLiIe"
-msgstr "Setting things up..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5nJVpw"
-msgstr "Getting everything ready..."
+msgid "5342HA"
+msgstr "Getting started..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "nwGJ65"
@@ -1090,8 +1085,9 @@ msgstr "Saving your progress..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgid "XxZuJi"
-msgstr "Putting it all together..."
+#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
+msgid "JUr8Er"
+msgstr "Finishing up..."
 
 #: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
 msgid "rPgekg"
@@ -1346,16 +1342,8 @@ msgid "BszFlm"
 msgstr "Saving your lesson..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "2e5abC"
-msgstr "Wrapping things up..."
-
-#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "bC9979"
 msgstr "Almost done..."
-
-#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JUr8Er"
-msgstr "Finishing up..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "ZRt4oT"
@@ -1600,10 +1588,6 @@ msgstr "Creating lesson thumbnail"
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "mIpv67"
 msgstr "Creating sentences"
-
-#: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "EKtClK"
-msgstr "Getting started"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "0zeST/"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1032,8 +1032,9 @@ msgstr "Eligiendo tipos de lección"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgid "aJev/w"
-msgstr "Preparando todo"
+#: src/app/generate/l/[id]/use-phase-labels.ts
+msgid "EKtClK"
+msgstr "Comenzando"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "SF9AtA"
@@ -1058,14 +1059,8 @@ msgstr "Revisando la combinación de lecciones..."
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "xrLiIe"
-msgstr "Configurando todo..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5nJVpw"
-msgstr "Preparando todo..."
+msgid "5342HA"
+msgstr "Comenzando..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "nwGJ65"
@@ -1090,8 +1085,9 @@ msgstr "Guardando tu progreso..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgid "XxZuJi"
-msgstr "Juntando todo..."
+#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
+msgid "JUr8Er"
+msgstr "Terminando..."
 
 #: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
 msgid "rPgekg"
@@ -1135,7 +1131,7 @@ msgstr "Escribiendo capítulos"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgid "d2xrsv"
-msgstr "Preparando todo"
+msgstr "Preparando tu curso"
 
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 msgid "CFWOGF"
@@ -1346,16 +1342,8 @@ msgid "BszFlm"
 msgstr "Guardando tu lección..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "2e5abC"
-msgstr "Terminando los detalles..."
-
-#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "bC9979"
 msgstr "Casi listo..."
-
-#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JUr8Er"
-msgstr "Terminando..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "ZRt4oT"
@@ -1600,10 +1588,6 @@ msgstr "Creando miniatura de la lección"
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "mIpv67"
 msgstr "Creando oraciones"
-
-#: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "EKtClK"
-msgstr "Comenzando"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "0zeST/"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1032,8 +1032,9 @@ msgstr "Escolhendo os tipos de aulas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgid "aJev/w"
-msgstr "Preparando as coisas"
+#: src/app/generate/l/[id]/use-phase-labels.ts
+msgid "EKtClK"
+msgstr "Começando"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "SF9AtA"
@@ -1058,14 +1059,8 @@ msgstr "Revisando a combinação de aulas..."
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "xrLiIe"
-msgstr "Configurando as coisas..."
-
-#: src/app/generate/ch/[id]/use-generation-phases.ts
-#: src/app/generate/cs/[id]/use-generation-phases.ts
-#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5nJVpw"
-msgstr "Preparando tudo..."
+msgid "5342HA"
+msgstr "Começando..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "nwGJ65"
@@ -1090,8 +1085,9 @@ msgstr "Salvando seu progresso..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/cs/[id]/use-generation-phases.ts
-msgid "XxZuJi"
-msgstr "Juntando tudo..."
+#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
+msgid "JUr8Er"
+msgstr "Finalizando..."
 
 #: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
 msgid "rPgekg"
@@ -1346,16 +1342,8 @@ msgid "BszFlm"
 msgstr "Salvando sua aula..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "2e5abC"
-msgstr "Finalizando as coisas..."
-
-#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "bC9979"
 msgstr "Quase pronto..."
-
-#: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JUr8Er"
-msgstr "Finalizando..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "ZRt4oT"
@@ -1600,10 +1588,6 @@ msgstr "Criando miniatura da aula"
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "mIpv67"
 msgstr "Criando frases"
-
-#: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "EKtClK"
-msgstr "Começando"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "0zeST/"

--- a/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/ch/[id]/use-generation-phases.ts
@@ -27,7 +27,7 @@ export function useGenerationPhases(
 
   const labels: Record<PhaseName, string> = {
     classifyingLessons: t("Choosing lesson types"),
-    gettingReady: t("Getting things ready"),
+    gettingReady: t("Getting started"),
     preparingLessons: t("Preparing lessons"),
     savingLessons: t("Saving your lessons"),
   };
@@ -63,15 +63,14 @@ export function useGenerationPhases(
       itemTemplate: (num) => t("Choosing type for lesson {number}...", { number: String(num) }),
       reviewMessage: t("Reviewing the lesson mix..."),
     }),
-    gettingReady: (index) =>
-      cycleMessage([t("Setting things up..."), t("Getting everything ready...")], index),
+    gettingReady: (index) => cycleMessage([t("Getting started...")], index),
     preparingLessons: createCountingGenerator({
       intro: [t("Exploring your topic..."), t("Mapping out the learning path...")],
       itemTemplate: (num) => t("Writing lesson {number}...", { number: String(num) }),
       reviewMessage: t("Reviewing the flow so far..."),
     }),
     savingLessons: (index) =>
-      cycleMessage([t("Saving your progress..."), t("Putting it all together...")], index),
+      cycleMessage([t("Saving your progress..."), t("Finishing up...")], index),
   };
 
   return {

--- a/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
+++ b/apps/main/src/app/generate/cs/[id]/use-generation-phases.ts
@@ -30,7 +30,7 @@ export function useGenerationPhases(
     checkingCourseIdentity: t("Checking for duplicates"),
     creatingCoverImage: t("Creating the cover image"),
     findingSimilarCourses: t("Finding similar courses"),
-    gettingReady: t("Getting things ready"),
+    gettingReady: t("Getting started"),
     outliningChapters: t("Writing chapters"),
     preparingCourse: t("Preparing your course"),
     savingCourseInfo: t("Saving your course"),
@@ -92,8 +92,7 @@ export function useGenerationPhases(
         ],
         index,
       ),
-    gettingReady: (index) =>
-      cycleMessage([t("Setting things up..."), t("Getting everything ready...")], index),
+    gettingReady: (index) => cycleMessage([t("Getting started...")], index),
     outliningChapters: createCountingGenerator({
       intro: [t("Planning the course structure...")],
       itemTemplate: (num) => t("Writing chapter {number}...", { number: String(num) }),
@@ -102,7 +101,7 @@ export function useGenerationPhases(
     preparingCourse: (index) =>
       cycleMessage([t("Creating the course shell..."), t("Preparing the workspace...")], index),
     savingCourseInfo: (index) =>
-      cycleMessage([t("Saving your progress..."), t("Putting it all together...")], index),
+      cycleMessage([t("Saving your progress..."), t("Finishing up...")], index),
     writingDescription: (index) =>
       cycleMessage([t("Summarizing what you'll learn..."), t("Writing the overview...")], index),
   };

--- a/apps/main/src/app/generate/l/[id]/phase-thinking-generators/content.ts
+++ b/apps/main/src/app/generate/l/[id]/phase-thinking-generators/content.ts
@@ -61,12 +61,7 @@ export function useContentPhaseGenerators(): Partial<Record<PhaseName, ThinkingM
       ),
     gettingStarted: (index) =>
       cycleMessage(
-        [
-          t("Getting everything ready..."),
-          t("Setting things up..."),
-          t("Loading lesson data..."),
-          t("Checking what we need..."),
-        ],
+        [t("Getting started..."), t("Loading lesson data..."), t("Checking what we need...")],
         index,
       ),
     preparingImages: (index) =>
@@ -80,15 +75,7 @@ export function useContentPhaseGenerators(): Partial<Record<PhaseName, ThinkingM
         index,
       ),
     saving: (index) =>
-      cycleMessage(
-        [
-          t("Saving your lesson..."),
-          t("Wrapping things up..."),
-          t("Almost done..."),
-          t("Finishing up..."),
-        ],
-        index,
-      ),
+      cycleMessage([t("Saving your lesson..."), t("Almost done..."), t("Finishing up...")], index),
     savingPrerequisites: (index) =>
       cycleMessage(
         [


### PR DESCRIPTION
## Summary

- Reuse the existing Getting started phase label across generation setup phases
- Replace generic setup/finalizing streaming messages with clearer, consistent copy
- Refresh main app translations for English, Spanish, and Portuguese

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes generation status messages across course and lesson flows to use clear, consistent copy like "Getting started..." and "Finishing up...". Reuses the existing "Getting started" phase label and updates English, Spanish, and Portuguese translations.

- **Refactors**
  - Reuse `EKtClK` "Getting started" label across setup phases in course (`cs`), chapter (`ch`), and lesson content flows.
  - Replace vague streaming messages: "Setting things up..." and "Getting everything ready..." → "Getting started..."; "Putting it all together..." → "Finishing up...".
  - Refresh translations in `en.po`, `es.po`, and `pt.po` (including Spanish tweak to "Preparando tu curso").

<sup>Written for commit 4570ad98278d2bfbbf0beb24db0e97f93ba02a56. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1547?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

