### PR TITLE
feat(main): add analytics tracking events

### DIFF
--- a/apps/main/src/app/(catalog)/_components/command-palette.tsx
+++ b/apps/main/src/app/(catalog)/_components/command-palette.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getMenu } from "@/lib/menu";
+import { trackCommandPaletteSearch } from "@/lib/track-events";
 import { logout } from "@zoonk/core/auth/client";
 import { Button } from "@zoonk/ui/components/button";
 import {
@@ -20,6 +21,8 @@ import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 import { type CourseSearchResult, searchCoursesAction } from "./search-courses-action";
 
+const EMPTY_COURSE_RESULTS: CourseSearchResult[] = [];
+
 /**
  * The catalog navbar sometimes hides the search trigger responsively while the
  * dialog logic stays unchanged. Accepting a trigger class keeps that layout
@@ -37,7 +40,11 @@ export function CommandPalette({
   const locale = useLocale();
 
   const handleSearch = useCallback(
-    (searchQuery: string) => searchCoursesAction({ language: locale, query: searchQuery }),
+    (searchQuery: string) => {
+      trackCommandPaletteSearch({ searchTerm: searchQuery });
+
+      return searchCoursesAction({ language: locale, query: searchQuery });
+    },
     [locale],
   );
 
@@ -49,7 +56,10 @@ export function CommandPalette({
     query,
     results: courses,
     setQuery,
-  } = useCommandPaletteSearch<CourseSearchResult[]>({ emptyResults: [], onSearch: handleSearch });
+  } = useCommandPaletteSearch<CourseSearchResult[]>({
+    emptyResults: EMPTY_COURSE_RESULTS,
+    onSearch: handleSearch,
+  });
 
   function handleSelect<T extends string>(url: Route<T>) {
     onSelectItem();

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -1,15 +1,25 @@
 "use client";
 
 import { ContentFeedback } from "@/components/feedback/content-feedback";
+import { trackLessonCompleted, trackPlayerLoaded, trackPlayerSecondStep } from "@/lib/track-events";
 import { type CompletionInput } from "@zoonk/core/player/contracts/completion-input-schema";
 import { type SerializedLesson } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { PlayerProvider, type PlayerStepChangeEvent } from "@zoonk/player/provider";
 import { PlayerShell } from "@zoonk/player/shell";
 import { useRouter } from "next/navigation";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { buildLessonPlayerModel } from "./lesson-player-model";
 import { preloadNextLesson } from "./preload-next-lesson-action";
 import { submitCompletion } from "./submit-completion-action";
+
+/**
+ * Identifies the exact funnel moment where a learner has advanced from the
+ * first player step to the second, regardless of whether the first step was
+ * static or interactive.
+ */
+function isSecondStepForwardEvent(event: PlayerStepChangeEvent) {
+  return event.direction === "next" && event.previousStepIndex === 0 && event.nextStepIndex === 1;
+}
 
 export function LessonPlayerClient({
   lesson,
@@ -42,6 +52,7 @@ export function LessonPlayerClient({
 }) {
   const router = useRouter();
   const hasRequestedNextLessonPreload = useRef(false);
+  const hasTrackedSecondStep = useRef(false);
 
   const model = buildLessonPlayerModel({
     brandSlug,
@@ -54,14 +65,55 @@ export function LessonPlayerClient({
   const onNextHref = model.onNextHref;
   const handleNext = onNextHref ? () => router.push(onNextHref) : undefined;
 
-  /** Fire-and-forget: the server validates and persists via `after()`. */
-  const handleComplete = useCallback((input: CompletionInput) => {
-    void submitCompletion(input);
-  }, []);
+  useEffect(() => {
+    hasRequestedNextLessonPreload.current = false;
+    hasTrackedSecondStep.current = false;
+  }, [lesson.id]);
+
+  useEffect(() => {
+    if (lesson.steps.length === 0) {
+      return;
+    }
+
+    trackPlayerLoaded({
+      lessonId: lesson.id,
+      lessonKind: lesson.kind,
+      stepCount: lesson.steps.length,
+    });
+  }, [lesson.id, lesson.kind, lesson.steps.length]);
+
+  /** Fire-and-forget: analytics runs for all learners; persistence requires auth. */
+  const handleComplete = useCallback(
+    (input: CompletionInput) => {
+      trackLessonCompleted({
+        lessonId: input.lessonId,
+        lessonKind: lesson.kind,
+        startedAt: input.startedAt,
+        stepCount: lesson.steps.length,
+      });
+
+      if (!isAuthenticated) {
+        return;
+      }
+
+      void submitCompletion(input);
+    },
+    [isAuthenticated, lesson.kind, lesson.steps.length],
+  );
 
   /** Fire once after the first forward step change; completion handles short lessons. */
   const handleStepChange = useCallback(
     (event: PlayerStepChangeEvent) => {
+      if (isSecondStepForwardEvent(event) && !hasTrackedSecondStep.current) {
+        hasTrackedSecondStep.current = true;
+
+        trackPlayerSecondStep({
+          lessonId: event.lessonId,
+          lessonKind: lesson.kind,
+          stepCount: lesson.steps.length,
+        });
+      }
+
       if (
         !isAuthenticated ||
         event.direction !== "next" ||
@@ -74,7 +126,7 @@ export function LessonPlayerClient({
       hasRequestedNextLessonPreload.current = true;
       void preloadNextLesson(event.lessonId);
     },
-    [isAuthenticated],
+    [isAuthenticated, lesson.kind, lesson.steps.length],
   );
 
   return (

--- a/apps/main/src/lib/track-events.ts
+++ b/apps/main/src/lib/track-events.ts
@@ -1,0 +1,64 @@
+import { track } from "@vercel/analytics";
+import { type LessonKind } from "@zoonk/core/steps/contract/content";
+
+type PlayerEventInput = { lessonId: string; lessonKind: LessonKind; stepCount: number };
+
+/**
+ * Records only submitted command-palette searches because the shared search
+ * hook debounces before calling the `onSearch` callback.
+ */
+export function trackCommandPaletteSearch({ searchTerm }: { searchTerm: string }) {
+  const trimmedSearchTerm = searchTerm.trim();
+
+  if (!trimmedSearchTerm) {
+    return;
+  }
+
+  track("Command Palette Search", { searchTerm: trimmedSearchTerm });
+}
+
+/**
+ * Counts learners who reached the first playable step after the player shell
+ * mounted, which is the funnel denominator for later player events.
+ */
+export function trackPlayerLoaded(input: PlayerEventInput) {
+  track("Player Loaded", getPlayerEventData(input));
+}
+
+/**
+ * Counts learners who moved beyond the first step without depending on a
+ * specific step renderer or interaction type.
+ */
+export function trackPlayerSecondStep(input: PlayerEventInput) {
+  track("Player Second Step", getPlayerEventData(input));
+}
+
+/**
+ * Reports lesson completions with the client-side duration because the player
+ * already owns the local lesson start timestamp before persistence runs.
+ */
+export function trackLessonCompleted({
+  startedAt,
+  ...input
+}: PlayerEventInput & { startedAt: number }) {
+  track("Lesson Completed", {
+    ...getPlayerEventData(input),
+    durationSeconds: getCompletionDurationSeconds({ startedAt }),
+  });
+}
+
+/**
+ * Reuses the same primitive payload shape across player events because Vercel
+ * Analytics custom event properties do not support nested objects.
+ */
+function getPlayerEventData({ lessonId, lessonKind, stepCount }: PlayerEventInput) {
+  return { lessonId, lessonKind, stepCount };
+}
+
+/**
+ * Clamps client timing so clock edge cases cannot send negative durations to
+ * analytics while still matching the server's whole-second completion metric.
+ */
+function getCompletionDurationSeconds({ startedAt }: { startedAt: number }) {
+  return Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
+}

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -56,13 +56,7 @@ export function PlayerProvider({
 
   const [state, dispatch] = useReducer(playerReducer, initInput, createInitialState);
 
-  const actions = usePlayerActions(
-    state,
-    dispatch,
-    onComplete,
-    viewer.isAuthenticated,
-    onStepChange,
-  );
+  const actions = usePlayerActions({ dispatch, onComplete, onStepChange, state });
 
   const screen = useMemo(() => getPlayerScreenModel(state), [state]);
 

--- a/packages/player/src/use-player-actions.test.tsx
+++ b/packages/player/src/use-player-actions.test.tsx
@@ -59,7 +59,7 @@ describe(usePlayerActions, () => {
       ],
     });
 
-    const { result } = renderHook(() => usePlayerActions(state, dispatch, onComplete, false));
+    const { result } = renderHook(() => usePlayerActions({ dispatch, onComplete, state }));
 
     act(() => {
       result.current.check();

--- a/packages/player/src/use-player-actions.ts
+++ b/packages/player/src/use-player-actions.ts
@@ -21,13 +21,21 @@ export type PlayerActions = {
   selectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
 };
 
-export function usePlayerActions(
-  state: PlayerState,
-  dispatch: Dispatch<Parameters<typeof playerReducer>[1]>,
-  onComplete: (input: CompletionInput) => void,
-  isAuthenticated: boolean,
-  onStepChange?: (event: PlayerStepChangeEvent) => void,
-) {
+/**
+ * Owns reducer dispatch side effects so host apps can react to semantic player
+ * events without needing to inspect reducer states themselves.
+ */
+export function usePlayerActions({
+  dispatch,
+  onComplete,
+  onStepChange,
+  state,
+}: {
+  dispatch: Dispatch<Parameters<typeof playerReducer>[1]>;
+  onComplete: (input: CompletionInput) => void;
+  onStepChange?: (event: PlayerStepChangeEvent) => void;
+  state: PlayerState;
+}) {
   const currentStep = state.steps[state.currentStepIndex];
 
   const dispatchTransition = useCallback(
@@ -35,7 +43,7 @@ export function usePlayerActions(
       const transition = getPlayerTransition(state, action);
       dispatch(action);
 
-      if (transition.shouldPersistCompletion && isAuthenticated) {
+      if (transition.shouldPersistCompletion) {
         onComplete(buildCompletionInput(transition.nextState));
       }
 
@@ -45,7 +53,7 @@ export function usePlayerActions(
         onStepChange?.(stepChangeEvent);
       }
     },
-    [dispatch, isAuthenticated, onComplete, onStepChange, state],
+    [dispatch, onComplete, onStepChange, state],
   );
 
   const selectAnswer = useCallback(

--- a/packages/ui/src/hooks/use-command-palette-search.ts
+++ b/packages/ui/src/hooks/use-command-palette-search.ts
@@ -3,15 +3,18 @@
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { useKeyboardCallback } from "./use-keyboard";
 
+const DEFAULT_SEARCH_DEBOUNCE_MS = 300;
+
 /**
  * A hook that handles common command palette search logic:
  * - Open/close state with Cmd+K keyboard shortcut
  * - Query state with controlled input
- * - Search with useTransition and race condition handling
+ * - Debounced search with useTransition and race condition handling
  * - Minimum query length before searching
  * - Reset on close
  */
 export function useCommandPaletteSearch<TResults>(options: {
+  debounceMs?: number;
   emptyResults: TResults;
   minQueryLength?: number;
   onSearch: (query: string) => Promise<TResults>;
@@ -26,7 +29,12 @@ export function useCommandPaletteSearch<TResults>(options: {
   setQuery: (query: string) => void;
   toggle: () => void;
 } {
-  const { emptyResults, minQueryLength = 2, onSearch } = options;
+  const {
+    debounceMs = DEFAULT_SEARCH_DEBOUNCE_MS,
+    emptyResults,
+    minQueryLength = 2,
+    onSearch,
+  } = options;
 
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -52,35 +60,35 @@ export function useCommandPaletteSearch<TResults>(options: {
     closePalette();
   }, [closePalette]);
 
-  // Search effect with race condition handling
   useEffect(() => {
     const trimmedQuery = query.trim();
+    requestIdRef.current += 1;
 
-    // Clear results if query is too short
     if (trimmedQuery.length < minQueryLength) {
       setResults(emptyResults);
       return;
     }
 
-    // Increment request ID to handle race conditions
-    requestIdRef.current += 1;
     const currentRequestId = requestIdRef.current;
 
-    startTransition(async () => {
-      try {
-        const data = await onSearch(trimmedQuery);
+    const timeoutId = globalThis.setTimeout(() => {
+      startTransition(async () => {
+        try {
+          const data = await onSearch(trimmedQuery);
 
-        // Only update if this is still the latest request
-        if (currentRequestId === requestIdRef.current) {
-          setResults(data);
+          if (currentRequestId === requestIdRef.current) {
+            setResults(data);
+          }
+        } catch {
+          if (currentRequestId === requestIdRef.current) {
+            setResults(emptyResults);
+          }
         }
-      } catch {
-        if (currentRequestId === requestIdRef.current) {
-          setResults(emptyResults);
-        }
-      }
-    });
-  }, [query, minQueryLength, onSearch, emptyResults]);
+      });
+    }, debounceMs);
+
+    return () => globalThis.clearTimeout(timeoutId);
+  }, [query, debounceMs, minQueryLength, onSearch, emptyResults]);
 
   return { closePalette, isOpen, isPending, onSelectItem, open, query, results, setQuery, toggle };
 }


### PR DESCRIPTION
## Summary

- Track submitted command palette searches from the debounced search callback
- Track player loaded, second-step, and lesson-completed events
- Include lesson completion duration in analytics payloads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add client analytics for command palette searches and the lesson player funnel (loaded, second step, completed with duration). Debounced command palette search and separated analytics from completion persistence so events fire for all learners.

- **New Features**
  - Track "Command Palette Search" when the debounced search runs.
  - Track "Player Loaded" and "Player Second Step" with lessonId, lessonKind, and stepCount.
  - Track "Lesson Completed" with durationSeconds (from startedAt) plus lesson metadata.
  - Send events via `@vercel/analytics`.

- **Refactors**
  - Added `apps/main/src/lib/track-events.ts` with shared helpers and flat payloads.
  - `usePlayerActions` now takes an options object and no longer gates persistence by auth; callers decide when to submit.
  - Updated `PlayerProvider` to the new hook API.
  - Added debounced search to `useCommandPaletteSearch` (300ms default) with a `debounceMs` option.

<sup>Written for commit 3a37f1628bd79083209029939743c5a92b5c9d6c. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1550?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

