### PR TITLE
feat(main): require login for generation

### DIFF
--- a/apps/api/e2e/helpers/auth.ts
+++ b/apps/api/e2e/helpers/auth.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from "node:crypto";
+import { type APIRequestContext, type APIResponse, request } from "@playwright/test";
+import { prisma } from "@zoonk/db";
+
+const AUTH_UNIQUE_ID_LENGTH = 8;
+const AUTH_PREFIX_MAX_LENGTH = 24;
+
+/**
+ * Fails auth setup with the upstream response body so workflow tests do not
+ * hide a broken signup or signin request behind a later 401 assertion.
+ */
+async function assertAuthResponseOk({
+  action,
+  response,
+}: {
+  action: string;
+  response: APIResponse;
+}) {
+  if (response.ok()) {
+    return;
+  }
+
+  throw new Error(`${action} failed with ${response.status()}: ${await response.text()}`);
+}
+
+/**
+ * Builds stable but unique test credentials for API workflow auth tests. The
+ * prefix keeps failures searchable by workflow while the UUID prevents parallel
+ * test workers from sharing Better Auth users.
+ */
+function getAuthCredentials(prefix: string) {
+  const uniqueId = randomUUID().slice(0, AUTH_UNIQUE_ID_LENGTH);
+  const safePrefix = prefix.replaceAll(/[^a-z0-9-]/gu, "-").slice(0, AUTH_PREFIX_MAX_LENGTH);
+
+  return { email: `e2e-${safePrefix}-${uniqueId}@zoonk.test`, password: "password123", uniqueId };
+}
+
+/**
+ * Creates a real Better Auth session for API route tests. Workflow triggers now
+ * reject anonymous requests before parsing route-specific details, so tests
+ * that exercise validation, 404s, or subscription checks need authenticated
+ * request contexts rather than direct database session shortcuts.
+ */
+export async function createAuthenticatedApiContext({
+  baseURL,
+  prefix,
+}: {
+  baseURL: string;
+  prefix: string;
+}): Promise<{ apiContext: APIRequestContext; uniqueId: string; user: { id: string } }> {
+  const credentials = getAuthCredentials(prefix);
+  const signupContext = await request.newContext({ baseURL });
+
+  const signupResponse = await signupContext.post("/v1/auth/sign-up/email", {
+    data: {
+      email: credentials.email,
+      name: `E2E User ${credentials.uniqueId}`,
+      password: credentials.password,
+    },
+  });
+
+  await assertAuthResponseOk({ action: "sign up", response: signupResponse });
+  await signupContext.dispose();
+
+  const user = await prisma.user.findUniqueOrThrow({ where: { email: credentials.email } });
+  const apiContext = await request.newContext({ baseURL });
+
+  const signInResponse = await apiContext.post("/v1/auth/sign-in/email", {
+    data: { email: credentials.email, password: credentials.password },
+  });
+
+  await assertAuthResponseOk({ action: "sign in", response: signInResponse });
+
+  return { apiContext, uniqueId: credentials.uniqueId, user };
+}
+
+/**
+ * Adds the active subscription row expected by workflow trigger routes that
+ * still require a paid plan after the user is authenticated.
+ */
+export async function createSubscribedApiContext({
+  baseURL,
+  prefix,
+}: {
+  baseURL: string;
+  prefix: string;
+}) {
+  const authContext = await createAuthenticatedApiContext({ baseURL, prefix });
+
+  await prisma.subscription.create({
+    data: {
+      id: randomUUID(),
+      plan: "hobby",
+      referenceId: authContext.user.id,
+      status: "active",
+      stripeCustomerId: `cus_test_${authContext.uniqueId}`,
+      stripeSubscriptionId: `sub_test_${authContext.uniqueId}`,
+    },
+  });
+
+  return authContext;
+}

--- a/apps/api/e2e/workflows-chapter-generation.test.ts
+++ b/apps/api/e2e/workflows-chapter-generation.test.ts
@@ -4,6 +4,7 @@ import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
 import { createOrganization, getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
 import { normalizeString } from "@zoonk/utils/string";
+import { createAuthenticatedApiContext, createSubscribedApiContext } from "./helpers/auth";
 
 test.describe("Chapter Generation Workflow API", () => {
   let baseURL: string;
@@ -20,8 +21,58 @@ test.describe("Chapter Generation Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("returns validation error when chapterId is missing", async () => {
+  test("returns 401 when triggering chapter generation without a session", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const courseTitle = `E2E Chapter Auth ${uniqueId}`;
+
+    const course = await prisma.course.create({
+      data: {
+        description: "Test course for chapter generation auth",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(courseTitle),
+        organizationId: aiOrgId,
+        slug: `e2e-chapter-auth-${uniqueId}`,
+        title: courseTitle,
+      },
+    });
+
+    const chapter = await prisma.chapter.create({
+      data: {
+        courseId: course.id,
+        description: "Test chapter for auth",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Chapter Auth"),
+        organizationId: aiOrgId,
+        position: 0,
+        slug: `e2e-chapter-auth-${uniqueId}`,
+        title: "Test Chapter Auth",
+      },
+    });
+
     const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
+      data: { chapterId: chapter.id },
+    });
+
+    expect(response.status()).toBe(401);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+    expect(body.error.message).toBe("Authentication required");
+
+    await apiContext.dispose();
+  });
+
+  test("returns validation error when chapterId is missing", async () => {
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "chapter-validation-missing",
+    });
 
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: {},
@@ -38,7 +89,10 @@ test.describe("Chapter Generation Workflow API", () => {
   });
 
   test("returns validation error when chapterId is invalid type", async () => {
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "chapter-validation-type",
+    });
 
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: "invalid" },
@@ -55,7 +109,10 @@ test.describe("Chapter Generation Workflow API", () => {
   });
 
   test("returns validation error when chapterId is negative", async () => {
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "chapter-validation-negative",
+    });
 
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: -1 },
@@ -102,7 +159,10 @@ test.describe("Chapter Generation Workflow API", () => {
       },
     });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "chapter-no-subscription",
+    });
 
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: chapter.id },
@@ -123,7 +183,7 @@ test.describe("Chapter Generation Workflow API", () => {
     await apiContext.dispose();
   });
 
-  test("allows first chapter generation without subscription", async () => {
+  test("allows signed-in first chapter generation without subscription", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const courseTitle = `E2E First Chapter Free ${uniqueId}`;
 
@@ -154,7 +214,10 @@ test.describe("Chapter Generation Workflow API", () => {
       },
     });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "chapter-first-free",
+    });
 
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: chapter.id },
@@ -200,7 +263,10 @@ test.describe("Chapter Generation Workflow API", () => {
       },
     });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "chapter-non-ai",
+    });
 
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: chapter.id },
@@ -227,32 +293,7 @@ test.describe("Chapter Generation Workflow API", () => {
 
   test("starts workflow successfully with active subscription", async () => {
     const uniqueId = randomUUID().slice(0, 8);
-    const email = `e2e-chapter-${uniqueId}@zoonk.test`;
-    const password = "password123";
-
-    // Create unique user via sign-up API
-    const signupContext = await request.newContext({ baseURL });
-
-    const signupResponse = await signupContext.post("/v1/auth/sign-up/email", {
-      data: { email, name: `E2E User ${uniqueId}`, password },
-    });
-
-    expect(signupResponse.ok()).toBe(true);
-    await signupContext.dispose();
-
-    // Get the user and create subscription
-    const user = await prisma.user.findUniqueOrThrow({ where: { email } });
-
-    await prisma.subscription.create({
-      data: {
-        id: randomUUID(),
-        plan: "hobby",
-        referenceId: user.id,
-        status: "active",
-        stripeCustomerId: `cus_test_${uniqueId}`,
-        stripeSubscriptionId: `sub_test_${uniqueId}`,
-      },
-    });
+    const { apiContext } = await createSubscribedApiContext({ baseURL, prefix: "chapter-success" });
 
     // Create test course and chapter with unique slugs
     const course = await prisma.course.create({
@@ -281,15 +322,6 @@ test.describe("Chapter Generation Workflow API", () => {
         title: "Test Chapter Success",
       },
     });
-
-    // Sign in and test
-    const apiContext = await request.newContext({ baseURL });
-
-    const signInResponse = await apiContext.post("/v1/auth/sign-in/email", {
-      data: { email, password },
-    });
-
-    expect(signInResponse.ok()).toBe(true);
 
     const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
       data: { chapterId: chapter.id },

--- a/apps/api/e2e/workflows-course-generation.test.ts
+++ b/apps/api/e2e/workflows-course-generation.test.ts
@@ -3,6 +3,7 @@ import { request } from "@playwright/test";
 import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { createAuthenticatedApiContext } from "./helpers/auth";
 
 /**
  * Creates a valid suggestion that will not drive the real generation pipeline.
@@ -36,8 +37,37 @@ test.describe("Course Generation Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("returns validation error when courseSuggestionId is missing", async () => {
+  test("returns 401 when triggering course generation without a session", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const suggestion = await createCompletedCourseSuggestion({
+      slug: `e2e-unauth-course-${uniqueId}`,
+      title: `E2E Unauth Course ${uniqueId}`,
+    });
+
     const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/course-generation/trigger", {
+      data: { courseSuggestionId: suggestion.id },
+    });
+
+    expect(response.status()).toBe(401);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+    expect(body.error.message).toBe("Authentication required");
+
+    await apiContext.dispose();
+  });
+
+  test("returns validation error when courseSuggestionId is missing", async () => {
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "course-validation-missing",
+    });
+
     const response = await apiContext.post("/v1/workflows/course-generation/trigger", { data: {} });
 
     expect(response.status()).toBe(400);
@@ -51,7 +81,10 @@ test.describe("Course Generation Workflow API", () => {
   });
 
   test("returns validation error when courseSuggestionId is invalid type", async () => {
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "course-validation-type",
+    });
 
     const response = await apiContext.post("/v1/workflows/course-generation/trigger", {
       data: { courseSuggestionId: "invalid" },
@@ -68,7 +101,10 @@ test.describe("Course Generation Workflow API", () => {
   });
 
   test("returns validation error when courseSuggestionId is negative", async () => {
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "course-validation-negative",
+    });
 
     const response = await apiContext.post("/v1/workflows/course-generation/trigger", {
       data: { courseSuggestionId: -1 },
@@ -92,7 +128,10 @@ test.describe("Course Generation Workflow API", () => {
       title: `E2E Workflow Test ${uniqueId}`,
     });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "course-workflow",
+    });
 
     const response = await apiContext.post("/v1/workflows/course-generation/trigger", {
       data: { courseSuggestionId: suggestion.id },
@@ -131,7 +170,10 @@ test.describe("Course Generation Workflow API", () => {
       title: `E2E Status Test ${uniqueId}`,
     });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "course-status",
+    });
 
     // First trigger the workflow to get a runId
     const triggerResponse = await apiContext.post("/v1/workflows/course-generation/trigger", {

--- a/apps/api/e2e/workflows-lesson-generation.test.ts
+++ b/apps/api/e2e/workflows-lesson-generation.test.ts
@@ -7,55 +7,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { normalizeString } from "@zoonk/utils/string";
-
-/**
- * Workflow trigger routes require the same signed-in, subscribed session that
- * the main app generation pages use. Creating it through the public auth API
- * keeps these route tests close to the real request path instead of bypassing
- * cookies or Better Auth session state.
- */
-async function createSubscribedApiContext({
-  baseURL,
-  uniqueId,
-}: {
-  baseURL: string;
-  uniqueId: string;
-}) {
-  const email = `e2e-lesson-${uniqueId}@zoonk.test`;
-  const password = "password123";
-
-  const signupContext = await request.newContext({ baseURL });
-
-  const signupResponse = await signupContext.post("/v1/auth/sign-up/email", {
-    data: { email, name: `E2E User ${uniqueId}`, password },
-  });
-
-  expect(signupResponse.ok()).toBe(true);
-  await signupContext.dispose();
-
-  const user = await prisma.user.findUniqueOrThrow({ where: { email } });
-
-  await prisma.subscription.create({
-    data: {
-      id: randomUUID(),
-      plan: "hobby",
-      referenceId: user.id,
-      status: "active",
-      stripeCustomerId: `cus_test_${uniqueId}`,
-      stripeSubscriptionId: `sub_test_${uniqueId}`,
-    },
-  });
-
-  const apiContext = await request.newContext({ baseURL });
-
-  const signInResponse = await apiContext.post("/v1/auth/sign-in/email", {
-    data: { email, password },
-  });
-
-  expect(signInResponse.ok()).toBe(true);
-
-  return apiContext;
-}
+import { createAuthenticatedApiContext, createSubscribedApiContext } from "./helpers/auth";
 
 /**
  * Route-contract tests only need a published AI-owned lesson with a specific
@@ -110,8 +62,32 @@ test.describe("Lesson Generation Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("returns validation error when lessonId is missing", async () => {
+  test("returns 401 when triggering lesson generation without a session", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const lesson = await createAiLessonForWorkflow({ aiOrgId, chapterPosition: 0, uniqueId });
     const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(401);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+    expect(body.error.message).toBe("Authentication required");
+
+    await apiContext.dispose();
+  });
+
+  test("returns validation error when lessonId is missing", async () => {
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "lesson-validation-missing",
+    });
+
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", { data: {} });
 
     expect(response.status()).toBe(400);
@@ -125,7 +101,10 @@ test.describe("Lesson Generation Workflow API", () => {
   });
 
   test("returns validation error when lessonId is invalid type", async () => {
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "lesson-validation-type",
+    });
 
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
       data: { lessonId: "invalid" },
@@ -142,7 +121,10 @@ test.describe("Lesson Generation Workflow API", () => {
   });
 
   test("returns validation error when lessonId is negative", async () => {
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "lesson-validation-negative",
+    });
 
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
       data: { lessonId: -1 },
@@ -162,7 +144,10 @@ test.describe("Lesson Generation Workflow API", () => {
     const uniqueId = randomUUID().slice(0, 8);
     const lesson = await createAiLessonForWorkflow({ aiOrgId, chapterPosition: 1, uniqueId });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "lesson-no-subscription",
+    });
 
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
       data: { lessonId: lesson.id },
@@ -179,12 +164,15 @@ test.describe("Lesson Generation Workflow API", () => {
     await apiContext.dispose();
   });
 
-  test("allows first chapter lesson generation without subscription", async () => {
+  test("allows signed-in first chapter lesson generation without subscription", async () => {
     const uniqueId = randomUUID().slice(0, 8);
 
     const lesson = await createAiLessonForWorkflow({ aiOrgId, chapterPosition: 0, uniqueId });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "lesson-first-free",
+    });
 
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
       data: { lessonId: lesson.id },
@@ -202,7 +190,11 @@ test.describe("Lesson Generation Workflow API", () => {
   });
 
   test("returns validation error for status endpoint when runId is missing", async () => {
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "lesson-non-ai",
+    });
+
     const response = await apiContext.get("/v1/workflows/lesson-generation/status");
 
     expect(response.status()).toBe(400);
@@ -260,7 +252,10 @@ test.describe("Lesson Generation Workflow API", () => {
       },
     });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "lesson-non-ai",
+    });
 
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
       data: { lessonId: lesson.id },
@@ -273,7 +268,11 @@ test.describe("Lesson Generation Workflow API", () => {
 
   test("returns 409 when practice has an incomplete explanation prerequisite", async () => {
     const uniqueId = randomUUID().slice(0, 8);
-    const apiContext = await createSubscribedApiContext({ baseURL, uniqueId });
+
+    const { apiContext } = await createSubscribedApiContext({
+      baseURL,
+      prefix: "lesson-blocked-practice",
+    });
 
     const course = await prisma.course.create({
       data: {
@@ -351,7 +350,11 @@ test.describe("Lesson Generation Workflow API", () => {
 
   test("returns 409 when translation has an incomplete vocabulary prerequisite", async () => {
     const uniqueId = randomUUID().slice(0, 8);
-    const apiContext = await createSubscribedApiContext({ baseURL, uniqueId });
+
+    const { apiContext } = await createSubscribedApiContext({
+      baseURL,
+      prefix: "lesson-blocked-translation",
+    });
 
     const course = await prisma.course.create({
       data: {
@@ -430,7 +433,7 @@ test.describe("Lesson Generation Workflow API", () => {
 
   test("starts workflow successfully with active subscription", async () => {
     const uniqueId = randomUUID().slice(0, 8);
-    const apiContext = await createSubscribedApiContext({ baseURL, uniqueId });
+    const { apiContext } = await createSubscribedApiContext({ baseURL, prefix: "lesson-success" });
 
     const course = await prisma.course.create({
       data: {

--- a/apps/api/e2e/workflows-lesson-preload.test.ts
+++ b/apps/api/e2e/workflows-lesson-preload.test.ts
@@ -6,6 +6,7 @@ import { createOrganization, getAiOrganization } from "@zoonk/e2e/fixtures/orgs"
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { createAuthenticatedApiContext } from "./helpers/auth";
 
 /**
  * Preload trigger tests should prove the subscription gate, not the lesson
@@ -60,12 +61,35 @@ test.describe("Lesson Preload Workflow API", () => {
     await prisma.$disconnect();
   });
 
+  test("returns 401 when triggering lesson preload without a session", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const lesson = await createAiLessonForPreload({ aiOrgId, chapterPosition: 0, uniqueId });
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(401);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("UNAUTHORIZED");
+    expect(body.error.message).toBe("Authentication required");
+
+    await apiContext.dispose();
+  });
+
   test("returns 402 when a later chapter lesson has no active subscription", async () => {
     const uniqueId = randomUUID().slice(0, 8);
 
     const lesson = await createAiLessonForPreload({ aiOrgId, chapterPosition: 1, uniqueId });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "preload-no-subscription",
+    });
 
     const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
       data: { lessonId: lesson.id },
@@ -82,12 +106,15 @@ test.describe("Lesson Preload Workflow API", () => {
     await apiContext.dispose();
   });
 
-  test("allows first chapter lesson preload without subscription", async () => {
+  test("allows signed-in first chapter lesson preload without subscription", async () => {
     const uniqueId = randomUUID().slice(0, 8);
 
     const lesson = await createAiLessonForPreload({ aiOrgId, chapterPosition: 0, uniqueId });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "preload-first-free",
+    });
 
     const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
       data: { lessonId: lesson.id },
@@ -104,7 +131,7 @@ test.describe("Lesson Preload Workflow API", () => {
     await apiContext.dispose();
   });
 
-  test("returns 404 before skipping auth for non-AI first chapter lessons", async () => {
+  test("returns 404 for signed-in requests to non-AI first chapter lessons", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const org = await createOrganization();
 
@@ -130,7 +157,10 @@ test.describe("Lesson Preload Workflow API", () => {
       title: `E2E Non-AI Preload Lesson ${uniqueId}`,
     });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "preload-non-ai",
+    });
 
     const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
       data: { lessonId: lesson.id },

--- a/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
@@ -3,7 +3,8 @@ import { parseBody } from "@/lib/body-parser";
 import { chapterGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import {
   getAiGenerationChapterForWorkflow,
-  hasWorkflowSubscriptionAccess,
+  getWorkflowAuthenticationError,
+  getWorkflowSubscriptionAccessError,
   requiresSubscriptionForChapterGeneration,
 } from "@/lib/workflow-generation-access";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
@@ -11,6 +12,12 @@ import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
 export async function POST(request: NextRequest) {
+  const authError = await getWorkflowAuthenticationError({ headers: request.headers });
+
+  if (authError) {
+    return authError;
+  }
+
   const parsed = await parseBody(request, chapterGenerationTriggerSchema);
 
   if (!parsed.success) {
@@ -23,13 +30,13 @@ export async function POST(request: NextRequest) {
     return errors.notFound();
   }
 
-  const hasAccess = await hasWorkflowSubscriptionAccess({
+  const accessError = await getWorkflowSubscriptionAccessError({
     headers: request.headers,
     requiresSubscription: requiresSubscriptionForChapterGeneration(chapter),
   });
 
-  if (!hasAccess) {
-    return errors.paymentRequired();
+  if (accessError) {
+    return accessError;
   }
 
   const run = await start(chapterGenerationWorkflow, [parsed.data.chapterId]);

--- a/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
@@ -1,11 +1,18 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
 import { courseGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
+import { getWorkflowAuthenticationError } from "@/lib/workflow-generation-access";
 import { courseGenerationWorkflow } from "@/workflows/course-generation/course-generation-workflow";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
 export async function POST(request: NextRequest) {
+  const accessError = await getWorkflowAuthenticationError({ headers: request.headers });
+
+  if (accessError) {
+    return accessError;
+  }
+
   const parsed = await parseBody(request, courseGenerationTriggerSchema);
 
   if (!parsed.success) {

--- a/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
@@ -3,7 +3,8 @@ import { parseBody } from "@/lib/body-parser";
 import { lessonGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import {
   getAiGenerationLessonForWorkflow,
-  hasWorkflowSubscriptionAccess,
+  getWorkflowAuthenticationError,
+  getWorkflowSubscriptionAccessError,
   requiresSubscriptionForLessonGeneration,
 } from "@/lib/workflow-generation-access";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
@@ -15,6 +16,12 @@ import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
 export async function POST(request: NextRequest) {
+  const authError = await getWorkflowAuthenticationError({ headers: request.headers });
+
+  if (authError) {
+    return authError;
+  }
+
   const parsed = await parseBody(request, lessonGenerationTriggerSchema);
 
   if (!parsed.success) {
@@ -27,13 +34,13 @@ export async function POST(request: NextRequest) {
     return errors.notFound();
   }
 
-  const hasAccess = await hasWorkflowSubscriptionAccess({
+  const accessError = await getWorkflowSubscriptionAccessError({
     headers: request.headers,
     requiresSubscription: requiresSubscriptionForLessonGeneration(lesson),
   });
 
-  if (!hasAccess) {
-    return errors.paymentRequired();
+  if (accessError) {
+    return accessError;
   }
 
   const blockingPrerequisite = hasLessonGenerationPrerequisites(lesson.kind)

--- a/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
@@ -3,7 +3,8 @@ import { parseBody } from "@/lib/body-parser";
 import { lessonPreloadTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import {
   getAiGenerationLessonForWorkflow,
-  hasWorkflowSubscriptionAccess,
+  getWorkflowAuthenticationError,
+  getWorkflowSubscriptionAccessError,
   requiresSubscriptionForLessonGeneration,
 } from "@/lib/workflow-generation-access";
 import { lessonPreloadWorkflow } from "@/workflows/lesson-preload/lesson-preload-workflow";
@@ -11,6 +12,12 @@ import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
 export async function POST(request: NextRequest) {
+  const authError = await getWorkflowAuthenticationError({ headers: request.headers });
+
+  if (authError) {
+    return authError;
+  }
+
   const parsed = await parseBody(request, lessonPreloadTriggerSchema);
 
   if (!parsed.success) {
@@ -23,13 +30,13 @@ export async function POST(request: NextRequest) {
     return errors.notFound();
   }
 
-  const hasAccess = await hasWorkflowSubscriptionAccess({
+  const accessError = await getWorkflowSubscriptionAccessError({
     headers: request.headers,
     requiresSubscription: requiresSubscriptionForLessonGeneration(lesson),
   });
 
-  if (!hasAccess) {
-    return errors.paymentRequired();
+  if (accessError) {
+    return accessError;
   }
 
   const run = await start(lessonPreloadWorkflow, [parsed.data.lessonId]);

--- a/apps/api/src/lib/openapi/schemas/responses.ts
+++ b/apps/api/src/lib/openapi/schemas/responses.ts
@@ -48,11 +48,19 @@ export function workflowTriggerEndpoint({
 }) {
   return {
     post: {
-      ...(requiresSubscription && { description: "Requires active subscription." }),
+      description: [
+        "Requires authentication.",
+        requiresSubscription
+          ? "Requires active subscription when the free generation rule does not apply."
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" "),
       requestBody: { content: { "application/json": { schema } } },
       responses: {
         "200": workflowStartedResponse,
         "400": validationErrorResponse,
+        "401": unauthorizedResponse,
         ...(requiresSubscription && { "402": subscriptionRequiredResponse }),
       },
       summary,

--- a/apps/api/src/lib/workflow-generation-access.ts
+++ b/apps/api/src/lib/workflow-generation-access.ts
@@ -1,3 +1,4 @@
+import { auth } from "@zoonk/core/auth";
 import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
 import {
   type Chapter,
@@ -6,6 +7,7 @@ import {
   getAiGenerationLessonWhere,
   prisma,
 } from "@zoonk/db";
+import { errors } from "./api-errors";
 
 type LessonWithChapter = Lesson & { chapter: Chapter };
 
@@ -54,16 +56,39 @@ export function requiresSubscriptionForLessonGeneration(lesson: {
 }
 
 /**
- * First-chapter workflow triggers should not even touch auth, while later
- * chapters must keep using the normal active-subscription check.
+ * Workflow generation is account-bound before route-specific ids are parsed or
+ * looked up. That keeps anonymous callers from probing workflow trigger inputs
+ * and prevents client-only page gates from protecting expensive starts.
  */
-export async function hasWorkflowSubscriptionAccess(params: {
+export async function getWorkflowAuthenticationError(params: { headers: Headers }) {
+  const session = await auth.api.getSession({ headers: params.headers });
+
+  if (!session) {
+    return errors.unauthorized();
+  }
+
+  return null;
+}
+
+/**
+ * Paid-plan checks still depend on the trusted chapter or lesson row because
+ * first-chapter content is free for signed-in learners. Run this only after the
+ * route has loaded the AI-owned entity and knows whether the subscription rule
+ * applies.
+ */
+export async function getWorkflowSubscriptionAccessError(params: {
   headers: Headers;
   requiresSubscription: boolean;
 }) {
   if (!params.requiresSubscription) {
-    return true;
+    return null;
   }
 
-  return hasActiveSubscription(params.headers);
+  const hasSubscription = await hasActiveSubscription(params.headers);
+
+  if (!hasSubscription) {
+    return errors.paymentRequired();
+  }
+
+  return null;
 }

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -143,7 +143,7 @@ test.describe("Command Palette - Unauthenticated", () => {
     await expect(page.getByRole("heading", { name: /explore courses/iu })).toBeVisible();
   });
 
-  test("selecting Learn shows learn form", async ({ page }) => {
+  test("selecting Learn asks unauthenticated users to log in", async ({ page }) => {
     await openCommandPalette(page);
 
     await page
@@ -151,8 +151,7 @@ test.describe("Command Palette - Unauthenticated", () => {
       .getByText(/learn something/iu)
       .click();
 
-    // Verify user sees learn page content
-    await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
   });
 });
 

--- a/apps/main/e2e/content-feedback.test.ts
+++ b/apps/main/e2e/content-feedback.test.ts
@@ -20,16 +20,16 @@ test.beforeAll(async () => {
 
 // Content feedback is tested on the course suggestions page where it's used
 test.describe("Content Feedback", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(`/learn/${encodeURIComponent(prompt)}`);
+  test.beforeEach(async ({ authenticatedPage }) => {
+    await authenticatedPage.goto(`/learn/${encodeURIComponent(prompt)}`);
 
     // Wait for content to load
-    await expect(page.getByText(suggestionTitle)).toBeVisible();
+    await expect(authenticatedPage.getByText(suggestionTitle)).toBeVisible();
   });
 
-  test("clicking feedback button marks it as pressed", async ({ page }) => {
-    const thumbsUp = page.getByRole("button", { name: /i liked it/iu });
-    const thumbsDown = page.getByRole("button", { name: /i didn't like it/iu });
+  test("clicking feedback button marks it as pressed", async ({ authenticatedPage }) => {
+    const thumbsUp = authenticatedPage.getByRole("button", { name: /i liked it/iu });
+    const thumbsDown = authenticatedPage.getByRole("button", { name: /i didn't like it/iu });
 
     // Initially neither should be pressed
     await expect(thumbsUp).toHaveAttribute("aria-pressed", "false");
@@ -46,11 +46,11 @@ test.describe("Content Feedback", () => {
     await expect(thumbsUp).toHaveAttribute("aria-pressed", "false");
   });
 
-  test("submit with valid data shows success message", async ({ page }) => {
-    const feedbackSubmission = await mockFeedbackSubmission(page);
+  test("submit with valid data shows success message", async ({ authenticatedPage }) => {
+    const feedbackSubmission = await mockFeedbackSubmission(authenticatedPage);
 
-    const feedbackButton = page.getByRole("button", { name: /send feedback/iu });
-    const dialog = page.getByRole("dialog");
+    const feedbackButton = authenticatedPage.getByRole("button", { name: /send feedback/iu });
+    const dialog = authenticatedPage.getByRole("dialog");
     await openDialog(feedbackButton, dialog);
 
     const emailInput = dialog.getByRole("textbox", { name: /email address/iu });
@@ -74,9 +74,9 @@ test.describe("Content Feedback", () => {
     });
   });
 
-  test("submit with invalid email shows validation error", async ({ page }) => {
-    const feedbackButton = page.getByRole("button", { name: /send feedback/iu });
-    const dialog = page.getByRole("dialog");
+  test("submit with invalid email shows validation error", async ({ authenticatedPage }) => {
+    const feedbackButton = authenticatedPage.getByRole("button", { name: /send feedback/iu });
+    const dialog = authenticatedPage.getByRole("dialog");
     await openDialog(feedbackButton, dialog);
 
     const emailInput = dialog.getByRole("textbox", { name: /email address/iu });
@@ -100,9 +100,9 @@ test.describe("Content Feedback", () => {
     await expect(emailInput).toBeFocused();
   });
 
-  test("submit failure shows error message", async ({ page }) => {
-    const feedbackButton = page.getByRole("button", { name: /send feedback/iu });
-    const dialog = page.getByRole("dialog");
+  test("submit failure shows error message", async ({ authenticatedPage }) => {
+    const feedbackButton = authenticatedPage.getByRole("button", { name: /send feedback/iu });
+    const dialog = authenticatedPage.getByRole("dialog");
     await openDialog(feedbackButton, dialog);
 
     const emailInput = dialog.getByRole("textbox", { name: /email address/iu });

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -19,7 +19,7 @@ async function mockWorkflowApis(route: Route) {
   const url = route.request().url();
   const method = route.request().method();
 
-  if (url.includes("/api/workflows/course-generation/trigger") && method === "POST") {
+  if (url.includes("/v1/workflows/course-generation/trigger") && method === "POST") {
     await route.fulfill({
       body: JSON.stringify({ message: "Workflow started", runId: TEST_RUN_ID }),
       contentType: "application/json",
@@ -29,7 +29,7 @@ async function mockWorkflowApis(route: Route) {
     return;
   }
 
-  if (url.includes("/api/workflows/course-generation/status")) {
+  if (url.includes("/v1/workflows/course-generation/status")) {
     await route.fulfill({
       body: `data: ${JSON.stringify({ status: "running", step: "getCourseSuggestion" })}\n\n`,
       contentType: "text/event-stream",
@@ -150,7 +150,7 @@ test.describe("Course Detail Page", () => {
     await expect(page.getByText(/not found|404/iu)).toBeVisible();
   });
 
-  test("redirects to generate page when course has no chapters", async ({ page }) => {
+  test("redirects to generate page when course has no chapters", async ({ authenticatedPage }) => {
     const org = await getAiOrganization();
 
     const slug = `e2e-no-chapters-${randomUUID().slice(0, UUID_SHORT_LENGTH)}`;
@@ -172,13 +172,15 @@ test.describe("Course Detail Page", () => {
       }),
     ]);
 
-    await page.route("**/api/workflows/**", mockWorkflowApis);
+    await authenticatedPage.route("**/v1/workflows/**", mockWorkflowApis);
 
-    await page.goto(`/b/${AI_ORG_SLUG}/c/${slug}`);
+    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${slug}`);
 
-    await page.waitForURL(`/generate/cs/${suggestion.id}`, { timeout: 10_000 });
+    await authenticatedPage.waitForURL(`/generate/cs/${suggestion.id}`, { timeout: 10_000 });
 
-    await expect(page.getByText(/creating your course/iu)).toBeVisible({ timeout: 10_000 });
+    await expect(authenticatedPage.getByText(/creating your course/iu)).toBeVisible({
+      timeout: 10_000,
+    });
   });
 
   test("non-AI courses with no chapters stay on the course page", async ({ page }) => {

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -186,6 +186,27 @@ test.describe("Generate Chapter Page - No Subscription", () => {
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
+
+  test("allows signed-in users to retry failed generation without subscription", async ({
+    authenticatedPage,
+  }) => {
+    const { chapter } = await createPendingChapter(1);
+
+    await prisma.chapter.update({
+      data: { generationStatus: "failed" },
+      where: { id: chapter.id },
+    });
+
+    await setupMockApis(authenticatedPage, {
+      statusDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getChapter" }],
+    });
+
+    await authenticatedPage.goto(`/generate/ch/${chapter.id}`);
+
+    await expect(authenticatedPage.getByText(/upgrade to create/iu)).toHaveCount(0);
+    await expect(authenticatedPage.getByRole("heading", { name: chapter.title })).toBeVisible();
+  });
 });
 
 test.describe("Generate Chapter Page - With Subscription", () => {

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -189,7 +189,9 @@ test.describe("Generate Chapter Page - No Subscription", () => {
 });
 
 test.describe("Generate Chapter Page - With Subscription", () => {
-  test("shows completion UI before redirecting when chapter is already ready", async ({ page }) => {
+  test("shows completion UI before redirecting when chapter is already ready", async ({
+    authenticatedPage,
+  }) => {
     const { chapter, course, organizationId } = await createPendingChapter();
     const uniqueId = randomUUID().slice(0, 8);
 
@@ -204,12 +206,12 @@ test.describe("Generate Chapter Page - With Subscription", () => {
       prisma.chapter.update({ data: { generationStatus: "completed" }, where: { id: chapter.id } }),
     ]);
 
-    await page.goto(`/generate/ch/${chapter.id}`);
+    await authenticatedPage.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByText(/your lessons are ready/iu)).toBeVisible();
-    await expect(page.getByText(/taking you to your chapter/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/your lessons are ready/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/taking you to your chapter/iu)).toBeVisible();
 
-    await page.waitForURL(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`, {
+    await authenticatedPage.waitForURL(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`, {
       timeout: 10_000,
     });
   });
@@ -369,22 +371,16 @@ test.describe("Generate Chapter Page - With Subscription", () => {
 });
 
 test.describe("Generate Chapter Page - First Chapter Free", () => {
-  test("unauthenticated user sees generation UI for first chapter", async ({ page }) => {
-    const { chapter, course } = await createPendingChapter(0);
-
-    await setupMockApis(page, {
-      statusDelayMs: 2500,
-      streamMessages: [{ status: "started", step: "getChapter" }],
-    });
+  test("unauthenticated user sees login prompt for first chapter", async ({ page }) => {
+    const { chapter } = await createPendingChapter(0);
 
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: chapter.title })).toBeVisible();
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
 
-    const exitLink = page.getByRole("link", { name: /back to course/iu });
-    await expect(exitLink).toBeVisible();
-    await expect(exitLink).toHaveAttribute("href", `/b/${AI_ORG_SLUG}/c/${course.slug}`);
+    const loginLink = page.getByRole("link", { name: /login/iu });
+    await expect(loginLink).toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
   });
 
   test("authenticated user without subscription sees generation UI for first chapter", async ({
@@ -404,8 +400,8 @@ test.describe("Generate Chapter Page - First Chapter Free", () => {
   });
 });
 
-test.describe("Generate Chapter Page - Running Generation Bypasses Auth", () => {
-  test("unauthenticated user sees generation UI for non-first chapter when status is running", async ({
+test.describe("Generate Chapter Page - Running Generation Requires Auth", () => {
+  test("unauthenticated user sees login prompt for non-first chapter when status is running", async ({
     page,
   }) => {
     const org = await getAiOrganization();
@@ -432,16 +428,13 @@ test.describe("Generate Chapter Page - Running Generation Bypasses Auth", () => 
       title: `E2E Running Chapter ${uniqueId}`,
     });
 
-    await setupMockApis(page, {
-      statusDelayMs: 2500,
-      streamMessages: [{ status: "started", step: "getChapter" }],
-    });
-
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toHaveCount(0);
-    await expect(page.getByText(/upgrade to create/iu)).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: chapter.title })).toBeVisible();
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+
+    const loginLink = page.getByRole("link", { name: /login/iu });
+    await expect(loginLink).toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
   });
 });
 

--- a/apps/main/e2e/generate-course-redirect.test.ts
+++ b/apps/main/e2e/generate-course-redirect.test.ts
@@ -13,7 +13,7 @@ async function mockWorkflowApis(route: Route) {
   const url = route.request().url();
   const method = route.request().method();
 
-  if (url.includes("/api/workflows/course-generation/trigger") && method === "POST") {
+  if (url.includes("/v1/workflows/course-generation/trigger") && method === "POST") {
     await route.fulfill({
       body: JSON.stringify({ message: "Workflow started", runId: TEST_RUN_ID }),
       contentType: "application/json",
@@ -23,7 +23,7 @@ async function mockWorkflowApis(route: Route) {
     return;
   }
 
-  if (url.includes("/api/workflows/course-generation/status")) {
+  if (url.includes("/v1/workflows/course-generation/status")) {
     // Return a simple in-progress message to show the generation UI
     await route.fulfill({
       body: `data: ${JSON.stringify({ status: "running", step: "getCourseSuggestion" })}\n\n`,
@@ -38,7 +38,9 @@ async function mockWorkflowApis(route: Route) {
 }
 
 test.describe("Generate Course Redirect", () => {
-  test("redirects to generate/cs/[id] when course suggestion exists", async ({ page }) => {
+  test("redirects signed-in users to generate/cs/[id] when course suggestion exists", async ({
+    authenticatedPage,
+  }) => {
     const slug = `e2e-redirect-${randomUUID().slice(0, 8)}`;
 
     const suggestion = await courseSuggestionFixture({
@@ -49,20 +51,37 @@ test.describe("Generate Course Redirect", () => {
     });
 
     // Mock the workflow APIs before navigating
-    await page.route("**/api/workflows/**", mockWorkflowApis);
+    await authenticatedPage.route("**/v1/workflows/**", mockWorkflowApis);
+
+    await authenticatedPage.goto(`/generate/c/${slug}`);
+
+    // Should redirect to /generate/cs/{id}
+    await authenticatedPage.waitForURL(`/generate/cs/${suggestion.id}`, { timeout: 10_000 });
+
+    // Verify we're on the generation page by checking for the header
+    await expect(authenticatedPage.getByText(/creating your course/iu)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("shows login prompt before redirecting unauthenticated users", async ({ page }) => {
+    const slug = `e2e-redirect-unauth-${randomUUID().slice(0, 8)}`;
+
+    await courseSuggestionFixture({
+      generationStatus: "pending",
+      language: "en",
+      slug,
+      title: "E2E Redirect Unauth Test",
+    });
 
     await page.goto(`/generate/c/${slug}`);
 
-    // Should redirect to /generate/cs/{id}
-    await page.waitForURL(`/generate/cs/${suggestion.id}`, { timeout: 10_000 });
-
-    // Verify we're on the generation page by checking for the header
-    await expect(page.getByText(/creating your course/iu)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
   });
 
-  test("shows 404 when course suggestion does not exist", async ({ page }) => {
-    await page.goto(`/generate/c/nonexistent-${randomUUID()}`);
+  test("shows 404 when course suggestion does not exist", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto(`/generate/c/nonexistent-${randomUUID()}`);
 
-    await expect(page.getByText(/not found|404/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/not found|404/iu)).toBeVisible();
   });
 });

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -157,8 +157,31 @@ async function createPublishedCourseWithLesson({
 }
 
 test.describe("Generate Course Page", () => {
+  test("shows login prompt before starting course generation", async ({ page }) => {
+    const slug = `e2e-unauth-course-${randomUUID().slice(0, 8)}`;
+
+    const suggestion = await courseSuggestionFixture({
+      generationStatus: "pending",
+      language: "en",
+      slug,
+      title: "E2E Unauth Course Generation",
+    });
+
+    await page.route("**/v1/workflows/course-generation/**", async (route) => {
+      throw new Error(`Generation workflow should not start: ${route.request().url()}`);
+    });
+
+    await page.goto(`/generate/cs/${suggestion.id}`);
+
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+
+    const loginLink = page.getByRole("link", { name: /login/iu });
+    await expect(loginLink).toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
+  });
+
   test.describe("Initial triggering state", () => {
-    test("shows triggering state immediately on page load", async ({ page }) => {
+    test("shows triggering state immediately on page load", async ({ authenticatedPage }) => {
       // Create a unique suggestion to avoid PPR caching issues with seeded data
       const slug = `e2e-trigger-${randomUUID().slice(0, 8)}`;
 
@@ -170,19 +193,23 @@ test.describe("Generate Course Page", () => {
       });
 
       // Set up route mocking before navigation
-      await setupMockApis(page, {
+      await setupMockApis(authenticatedPage, {
         streamMessages: [{ status: "started", step: "getCourseSuggestion" }],
       });
 
       // Navigate directly to the generate page with the unique suggestion
-      await page.goto(`/generate/cs/${suggestion.id}`);
+      await authenticatedPage.goto(`/generate/cs/${suggestion.id}`);
 
       // Should show triggering or streaming state (no idle state)
-      await expect(page.getByText(/creating your course/iu)).toBeVisible({ timeout: 10_000 });
+      await expect(authenticatedPage.getByText(/creating your course/iu)).toBeVisible({
+        timeout: 10_000,
+      });
 
-      await expect(page.getByText(/this usually takes about 2 minutes/iu)).toBeVisible();
+      await expect(
+        authenticatedPage.getByText(/this usually takes about 2 minutes/iu),
+      ).toBeVisible();
 
-      const exitLink = page.getByRole("link", { name: /back home/iu });
+      const exitLink = authenticatedPage.getByRole("link", { name: /back home/iu });
       await expect(exitLink).toBeVisible();
       await expect(exitLink).toHaveAttribute("href", "/");
     });
@@ -216,7 +243,7 @@ test.describe("Generate Course Page", () => {
       await page.waitForURL(new RegExp(`/b/ai/c/${courseSlug}`, "u"), { timeout: 10_000 });
     });
 
-    test("shows completion state and redirects to course page", async ({ page }) => {
+    test("shows completion state and redirects to course page", async ({ authenticatedPage }) => {
       const slug = `e2e-completion-${randomUUID().slice(0, 8)}`;
       const org = await getAiOrganization();
 
@@ -243,7 +270,7 @@ test.describe("Generate Course Page", () => {
 
       await lessonFixture({ chapterId: chapter.id, isPublished: true, organizationId: org.id });
 
-      await setupMockApis(page, {
+      await setupMockApis(authenticatedPage, {
         streamMessages: [
           { status: "started", step: "getCourseSuggestion" },
           { status: "completed", step: "getCourseSuggestion" },
@@ -252,13 +279,13 @@ test.describe("Generate Course Page", () => {
         ],
       });
 
-      await page.goto(`/generate/cs/${suggestion.id}`);
+      await authenticatedPage.goto(`/generate/cs/${suggestion.id}`);
 
       // Should complete and redirect to course page
-      await page.waitForURL(/\/b\/ai\/c\//u, { timeout: 10_000 });
+      await authenticatedPage.waitForURL(/\/b\/ai\/c\//u, { timeout: 10_000 });
     });
 
-    test("redirects to the completed workflow course slug", async ({ page }) => {
+    test("redirects to the completed workflow course slug", async ({ authenticatedPage }) => {
       const sourceSlug = `e2e-identity-source-${randomUUID().slice(0, 8)}`;
       const courseSlug = `e2e-identity-course-${randomUUID().slice(0, 8)}`;
 
@@ -274,7 +301,7 @@ test.describe("Generate Course Page", () => {
         title: "E2E Identity Redirect Course",
       });
 
-      await setupMockApis(page, {
+      await setupMockApis(authenticatedPage, {
         streamMessages: [
           { status: "started", step: "getCourseSuggestion" },
           { status: "completed", step: "getCourseSuggestion" },
@@ -283,13 +310,16 @@ test.describe("Generate Course Page", () => {
         ],
       });
 
-      await page.goto(`/generate/cs/${suggestion.id}`);
+      await authenticatedPage.goto(`/generate/cs/${suggestion.id}`);
 
-      await page.waitForURL(new RegExp(`/b/ai/c/${courseSlug}`, "u"), { timeout: 10_000 });
-      expect(page.url()).not.toContain(sourceSlug);
+      await authenticatedPage.waitForURL(new RegExp(`/b/ai/c/${courseSlug}`, "u"), {
+        timeout: 10_000,
+      });
+
+      expect(authenticatedPage.url()).not.toContain(sourceSlug);
     });
 
-    test("redirects to suffixed slug for non-English courses", async ({ page }) => {
+    test("redirects to suffixed slug for non-English courses", async ({ authenticatedPage }) => {
       const slug = `e2e-locale-${randomUUID().slice(0, 8)}`;
       const suffixedSlug = `${slug}-pt`;
       const org = await getAiOrganization();
@@ -320,7 +350,7 @@ test.describe("Generate Course Page", () => {
         }),
       ]);
 
-      await setupMockApis(page, {
+      await setupMockApis(authenticatedPage, {
         streamMessages: [
           { status: "started", step: "getCourseSuggestion" },
           { status: "completed", step: "getCourseSuggestion" },
@@ -329,15 +359,17 @@ test.describe("Generate Course Page", () => {
         ],
       });
 
-      await page.goto(`/generate/cs/${suggestion.id}`);
+      await authenticatedPage.goto(`/generate/cs/${suggestion.id}`);
 
       // Should redirect to the suffixed slug, not the raw suggestion slug
-      await page.waitForURL(new RegExp(`/b/ai/c/${suffixedSlug}`, "u"), { timeout: 10_000 });
+      await authenticatedPage.waitForURL(new RegExp(`/b/ai/c/${suffixedSlug}`, "u"), {
+        timeout: 10_000,
+      });
     });
   });
 
   test.describe("Error handling", () => {
-    test("shows error when stream returns error status", async ({ page }) => {
+    test("shows error when stream returns error status", async ({ authenticatedPage }) => {
       const suggestion = await courseSuggestionFixture({
         generationStatus: "pending",
         language: "en",
@@ -345,17 +377,19 @@ test.describe("Generate Course Page", () => {
         title: "E2E Error Handling Test",
       });
 
-      await setupMockApis(page, {
+      await setupMockApis(authenticatedPage, {
         streamMessages: [
           { status: "started", step: "getCourseSuggestion" },
           { reason: "notFound", status: "error", step: "getCourseSuggestion" },
         ],
       });
 
-      await page.goto(`/generate/cs/${suggestion.id}`);
+      await authenticatedPage.goto(`/generate/cs/${suggestion.id}`);
 
       // Should show error message when a step errors
-      await expect(page.getByText(/something went wrong/iu)).toBeVisible({ timeout: 10_000 });
+      await expect(authenticatedPage.getByText(/something went wrong/iu)).toBeVisible({
+        timeout: 10_000,
+      });
     });
   });
 

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -216,7 +216,9 @@ test.describe("Generate Course Page", () => {
   });
 
   test.describe("Workflow completion and redirect", () => {
-    test("redirects to linked completed course without starting generation", async ({ page }) => {
+    test("redirects to linked completed course without starting generation", async ({
+      authenticatedPage,
+    }) => {
       const sourceSlug = `e2e-linked-source-${randomUUID().slice(0, 8)}`;
       const courseSlug = `e2e-linked-course-${randomUUID().slice(0, 8)}`;
 
@@ -234,13 +236,15 @@ test.describe("Generate Course Page", () => {
         title: "E2E Linked Completed Suggestion",
       });
 
-      await page.route("**/v1/workflows/course-generation/**", async (route) => {
+      await authenticatedPage.route("**/v1/workflows/course-generation/**", async (route) => {
         throw new Error(`Generation workflow should not start: ${route.request().url()}`);
       });
 
-      await page.goto(`/generate/cs/${suggestion.id}`);
+      await authenticatedPage.goto(`/generate/cs/${suggestion.id}`);
 
-      await page.waitForURL(new RegExp(`/b/ai/c/${courseSlug}`, "u"), { timeout: 10_000 });
+      await authenticatedPage.waitForURL(new RegExp(`/b/ai/c/${courseSlug}`, "u"), {
+        timeout: 10_000,
+      });
     });
 
     test("shows completion state and redirects to course page", async ({ authenticatedPage }) => {
@@ -394,14 +398,14 @@ test.describe("Generate Course Page", () => {
   });
 
   test.describe("Not found", () => {
-    test("invalid suggestion ID shows 404 page", async ({ page }) => {
-      await page.goto("/generate/cs/999999");
-      await expect(page.getByText(/not found|404/iu)).toBeVisible();
+    test("invalid suggestion ID shows 404 page", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/generate/cs/999999");
+      await expect(authenticatedPage.getByText(/not found|404/iu)).toBeVisible();
     });
 
-    test("non-numeric suggestion ID shows 404 page", async ({ page }) => {
-      await page.goto("/generate/cs/invalid-id");
-      await expect(page.getByText(/not found|404/iu)).toBeVisible();
+    test("non-numeric suggestion ID shows 404 page", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/generate/cs/invalid-id");
+      await expect(authenticatedPage.getByText(/not found|404/iu)).toBeVisible();
     });
   });
 });

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -258,6 +258,27 @@ test.describe("Generate Lesson Page - No Subscription", () => {
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
+
+  test("allows signed-in users to retry failed generation without subscription", async ({
+    authenticatedPage,
+  }) => {
+    const { lesson } = await createPendingLesson(1);
+
+    await prisma.lesson.update({ data: { generationStatus: "failed" }, where: { id: lesson.id } });
+
+    await setupMockApis(authenticatedPage, {
+      statusDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getLesson" }],
+    });
+
+    await authenticatedPage.goto(`/generate/l/${lesson.id}`);
+
+    await expect(authenticatedPage.getByText(/upgrade to create/iu)).toHaveCount(0);
+
+    await expect(
+      authenticatedPage.getByRole("heading", { name: lesson.title ?? "" }),
+    ).toBeVisible();
+  });
 });
 
 test.describe("Generate Lesson Page - First Chapter Free", () => {

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -16,7 +16,7 @@ import { expect, test } from "./fixtures";
  * The generation page has 4 access states:
  * 1. Unauthenticated later chapter - Shows login prompt
  * 2. Authenticated later chapter without subscription - Shows upgrade CTA
- * 3. First chapter or running generation - Shows generation UI without gating
+ * 3. Authenticated first chapter - Shows generation UI without subscription
  * 4. Authenticated with subscription - Shows generation UI
  *
  * The generation flow interacts with 2 APIs on the API server:
@@ -261,27 +261,16 @@ test.describe("Generate Lesson Page - No Subscription", () => {
 });
 
 test.describe("Generate Lesson Page - First Chapter Free", () => {
-  test("unauthenticated user sees generation UI for first chapter lesson", async ({ page }) => {
-    const { chapter, course, lesson } = await createPendingLesson(0);
-
-    await setupMockApis(page, {
-      statusDelayMs: 2500,
-      streamMessages: [{ status: "started", step: "getLesson" }],
-    });
+  test("unauthenticated user sees login prompt for first chapter lesson", async ({ page }) => {
+    const { lesson } = await createPendingLesson(0);
 
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toHaveCount(0);
-    await expect(page.getByText(/upgrade to create/iu)).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: lesson.title ?? "" })).toBeVisible();
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
 
-    const exitLink = page.getByRole("link", { name: /back to chapter/iu });
-    await expect(exitLink).toBeVisible();
-
-    await expect(exitLink).toHaveAttribute(
-      "href",
-      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`,
-    );
+    const loginLink = page.getByRole("link", { name: /login/iu });
+    await expect(loginLink).toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
   });
 
   test("authenticated user without subscription sees generation UI for first chapter lesson", async ({
@@ -305,23 +294,33 @@ test.describe("Generate Lesson Page - First Chapter Free", () => {
 });
 
 test.describe("Generate Lesson Page - Prerequisites", () => {
-  test("links to the required explanation when practice is blocked", async ({ page }) => {
+  test("links to the required explanation when practice is blocked", async ({
+    authenticatedPage,
+  }) => {
     const { explanation, practice } = await createBlockedPracticeLesson();
 
-    await page.goto(`/generate/l/${practice.id}`);
+    await authenticatedPage.goto(`/generate/l/${practice.id}`);
 
-    await expect(page.getByRole("heading", { name: practice.title ?? "" })).toBeVisible();
-    await expect(page.getByText("Lesson locked")).toBeVisible();
-    await expect(page.getByText("Create the required lesson first.")).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("heading", { name: practice.title ?? "" }),
+    ).toBeVisible();
 
-    const requiredLessonLink = page.getByRole("link", { name: "Open required lesson" });
+    await expect(authenticatedPage.getByText("Lesson locked")).toBeVisible();
+    await expect(authenticatedPage.getByText("Create the required lesson first.")).toBeVisible();
+
+    const requiredLessonLink = authenticatedPage.getByRole("link", {
+      name: "Open required lesson",
+    });
+
     await expect(requiredLessonLink).toBeVisible();
     await expect(requiredLessonLink).toHaveAttribute("href", `/generate/l/${explanation.id}`);
   });
 });
 
 test.describe("Generate Lesson Page - With Subscription", () => {
-  test("shows completion UI before redirecting when lesson is already ready", async ({ page }) => {
+  test("shows completion UI before redirecting when lesson is already ready", async ({
+    authenticatedPage,
+  }) => {
     const { lesson } = await createPendingLesson();
     const uniqueId = randomUUID().slice(0, 8);
 
@@ -339,14 +338,15 @@ test.describe("Generate Lesson Page - With Subscription", () => {
       prisma.lesson.update({ data: { generationStatus: "completed" }, where: { id: lesson.id } }),
     ]);
 
-    await page.goto(`/generate/l/${lesson.id}`);
+    await authenticatedPage.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByText(/your lesson is ready/iu)).toBeVisible();
-    await expect(page.getByText(/taking you to your lesson/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/your lesson is ready/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/taking you to your lesson/iu)).toBeVisible();
 
-    await page.waitForURL(new RegExp(`/b/${AI_ORG_SLUG}/c/.+/ch/.+/l/${lesson.slug}`, "u"), {
-      timeout: 10_000,
-    });
+    await authenticatedPage.waitForURL(
+      new RegExp(`/b/${AI_ORG_SLUG}/c/.+/ch/.+/l/${lesson.slug}`, "u"),
+      { timeout: 10_000 },
+    );
   });
 
   test("shows generation UI and completes workflow", async ({
@@ -442,8 +442,8 @@ test.describe("Generate Lesson Page - With Subscription", () => {
   });
 });
 
-test.describe("Generate Lesson Page - Running Generation Bypasses Auth", () => {
-  test("unauthenticated user sees generation UI when status is running", async ({ page }) => {
+test.describe("Generate Lesson Page - Running Generation Requires Auth", () => {
+  test("unauthenticated user sees login prompt when status is running", async ({ page }) => {
     const org = await getAiOrganization();
     const uniqueId = randomUUID().slice(0, 8);
 
@@ -478,16 +478,13 @@ test.describe("Generate Lesson Page - Running Generation Bypasses Auth", () => {
       title: lessonTitle,
     });
 
-    await setupMockApis(page, {
-      statusDelayMs: 2500,
-      streamMessages: [{ status: "started", step: "getLesson" }],
-    });
-
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toHaveCount(0);
-    await expect(page.getByText(/upgrade to create/iu)).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: lessonTitle })).toBeVisible();
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+
+    const loginLink = page.getByRole("link", { name: /login/iu });
+    await expect(loginLink).toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
   });
 });
 

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -25,7 +25,8 @@ test.describe("Home Page - Unauthenticated", () => {
 
     await hero.getByRole("link", { exact: true, name: "Create a course with AI" }).click();
 
-    await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();
+    await expect(page).toHaveURL(/\/learn$/u);
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
   });
 
   test("does not show progress section", async ({ page }) => {

--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -80,19 +80,23 @@ test.beforeAll(async () => {
 });
 
 test.describe("Learn Form", () => {
-  test("shows form with auto-focused input", async ({ page }) => {
-    await page.goto("/learn");
+  test("shows form with auto-focused input", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/learn");
 
-    await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("heading", { name: /learn anything/iu }),
+    ).toBeVisible();
 
-    const input = page.getByRole("textbox");
+    const input = authenticatedPage.getByRole("textbox");
     await expect(input).toBeFocused();
   });
 
-  test("clicking a suggestion link navigates to the subject page", async ({ page }) => {
-    await page.goto("/learn");
+  test("clicking a suggestion link navigates to the subject page", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/learn");
 
-    const suggestions = page.getByRole("navigation", { name: /suggested subjects/iu });
+    const suggestions = authenticatedPage.getByRole("navigation", { name: /suggested subjects/iu });
     const firstLink = suggestions.getByRole("link").first();
     const subject = await firstLink.textContent();
 
@@ -103,54 +107,83 @@ test.describe("Learn Form", () => {
     await ensureSuggestionsForPrompt(subject);
     await firstLink.click();
 
-    await expect(page).toHaveURL(/\/learn\/.+/u);
+    await expect(authenticatedPage).toHaveURL(/\/learn\/.+/u);
   });
 
-  test("submitting prompt navigates to suggestions page", async ({ page }) => {
+  test("submitting prompt navigates signed-in users to suggestions page", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto("/learn");
+
+    await authenticatedPage.getByRole("textbox").fill(prompt);
+    await authenticatedPage.keyboard.press("Enter");
+
+    await expect(
+      authenticatedPage.getByRole("heading", { name: /course ideas for/iu }),
+    ).toBeVisible();
+  });
+
+  test("shows login prompt for unauthenticated users", async ({ page }) => {
     await page.goto("/learn");
 
-    await page.getByRole("textbox").fill(prompt);
-    await page.keyboard.press("Enter");
-
-    await expect(page.getByRole("heading", { name: /course ideas for/iu })).toBeVisible();
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+    await expect(page.getByRole("link", { name: /login/iu })).toBeVisible();
   });
 });
 
 test.describe("Course Suggestions", () => {
-  test("shows suggestions with title, description, and generate link", async ({ page }) => {
+  test("shows login prompt for unauthenticated users", async ({ page }) => {
     await page.goto(`/learn/${encodeURIComponent(prompt)}`);
 
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+  });
+
+  test("shows suggestions with title, description, and generate link", async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto(`/learn/${encodeURIComponent(prompt)}`);
+
     await expect(
-      page.getByRole("heading", { name: new RegExp(`course ideas for ${prompt}`, "iu") }),
+      authenticatedPage.getByRole("heading", {
+        name: new RegExp(`course ideas for ${prompt}`, "iu"),
+      }),
     ).toBeVisible();
 
-    await expect(page.getByText(suggestionTitle)).toBeVisible();
-    await expect(page.getByText(suggestionDescription)).toBeVisible();
+    await expect(authenticatedPage.getByText(suggestionTitle)).toBeVisible();
+    await expect(authenticatedPage.getByText(suggestionDescription)).toBeVisible();
 
-    const generateLinks = page.getByRole("link", { name: /create/iu });
+    const generateLinks = authenticatedPage.getByRole("link", { name: /create/iu });
     await expect(generateLinks.first()).toBeVisible();
   });
 
-  test("Generate link navigates to generate page", async ({ page }) => {
-    await mockCourseGenerationWorkflow(page);
+  test("Generate link navigates signed-in users to generate page", async ({
+    authenticatedPage,
+  }) => {
+    await mockCourseGenerationWorkflow(authenticatedPage);
 
-    await page.goto(`/learn/${encodeURIComponent(prompt)}`);
+    await authenticatedPage.goto(`/learn/${encodeURIComponent(prompt)}`);
 
-    await expect(page.getByRole("heading", { name: /course ideas for/iu })).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("heading", { name: /course ideas for/iu }),
+    ).toBeVisible();
 
-    const generateLink = page.getByRole("link", { name: /create/iu }).first();
+    const generateLink = authenticatedPage.getByRole("link", { name: /create/iu }).first();
     await generateLink.click();
 
-    await expect(page).toHaveURL(/\/generate\/cs\/\d+/u);
+    await expect(authenticatedPage).toHaveURL(/\/generate\/cs\/[-a-f0-9]+/u);
   });
 
-  test("Change subject navigates back to learn form", async ({ page }) => {
-    await page.goto(`/learn/${encodeURIComponent(prompt)}`);
+  test("Change subject navigates back to learn form", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto(`/learn/${encodeURIComponent(prompt)}`);
 
-    await expect(page.getByRole("heading", { name: /course ideas for/iu })).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("heading", { name: /course ideas for/iu }),
+    ).toBeVisible();
 
-    await page.getByRole("link", { name: /change subject/iu }).click();
+    await authenticatedPage.getByRole("link", { name: /change subject/iu }).click();
 
-    await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("heading", { name: /learn anything/iu }),
+    ).toBeVisible();
   });
 });

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -9,7 +9,9 @@ import { chapterWordFixture, wordFixture } from "@zoonk/testing/fixtures/words";
 import { type Page, expect, test } from "./fixtures";
 
 async function createTestLesson(options?: {
+  chapterPosition?: number;
   generationStatus?: "pending" | "completed";
+  lessonPosition?: number;
   stepCount?: number;
 }) {
   const org = await getAiOrganization();
@@ -27,6 +29,7 @@ async function createTestLesson(options?: {
     courseId: course.id,
     isPublished: true,
     organizationId: org.id,
+    ...(options?.chapterPosition === undefined ? {} : { position: options.chapterPosition }),
     slug: `e2e-lesson-chapter-${uniqueId}`,
     title: `E2E Lesson Chapter ${uniqueId}`,
   });
@@ -40,6 +43,7 @@ async function createTestLesson(options?: {
     isPublished: true,
     kind: "explanation",
     organizationId: org.id,
+    ...(options?.lessonPosition === undefined ? {} : { position: options.lessonPosition }),
     slug: `e2e-lesson-lesson-${uniqueId}`,
     title: lessonTitle,
   });
@@ -424,7 +428,7 @@ async function createDerivedListeningLesson() {
 }
 
 test.describe("Lesson Player Page", () => {
-  test("generated lesson player renders the seeded step content", async ({ page }) => {
+  test("unauthenticated users can play the first lesson of the first chapter", async ({ page }) => {
     const { chapter, course, lesson, uniqueId } = await createTestLesson({
       generationStatus: "completed",
     });
@@ -433,6 +437,21 @@ test.describe("Lesson Player Page", () => {
 
     await expect(page.getByRole("heading", { name: `Step ${uniqueId} #0` })).toBeVisible();
     await expect(page.getByText(`Test step content ${uniqueId} #0`)).toBeVisible();
+  });
+
+  test("unauthenticated users see login prompt for later lessons", async ({ page }) => {
+    const { chapter, course, lesson } = await createTestLesson({
+      generationStatus: "completed",
+      lessonPosition: 1,
+    });
+
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+
+    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+
+    const loginLink = page.getByRole("link", { name: /login/iu });
+    await expect(loginLink).toBeVisible();
+    await expect(loginLink).toHaveAttribute("href", "/login");
   });
 
   test("close link has correct href", async ({ page }) => {
@@ -468,82 +487,98 @@ test.describe("Lesson Player Page", () => {
   });
 
   test("blocked practice lessons link to the required explanation generation page", async ({
-    page,
+    authenticatedPage,
   }) => {
     const { chapter, course, explanation, practice } = await createBlockedPracticeLesson();
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${practice.slug}`);
+    await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${practice.slug}`);
 
-    await expect(page.getByText("Lesson locked")).toBeVisible();
-    await expect(page.getByText("Create the required lesson first.")).toBeVisible();
+    await expect(authenticatedPage.getByText("Lesson locked")).toBeVisible();
+    await expect(authenticatedPage.getByText("Create the required lesson first.")).toBeVisible();
 
-    const requiredLessonLink = page.getByRole("link", { name: "Open required lesson" });
+    const requiredLessonLink = authenticatedPage.getByRole("link", {
+      name: "Open required lesson",
+    });
+
     await expect(requiredLessonLink).toBeVisible();
     await expect(requiredLessonLink).toHaveAttribute("href", `/generate/l/${explanation.id}`);
     await expect(requiredLessonLink).toHaveAttribute("rel", "nofollow");
   });
 
   test("empty review lessons link to the first earlier lesson that needs generation", async ({
-    page,
+    authenticatedPage,
   }) => {
     const { chapter, course, requiredLesson, review } = await createEmptyReviewLesson();
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${review.slug}`);
+    await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${review.slug}`);
 
-    await expect(page.getByText("Review locked")).toBeVisible();
+    await expect(authenticatedPage.getByText("Review locked")).toBeVisible();
 
     await expect(
-      page.getByText("Create earlier lessons first, then come back to review."),
+      authenticatedPage.getByText("Create earlier lessons first, then come back to review."),
     ).toBeVisible();
 
-    const requiredLessonLink = page.getByRole("link", { name: "Open required lesson" });
+    const requiredLessonLink = authenticatedPage.getByRole("link", {
+      name: "Open required lesson",
+    });
+
     await expect(requiredLessonLink).toBeVisible();
     await expect(requiredLessonLink).toHaveAttribute("href", `/generate/l/${requiredLesson.id}`);
     await expect(requiredLessonLink).toHaveAttribute("rel", "nofollow");
   });
 
-  test("derived translation lessons show source vocabulary distractors", async ({ page }) => {
+  test("derived translation lessons show source vocabulary distractors", async ({
+    authenticatedPage,
+  }) => {
     const { correctOption, distractorOption, prompt, url } = await createDerivedTranslationLesson();
 
-    await page.goto(url);
+    await authenticatedPage.goto(url);
 
-    await expect(page.getByText(prompt)).toBeVisible();
+    await expect(authenticatedPage.getByText(prompt)).toBeVisible();
 
-    const options = page.getByRole("radiogroup", { name: /answer options/iu });
+    const options = authenticatedPage.getByRole("radiogroup", { name: /answer options/iu });
     await expect(options.getByRole("radio", { name: correctOption })).toBeVisible();
     await expect(options.getByRole("radio", { name: distractorOption })).toBeVisible();
   });
 
-  test("derived listening lessons show source reading word banks", async ({ page }) => {
+  test("derived listening lessons show source reading word banks", async ({
+    authenticatedPage,
+  }) => {
     const { distractor, firstWord, secondWord, url } = await createDerivedListeningLesson();
 
-    await page.goto(url);
+    await authenticatedPage.goto(url);
 
-    const wordBank = page.getByRole("group", { name: /word bank/iu });
+    const wordBank = authenticatedPage.getByRole("group", { name: /word bank/iu });
     await expect(wordBank.getByRole("button", { name: firstWord })).toBeVisible();
     await expect(wordBank.getByRole("button", { name: secondWord })).toBeVisible();
     await expect(wordBank.getByRole("button", { name: distractor })).toBeVisible();
   });
 
-  test("review translation steps show source vocabulary distractors", async ({ page }) => {
+  test("review translation steps show source vocabulary distractors", async ({
+    authenticatedPage,
+  }) => {
     const { correctOption, distractorOption, prompt, reviewUrl } =
       await createDerivedTranslationLesson();
 
-    await page.goto(reviewUrl);
+    await authenticatedPage.goto(reviewUrl);
 
-    await showReviewTranslationStep({ page, prompt, readingAnswer: correctOption });
+    await showReviewTranslationStep({
+      page: authenticatedPage,
+      prompt,
+      readingAnswer: correctOption,
+    });
 
-    const options = page.getByRole("radiogroup", { name: /answer options/iu });
+    const options = authenticatedPage.getByRole("radiogroup", { name: /answer options/iu });
     await expect(options.getByRole("radio", { name: correctOption })).toBeVisible();
     await expect(options.getByRole("radio", { name: distractorOption })).toBeVisible();
   });
 
-  test("review listening steps show source reading word banks", async ({ page }) => {
+  test("review listening steps show source reading word banks", async ({ authenticatedPage }) => {
     const { distractor, firstWord, reviewUrl, secondWord } = await createDerivedListeningLesson();
 
-    await page.goto(reviewUrl);
+    await authenticatedPage.goto(reviewUrl);
 
-    const wordBank = page.getByRole("group", { name: /word bank/iu });
+    const wordBank = authenticatedPage.getByRole("group", { name: /word bank/iu });
     await expect(wordBank.getByRole("button", { name: firstWord })).toBeVisible();
     await expect(wordBank.getByRole("button", { name: secondWord })).toBeVisible();
     await expect(wordBank.getByRole("button", { name: distractor })).toBeVisible();
@@ -614,7 +649,7 @@ test.describe("Lesson Player Page", () => {
     await expect(page).toHaveTitle(new RegExp(lessonTitle, "u"));
   });
 
-  test("page title describes lessons without a stored title", async ({ page }) => {
+  test("page title describes lessons without a stored title", async ({ authenticatedPage }) => {
     const org = await getAiOrganization();
     const uniqueId = randomUUID().slice(0, 8);
 
@@ -654,10 +689,13 @@ test.describe("Lesson Player Page", () => {
       lessonId: lesson.id,
     });
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page).toHaveTitle(new RegExp(`${chapter.title} Quiz ${lesson.position + 1}`, "u"));
-    await expect(page).not.toHaveTitle(/Quiz Quiz/u);
+    await expect(authenticatedPage).toHaveTitle(
+      new RegExp(`${chapter.title} Quiz ${lesson.position + 1}`, "u"),
+    );
+
+    await expect(authenticatedPage).not.toHaveTitle(/Quiz Quiz/u);
   });
 
   test("unpublished lesson shows 404 page", async ({ page }) => {

--- a/apps/main/e2e/review-step.test.ts
+++ b/apps/main/e2e/review-step.test.ts
@@ -305,7 +305,7 @@ async function completeRemainingReviewSteps({
 }
 
 test.describe("Review Step", () => {
-  test("complete all review steps to reach completion screen", async ({ page }) => {
+  test("complete all review steps to reach completion screen", async ({ authenticatedPage }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const completionScoreText = "5/5";
     const sentenceWord1 = `Hola-${uniqueId}`;
@@ -332,20 +332,20 @@ test.describe("Review Step", () => {
       words,
     });
 
-    await page.goto(url);
+    await authenticatedPage.goto(url);
 
     // Steps are shuffled, so complete each step by detecting its type.
     // 5 total steps: 4 vocabulary + 1 reading
     await completeRemainingReviewSteps({
       completionScoreText,
-      page,
+      page: authenticatedPage,
       remainingStepCount: 5,
       sentenceWord1,
       sentenceWord2,
       translationToWord,
     });
 
-    const completionScreen = page.getByRole("status");
+    const completionScreen = authenticatedPage.getByRole("status");
 
     await expect(completionScreen).toBeVisible();
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -387,12 +387,20 @@ msgid "47FYwb"
 msgstr "Cancel"
 
 #: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
-msgid "7x4411"
-msgstr "Course ideas for {prompt}"
-
-#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+#: src/app/generate/c/[slug]/generate-course-content.tsx
 msgid "RbslnC"
 msgstr "Change subject"
+
+#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+#: src/app/(catalog)/learn/page.tsx
+#: src/app/generate/c/[slug]/generate-course-content.tsx
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "LvUoVs"
+msgstr "Create Course"
+
+#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+msgid "7x4411"
+msgstr "Course ideas for {prompt}"
 
 #: src/app/(catalog)/learn/[prompt]/page.tsx
 msgid "CaU/nf"
@@ -413,6 +421,11 @@ msgstr "Tell Zoonk what you want to learn and get a course created with AI. Star
 #: src/app/(catalog)/learn/page.tsx
 msgid "Zs1QEq"
 msgstr "Learn Anything with AI"
+
+#: src/app/(catalog)/learn/page.tsx
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "rPgekg"
+msgstr "Back home"
 
 #: src/app/(catalog)/learn/page.tsx
 msgid "l450Bl"
@@ -993,6 +1006,7 @@ msgid "ZzznjM"
 msgstr "Create lesson"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgid "/N8rYN"
 msgstr "Back to chapter"
@@ -1105,10 +1119,6 @@ msgstr "Saving your progress..."
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JUr8Er"
 msgstr "Finishing up..."
-
-#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
-msgid "rPgekg"
-msgstr "Back home"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -387,12 +387,20 @@ msgid "47FYwb"
 msgstr "Cancelar"
 
 #: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
-msgid "7x4411"
-msgstr "Ideas de cursos para {prompt}"
-
-#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+#: src/app/generate/c/[slug]/generate-course-content.tsx
 msgid "RbslnC"
 msgstr "Cambiar tema"
+
+#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+#: src/app/(catalog)/learn/page.tsx
+#: src/app/generate/c/[slug]/generate-course-content.tsx
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "LvUoVs"
+msgstr "Crear Curso"
+
+#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+msgid "7x4411"
+msgstr "Ideas de cursos para {prompt}"
 
 #: src/app/(catalog)/learn/[prompt]/page.tsx
 msgid "CaU/nf"
@@ -413,6 +421,11 @@ msgstr "Dile a Zoonk qué quieres aprender y obtén un curso creado con IA. Empi
 #: src/app/(catalog)/learn/page.tsx
 msgid "Zs1QEq"
 msgstr "Aprende cualquier cosa con IA"
+
+#: src/app/(catalog)/learn/page.tsx
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "rPgekg"
+msgstr "Volver al inicio"
 
 #: src/app/(catalog)/learn/page.tsx
 msgid "l450Bl"
@@ -993,6 +1006,7 @@ msgid "ZzznjM"
 msgstr "Crear lección"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgid "/N8rYN"
 msgstr "Volver al capítulo"
@@ -1105,10 +1119,6 @@ msgstr "Guardando tu progreso..."
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JUr8Er"
 msgstr "Terminando..."
-
-#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
-msgid "rPgekg"
-msgstr "Volver al inicio"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -387,12 +387,20 @@ msgid "47FYwb"
 msgstr "Cancelar"
 
 #: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
-msgid "7x4411"
-msgstr "Ideias de cursos para {prompt}"
-
-#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+#: src/app/generate/c/[slug]/generate-course-content.tsx
 msgid "RbslnC"
 msgstr "Mudar assunto"
+
+#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+#: src/app/(catalog)/learn/page.tsx
+#: src/app/generate/c/[slug]/generate-course-content.tsx
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "LvUoVs"
+msgstr "Criar Curso"
+
+#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+msgid "7x4411"
+msgstr "Ideias de cursos para {prompt}"
 
 #: src/app/(catalog)/learn/[prompt]/page.tsx
 msgid "CaU/nf"
@@ -413,6 +421,11 @@ msgstr "Conte ao Zoonk o que você quer aprender e receba um curso criado com IA
 #: src/app/(catalog)/learn/page.tsx
 msgid "Zs1QEq"
 msgstr "Aprenda qualquer coisa com IA"
+
+#: src/app/(catalog)/learn/page.tsx
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "rPgekg"
+msgstr "Voltar para o início"
 
 #: src/app/(catalog)/learn/page.tsx
 msgid "l450Bl"
@@ -993,6 +1006,7 @@ msgid "ZzznjM"
 msgstr "Criar aula"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
 msgid "/N8rYN"
 msgstr "Voltar para o capítulo"
@@ -1105,10 +1119,6 @@ msgstr "Salvando seu progresso..."
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JUr8Er"
 msgstr "Finalizando..."
-
-#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
-msgid "rPgekg"
-msgstr "Voltar para o início"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"

--- a/apps/main/src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+++ b/apps/main/src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
@@ -1,3 +1,4 @@
+import { LoginRequired } from "@/components/auth/login-required";
 import { ContentFeedback } from "@/components/feedback/content-feedback";
 import { generateCourseSuggestions } from "@/data/courses/course-suggestions";
 import { getSession } from "@zoonk/core/users/session/get";
@@ -17,11 +18,15 @@ import { CourseSuggestionItem } from "./course-suggestion-item";
 export async function CourseSuggestions({ prompt }: { prompt: string }) {
   const locale = await getLocale();
   const t = await getExtracted();
+  const session = await getSession();
 
-  const [session, { suggestions }] = await Promise.all([
-    getSession(),
-    generateCourseSuggestions({ language: locale, prompt }),
-  ]);
+  if (!session) {
+    return (
+      <LoginRequired backHref="/learn" backLabel={t("Change subject")} title={t("Create Course")} />
+    );
+  }
+
+  const { suggestions } = await generateCourseSuggestions({ language: locale, prompt });
 
   return (
     <Container variant="narrow">

--- a/apps/main/src/app/(catalog)/learn/page.tsx
+++ b/apps/main/src/app/(catalog)/learn/page.tsx
@@ -1,3 +1,5 @@
+import { LoginRequired } from "@/components/auth/login-required";
+import { getSession } from "@zoonk/core/users/session/get";
 import { shuffle } from "@zoonk/utils/shuffle";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
@@ -19,6 +21,11 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Learn() {
   const t = await getExtracted();
+  const session = await getSession();
+
+  if (!session) {
+    return <LoginRequired backHref="/" backLabel={t("Back home")} title={t("Create Course")} />;
+  }
 
   const allSuggestions = [
     t("Computer Science"),

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -1,3 +1,4 @@
+import { LoginRequired } from "@/components/auth/login-required";
 import { getLesson as getCatalogLesson } from "@/data/lessons/get-lesson";
 import { getLessonDisplayMeta, getLessonSeoMeta } from "@/lib/lessons";
 import { getBlockingLessonGenerationPrerequisite } from "@zoonk/core/lessons/generation-prerequisites";
@@ -15,6 +16,7 @@ import { getTotalBrainPower } from "@zoonk/core/player/queries/get-total-brain-p
 import { getSession } from "@zoonk/core/users/session/get";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Metadata } from "next";
+import { getExtracted } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { after } from "next/server";
 import { fetchReviewLessonData } from "./lesson-data-loaders";
@@ -23,6 +25,69 @@ import { LessonPlayerClient } from "./lesson-player-client";
 import { ReviewLessonEmpty } from "./review-lesson-empty";
 
 type Props = PageProps<"/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">;
+type LessonShell = NonNullable<Awaited<ReturnType<typeof getCatalogLesson>>>;
+type LessonSession = Awaited<ReturnType<typeof getSession>>;
+type PlayerLesson = NonNullable<Awaited<ReturnType<typeof getPlayerLesson>>>;
+
+/**
+ * The public lesson preview is intentionally only the first lesson in the
+ * first chapter. Later lessons may include progression-dependent review,
+ * preload, and completion behavior, so anonymous learners need to sign in
+ * before the player loads them.
+ */
+function canPlayWithoutSession(lesson: { position: number; chapter: { position: number } }) {
+  return lesson.chapter.position === 0 && lesson.position === 0;
+}
+
+/**
+ * Keeps anonymous users out of player-only queries unless they are opening the
+ * public preview lesson. The login wall needs the lesson title, so this lives
+ * beside the route instead of inside a generic auth component.
+ */
+async function getAnonymousLessonGate({
+  brandSlug,
+  chapterSlug,
+  courseSlug,
+  lesson,
+  session,
+}: {
+  brandSlug: string;
+  chapterSlug: string;
+  courseSlug: string;
+  lesson: LessonShell;
+  session: LessonSession;
+}) {
+  if (session || canPlayWithoutSession(lesson)) {
+    return null;
+  }
+
+  const backHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}` as const;
+  const lessonMeta = await getLessonDisplayMeta(lesson);
+  const t = await getExtracted();
+
+  return (
+    <LoginRequired backHref={backHref} backLabel={t("Back to chapter")} title={lessonMeta.title} />
+  );
+}
+
+/**
+ * Generation recovery links only apply to AI-owned lessons. Courses from other
+ * organizations can still show the not-generated state, but they should not
+ * expose AI generation prerequisite links.
+ */
+async function getAiBlockingLessonGenerationPrerequisite({
+  brandSlug,
+  lesson,
+}: {
+  brandSlug: string;
+  lesson: PlayerLesson;
+}) {
+  if (brandSlug !== AI_ORG_SLUG) {
+    return null;
+  }
+
+  return getBlockingLessonGenerationPrerequisite(lesson);
+}
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { brandSlug, chapterSlug, courseSlug, lessonSlug } = await params;
@@ -44,31 +109,45 @@ export default async function LessonPage({ params }: Props) {
     notFound();
   }
 
-  const [lesson, nextChapter, nextLesson, session, reviewLessonData, totalBrainPower] =
-    await Promise.all([
-      getPlayerLesson({ lessonId: lessonShell.id }),
-      getNextChapterInCourse({
-        chapterPosition: lessonShell.chapter.position,
-        courseId: lessonShell.chapter.course.id,
-      }),
-      getNextLessonInCourse({
-        chapterId: lessonShell.chapter.id,
-        chapterPosition: lessonShell.chapter.position,
-        courseId: lessonShell.chapter.course.id,
-        lessonPosition: lessonShell.position,
-      }),
-      getSession(),
-      fetchReviewLessonData(lessonShell.id),
-      getTotalBrainPower(),
-    ]);
+  const session = await getSession();
+
+  const anonymousGate = await getAnonymousLessonGate({
+    brandSlug,
+    chapterSlug,
+    courseSlug,
+    lesson: lessonShell,
+    session,
+  });
+
+  if (anonymousGate) {
+    return anonymousGate;
+  }
+
+  const [lesson, nextChapter, nextLesson, reviewLessonData, totalBrainPower] = await Promise.all([
+    getPlayerLesson({ lessonId: lessonShell.id }),
+    getNextChapterInCourse({
+      chapterPosition: lessonShell.chapter.position,
+      courseId: lessonShell.chapter.course.id,
+    }),
+    getNextLessonInCourse({
+      chapterId: lessonShell.chapter.id,
+      chapterPosition: lessonShell.chapter.position,
+      courseId: lessonShell.chapter.course.id,
+      lessonPosition: lessonShell.position,
+    }),
+    fetchReviewLessonData(lessonShell.id),
+    getTotalBrainPower(),
+  ]);
 
   if (!lesson) {
     notFound();
   }
 
   if (lesson.generationStatus !== "completed") {
-    const blockingPrerequisite =
-      brandSlug === AI_ORG_SLUG ? await getBlockingLessonGenerationPrerequisite(lesson) : null;
+    const blockingPrerequisite = await getAiBlockingLessonGenerationPrerequisite({
+      brandSlug,
+      lesson,
+    });
 
     return (
       <main className="flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center p-4">

--- a/apps/main/src/app/generate/c/[slug]/generate-course-content.tsx
+++ b/apps/main/src/app/generate/c/[slug]/generate-course-content.tsx
@@ -1,10 +1,21 @@
+import { LoginRequired } from "@/components/auth/login-required";
 import { getCourseSuggestionBySlug } from "@/data/courses/course-suggestions";
+import { getSession } from "@zoonk/core/users/session/get";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { getLocale } from "next-intl/server";
+import { getExtracted, getLocale } from "next-intl/server";
 import { notFound, redirect } from "next/navigation";
 
 export async function GenerateCourseContent({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
+  const t = await getExtracted();
+  const session = await getSession();
+
+  if (!session) {
+    return (
+      <LoginRequired backHref="/learn" backLabel={t("Change subject")} title={t("Create Course")} />
+    );
+  }
+
   const locale = await getLocale();
 
   const suggestion = await getCourseSuggestionBySlug({ language: locale, slug });

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -31,6 +31,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
   const bypassSubscription =
     isFirstChapter ||
     chapter.generationStatus === "running" ||
+    chapter.generationStatus === "failed" ||
     chapter.generationStatus === "completed";
 
   const t = await getExtracted();

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -26,9 +26,13 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
     notFound();
   }
 
-  const hasStarted = chapter.generationStatus !== "pending";
   const isFirstChapter = chapter.position === 0;
-  const bypassAuth = isFirstChapter || hasStarted;
+
+  const bypassSubscription =
+    isFirstChapter ||
+    chapter.generationStatus === "running" ||
+    chapter.generationStatus === "completed";
+
   const t = await getExtracted();
 
   const backHref = `/b/${AI_ORG_SLUG}/c/${chapter.course.slug}` as const;
@@ -39,7 +43,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
     isReadyForRedirect: chapter._count.lessons > 0,
   });
 
-  if (!session && !bypassAuth) {
+  if (!session) {
     return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Chapter")} />;
   }
 
@@ -55,7 +59,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={bypassAuth}>
+        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={bypassSubscription}>
           <GenerationClient
             chapterId={id}
             chapterSlug={chapter.slug}

--- a/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
@@ -1,8 +1,10 @@
+import { LoginRequired } from "@/components/auth/login-required";
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import {
   getCourseSuggestionById,
   getLinkedCourseForSuggestion,
 } from "@/data/courses/course-suggestions";
+import { getSession } from "@zoonk/core/users/session/get";
 import {
   Container,
   ContainerBody,
@@ -38,6 +40,11 @@ export async function GenerateCourseSuggestionContent({
   }
 
   const t = await getExtracted();
+  const session = await getSession();
+
+  if (!session) {
+    return <LoginRequired backHref="/" backLabel={t("Back home")} title={t("Create Course")} />;
+  }
 
   return (
     <Container variant="narrow">

--- a/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
@@ -27,6 +27,13 @@ export async function GenerateCourseSuggestionContent({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const t = await getExtracted();
+  const session = await getSession();
+
+  if (!session) {
+    return <LoginRequired backHref="/" backLabel={t("Back home")} title={t("Create Course")} />;
+  }
+
   const suggestion = await getCourseSuggestionById(id);
 
   if (!suggestion) {
@@ -37,13 +44,6 @@ export async function GenerateCourseSuggestionContent({
 
   if (linkedCourse?.generationStatus === "completed") {
     redirect(`/b/${AI_ORG_SLUG}/c/${linkedCourse.slug}`);
-  }
-
-  const t = await getExtracted();
-  const session = await getSession();
-
-  if (!session) {
-    return <LoginRequired backHref="/" backLabel={t("Back home")} title={t("Create Course")} />;
   }
 
   return (

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -54,10 +54,24 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
     notFound();
   }
 
-  const hasStarted = lesson.generationStatus !== "pending";
   const isFirstChapter = lesson.chapter.position === 0;
-  const bypassAuth = isFirstChapter || hasStarted;
+
+  const bypassSubscription =
+    isFirstChapter ||
+    lesson.generationStatus === "running" ||
+    lesson.generationStatus === "completed";
+
   const t = await getExtracted();
+
+  const backHref =
+    `/b/${AI_ORG_SLUG}/c/${lesson.chapter.course.slug}/ch/${lesson.chapter.slug}` as const;
+
+  const backLabel = t("Back to chapter");
+
+  if (!session) {
+    return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Lesson")} />;
+  }
+
   const lessonMeta = await getLessonDisplayMeta(lesson);
 
   const blockingPrerequisite = shouldCheckGenerationPrerequisites({
@@ -65,11 +79,6 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
   })
     ? await getBlockingLessonGenerationPrerequisite(lesson)
     : null;
-
-  const backHref =
-    `/b/${AI_ORG_SLUG}/c/${lesson.chapter.course.slug}/ch/${lesson.chapter.slug}` as const;
-
-  const backLabel = t("Back to chapter");
 
   const initialStatus = getInitialGenerationPageStatus({
     generationStatus: lesson.generationStatus,
@@ -116,10 +125,6 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
     );
   }
 
-  if (!session && !bypassAuth) {
-    return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Lesson")} />;
-  }
-
   return (
     <Container variant="narrow">
       <ContainerHeader>
@@ -130,7 +135,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={bypassAuth}>
+        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={bypassSubscription}>
           <GenerationClient
             chapterSlug={lesson.chapter.slug}
             courseSlug={lesson.chapter.course.slug}

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -59,6 +59,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
   const bypassSubscription =
     isFirstChapter ||
     lesson.generationStatus === "running" ||
+    lesson.generationStatus === "failed" ||
     lesson.generationStatus === "completed";
 
   const t = await getExtracted();


### PR DESCRIPTION
## Summary

- Require login before course suggestion, course, chapter, and lesson generation surfaces can start generation
- Enforce authentication on API workflow trigger endpoints while keeping feedback public
- Keep anonymous lesson playback limited to the first lesson of the first chapter

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require login for Learn, course suggestions, and all generation pages; workflow trigger APIs now return 401 for anonymous requests. Anonymous lesson playback remains limited to the first lesson of the first chapter; later lessons prompt login.

- **New Features**
  - Learn and course suggestions require sign-in; show LoginRequired with back links.
  - Generation pages for course, chapter, and lesson require sign-in; signed-in first-chapter content and running/failed/completed generations bypass subscription (retry/resume supported).
  - Lesson player allows anonymous users to play only the first lesson of the first chapter; later lessons prompt login.
  - API: `/v1/workflows/*/trigger` endpoints enforce authentication before subscription checks; OpenAPI notes “Requires authentication” and documents 401 responses.

- **Refactors**
  - Added `getWorkflowAuthenticationError` and `getWorkflowSubscriptionAccessError`; trigger routes updated to use these.
  - Introduced API test auth helpers to create real sessions/subscriptions; e2e tests now use authenticated contexts and assert 401 for anonymous calls; test routes aligned to `/v1/workflows/*`.
  - Updated UI copy and messages.

<sup>Written for commit 1c0c06261e776a9a5a9024879dc3132789d3b61d. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1556?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

