### PR TITLE
fix(main): recover interrupted generation streams

### DIFF
--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -369,6 +369,130 @@ test.describe("Generate Chapter Page - With Subscription", () => {
     await userWithoutProgress.waitForURL(/\/b\/ai\/c\//u, { timeout: 10_000 });
   });
 
+  test("keeps checking progress when the status connection is interrupted", async ({
+    userWithoutProgress,
+    noProgressUser,
+  }) => {
+    await createTestSubscription(noProgressUser.id);
+    const { chapter, organizationId } = await createPendingChapter();
+
+    const uniqueId = randomUUID().slice(0, 8);
+
+    await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId,
+      slug: `e2e-interrupted-lesson-${uniqueId}`,
+      title: `E2E Interrupted Lesson ${uniqueId}`,
+    });
+
+    await userWithoutProgress.route("**/v1/workflows/chapter-generation/**", async (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+
+      if (url.includes("/trigger") && method === "POST") {
+        await route.fulfill({
+          body: JSON.stringify({ message: "Workflow started", runId: TEST_RUN_ID }),
+          contentType: "application/json",
+          status: 200,
+        });
+
+        return;
+      }
+
+      if (url.includes("/status")) {
+        const reconnectCount = new URL(url).searchParams.get("_rc");
+
+        if (reconnectCount === "0") {
+          await route.abort("failed");
+          return;
+        }
+
+        await route.fulfill({
+          body: createSSEStream([
+            { status: "started", step: "setChapterAsCompleted" },
+            { status: "completed", step: "setChapterAsCompleted" },
+          ]),
+          contentType: "text/event-stream",
+          status: 200,
+        });
+
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await userWithoutProgress.goto(`/generate/ch/${chapter.id}`);
+
+    await expect(userWithoutProgress.getByText(/something went wrong/iu)).toHaveCount(0);
+
+    await expect(userWithoutProgress.getByText(/your lessons are ready/iu)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await prisma.chapter.update({
+      data: { generationStatus: "completed" },
+      where: { id: chapter.id },
+    });
+
+    await userWithoutProgress.waitForURL(/\/b\/ai\/c\//u, { timeout: 10_000 });
+  });
+
+  test("checks server state when connection retry is clicked", async ({
+    userWithoutProgress,
+    noProgressUser,
+  }) => {
+    await createTestSubscription(noProgressUser.id);
+    const { chapter, organizationId } = await createPendingChapter();
+
+    const uniqueId = randomUUID().slice(0, 8);
+
+    await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId,
+      slug: `e2e-retry-lesson-${uniqueId}`,
+      title: `E2E Retry Lesson ${uniqueId}`,
+    });
+
+    await userWithoutProgress.route("**/v1/workflows/chapter-generation/**", async (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+
+      if (url.includes("/trigger") && method === "POST") {
+        await route.fulfill({
+          body: JSON.stringify({ message: "Workflow started", runId: TEST_RUN_ID }),
+          contentType: "application/json",
+          status: 200,
+        });
+
+        return;
+      }
+
+      if (url.includes("/status")) {
+        await route.abort("failed");
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await userWithoutProgress.goto(`/generate/ch/${chapter.id}`);
+
+    await expect(userWithoutProgress.getByText(/connection interrupted/iu)).toBeVisible({
+      timeout: 12_000,
+    });
+
+    await prisma.chapter.update({
+      data: { generationStatus: "completed" },
+      where: { id: chapter.id },
+    });
+
+    await userWithoutProgress.getByRole("button", { name: /check again/iu }).click();
+    await userWithoutProgress.waitForURL(/\/b\/ai\/c\//u, { timeout: 10_000 });
+  });
+
   test("shows error when stream returns error status", async ({
     userWithoutProgress,
     noProgressUser,

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -345,16 +345,12 @@ msgid "T0mfNV"
 msgstr "Loading more courses…"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
 msgid "W/5hwr"
 msgstr "Something went wrong. Please try again."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
 msgid "FazwRl"
 msgstr "Try again"
 
@@ -1051,12 +1047,6 @@ msgstr "Taking you to your chapter..."
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "45uo73"
 msgstr "Your lessons are ready"
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgid "JqiqNj"
-msgstr "Something went wrong"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "gnxL73"
@@ -1766,6 +1756,22 @@ msgstr "Feedback"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "eUzs3M"
 msgstr "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "ctqXbT"
+msgstr "We lost the progress connection. Your content may still be generating."
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "1A8Z/l"
+msgstr "Check again"
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "yHqv96"
+msgstr "Connection interrupted"
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "JqiqNj"
+msgstr "Something went wrong"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "IS/YjO"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -345,16 +345,12 @@ msgid "T0mfNV"
 msgstr "Cargando más cursos…"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
 msgid "W/5hwr"
 msgstr "Algo salió mal. Por favor, intenta de nuevo."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
 msgid "FazwRl"
 msgstr "Intentar de nuevo"
 
@@ -1051,12 +1047,6 @@ msgstr "Llevándote a tu capítulo..."
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "45uo73"
 msgstr "Tus lecciones están listas"
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgid "JqiqNj"
-msgstr "Algo salió mal"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "gnxL73"
@@ -1766,6 +1756,22 @@ msgstr "Comentarios"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "eUzs3M"
 msgstr "Envíanos comentarios, preguntas o sugerencias. Completa el formulario a continuación o escríbenos directamente a contacto@zoonk.com."
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "ctqXbT"
+msgstr "Perdimos la conexión del progreso. Es posible que tu contenido aún se esté generando."
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "1A8Z/l"
+msgstr "Comprobar de nuevo"
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "yHqv96"
+msgstr "Conexión interrumpida"
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "JqiqNj"
+msgstr "Algo salió mal"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "IS/YjO"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -345,16 +345,12 @@ msgid "T0mfNV"
 msgstr "Carregando mais cursos…"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
 msgid "W/5hwr"
 msgstr "Algo deu errado. Por favor, tente novamente."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
 msgid "FazwRl"
 msgstr "Tentar de novo"
 
@@ -1051,12 +1047,6 @@ msgstr "Levando você para seu capítulo..."
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "45uo73"
 msgstr "Suas aulas estão prontas"
-
-#: src/app/generate/ch/[id]/generation-client.tsx
-#: src/app/generate/cs/[id]/generation-client.tsx
-#: src/app/generate/l/[id]/generation-client.tsx
-msgid "JqiqNj"
-msgstr "Algo deu errado"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "gnxL73"
@@ -1766,6 +1756,22 @@ msgstr "Opinião"
 #: src/components/feedback/feedback-dialog.tsx
 msgid "eUzs3M"
 msgstr "Envie sua opinião, perguntas ou sugestões para a gente. Preencha o formulário abaixo ou envie um email diretamente para contato@zoonk.com."
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "ctqXbT"
+msgstr "Perdemos a conexão do progresso. Seu conteúdo ainda pode estar sendo gerado."
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "1A8Z/l"
+msgstr "Verificar novamente"
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "yHqv96"
+msgstr "Conexão interrompida"
+
+#: src/components/generation/workflow-generation-error.tsx
+msgid "JqiqNj"
+msgstr "Algo deu errado"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "IS/YjO"

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -2,7 +2,6 @@
 
 import {
   GenerationProgressCompleted,
-  GenerationProgressError,
   GenerationTimeline,
   GenerationTimelineHeader,
   GenerationTimelineProgress,
@@ -11,6 +10,7 @@ import {
   GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { WorkflowGenerationError } from "@/components/generation/workflow-generation-error";
 import { type GenerationStatus } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
@@ -116,13 +116,11 @@ export function GenerationClient({
 
   if (generation.status === "error") {
     return (
-      <GenerationProgressError
-        description={generation.error || t("Something went wrong. Please try again.")}
+      <WorkflowGenerationError
+        error={generation.error}
+        errorKind={generation.errorKind}
         onRetry={generation.retry}
-        retryLabel={t("Try again")}
-      >
-        {t("Something went wrong")}
-      </GenerationProgressError>
+      />
     );
   }
 

--- a/apps/main/src/app/generate/cs/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generation-client.tsx
@@ -2,7 +2,6 @@
 
 import {
   GenerationProgressCompleted,
-  GenerationProgressError,
   GenerationTimeline,
   GenerationTimelineHeader,
   GenerationTimelineProgress,
@@ -11,6 +10,7 @@ import {
   GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { WorkflowGenerationError } from "@/components/generation/workflow-generation-error";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
@@ -115,13 +115,11 @@ export function GenerationClient({
 
   if (generation.status === "error") {
     return (
-      <GenerationProgressError
-        description={generation.error || t("Something went wrong. Please try again.")}
+      <WorkflowGenerationError
+        error={generation.error}
+        errorKind={generation.errorKind}
         onRetry={generation.retry}
-        retryLabel={t("Try again")}
-      >
-        {t("Something went wrong")}
-      </GenerationProgressError>
+      />
     );
   }
 

--- a/apps/main/src/app/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/l/[id]/generation-client.tsx
@@ -2,7 +2,6 @@
 
 import {
   GenerationProgressCompleted,
-  GenerationProgressError,
   GenerationTimeline,
   GenerationTimelineHeader,
   GenerationTimelineProgress,
@@ -11,6 +10,7 @@ import {
   GenerationTimelineSubtitle,
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
+import { WorkflowGenerationError } from "@/components/generation/workflow-generation-error";
 import { type GenerationStatus } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
@@ -122,13 +122,11 @@ export function GenerationClient({
 
   if (generation.status === "error") {
     return (
-      <GenerationProgressError
-        description={generation.error || t("Something went wrong. Please try again.")}
+      <WorkflowGenerationError
+        error={generation.error}
+        errorKind={generation.errorKind}
         onRetry={generation.retry}
-        retryLabel={t("Try again")}
-      >
-        {t("Something went wrong")}
-      </GenerationProgressError>
+      />
     );
   }
 

--- a/apps/main/src/components/generation/workflow-generation-error.tsx
+++ b/apps/main/src/components/generation/workflow-generation-error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { type GenerationErrorKind } from "@/lib/workflow/generation-store";
+import { useExtracted } from "next-intl";
+import { GenerationProgressError } from "./generation-progress";
+
+/**
+ * Keeps workflow transport failures visually separate from real generation
+ * failures. A dropped phone connection does not mean the server workflow failed,
+ * so the retry action should re-read the server state instead of starting a new
+ * generation run.
+ */
+export function WorkflowGenerationError({
+  error,
+  errorKind,
+  onRetry,
+}: {
+  error: string | null;
+  errorKind: GenerationErrorKind | null;
+  onRetry: () => void;
+}) {
+  const t = useExtracted();
+  const isConnectionError = errorKind === "connection";
+
+  if (isConnectionError) {
+    return (
+      <GenerationProgressError
+        description={
+          error || t("We lost the progress connection. Your content may still be generating.")
+        }
+        onRetry={onRetry}
+        retryLabel={t("Check again")}
+      >
+        {t("Connection interrupted")}
+      </GenerationProgressError>
+    );
+  }
+
+  return (
+    <GenerationProgressError
+      description={error || t("Something went wrong. Please try again.")}
+      onRetry={onRetry}
+      retryLabel={t("Try again")}
+    >
+      {t("Something went wrong")}
+    </GenerationProgressError>
+  );
+}

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -97,6 +97,30 @@ describe(generationReducer, () => {
     });
   });
 
+  describe("setError", () => {
+    it("stores connection errors separately from generation errors", () => {
+      const state = generationReducer(initialGenerationState({ status: "streaming" }), {
+        error: null,
+        errorKind: "connection",
+        type: "setError",
+      });
+
+      expect(state.status).toBe("error");
+      expect(state.error).toBeNull();
+      expect(state.errorKind).toBe("connection");
+    });
+
+    it("treats unclassified errors as generation errors", () => {
+      const state = generationReducer(initialGenerationState({ status: "streaming" }), {
+        error: "Step failed",
+        type: "setError",
+      });
+
+      expect(state.status).toBe("error");
+      expect(state.errorKind).toBe("generation");
+    });
+  });
+
   describe("streamEnded", () => {
     it("does not transition from error state", () => {
       const state = generationReducer(

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -2,10 +2,13 @@ import { type StepStreamMessage } from "@zoonk/core/workflows/steps";
 
 export type GenerationStatus = "idle" | "triggering" | "streaming" | "completed" | "error";
 
+export type GenerationErrorKind = "connection" | "generation";
+
 export type GenerationState<TStep extends string = string> = {
   completedSteps: TStep[];
   currentStep: TStep | null;
   error: string | null;
+  errorKind: GenerationErrorKind | null;
   completionEntityId: string | null;
   reconnectCount: number;
   runId: string | null;
@@ -16,7 +19,7 @@ export type GenerationState<TStep extends string = string> = {
 export type GenerationAction<TStep extends string = string> =
   | { type: "reconnect" }
   | { type: "reset" }
-  | { type: "setError"; error: string }
+  | { type: "setError"; error: string | null; errorKind?: GenerationErrorKind }
   | { type: "stepCompleted"; step: TStep }
   | { type: "stepStarted"; step: TStep }
   | { type: "streamEnded"; completionStep?: TStep; entityId?: string }
@@ -31,6 +34,7 @@ export function initialGenerationState<TStep extends string = string>(
     completionEntityId: null,
     currentStep: null,
     error: null,
+    errorKind: null,
     reconnectCount: 0,
     runId: null,
     startedSteps: [] as TStep[],
@@ -49,7 +53,12 @@ export function generationReducer<TStep extends string>(
     case "reset":
       return initialGenerationState<TStep>();
     case "setError":
-      return { ...state, error: action.error, status: "error" };
+      return {
+        ...state,
+        error: action.error,
+        errorKind: action.errorKind ?? "generation",
+        status: "error",
+      };
     case "stepCompleted":
       return {
         ...state,
@@ -82,7 +91,7 @@ export function generationReducer<TStep extends string>(
       return { ...state, completionEntityId: action.entityId ?? null, status: "completed" };
 
     case "triggerStart":
-      return { ...state, error: null, status: "triggering" };
+      return { ...state, error: null, errorKind: null, status: "triggering" };
     case "triggerSuccess":
       return { ...state, runId: action.runId, status: "streaming" };
     default: {

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -53,6 +53,23 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   );
 
   /**
+   * Status streams are best-effort browser connections. Mobile browsers can
+   * suspend or tear them down while the workflow keeps running on the server,
+   * so a transport failure should resume the same run instead of being shown as
+   * a failed generation.
+   */
+  const reconnectStream = useEffectEvent(() => {
+    if (state.reconnectCount >= MAX_STREAM_RECONNECTS) {
+      dispatch({ error: null, errorKind: "connection", type: "setError" });
+      return;
+    }
+
+    setTimeout(() => {
+      dispatch({ type: "reconnect" });
+    }, 1000);
+  });
+
+  /**
    * When the SSE stream closes, check whether we received the expected completion
    * step. If not, the stream was likely cut off (e.g., Vercel function timeout)
    * while the workflow is still running. In that case, schedule a reconnection
@@ -68,19 +85,15 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
      */
     const isComplete = state.status === "completed" || !completionStep;
 
-    if (isComplete || state.reconnectCount >= MAX_STREAM_RECONNECTS) {
+    if (isComplete) {
       dispatch({ completionStep, type: "streamEnded" });
       return;
     }
 
-    setTimeout(() => {
-      dispatch({ type: "reconnect" });
-    }, 1000);
+    reconnectStream();
   });
 
-  const handleError = useEffectEvent((err: Error) =>
-    dispatch({ error: err.message, type: "setError" }),
-  );
+  const handleError = useEffectEvent(() => reconnectStream());
 
   /**
    * Include `_rc` (reconnect count) in the URL so that when `reconnectCount`
@@ -141,16 +154,22 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   }, [autoTrigger, state.status]);
 
   const retry = useCallback(() => {
+    if (state.errorKind === "connection") {
+      globalThis.location.reload();
+      return;
+    }
+
     hasTriggeredRef.current = false;
     resetIndex();
     dispatch({ type: "reset" });
-  }, [resetIndex]);
+  }, [resetIndex, state.errorKind]);
 
   return {
     completedSteps: state.completedSteps,
     completionEntityId: state.completionEntityId,
     currentStep: state.currentStep,
     error: state.error,
+    errorKind: state.errorKind,
     retry,
     startedSteps: state.startedSteps,
     status: state.status,


### PR DESCRIPTION
Reconnects generation status streams after browser or network interruptions, separates connection recovery from real workflow failures, and covers the retry path with e2e tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers interrupted generation status streams and treats network drops separately from real workflow failures. Improves UX with a clear “Connection interrupted” state and a “Check again” action that verifies server state without restarting generation.

- **Bug Fixes**
  - Reconnects the SSE status stream and resumes the same run; if retries are exhausted, show a connection error instead of a workflow failure.
  - Tracks error types in the store via `errorKind` (`connection` vs `generation`) and only re-triggers on real failures.
  - Replaces inline error UI with `WorkflowGenerationError` and updates localized copy (“Connection interrupted”, “Check again”) in `en.po`, `es.po`, and `pt.po`.
  - Adds e2e tests for interrupted stream recovery and the “Check again” flow that checks server state and redirects when generation completed.

<sup>Written for commit 2e930c466b6abaaac6f9d9290ef8056705c2bef5. Summary will update on new commits. <a href="https://cubic.dev/pr/zoonk/zoonk/pull/1561?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

