### PR TITLE
fix(main): restore explore courses hero link

### DIFF
--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -18,10 +18,13 @@ test.describe("Home Page - Unauthenticated", () => {
 
     await expect(hero.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
 
-    const loginLink = hero.getByRole("link", { name: "Log in to save your progress" });
+    const exploreCoursesLink = hero.getByRole("link", { name: "Explore courses" });
 
-    await expect(hero.getByRole("link", { name: "Explore courses" })).not.toBeVisible();
-    await expect(loginLink).toHaveAttribute("href", "/login");
+    await expect(exploreCoursesLink).toHaveAttribute("href", "/courses");
+
+    await expect(
+      hero.getByRole("link", { name: "Log in to save your progress" }),
+    ).not.toBeVisible();
 
     await hero.getByRole("link", { exact: true, name: "Create a course with AI" }).click();
 
@@ -60,6 +63,8 @@ test.describe("Home Page - Authenticated", () => {
     await expect(
       userWithoutProgress.getByRole("heading", { name: /learn anything with ai/iu }),
     ).toBeVisible();
+
+    await expect(userWithoutProgress.getByRole("link", { name: "Explore courses" })).toBeVisible();
 
     await expect(
       userWithoutProgress.getByRole("link", { name: "Log in to save your progress" }),

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -213,8 +213,10 @@ msgid "jHCDDq"
 msgstr "Create a course with AI"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "M8B177"
-msgstr "Log in to save your progress"
+#: src/app/(catalog)/courses/page.tsx
+#: src/app/(catalog)/my/user-course-list.tsx
+msgid "s+Ncqj"
+msgstr "Explore courses"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
@@ -359,11 +361,6 @@ msgstr "Explore all Zoonk courses to learn anything using AI. Find interactive l
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
 msgstr "Online Courses using AI"
-
-#: src/app/(catalog)/courses/page.tsx
-#: src/app/(catalog)/my/user-course-list.tsx
-msgid "s+Ncqj"
-msgstr "Explore courses"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -213,8 +213,10 @@ msgid "jHCDDq"
 msgstr "Crear un curso con IA"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "M8B177"
-msgstr "Iniciar sesión para guardar tu progreso"
+#: src/app/(catalog)/courses/page.tsx
+#: src/app/(catalog)/my/user-course-list.tsx
+msgid "s+Ncqj"
+msgstr "Explorar cursos"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
@@ -359,11 +361,6 @@ msgstr "Explora todos los cursos de Zoonk para aprender cualquier cosa usando IA
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
 msgstr "Cursos en línea con IA"
-
-#: src/app/(catalog)/courses/page.tsx
-#: src/app/(catalog)/my/user-course-list.tsx
-msgid "s+Ncqj"
-msgstr "Explorar cursos"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -213,8 +213,10 @@ msgid "jHCDDq"
 msgstr "Criar um curso com IA"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "M8B177"
-msgstr "Entrar para salvar seu progresso"
+#: src/app/(catalog)/courses/page.tsx
+#: src/app/(catalog)/my/user-course-list.tsx
+msgid "s+Ncqj"
+msgstr "Explorar cursos"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
@@ -359,11 +361,6 @@ msgstr "Explore todos os cursos do Zoonk para aprender qualquer coisa usando IA.
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
 msgstr "Cursos online usando IA"
-
-#: src/app/(catalog)/courses/page.tsx
-#: src/app/(catalog)/my/user-course-list.tsx
-msgid "s+Ncqj"
-msgstr "Explorar cursos"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"

--- a/apps/main/src/app/(catalog)/(home)/hero.tsx
+++ b/apps/main/src/app/(catalog)/(home)/hero.tsx
@@ -1,15 +1,13 @@
-import { getSession } from "@zoonk/core/users/session/get";
 import { buttonVariants } from "@zoonk/ui/components/button";
-import { SparklesIcon } from "lucide-react";
+import { ArrowRightIcon, SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 
 /**
- * Shows the zero-progress home state. The hero stays focused on course creation,
- * while guests get a quiet login prompt because anonymous progress is not saved.
+ * Shows the zero-progress home state with one action for creating a new course
+ * and one action for browsing existing courses.
  */
 export async function Hero() {
-  const session = await getSession();
   const t = await getExtracted();
 
   return (
@@ -24,7 +22,7 @@ export async function Hero() {
         </p>
       </div>
 
-      <div className="flex flex-col items-center gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
         <Link
           className={buttonVariants({ className: "gap-2", size: "lg", variant: "default" })}
           href="/learn"
@@ -34,15 +32,14 @@ export async function Hero() {
           {t("Create a course with AI")}
         </Link>
 
-        {!session && (
-          <Link
-            className="text-muted-foreground hover:text-foreground text-sm underline-offset-4 transition-colors hover:underline"
-            href="/login"
-            prefetch={false}
-          >
-            {t("Log in to save your progress")}
-          </Link>
-        )}
+        <Link
+          className={buttonVariants({ className: "gap-2", size: "lg", variant: "outline" })}
+          href="/courses"
+          prefetch
+        >
+          {t("Explore courses")}
+          <ArrowRightIcon aria-hidden="true" />
+        </Link>
       </div>
     </main>
   );


### PR DESCRIPTION
Restores the hero Explore courses CTA and removes the login prompt from the zero-progress hero.

Updates the home e2e coverage and main app message references for the restored CTA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the "Explore courses" CTA in the home hero and removes the login prompt from the zero-progress state. Updates e2e coverage and i18n to match the new CTA.

- **Bug Fixes**
  - Home hero: show "Explore courses" as an outline button linking to /courses, remove the session-based login prompt, and use a two-button layout with an arrow icon.
  - Tests and i18n: update home e2e to expect the CTA and hide the login prompt; move the "Explore courses" message key to the hero and remove the unused login string in `en.po`, `es.po`, and `pt.po`.

<sup>Written for commit de45ed38a49f51f88fd76f16c486d0a78ba470e0. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1557?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

