### PR TITLE
fix(main): track lesson analytics with slugs

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -29,6 +29,7 @@ export function LessonPlayerClient({
   chapterSlug,
   isAuthenticated,
   lessonDescription,
+  lessonSlug,
   lessonTitle,
   nextChapter,
   nextLesson,
@@ -43,6 +44,7 @@ export function LessonPlayerClient({
   chapterSlug: string;
   isAuthenticated: boolean;
   lessonDescription: string;
+  lessonSlug: string;
   lessonTitle: string;
   nextChapter: { brandSlug: string; chapterSlug: string; courseSlug: string } | null;
   nextLesson: { chapterSlug: string; lessonSlug: string; lessonTitle: string | null } | null;
@@ -76,18 +78,20 @@ export function LessonPlayerClient({
     }
 
     trackPlayerLoaded({
-      lessonId: lesson.id,
+      courseSlug,
       lessonKind: lesson.kind,
+      lessonSlug,
       stepCount: lesson.steps.length,
     });
-  }, [lesson.id, lesson.kind, lesson.steps.length]);
+  }, [courseSlug, lesson.id, lesson.kind, lessonSlug, lesson.steps.length]);
 
   /** Fire-and-forget: analytics runs for all learners; persistence requires auth. */
   const handleComplete = useCallback(
     (input: CompletionInput) => {
       trackLessonCompleted({
-        lessonId: input.lessonId,
+        courseSlug,
         lessonKind: lesson.kind,
+        lessonSlug,
         startedAt: input.startedAt,
         stepCount: lesson.steps.length,
       });
@@ -98,7 +102,7 @@ export function LessonPlayerClient({
 
       void submitCompletion(input);
     },
-    [isAuthenticated, lesson.kind, lesson.steps.length],
+    [courseSlug, isAuthenticated, lesson.kind, lessonSlug, lesson.steps.length],
   );
 
   /** Fire once after the first forward step change; completion handles short lessons. */
@@ -108,8 +112,9 @@ export function LessonPlayerClient({
         hasTrackedSecondStep.current = true;
 
         trackPlayerSecondStep({
-          lessonId: event.lessonId,
+          courseSlug,
           lessonKind: lesson.kind,
+          lessonSlug,
           stepCount: lesson.steps.length,
         });
       }
@@ -126,7 +131,7 @@ export function LessonPlayerClient({
       hasRequestedNextLessonPreload.current = true;
       void preloadNextLesson(event.lessonId);
     },
-    [isAuthenticated, lesson.kind, lesson.steps.length],
+    [courseSlug, isAuthenticated, lesson.kind, lessonSlug, lesson.steps.length],
   );
 
   return (

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -129,6 +129,7 @@ export default async function LessonPage({ params }: Props) {
       chapterSlug={chapterSlug}
       isAuthenticated={Boolean(session)}
       lessonDescription={lessonMeta.description}
+      lessonSlug={lessonSlug}
       lessonTitle={lessonMeta.title}
       nextChapter={nextChapter}
       nextLesson={nextLesson}

--- a/apps/main/src/lib/track-events.ts
+++ b/apps/main/src/lib/track-events.ts
@@ -1,7 +1,12 @@
 import { track } from "@vercel/analytics";
 import { type LessonKind } from "@zoonk/core/steps/contract/content";
 
-type PlayerEventInput = { lessonId: string; lessonKind: LessonKind; stepCount: number };
+type PlayerEventInput = {
+  courseSlug: string;
+  lessonKind: LessonKind;
+  lessonSlug: string;
+  stepCount: number;
+};
 
 /**
  * Records only submitted command-palette searches because the shared search
@@ -51,8 +56,8 @@ export function trackLessonCompleted({
  * Reuses the same primitive payload shape across player events because Vercel
  * Analytics custom event properties do not support nested objects.
  */
-function getPlayerEventData({ lessonId, lessonKind, stepCount }: PlayerEventInput) {
-  return { lessonId, lessonKind, stepCount };
+function getPlayerEventData({ courseSlug, lessonKind, lessonSlug, stepCount }: PlayerEventInput) {
+  return { courseSlug, lessonKind, lessonSlug, stepCount };
 }
 
 /**


### PR DESCRIPTION
## Summary

- replace lesson analytics IDs with course and lesson slugs
- keep lesson IDs only for player persistence and preload behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch lesson analytics events to use `courseSlug` and `lessonSlug` instead of internal IDs. Keeps IDs only for player persistence and preload, improving event stability and readability.

- **Refactors**
  - Changed `track-events` payload to { `courseSlug`, `lessonSlug`, `lessonKind`, `stepCount` }.
  - Updated `LessonPlayerClient` to send slugs in `trackPlayerLoaded`, `trackPlayerSecondStep`, and `trackLessonCompleted`.
  - Retained `lessonId` for persistence and next-lesson preload only.

- **Migration**
  - Update analytics dashboards/queries to use `courseSlug` and `lessonSlug` instead of `lessonId`.

<sup>Written for commit a0fd889cd60387e499d055455257e21aa6d0973e. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1553?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

