### PR TITLE
feat(admin): filter step images by lesson slug

### DIFF
--- a/apps/admin/src/app/(private)/review/[group]/[task]/lesson-slug-filter.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/lesson-slug-filter.tsx
@@ -1,0 +1,52 @@
+import { getTaskPath } from "@/lib/review-utils";
+import { Button, buttonVariants } from "@zoonk/ui/components/button";
+import { Input } from "@zoonk/ui/components/input";
+import { SearchIcon, XIcon } from "lucide-react";
+import Link from "next/link";
+
+/**
+ * Reviewers often need to audit every generated image in one lesson before
+ * moving back to the global queue, so this keeps the lesson scope in the URL
+ * and lets normal server rendering fetch the narrowed queue.
+ */
+export function LessonSlugFilter({ lessonSlug }: { lessonSlug?: string }) {
+  const taskPath = getTaskPath("stepImage");
+
+  return (
+    <form
+      action={taskPath}
+      className="flex flex-col gap-2 sm:max-w-xl sm:flex-row sm:items-center"
+      method="get"
+    >
+      <label className="sr-only" htmlFor="lesson-slug">
+        Lesson slug
+      </label>
+
+      <Input
+        className="sm:flex-1"
+        defaultValue={lessonSlug}
+        id="lesson-slug"
+        name="lessonSlug"
+        placeholder="Filter by lesson slug"
+        type="search"
+      />
+
+      <div className="flex shrink-0 gap-2">
+        <Button type="submit" variant="outline">
+          <SearchIcon />
+          Filter
+        </Button>
+
+        {lessonSlug ? (
+          <Link
+            aria-label="Clear lesson slug filter"
+            className={buttonVariants({ size: "icon", variant: "ghost" })}
+            href={taskPath}
+          >
+            <XIcon />
+          </Link>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/apps/admin/src/app/(private)/review/[group]/[task]/page.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/page.tsx
@@ -1,3 +1,4 @@
+import { parseOptionalSearchParam } from "@/lib/parse-search-params";
 import { getTaskLabel, resolveTaskType } from "@/lib/review-utils";
 import {
   Container,
@@ -10,6 +11,7 @@ import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { FlaggedList } from "./flagged-list";
+import { LessonSlugFilter } from "./lesson-slug-filter";
 import { ReviewQueue } from "./review-queue";
 import { ReviewTabs } from "./review-tabs";
 
@@ -35,8 +37,13 @@ export default async function ReviewTaskPage({
   }
 
   const resolvedParams = await searchParams;
-  const view = typeof resolvedParams.view === "string" ? resolvedParams.view : undefined;
-  const currentId = typeof resolvedParams.current === "string" ? resolvedParams.current : undefined;
+  const view = parseOptionalSearchParam(resolvedParams.view);
+  const currentId = parseOptionalSearchParam(resolvedParams.current);
+
+  const lessonSlug =
+    taskType === "stepImage" ? parseOptionalSearchParam(resolvedParams.lessonSlug) : undefined;
+
+  const showLessonSlugFilter = taskType === "stepImage" && view !== "flagged";
 
   return (
     <Container>
@@ -51,11 +58,13 @@ export default async function ReviewTaskPage({
           <ReviewTabs taskType={taskType} view={view} />
         </Suspense>
 
+        {showLessonSlugFilter ? <LessonSlugFilter lessonSlug={lessonSlug} /> : null}
+
         <Suspense fallback={<QueueSkeleton />}>
           {view === "flagged" ? (
             <FlaggedList taskType={taskType} searchParams={searchParams} />
           ) : (
-            <ReviewQueue taskType={taskType} currentId={currentId} />
+            <ReviewQueue taskType={taskType} currentId={currentId} lessonSlug={lessonSlug} />
           )}
         </Suspense>
       </ContainerBody>

--- a/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/review-queue.tsx
@@ -64,11 +64,13 @@ async function renderContent(taskType: ReviewTaskType, entityId: string) {
 export async function ReviewQueue({
   taskType,
   currentId,
+  lessonSlug,
 }: {
   taskType: ReviewTaskType;
   currentId?: string;
+  lessonSlug?: string;
 }) {
-  const queue = await getNextReviewItem(taskType);
+  const queue = await getNextReviewItem(taskType, lessonSlug);
   const entityId = currentId ?? queue.entityId;
 
   if (!entityId) {
@@ -87,7 +89,7 @@ export async function ReviewQueue({
 
       {content}
 
-      <ReviewActions taskType={taskType} entityId={entityId} />
+      <ReviewActions taskType={taskType} entityId={entityId} lessonSlug={lessonSlug} />
     </div>
   );
 }

--- a/apps/admin/src/app/(private)/review/_actions/mark-needs-changes.ts
+++ b/apps/admin/src/app/(private)/review/_actions/mark-needs-changes.ts
@@ -2,7 +2,7 @@
 
 import { getNextReviewItem } from "@/data/review/get-next-review-item";
 import { assertAdmin } from "@/lib/admin-guard";
-import { getTaskPath, isValidTaskType } from "@/lib/review-utils";
+import { getReviewQueuePath, isValidTaskType } from "@/lib/review-utils";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
@@ -13,6 +13,7 @@ export async function markNeedsChangesAction(formData: FormData) {
 
   const taskType = parseFormField(formData, "taskType");
   const entityId = parseFormField(formData, "entityId");
+  const lessonSlug = parseFormField(formData, "lessonSlug") ?? undefined;
 
   if (!taskType || !entityId || !isValidTaskType(taskType)) {
     throw new Error("Invalid form data");
@@ -32,12 +33,7 @@ export async function markNeedsChangesAction(formData: FormData) {
     throw error;
   }
 
-  const next = await getNextReviewItem(taskType);
-  const basePath = getTaskPath(taskType);
+  const next = await getNextReviewItem(taskType, lessonSlug);
 
-  if (next.entityId) {
-    redirect(`${basePath}?current=${next.entityId}`);
-  }
-
-  redirect(basePath);
+  redirect(getReviewQueuePath({ currentId: next.entityId, lessonSlug, taskType }));
 }

--- a/apps/admin/src/app/(private)/review/_actions/mark-reviewed.ts
+++ b/apps/admin/src/app/(private)/review/_actions/mark-reviewed.ts
@@ -2,7 +2,7 @@
 
 import { getNextReviewItem } from "@/data/review/get-next-review-item";
 import { assertAdmin } from "@/lib/admin-guard";
-import { getTaskPath, isValidTaskType } from "@/lib/review-utils";
+import { getReviewQueuePath, isValidTaskType } from "@/lib/review-utils";
 import { prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
@@ -13,6 +13,7 @@ export async function markReviewedAction(formData: FormData) {
 
   const taskType = parseFormField(formData, "taskType");
   const entityId = parseFormField(formData, "entityId");
+  const lessonSlug = parseFormField(formData, "lessonSlug") ?? undefined;
 
   if (!taskType || !entityId || !isValidTaskType(taskType)) {
     throw new Error("Invalid form data");
@@ -32,12 +33,7 @@ export async function markReviewedAction(formData: FormData) {
     throw error;
   }
 
-  const next = await getNextReviewItem(taskType);
-  const basePath = getTaskPath(taskType);
+  const next = await getNextReviewItem(taskType, lessonSlug);
 
-  if (next.entityId) {
-    redirect(`${basePath}?current=${next.entityId}`);
-  }
-
-  redirect(basePath);
+  redirect(getReviewQueuePath({ currentId: next.entityId, lessonSlug, taskType }));
 }

--- a/apps/admin/src/app/(private)/review/_components/review-actions.tsx
+++ b/apps/admin/src/app/(private)/review/_components/review-actions.tsx
@@ -18,18 +18,28 @@ function NeedsChangesButton() {
   );
 }
 
-export function ReviewActions({ taskType, entityId }: { taskType: string; entityId: string }) {
+export function ReviewActions({
+  taskType,
+  entityId,
+  lessonSlug,
+}: {
+  taskType: string;
+  entityId: string;
+  lessonSlug?: string;
+}) {
   return (
     <div className="flex items-center justify-between pt-4">
       <form action={markNeedsChangesAction}>
         <input type="hidden" name="taskType" value={taskType} />
         <input type="hidden" name="entityId" value={entityId} />
+        {lessonSlug ? <input type="hidden" name="lessonSlug" value={lessonSlug} /> : null}
         <NeedsChangesButton />
       </form>
 
       <form action={markReviewedAction}>
         <input type="hidden" name="taskType" value={taskType} />
         <input type="hidden" name="entityId" value={entityId} />
+        {lessonSlug ? <input type="hidden" name="lessonSlug" value={lessonSlug} /> : null}
         <SubmitButton>Looks good</SubmitButton>
       </form>
     </div>

--- a/apps/admin/src/data/review/get-next-review-item.ts
+++ b/apps/admin/src/data/review/get-next-review-item.ts
@@ -11,6 +11,25 @@ type ReviewQueueResult = { entityId: string | null; remaining: number };
 
 const EMPTY_RESULT: ReviewQueueResult = { entityId: null, remaining: 0 };
 
+/**
+ * Step image review stores image eligibility inside the JSON step content, so
+ * Prisma can narrow the cheap relational fields first and the caller can then
+ * keep only static steps whose parsed content actually contains an image URL.
+ */
+function getStepImageReviewWhere({
+  excludeIds,
+  lessonSlug,
+}: {
+  excludeIds: string[];
+  lessonSlug?: string;
+}) {
+  return {
+    NOT: { id: { in: excludeIds } },
+    kind: "static" as const,
+    lesson: { organization: { slug: AI_ORG_SLUG }, ...(lessonSlug ? { slug: lessonSlug } : {}) },
+  };
+}
+
 function hasStepImage(content: unknown): boolean {
   try {
     return Boolean(parseStepContent("static", content).image?.url);
@@ -32,17 +51,14 @@ async function getNextCourseSuggestion(): Promise<ReviewQueueResult> {
   return { entityId: next?.id ?? null, remaining };
 }
 
-async function getNextStepImage(): Promise<ReviewQueueResult> {
+async function getNextStepImage(lessonSlug?: string): Promise<ReviewQueueResult> {
   const excludeIds = await reviewedEntityIds("stepImage");
+  const where = getStepImageReviewWhere({ excludeIds, lessonSlug });
 
   const steps = await prisma.step.findMany({
     orderBy: { createdAt: "asc" },
     select: { content: true, id: true },
-    where: {
-      NOT: { id: { in: excludeIds } },
-      kind: "static",
-      lesson: { organization: { slug: AI_ORG_SLUG } },
-    },
+    where,
   });
 
   const pending = steps.filter((step) => hasStepImage(step.content));
@@ -101,7 +117,7 @@ async function getNextStepSelectImage(): Promise<ReviewQueueResult> {
 }
 
 export const getNextReviewItem = cache(
-  async (taskType: ReviewTaskType): Promise<ReviewQueueResult> => {
+  async (taskType: ReviewTaskType, lessonSlug?: string): Promise<ReviewQueueResult> => {
     if (!(await isAdmin())) {
       return EMPTY_RESULT;
     }
@@ -111,7 +127,7 @@ export const getNextReviewItem = cache(
     }
 
     if (taskType === "stepImage") {
-      return getNextStepImage();
+      return getNextStepImage(lessonSlug);
     }
 
     if (taskType === "stepSelectImage") {

--- a/apps/admin/src/lib/parse-search-params.ts
+++ b/apps/admin/src/lib/parse-search-params.ts
@@ -5,6 +5,16 @@ const MIN_PAGE_SIZE = 1;
 
 type SearchParamValue = string | string[] | undefined;
 
+/**
+ * Free-text filters should treat repeated URL params the same way as admin
+ * pagination and should not pass blank strings into Prisma filters.
+ */
+export function parseOptionalSearchParam(value: SearchParamValue): string | undefined {
+  const trimmedValue = getFirstSearchParam(value)?.trim();
+
+  return trimmedValue || undefined;
+}
+
 export function parseSearchParams(params: Partial<Record<string, string | string[]>>): {
   page: number;
   limit: number;

--- a/apps/admin/src/lib/review-utils.ts
+++ b/apps/admin/src/lib/review-utils.ts
@@ -46,6 +46,41 @@ function getTaskPath(taskType: ReviewTaskType) {
   return REVIEW_TASKS[taskType].path;
 }
 
+/**
+ * URLSearchParams only accepts complete string pairs. Review queue links build
+ * their params from optional filters, so this keeps the final constructor input
+ * narrow without mutating an array as each optional value is discovered.
+ */
+function isReviewQueueParam(entry: [string, string] | undefined): entry is [string, string] {
+  return Array.isArray(entry);
+}
+
+/**
+ * Review actions redirect to the next item after each decision. Building that
+ * queue URL in one place keeps route filters such as `lessonSlug` attached
+ * without duplicating query-string rules across every action.
+ */
+function getReviewQueuePath({
+  currentId,
+  lessonSlug,
+  taskType,
+}: {
+  currentId?: string | null;
+  lessonSlug?: string | null;
+  taskType: ReviewTaskType;
+}) {
+  const queueParams: ([string, string] | undefined)[] = [
+    lessonSlug ? ["lessonSlug", lessonSlug] : undefined,
+    currentId ? ["current", currentId] : undefined,
+  ];
+
+  const params = new URLSearchParams(queueParams.filter((entry) => isReviewQueueParam(entry)));
+  const queryString = params.toString();
+  const taskPath = getTaskPath(taskType);
+
+  return queryString ? `${taskPath}?${queryString}` : taskPath;
+}
+
 function resolveTaskType(group: string, task: string): ReviewTaskType | null {
   const taskType = fromKebabCase(task);
 
@@ -75,6 +110,7 @@ export {
   REVIEW_TASK_TYPES,
   getTaskLabel,
   getTaskPath,
+  getReviewQueuePath,
   getTasksByGroup,
   isValidTaskType,
   resolveTaskType,


### PR DESCRIPTION
Adds a lesson slug filter to the admin Step Images review queue.\n\nKeeps the selected lesson slug in the URL and preserves it while reviewers mark images approved or needing changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lesson slug filter to the Step Image review queue so reviewers can focus on a single lesson. The filter persists in the URL and is preserved across review actions and redirects.

- **New Features**
  - Added `LessonSlugFilter` UI for `stepImage` (hidden on Flagged view).
  - Server-side queue now accepts `lessonSlug`; narrows Prisma query before parsing content.
  - Review actions include `lessonSlug` via hidden inputs and redirect with `getReviewQueuePath`.

- **Refactors**
  - Added `parseOptionalSearchParam` to normalize free-text params.
  - Centralized queue URL building with `getReviewQueuePath` to avoid duplicated redirect logic.

<sup>Written for commit f09bdb7148271cdd8fb20b67038e941fdc7c8ca6. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1554?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

