### PR TITLE
fix(api): allow staging cors from previews

### DIFF
--- a/apps/api/src/proxy.test.ts
+++ b/apps/api/src/proxy.test.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { proxy } from "./proxy";
+
+const previewOrigin = "https://zoonk-git-cw-restore-explore-courses-link-zoonk.vercel.app";
+
+describe(proxy, () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("allows staging API preflight requests from Zoonk preview deployments", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_DOMAIN", "api.zoonk.dev");
+    vi.stubEnv("VERCEL_ENV", "production");
+
+    const response = proxy(
+      new NextRequest("https://api.zoonk.dev/v1/workflows/course-generation/trigger", {
+        headers: { origin: previewOrigin },
+        method: "OPTIONS",
+      }),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(previewOrigin);
+  });
+
+  it("keeps production API preflight requests closed to Zoonk preview deployments", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_DOMAIN", "api.zoonk.com");
+    vi.stubEnv("VERCEL_ENV", "production");
+
+    const response = proxy(
+      new NextRequest("https://api.zoonk.com/v1/workflows/course-generation/trigger", {
+        headers: { origin: previewOrigin },
+        method: "OPTIONS",
+      }),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBeNull();
+  });
+});

--- a/packages/utils/src/origin.test.ts
+++ b/packages/utils/src/origin.test.ts
@@ -74,8 +74,15 @@ describe(getAllowedHosts, () => {
   });
 
   it("excludes *-zoonk.vercel.app in Vercel production", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_DOMAIN", "api.zoonk.com");
     vi.stubEnv("VERCEL_ENV", "production");
     expect(getAllowedHosts()).not.toContain("*-zoonk.vercel.app");
+  });
+
+  it("includes *-zoonk.vercel.app for the staging API domain", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_DOMAIN", "api.zoonk.dev");
+    vi.stubEnv("VERCEL_ENV", "production");
+    expect(getAllowedHosts()).toContain("*-zoonk.vercel.app");
   });
 });
 
@@ -164,8 +171,20 @@ describe(isCorsAllowedOrigin, () => {
     });
 
     it("rejects vercel preview deployments in production", () => {
+      vi.stubEnv("NEXT_PUBLIC_APP_DOMAIN", "api.zoonk.com");
       vi.stubEnv("VERCEL_ENV", "production");
       expect(isCorsAllowedOrigin("https://my-branch-zoonk.vercel.app")).toBe(false);
+    });
+
+    it("allows vercel preview deployments for the staging API domain", () => {
+      vi.stubEnv("NEXT_PUBLIC_APP_DOMAIN", "api.zoonk.dev");
+      vi.stubEnv("VERCEL_ENV", "production");
+
+      const isAllowed = isCorsAllowedOrigin(
+        "https://zoonk-git-cw-restore-explore-courses-link-zoonk.vercel.app",
+      );
+
+      expect(isAllowed).toBe(true);
     });
   });
 

--- a/packages/utils/src/origin.ts
+++ b/packages/utils/src/origin.ts
@@ -48,26 +48,26 @@ export function buildAuthLoginUrl({ callbackUrl }: { callbackUrl: string }): str
 }
 
 const ZOONK_DOMAINS = ["zoonk.com", "zoonk.dev"];
+const ZOONK_STAGING_API_DOMAIN = "api.zoonk.dev";
+const ZOONK_VERCEL_PREVIEW_HOST = "*-zoonk.vercel.app";
+const ZOONK_VERCEL_PREVIEW_ORIGIN_SUFFIX = "-zoonk.vercel.app";
 
 /**
  * Builds the allowed hosts list for Better Auth's dynamic base URL.
- * Includes zoonk domains, localhost (dev/e2e), and Vercel previews (non-production).
+ * Includes zoonk domains, localhost (dev/e2e), and Vercel previews for
+ * environments that are allowed to receive requests from preview frontends.
  */
 export function getAllowedHosts(): string[] {
   return [
     ...ZOONK_DOMAINS.flatMap((domain) => [domain, `*.${domain}`]),
     ...(isLocalhostSupported() ? ["localhost:*"] : []),
-    ...(getEnvironment() === "production" ? [] : ["*-zoonk.vercel.app"]),
+    ...(canAcceptVercelPreviewOrigins() ? [ZOONK_VERCEL_PREVIEW_HOST] : []),
   ];
 }
 
 /**
- * Checks if an origin is allowed for CORS.
- *
- * Allows:
- * - Any subdomain of zoonk.com, zoonk.dev (https only)
- * - localhost with valid port (dev/e2e only)
- * - Vercel preview deployments (*-zoonk.vercel.app, https only, non-production only)
+ * Matches the exact domain or an HTTPS subdomain. This keeps origin checks
+ * small and explicit so lookalike domains such as zoonk.com.evil.com fail.
  */
 function isHttpsOriginOf(origin: string, domain: string): boolean {
   return (
@@ -76,6 +76,32 @@ function isHttpsOriginOf(origin: string, domain: string): boolean {
   );
 }
 
+/**
+ * Tells shared origin checks whether this API host is the custom staging
+ * environment. Vercel can still expose that deployment with production-like
+ * runtime flags, so the configured app domain is the stable product boundary.
+ */
+function isStagingApiDomain(): boolean {
+  return process.env.NEXT_PUBLIC_APP_DOMAIN === ZOONK_STAGING_API_DOMAIN;
+}
+
+/**
+ * Decides whether this API deployment can receive browser requests from
+ * Zoonk Vercel preview frontends. The staging API must support previews, while
+ * the production API must stay closed to unreviewed preview deployments.
+ */
+function canAcceptVercelPreviewOrigins(): boolean {
+  return getEnvironment() !== "production" || isStagingApiDomain();
+}
+
+/**
+ * Checks if a browser origin may call the public API with credentials.
+ *
+ * Allows:
+ * - Any subdomain of zoonk.com, zoonk.dev (https only)
+ * - localhost with valid port (dev/e2e only)
+ * - Vercel preview deployments (*-zoonk.vercel.app, https only, preview/staging only)
+ */
 export function isCorsAllowedOrigin(origin: string): boolean {
   if (ZOONK_DOMAINS.some((domain) => isHttpsOriginOf(origin, domain))) {
     return true;
@@ -89,12 +115,12 @@ export function isCorsAllowedOrigin(origin: string): boolean {
     return true;
   }
 
-  // Production servers reject Vercel preview origins to prevent
-  // untested preview deployments from making requests to production.
+  // The production API domain rejects Vercel preview origins to prevent
+  // untested preview deployments from making requests to production data.
   const isAllowedVercelPreview =
-    getEnvironment() !== "production" &&
+    canAcceptVercelPreviewOrigins() &&
     origin.startsWith("https://") &&
-    origin.endsWith("-zoonk.vercel.app");
+    origin.endsWith(ZOONK_VERCEL_PREVIEW_ORIGIN_SUFFIX);
 
   return isAllowedVercelPreview;
 }


### PR DESCRIPTION
## Summary

- Allow the staging API domain to accept CORS requests from Zoonk Vercel preview deployments.
- Keep production API CORS closed to preview origins.
- Add focused origin and proxy preflight coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows the staging API (`api.zoonk.dev`) to accept CORS from Zoonk Vercel preview domains while keeping the production API (`api.zoonk.com`) closed to previews. Adds stricter origin helpers and preflight coverage to avoid lookalike domains and regressions.

- **Bug Fixes**
  - Allow `*-zoonk.vercel.app` only for staging or non-production; keep production blocked.
  - Add `isStagingApiDomain` and `canAcceptVercelPreviewOrigins`; tighten HTTPS subdomain checks.
  - Add tests for allowed hosts, CORS decisions, and proxy preflight (staging allows, production rejects).

<sup>Written for commit 3400e7a39975bc7732ff4471486573d94a07c879. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1559?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

