### PR TITLE
fix(main): retry failed course infinite loads

### DIFF
--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -5,7 +5,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
-import { expect, test } from "./fixtures";
+import { type Page, expect, test } from "./fixtures";
 
 const UUID_SHORT_LENGTH = 8;
 
@@ -33,6 +33,36 @@ async function createPublishedCourse(language: string) {
   });
 
   return course;
+}
+
+/**
+ * Sentry reports this regression through the browser's unhandled rejection
+ * handler, so the e2e test records that same signal while the UI keeps running.
+ */
+async function recordUnhandledRejections(page: Page) {
+  await page.addInitScript(() => {
+    const unhandledRejections: string[] = [];
+
+    Object.defineProperty(globalThis, "zoonkE2EUnhandledRejections", {
+      value: unhandledRejections,
+    });
+
+    globalThis.addEventListener("unhandledrejection", (event) => {
+      const reason = event.reason;
+      unhandledRejections.push(reason instanceof Error ? reason.message : String(reason));
+    });
+  });
+}
+
+/**
+ * Browser-side rejection events are stored in the page context because
+ * Playwright does not expose all `unhandledrejection` events as test failures.
+ */
+async function getUnhandledRejections(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const target = globalThis as unknown as { zoonkE2EUnhandledRejections?: string[] };
+    return target.zoonkE2EUnhandledRejections ?? [];
+  });
 }
 
 test.describe("Courses Page - Basic", () => {
@@ -74,13 +104,75 @@ test.describe("Courses Page - Infinite Loading", () => {
     }).toPass({ timeout: 15_000 });
 
     // Scroll to the bottom to trigger infinite loading
-    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.evaluate(() => globalThis.scrollTo(0, document.body.scrollHeight));
 
     // Verify more courses loaded after scrolling
     await expect(async () => {
       const count = await courseLinks.count();
       expect(count).toBeGreaterThan(20);
     }).toPass({ timeout: 10_000 });
+  });
+
+  test("lets users retry failed load-more requests without unhandled rejections", async ({
+    page,
+  }) => {
+    const org = await getAiOrganization();
+    const failedLoadMoreRequests: string[] = [];
+    const loadMoreRequests: string[] = [];
+
+    await recordUnhandledRejections(page);
+
+    await Promise.all(
+      Array.from({ length: 25 }, () =>
+        courseFixture({ isPublished: true, language: "en", organizationId: org.id }),
+      ),
+    );
+
+    await page.route("**/courses", async (route) => {
+      const request = route.request();
+      const isLoadMoreAction = request.method() === "POST";
+
+      if (isLoadMoreAction) {
+        loadMoreRequests.push(request.url());
+
+        if (loadMoreRequests.length === 1) {
+          failedLoadMoreRequests.push(request.url());
+          await route.abort("failed");
+          return;
+        }
+      }
+
+      await route.continue();
+    });
+
+    const courseList = page.getByRole("main").getByRole("list");
+    const courseLinks = courseList.getByRole("link");
+
+    await expect(async () => {
+      await page.goto("/courses");
+      await expect(courseLinks).toHaveCount(20, { timeout: 5000 });
+    }).toPass({ timeout: 15_000 });
+
+    await page.evaluate(() => globalThis.scrollTo(0, document.body.scrollHeight));
+
+    await expect(async () => {
+      expect(failedLoadMoreRequests.length).toBeGreaterThan(0);
+    }).toPass({ timeout: 10_000 });
+
+    await expect(page.getByLabel(/loading more courses/iu)).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /try again/iu })).toBeVisible();
+    expect(failedLoadMoreRequests).toHaveLength(1);
+    expect(await getUnhandledRejections(page)).toEqual([]);
+
+    await page.getByRole("button", { name: /try again/iu }).click();
+
+    await expect(async () => {
+      const count = await courseLinks.count();
+      expect(count).toBeGreaterThan(20);
+    }).toPass({ timeout: 10_000 });
+
+    expect(loadMoreRequests).toHaveLength(2);
+    expect(await getUnhandledRejections(page)).toEqual([]);
   });
 });
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -326,6 +326,20 @@ msgstr "No courses"
 msgid "T0mfNV"
 msgstr "Loading more courses…"
 
+#: src/app/(catalog)/courses/course-list-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
+#: src/app/generate/l/[id]/generation-client.tsx
+msgid "W/5hwr"
+msgstr "Something went wrong. Please try again."
+
+#: src/app/(catalog)/courses/course-list-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
+#: src/app/generate/l/[id]/generation-client.tsx
+msgid "FazwRl"
+msgstr "Try again"
+
 #: src/app/(catalog)/courses/page.tsx
 msgid "WgPMAP"
 msgstr "Explore all Zoonk courses to learn anything using AI. Find interactive lessons to learn subjects like science, math, technology, and more."
@@ -1010,18 +1024,6 @@ msgstr "Taking you to your chapter..."
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "45uo73"
 msgstr "Your lessons are ready"
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgid "W/5hwr"
-msgstr "Something went wrong. Please try again."
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgid "FazwRl"
-msgstr "Try again"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/cs/[id]/generation-client.tsx

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -326,6 +326,20 @@ msgstr "No hay cursos"
 msgid "T0mfNV"
 msgstr "Cargando más cursos…"
 
+#: src/app/(catalog)/courses/course-list-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
+#: src/app/generate/l/[id]/generation-client.tsx
+msgid "W/5hwr"
+msgstr "Algo salió mal. Por favor, intenta de nuevo."
+
+#: src/app/(catalog)/courses/course-list-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
+#: src/app/generate/l/[id]/generation-client.tsx
+msgid "FazwRl"
+msgstr "Intentar de nuevo"
+
 #: src/app/(catalog)/courses/page.tsx
 msgid "WgPMAP"
 msgstr "Explora todos los cursos de Zoonk para aprender cualquier cosa usando IA. Encuentra lecciones interactivas para aprender temas como ciencia, matemáticas, tecnología y más."
@@ -1010,18 +1024,6 @@ msgstr "Llevándote a tu capítulo..."
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "45uo73"
 msgstr "Tus lecciones están listas"
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgid "W/5hwr"
-msgstr "Algo salió mal. Por favor, intenta de nuevo."
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgid "FazwRl"
-msgstr "Intentar de nuevo"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/cs/[id]/generation-client.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -326,6 +326,20 @@ msgstr "Nenhum curso"
 msgid "T0mfNV"
 msgstr "Carregando mais cursos…"
 
+#: src/app/(catalog)/courses/course-list-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
+#: src/app/generate/l/[id]/generation-client.tsx
+msgid "W/5hwr"
+msgstr "Algo deu errado. Por favor, tente novamente."
+
+#: src/app/(catalog)/courses/course-list-client.tsx
+#: src/app/generate/ch/[id]/generation-client.tsx
+#: src/app/generate/cs/[id]/generation-client.tsx
+#: src/app/generate/l/[id]/generation-client.tsx
+msgid "FazwRl"
+msgstr "Tentar de novo"
+
 #: src/app/(catalog)/courses/page.tsx
 msgid "WgPMAP"
 msgstr "Explore todos os cursos do Zoonk para aprender qualquer coisa usando IA. Encontre aulas interativas para aprender assuntos como ciência, matemática, tecnologia e mais."
@@ -1010,18 +1024,6 @@ msgstr "Levando você para seu capítulo..."
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "45uo73"
 msgstr "Suas aulas estão prontas"
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgid "W/5hwr"
-msgstr "Algo deu errado. Por favor, tente novamente."
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgid "FazwRl"
-msgstr "Tentar de novo"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/cs/[id]/generation-client.tsx

--- a/apps/main/src/app/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/(catalog)/courses/course-list-client.tsx
@@ -3,6 +3,7 @@
 import { CatalogGridContent, CatalogGridItem } from "@/components/catalog/catalog-grid";
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { type CourseWithOrg } from "@/data/courses/list-courses";
+import { Button } from "@zoonk/ui/components/button";
 import {
   GridGroup,
   GridItemContent,
@@ -13,7 +14,7 @@ import {
 import { useInfiniteList } from "@zoonk/ui/hooks/infinite-list";
 import { EmptyView } from "@zoonk/ui/patterns/empty";
 import { type CourseCategory } from "@zoonk/utils/categories";
-import { Loader2Icon, NotebookPenIcon } from "lucide-react";
+import { Loader2Icon, NotebookPenIcon, RefreshCwIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { loadMoreCourses } from "./actions";
 
@@ -59,8 +60,10 @@ export function CourseListClient({
   const t = useExtracted();
 
   const {
+    hasLoadError,
     items: courses,
     isLoading,
+    retry,
     sentryRef,
   } = useInfiniteList<CourseWithOrg>({
     fetchMore: (cursor) => loadMoreCourses({ category, cursor: String(cursor), language }),
@@ -93,6 +96,18 @@ export function CourseListClient({
             aria-label={t("Loading more courses…")}
             className="text-muted-foreground size-5 animate-spin"
           />
+        )}
+
+        {hasLoadError && !isLoading && (
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <p className="text-muted-foreground text-sm">
+              {t("Something went wrong. Please try again.")}
+            </p>
+            <Button onClick={retry} size="sm" variant="outline">
+              <RefreshCwIcon aria-hidden="true" />
+              {t("Try again")}
+            </Button>
+          </div>
         )}
       </div>
     </CatalogGridContent>

--- a/packages/ui/src/hooks/use-infinite-list.ts
+++ b/packages/ui/src/hooks/use-infinite-list.ts
@@ -1,8 +1,13 @@
 "use client";
 
+import { safeAsync } from "@zoonk/utils/error";
 import { useCallback, useRef, useState } from "react";
 import useInfiniteScroll from "react-infinite-scroll-hook";
 
+/**
+ * Infinite lists page from the last rendered item, so this keeps cursor
+ * bookkeeping tied to the deduped list instead of the raw server response.
+ */
 function getLastKey<TItem>(
   items: TItem[],
   getKey: (item: TItem) => string | number,
@@ -25,24 +30,38 @@ export function useInfiniteList<TItem>({
   rootMargin?: string;
 }): {
   hasNextPage: boolean;
+  hasLoadError: boolean;
   isLoading: boolean;
   items: TItem[];
+  retry: () => void;
   sentryRef: (node: Element | null) => void;
 } {
   const [items, setItems] = useState(initialItems);
   const [isLoading, setIsLoading] = useState(false);
+  const [hasLoadError, setHasLoadError] = useState(false);
   const [hasNextPage, setHasNextPage] = useState(initialItems.length >= limit);
   const lastKeyRef = useRef(getLastKey(initialItems, getKey));
 
+  /**
+   * Load-more requests are opportunistic background fetches. Network failures
+   * should stop auto-loading instead of escaping as global promise rejections.
+   */
   const loadMore = useCallback(async () => {
-    if (lastKeyRef.current === null) {
+    const cursor = lastKeyRef.current;
+
+    if (cursor === null) {
       return;
     }
 
     setIsLoading(true);
 
     try {
-      const newItems = await fetchMore(lastKeyRef.current);
+      const { data: newItems, error } = await safeAsync(() => fetchMore(cursor));
+
+      if (error) {
+        setHasLoadError(true);
+        return;
+      }
 
       if (newItems.length < limit) {
         setHasNextPage(false);
@@ -61,17 +80,29 @@ export function useInfiniteList<TItem>({
 
         return [...prev, ...uniqueNewItems];
       });
+
+      setHasLoadError(false);
     } finally {
       setIsLoading(false);
     }
   }, [fetchMore, getKey, limit]);
 
+  /**
+   * A failed background load should be user-recoverable without reloading the
+   * page, but retrying only on intent prevents a visible sentinel from looping.
+   */
+  const retry = useCallback(() => {
+    setHasLoadError(false);
+    void loadMore();
+  }, [loadMore]);
+
   const [sentryRef] = useInfiniteScroll({
+    disabled: hasLoadError,
     hasNextPage,
     loading: isLoading,
     onLoadMore: loadMore,
     rootMargin,
   });
 
-  return { hasNextPage, isLoading, items, sentryRef };
+  return { hasLoadError, hasNextPage, isLoading, items, retry, sentryRef };
 }


### PR DESCRIPTION
## Summary

- catch failed course load-more requests so they do not surface as unhandled browser rejections
- show a retry affordance when course infinite loading fails
- cover the failed request and retry path in courses e2e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unhandled promise rejections when course infinite loading fails and adds a simple retry flow. Users now see an inline error with a “Try again” button, and scrolling continues after a successful retry.

- **Bug Fixes**
  - In `@zoonk/ui` `useInfiniteList`, catch load-more errors with `safeAsync`, expose `hasLoadError` and `retry`, and disable the sentinel on error to avoid global unhandledrejection events.

- **New Features**
  - Courses list shows an inline error and a “Try again” button that calls `retry`; i18n strings added for en/es/pt.
  - E2E tests cover failed load-more, the retry path, and assert no browser unhandledrejection events.

<sup>Written for commit b767c60c0ef45e065689200b1b7cc3392efc476c. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1552?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

