### PR TITLE
feat(main): add empty search course cta

### DIFF
--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -287,14 +287,24 @@ test.describe("Command Palette - Course Search", () => {
     });
   });
 
-  test("shows No results found for non-matching query", async ({ page }) => {
+  test("suggests creating a course for non-matching query", async ({ page }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const prompt = `E2E Empty Search ${uniqueId}`;
+
     await page.goto("/");
     await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
-    await dialog.getByPlaceholder(/search/iu).fill("xyznonexistent");
+    await dialog.getByPlaceholder(/search/iu).fill(prompt);
 
     await expect(dialog.getByText(/no results found/iu)).toBeVisible();
+
+    const createCourseLink = dialog.getByRole("link", { name: `Create ${prompt} course` });
+
+    await expect(createCourseLink).toBeVisible();
+    await createCourseLink.click();
+
+    await expect(page).toHaveURL(new RegExp(`/learn/${encodeURIComponent(prompt)}$`, "u"));
   });
 
   test("handles rapid typing correctly", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -78,10 +78,6 @@ msgid "HC7Mi4"
 msgstr "Search courses or pages..."
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "hX5PAb"
-msgstr "No results found"
-
-#: src/app/(catalog)/_components/command-palette.tsx
 msgid "CxfKLC"
 msgstr "Pages"
 
@@ -98,6 +94,14 @@ msgstr "Logout"
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"
 msgstr "Help"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "hX5PAb"
+msgstr "No results found"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "XZfEtS"
+msgstr "Create {term} course"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
 msgid "onRJrc"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -78,10 +78,6 @@ msgid "HC7Mi4"
 msgstr "Buscar cursos o páginas..."
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "hX5PAb"
-msgstr "No se encontraron resultados"
-
-#: src/app/(catalog)/_components/command-palette.tsx
 msgid "CxfKLC"
 msgstr "Páginas"
 
@@ -98,6 +94,14 @@ msgstr "Cerrar sesión"
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"
 msgstr "Ayuda"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "hX5PAb"
+msgstr "No se encontraron resultados"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "XZfEtS"
+msgstr "Crear curso de {term}"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
 msgid "onRJrc"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -78,10 +78,6 @@ msgid "HC7Mi4"
 msgstr "Pesquisar cursos ou páginas..."
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "hX5PAb"
-msgstr "Nenhum resultado encontrado"
-
-#: src/app/(catalog)/_components/command-palette.tsx
 msgid "CxfKLC"
 msgstr "Páginas"
 
@@ -98,6 +94,14 @@ msgstr "Sair"
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"
 msgstr "Ajuda"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "hX5PAb"
+msgstr "Nenhum resultado encontrado"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "XZfEtS"
+msgstr "Criar curso de {term}"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
 msgid "onRJrc"

--- a/apps/main/src/app/(catalog)/_components/command-palette.tsx
+++ b/apps/main/src/app/(catalog)/_components/command-palette.tsx
@@ -3,7 +3,7 @@
 import { getMenu } from "@/lib/menu";
 import { trackCommandPaletteSearch } from "@/lib/track-events";
 import { logout } from "@zoonk/core/auth/client";
-import { Button } from "@zoonk/ui/components/button";
+import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import {
   CommandDialog,
   CommandEmpty,
@@ -13,10 +13,11 @@ import {
   CommandList,
 } from "@zoonk/ui/components/command";
 import { useCommandPaletteSearch } from "@zoonk/ui/hooks/command-palette-search";
-import { BookOpenIcon, LogOut, Search } from "lucide-react";
+import { BookOpenIcon, LogOut, PlusIcon, Search } from "lucide-react";
 import { type Route } from "next";
 import { useExtracted, useLocale } from "next-intl";
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 import { type CourseSearchResult, searchCoursesAction } from "./search-courses-action";
@@ -118,7 +119,7 @@ export function CommandPalette({
 
         <CommandList>
           <CommandEmpty>
-            <p>{t("No results found")}</p>
+            <CreateCourseEmptyState onSelect={onSelectItem} query={query} />
           </CommandEmpty>
 
           <CommandGroup heading={t("Pages")}>
@@ -180,6 +181,62 @@ export function CommandPalette({
       </CommandDialog>
     </>
   );
+}
+
+/**
+ * Empty palette searches usually mean the learner asked for something Zoonk
+ * cannot find yet, so the dead end should lead into the same prompt-based
+ * creation flow used by the Learn page.
+ */
+function CreateCourseEmptyState({ onSelect, query }: { onSelect: () => void; query: string }) {
+  const t = useExtracted();
+  const prompt = getCreateCoursePrompt(query);
+
+  return (
+    <div className="flex flex-col items-center gap-3 px-4">
+      <p className="text-muted-foreground">{t("No results found")}</p>
+
+      {prompt && (
+        <Link
+          className={buttonVariants({
+            className:
+              "h-auto min-h-8 max-w-full whitespace-normal py-1.5 text-center leading-snug",
+            size: "sm",
+            variant: "outline",
+          })}
+          href={getLearnPromptHref(prompt)}
+          onClick={onSelect}
+        >
+          <PlusIcon aria-hidden="true" />
+          <span className="min-w-0 wrap-break-word">
+            {t("Create {term} course", { term: prompt })}
+          </span>
+        </Link>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The palette input may contain only whitespace while cmdk is still rendering
+ * an empty result, and the Learn route should only receive a real subject.
+ */
+function getCreateCoursePrompt(query: string) {
+  const prompt = query.trim();
+
+  if (!prompt) {
+    return null;
+  }
+
+  return prompt;
+}
+
+/**
+ * The Learn prompt is stored in a dynamic path segment, so the raw search term
+ * must be encoded before it is sent through Next.js navigation.
+ */
+function getLearnPromptHref(prompt: string) {
+  return `/learn/${encodeURIComponent(prompt)}` as const;
 }
 
 function CourseItem({


### PR DESCRIPTION
## Summary
- add a create-course CTA to command palette empty search results
- route the CTA to the prompt-based learn page
- cover the empty-result path with e2e coverage and translations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a create-course CTA to the command palette when no search results are found, directing users into the prompt-based Learn flow. Includes E2E coverage and translations.

- **New Features**
  - Shows “Create {term} course” link in empty search results.
  - Navigates to /learn/{encoded term} and ignores blank/whitespace input.
  - Adds E2E test and i18n strings (en, es, pt).

<sup>Written for commit 3adb854b2ccb1a123b936ebaa4bbfb084e9b7c41. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1558?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

