### PR TITLE
feat(main): update zero-progress hero ctas

### DIFF
--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -18,8 +18,12 @@ test.describe("Home Page - Unauthenticated", () => {
 
     await expect(hero.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
 
-    // Test Learn anything CTA
-    await hero.getByRole("link", { exact: true, name: "Learn anything" }).click();
+    const loginLink = hero.getByRole("link", { name: "Log in to save your progress" });
+
+    await expect(hero.getByRole("link", { name: "Explore courses" })).not.toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
+
+    await hero.getByRole("link", { exact: true, name: "Create a course with AI" }).click();
 
     await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();
   });
@@ -55,6 +59,10 @@ test.describe("Home Page - Authenticated", () => {
     await expect(
       userWithoutProgress.getByRole("heading", { name: /learn anything with ai/iu }),
     ).toBeVisible();
+
+    await expect(
+      userWithoutProgress.getByRole("link", { name: "Log in to save your progress" }),
+    ).not.toBeVisible();
   });
 
   test("shows pending course when next lesson has no generated lessons", async ({

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -209,14 +209,12 @@ msgid "VcxnWX"
 msgstr "Interactive courses built for you. Just tell us what you want to learn."
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "nlT+zW"
-msgstr "Learn anything"
+msgid "jHCDDq"
+msgstr "Create a course with AI"
 
 #: src/app/(catalog)/(home)/hero.tsx
-#: src/app/(catalog)/courses/page.tsx
-#: src/app/(catalog)/my/user-course-list.tsx
-msgid "s+Ncqj"
-msgstr "Explore courses"
+msgid "M8B177"
+msgstr "Log in to save your progress"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
@@ -335,6 +333,11 @@ msgstr "Explore all Zoonk courses to learn anything using AI. Find interactive l
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
 msgstr "Online Courses using AI"
+
+#: src/app/(catalog)/courses/page.tsx
+#: src/app/(catalog)/my/user-course-list.tsx
+msgid "s+Ncqj"
+msgstr "Explore courses"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -209,14 +209,12 @@ msgid "VcxnWX"
 msgstr "Cursos interactivos creados para ti. Solo dinos qué quieres aprender."
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "nlT+zW"
-msgstr "Aprende cualquier cosa"
+msgid "jHCDDq"
+msgstr "Crear un curso con IA"
 
 #: src/app/(catalog)/(home)/hero.tsx
-#: src/app/(catalog)/courses/page.tsx
-#: src/app/(catalog)/my/user-course-list.tsx
-msgid "s+Ncqj"
-msgstr "Explorar cursos"
+msgid "M8B177"
+msgstr "Iniciar sesión para guardar tu progreso"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
@@ -335,6 +333,11 @@ msgstr "Explora todos los cursos de Zoonk para aprender cualquier cosa usando IA
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
 msgstr "Cursos en línea con IA"
+
+#: src/app/(catalog)/courses/page.tsx
+#: src/app/(catalog)/my/user-course-list.tsx
+msgid "s+Ncqj"
+msgstr "Explorar cursos"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -209,14 +209,12 @@ msgid "VcxnWX"
 msgstr "Cursos interativos criados para você. Apenas nos diga o que você quer aprender."
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "nlT+zW"
-msgstr "Aprenda qualquer coisa"
+msgid "jHCDDq"
+msgstr "Criar um curso com IA"
 
 #: src/app/(catalog)/(home)/hero.tsx
-#: src/app/(catalog)/courses/page.tsx
-#: src/app/(catalog)/my/user-course-list.tsx
-msgid "s+Ncqj"
-msgstr "Explorar cursos"
+msgid "M8B177"
+msgstr "Entrar para salvar seu progresso"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
@@ -335,6 +333,11 @@ msgstr "Explore todos os cursos do Zoonk para aprender qualquer coisa usando IA.
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
 msgstr "Cursos online usando IA"
+
+#: src/app/(catalog)/courses/page.tsx
+#: src/app/(catalog)/my/user-course-list.tsx
+msgid "s+Ncqj"
+msgstr "Explorar cursos"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"

--- a/apps/main/src/app/(catalog)/(home)/hero.tsx
+++ b/apps/main/src/app/(catalog)/(home)/hero.tsx
@@ -1,9 +1,15 @@
+import { getSession } from "@zoonk/core/users/session/get";
 import { buttonVariants } from "@zoonk/ui/components/button";
-import { ArrowRightIcon, SparklesIcon } from "lucide-react";
+import { SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 
+/**
+ * Shows the zero-progress home state. The hero stays focused on course creation,
+ * while guests get a quiet login prompt because anonymous progress is not saved.
+ */
 export async function Hero() {
+  const session = await getSession();
   const t = await getExtracted();
 
   return (
@@ -18,24 +24,25 @@ export async function Hero() {
         </p>
       </div>
 
-      <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
+      <div className="flex flex-col items-center gap-3">
         <Link
           className={buttonVariants({ className: "gap-2", size: "lg", variant: "default" })}
           href="/learn"
           prefetch
         >
           <SparklesIcon aria-hidden="true" />
-          {t("Learn anything")}
+          {t("Create a course with AI")}
         </Link>
 
-        <Link
-          className={buttonVariants({ className: "gap-2", size: "lg", variant: "outline" })}
-          href="/courses"
-          prefetch
-        >
-          {t("Explore courses")}
-          <ArrowRightIcon aria-hidden="true" />
-        </Link>
+        {!session && (
+          <Link
+            className="text-muted-foreground hover:text-foreground text-sm underline-offset-4 transition-colors hover:underline"
+            href="/login"
+            prefetch={false}
+          >
+            {t("Log in to save your progress")}
+          </Link>
+        )}
       </div>
     </main>
   );

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -82,8 +82,8 @@ msgstr "Sign up to track your progress"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
-msgid "AyGauy"
-msgstr "Login"
+msgid "M8B177"
+msgstr "Log in to save your progress"
 
 #: src/components/completion-milestone-actions.tsx
 msgid "DiIkZH"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -82,8 +82,8 @@ msgstr "Regístrate para seguir tu progreso"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
-msgid "AyGauy"
-msgstr "Iniciar sesión"
+msgid "M8B177"
+msgstr "Iniciar sesión para guardar tu progreso"
 
 #: src/components/completion-milestone-actions.tsx
 msgid "DiIkZH"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -82,8 +82,8 @@ msgstr "Cadastre-se para acompanhar seu progresso"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
-msgid "AyGauy"
-msgstr "Entrar"
+msgid "M8B177"
+msgstr "Entrar para salvar seu progresso"
 
 #: src/components/completion-milestone-actions.tsx
 msgid "DiIkZH"

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -141,7 +141,11 @@ describe("player browser integration: completion", () => {
     await completeSingleChoiceLesson();
 
     const completionScreen = page.getByRole("status");
-    const loginLink = completionScreen.getByRole("link", { name: /login/iu });
+
+    const loginLink = completionScreen.getByRole("link", {
+      name: /log in to save your progress/iu,
+    });
+
     const nextLink = completionScreen.getByRole("link", { name: "Next" });
 
     await expect.element(completionScreen.getByText("1/1")).toBeInTheDocument();
@@ -229,7 +233,10 @@ describe("player browser integration: completion", () => {
     await completeSingleChoiceLesson();
 
     const completionScreen = page.getByRole("status");
-    const loginLink = completionScreen.getByRole("link", { name: /login/iu });
+
+    const loginLink = completionScreen.getByRole("link", {
+      name: /log in to save your progress/iu,
+    });
 
     await expect
       .element(completionScreen.getByText(/sign up to track your progress/iu))

--- a/packages/player/src/components/completion-auth-branch.tsx
+++ b/packages/player/src/components/completion-auth-branch.tsx
@@ -170,7 +170,7 @@ function UnauthenticatedContent({
           )}
           href={loginHref}
         >
-          {t("Login")}
+          {t("Log in to save your progress")}
         </PlayerLink>
 
         {nextLessonHref && (

--- a/packages/player/src/components/completion-milestone-actions.tsx
+++ b/packages/player/src/components/completion-milestone-actions.tsx
@@ -94,7 +94,7 @@ export function UnauthenticatedMilestoneActions({ loginHref }: { loginHref: Play
 
       <div className="flex w-full flex-col gap-3" data-slot="completion-actions">
         <PlayerLink className={cn(buttonVariants(), "w-full")} href={loginHref}>
-          {t("Login")}
+          {t("Log in to save your progress")}
         </PlayerLink>
 
         <SecondaryActionLink href={milestone.reviewHref} shortcut="Esc">


### PR DESCRIPTION
Updates the zero-progress home hero to focus on AI course creation and adds a subtle guest login prompt for saving progress.

Updates guest lesson completion CTAs to say they save progress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refocuses the zero‑progress home hero on course creation and adds a subtle guest login link to save progress. Aligns player completion CTAs for guests to “Log in to save your progress,” with i18n and tests updated.

- **New Features**
  - Primary CTA is now “Create a course with AI”; “Explore courses” removed from the hero.
  - Shows “Log in to save your progress” linking to /login only for guests (hidden when authenticated).
  - Player completion screens for guests use the same copy; en/es/pt messages and e2e/browser tests updated.

<sup>Written for commit 510a2d21f4814aaaf53337a8562945ec69cbf208. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1549?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

