### PR TITLE
feat(main): add chapter generation empty state

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -375,10 +375,27 @@ test.describe("Chapter Lesson Search - Mobile", () => {
 });
 
 test.describe("Chapter - No Lessons", () => {
-  test("chapter with no lessons redirects to generate page", async ({ page }) => {
+  test("AI chapter with no lessons shows a create chapter link", async ({ page }) => {
     await page.goto(noLessonsChapterUrl);
 
-    await page.waitForURL(new RegExp(`/generate/ch/${noLessonsChapterId}`, "u"));
+    await expect(page).toHaveURL(noLessonsChapterUrl);
+    await expect(page.getByText(/chapter not available/iu)).toBeVisible();
+    await expect(page.getByText(/hasn't been created yet/iu)).toBeVisible();
+
+    const generateLink = page.getByRole("link", { name: /create chapter/iu });
+
+    await expect(generateLink).toBeVisible();
+
+    await expect(generateLink).toHaveAttribute(
+      "href",
+      new RegExp(`/generate/ch/${noLessonsChapterId}`, "u"),
+    );
+
+    await expect(generateLink).toHaveAttribute("rel", "nofollow");
+
+    const actionsButton = page.getByRole("main").getByRole("button", { name: /more options/iu });
+
+    await expect(actionsButton).toHaveCount(0);
   });
 
   test("non-AI chapters with no lessons stay on the chapter page", async ({ page }) => {

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -183,8 +183,8 @@ async function createChapterCompleteScenario(prefix: string) {
 
 /**
  * The next chapter can exist before its lesson shells are generated. Completing
- * the current chapter should still show a chapter milestone, then let the
- * chapter page redirect to generation instead of declaring the course done.
+ * the current chapter should still show a chapter milestone, then send the
+ * learner to the next chapter page where generation is an explicit action.
  */
 async function createChapterCompleteWithUngeneratedNextChapterScenario(prefix: string) {
   const org = await getAiOrganization();
@@ -229,6 +229,7 @@ async function createChapterCompleteWithUngeneratedNextChapterScenario(prefix: s
   return {
     chapter2,
     lessonUrl: `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter1.slug}/l/${lesson.slug}`,
+    nextChapterUrl: `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter2.slug}`,
     uniqueId,
   };
 }
@@ -368,7 +369,7 @@ test.describe("Lesson Completion UX", () => {
     const email = await createUniqueUser(baseURL!);
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
-    const { chapter2, lessonUrl, uniqueId } =
+    const { chapter2, lessonUrl, nextChapterUrl, uniqueId } =
       await createChapterCompleteWithUngeneratedNextChapterScenario("chpending");
 
     await page.goto(lessonUrl);
@@ -380,7 +381,13 @@ test.describe("Lesson Completion UX", () => {
     await expect(completionScreen.getByText(/course complete/iu)).not.toBeVisible();
 
     await completionScreen.getByRole("link", { name: /next chapter/iu }).click();
-    await expect(page).toHaveURL(new RegExp(`/generate/ch/${chapter2.id}$`, "u"));
+    await expect(page).toHaveURL(nextChapterUrl);
+
+    const createChapterLink = page.getByRole("link", { name: /create chapter/iu });
+
+    await expect(createChapterLink).toBeVisible();
+    await expect(createChapterLink).toHaveAttribute("href", `/generate/ch/${chapter2.id}`);
+    await expect(createChapterLink).toHaveAttribute("rel", "nofollow");
 
     await browserContext.close();
   });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -267,6 +267,18 @@ msgstr "Score"
 msgid "4dsZTc"
 msgstr "{value}% correct answers"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+msgid "9SgWiD"
+msgstr "Chapter not available"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+msgid "ml8Duy"
+msgstr "This chapter hasn't been created yet."
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+msgid "3IOFp2"
+msgstr "Create chapter"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
 msgstr "Search lessons..."

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -267,6 +267,18 @@ msgstr "Aciertos"
 msgid "4dsZTc"
 msgstr "{value}% de respuestas correctas"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+msgid "9SgWiD"
+msgstr "Capítulo no disponible"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+msgid "ml8Duy"
+msgstr "Este capítulo aún no se ha creado."
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+msgid "3IOFp2"
+msgstr "Crear capítulo"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
 msgstr "Buscar lecciones..."

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -267,6 +267,18 @@ msgstr "Acertos"
 msgid "4dsZTc"
 msgstr "{value}% de respostas corretas"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+msgid "9SgWiD"
+msgstr "Capítulo indisponível"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+msgid "ml8Duy"
+msgstr "Este capítulo ainda não foi criado."
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+msgid "3IOFp2"
+msgstr "Criar capítulo"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
 msgstr "Buscar aulas..."

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
@@ -1,0 +1,47 @@
+import { buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@zoonk/ui/components/empty";
+import { SparklesIcon } from "lucide-react";
+import { getExtracted } from "next-intl/server";
+import Link from "next/link";
+
+/**
+ * AI chapter pages can exist before their lesson rows are generated. Showing a
+ * normal page-level empty state keeps the chapter URL stable while making the
+ * generation step an explicit learner action.
+ */
+export async function ChapterNotGenerated({ chapterId }: { chapterId: string }) {
+  const t = await getExtracted();
+
+  return (
+    <Empty className="min-h-80 border-0">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <SparklesIcon />
+        </EmptyMedia>
+
+        <EmptyTitle>{t("Chapter not available")}</EmptyTitle>
+
+        <EmptyDescription>{t("This chapter hasn't been created yet.")}</EmptyDescription>
+      </EmptyHeader>
+
+      <EmptyContent>
+        <Link
+          className={buttonVariants({ variant: "outline" })}
+          href={`/generate/ch/${chapterId}`}
+          prefetch={false}
+          rel="nofollow"
+        >
+          <SparklesIcon data-icon="inline-start" />
+          {t("Create chapter")}
+        </Link>
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -12,9 +12,10 @@ import { getSession } from "@zoonk/core/users/session/get";
 import { Grid, GridToolbar } from "@zoonk/ui/components/grid";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Metadata } from "next";
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { ChapterHeader } from "./chapter-header";
+import { ChapterNotGenerated } from "./chapter-not-generated";
 import { LessonList } from "./lesson-list";
 
 export async function generateMetadata({
@@ -50,9 +51,7 @@ export default async function ChapterPage({
     getNextChapterInCourse({ chapterPosition: chapter.position, courseId: chapter.courseId }),
   ]);
 
-  if (brandSlug === AI_ORG_SLUG && lessons.length === 0) {
-    redirect(`/generate/ch/${chapter.id}`);
-  }
+  const shouldShowCreateChapterPrompt = brandSlug === AI_ORG_SLUG && lessons.length === 0;
 
   const completedHref = nextChapter
     ? (`/b/${nextChapter.brandSlug}/c/${nextChapter.courseSlug}/ch/${nextChapter.chapterSlug}` as const)
@@ -72,35 +71,41 @@ export default async function ChapterPage({
             courseSlug={courseSlug}
             variant="sidebar"
           />
-          <GridToolbar>
-            <Suspense fallback={<ContinueLessonLinkSkeleton />}>
-              <ContinueLessonLink
-                chapterId={chapter.id}
-                completedHref={completedHref}
-                fallbackHref={fallbackHref}
+          {!shouldShowCreateChapterPrompt && (
+            <GridToolbar>
+              <Suspense fallback={<ContinueLessonLinkSkeleton />}>
+                <ContinueLessonLink
+                  chapterId={chapter.id}
+                  completedHref={completedHref}
+                  fallbackHref={fallbackHref}
+                />
+              </Suspense>
+              <CatalogActions
+                contentId={`${courseSlug}/${chapterSlug}`}
+                defaultEmail={session?.user.email}
+                kind="chapter"
               />
-            </Suspense>
-            <CatalogActions
-              contentId={`${courseSlug}/${chapterSlug}`}
-              defaultEmail={session?.user.email}
-              kind="chapter"
-            />
-          </GridToolbar>
+            </GridToolbar>
+          )}
         </>
       }
     >
       <Grid variant="pane">
-        <Suspense
-          fallback={<CatalogGridSkeleton count={lessons.length} groupVariant="pane" search />}
-        >
-          <LessonList
-            brandSlug={brandSlug}
-            chapterId={chapter.id}
-            chapterSlug={chapterSlug}
-            courseSlug={courseSlug}
-            lessons={lessons}
-          />
-        </Suspense>
+        {shouldShowCreateChapterPrompt ? (
+          <ChapterNotGenerated chapterId={chapter.id} />
+        ) : (
+          <Suspense
+            fallback={<CatalogGridSkeleton count={lessons.length} groupVariant="pane" search />}
+          >
+            <LessonList
+              brandSlug={brandSlug}
+              chapterId={chapter.id}
+              chapterSlug={chapterSlug}
+              courseSlug={courseSlug}
+              lessons={lessons}
+            />
+          </Suspense>
+        )}
       </Grid>
     </CatalogDetailLayout>
   );


### PR DESCRIPTION
## Summary

- show a create chapter empty state instead of redirecting ungenerated AI chapters
- hide chapter catalog actions until generated lessons exist
- cover the no-lessons chapter behavior in e2e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an empty “chapter not available” state for AI chapters with no lessons instead of redirecting, and hide chapter actions until lessons exist. Adds i18n strings and updates e2e coverage.

- **New Features**
  - New empty state with a “Create chapter” link to `/generate/ch/{chapterId}` (rel="nofollow").
  - Keeps the chapter URL; no redirect for AI chapters without lessons.
  - Hides chapter toolbar actions until lessons are generated.
  - Adds translations for en/es/pt.
  - Updates e2e tests for the chapter page and lesson completion flow to assert this behavior.

<sup>Written for commit 742fa53f02feed5145f38ac3c3bab57952c35bfc. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1555?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

