### PR TITLE
feat(main): preload next chapter from lesson progress

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/preload-next-lesson-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/preload-next-lesson-action.ts
@@ -1,13 +1,18 @@
 "use server";
 
-import { triggerLessonPreload } from "@/data/progress/trigger-lesson-preload";
-import { getNextLessonPreloadTarget } from "@zoonk/core/player/commands/get-next-lesson-preload-target";
+import { triggerPreloadTarget } from "@/data/progress/trigger-preload-target";
+import { getNextPreloadTarget } from "@zoonk/core/player/commands/get-next-lesson-preload-target";
 import { getSession } from "@zoonk/core/users/session/get";
 import { logError } from "@zoonk/utils/logger";
 import { headers } from "next/headers";
 import { after } from "next/server";
 
-type NextLessonPreloadInput = { cookieHeader: string; lessonId: string; userId: string };
+type NextPreloadInput = {
+  cookieHeader: string;
+  lessonId: string;
+  requestHeaders: Headers;
+  userId: string;
+};
 
 /**
  * Runs the expensive preload path after the server action returns. Keeping this
@@ -15,28 +20,29 @@ type NextLessonPreloadInput = { cookieHeader: string; lessonId: string; userId: 
  * while still swallowing background errors so preload failures do not surface
  * as user-visible player errors.
  */
-async function triggerNextLessonPreload(input: NextLessonPreloadInput): Promise<void> {
+async function triggerNextPreload(input: NextPreloadInput): Promise<void> {
   try {
-    const preloadLessonId = await getNextLessonPreloadTarget({
-      lessonId: input.lessonId,
-      userId: input.userId,
-    });
+    const target = await getNextPreloadTarget({ lessonId: input.lessonId, userId: input.userId });
 
-    if (!preloadLessonId) {
+    if (!target) {
       return;
     }
 
-    await triggerLessonPreload({ cookieHeader: input.cookieHeader, lessonId: preloadLessonId });
+    await triggerPreloadTarget({
+      cookieHeader: input.cookieHeader,
+      requestHeaders: input.requestHeaders,
+      target,
+    });
   } catch (error) {
-    logError("[preloadNextLesson] Failed to trigger next lesson preload:", error);
+    logError("[preloadNextLesson] Failed to trigger preload:", error);
   }
 }
 
 /**
- * Starts generating the next lesson after the learner has shown real progress
- * in the current lesson. The client only sends the current lesson id; the
- * server derives the expensive generation target after auth and visibility
- * checks so this cannot be used as a generic lesson-generation proxy.
+ * Starts preparing the next generated item after the learner has shown real
+ * progress in the current lesson. The client only sends the current lesson id;
+ * the server derives the expensive generation target after auth and visibility
+ * checks so this cannot be used as a generic generation proxy.
  */
 export async function preloadNextLesson(lessonId: string): Promise<void> {
   const reqHeaders = await headers();
@@ -47,9 +53,10 @@ export async function preloadNextLesson(lessonId: string): Promise<void> {
   }
 
   after(() =>
-    triggerNextLessonPreload({
+    triggerNextPreload({
       cookieHeader: reqHeaders.get("cookie") ?? "",
       lessonId,
+      requestHeaders: reqHeaders,
       userId: session.user.id,
     }),
   );

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/submit-completion-action.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { triggerLessonPreload } from "@/data/progress/trigger-lesson-preload";
 import { submitPlayerCompletion } from "@zoonk/core/player/commands/submit-player-completion";
 import {
   type CompletionInput,
@@ -36,7 +35,6 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<void>
   }
 
   const userId = session.user.id;
-  const lessonId = input.lessonId;
 
   // Revalidate outside after() so the signal is included in the RSC response.
   // This tells the client Router Cache to purge "/", ensuring the next
@@ -47,18 +45,7 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<void>
 
   after(async () => {
     try {
-      const effects = await submitPlayerCompletion({ input, userId });
-
-      if (!effects) {
-        logError(`[submitCompletion] Lesson ${lessonId} not found`);
-        return;
-      }
-
-      const cookieHeader = reqHeaders.get("cookie") ?? "";
-
-      if (effects.preloadLessonId) {
-        await triggerLessonPreload({ cookieHeader, lessonId: effects.preloadLessonId });
-      }
+      await submitPlayerCompletion({ input, userId });
     } catch (error) {
       logError("[submitCompletion] Failed to persist lesson completion:", error);
     }

--- a/apps/main/src/data/progress/trigger-chapter-generation.ts
+++ b/apps/main/src/data/progress/trigger-chapter-generation.ts
@@ -1,0 +1,20 @@
+import "server-only";
+import { triggerWorkflow } from "./trigger-workflow";
+
+/**
+ * Chapter-boundary preload uses the normal chapter-generation workflow trigger
+ * so it shares the API route's auth, AI-curriculum, subscription, and workflow
+ * idempotency checks with the visible chapter generation page.
+ */
+export async function triggerChapterGeneration(input: {
+  chapterId: string;
+  cookieHeader: string;
+}): Promise<void> {
+  await triggerWorkflow({
+    body: { chapterId: input.chapterId },
+    cookieHeader: input.cookieHeader,
+    endpoint: "/v1/workflows/chapter-generation/trigger",
+    failureContext: { chapterId: input.chapterId },
+    logPrefix: "[triggerChapterGeneration] Workflow trigger failed:",
+  });
+}

--- a/apps/main/src/data/progress/trigger-lesson-preload.ts
+++ b/apps/main/src/data/progress/trigger-lesson-preload.ts
@@ -1,6 +1,5 @@
 import "server-only";
-import { logError } from "@zoonk/utils/logger";
-import { API_URL } from "@zoonk/utils/url";
+import { triggerWorkflow } from "./trigger-workflow";
 
 /**
  * This helper exists so every lesson-preload caller shares the same trusted
@@ -11,17 +10,11 @@ export async function triggerLessonPreload(input: {
   cookieHeader: string;
   lessonId: string;
 }): Promise<void> {
-  const response = await fetch(`${API_URL}/v1/workflows/lesson-preload/trigger`, {
-    body: JSON.stringify({ lessonId: input.lessonId }),
-    headers: { "Content-Type": "application/json", Cookie: input.cookieHeader },
-    method: "POST",
+  await triggerWorkflow({
+    body: { lessonId: input.lessonId },
+    cookieHeader: input.cookieHeader,
+    endpoint: "/v1/workflows/lesson-preload/trigger",
+    failureContext: { lessonId: input.lessonId },
+    logPrefix: "[triggerLessonPreload] Workflow trigger failed:",
   });
-
-  if (!response.ok) {
-    logError("[triggerLessonPreload] Workflow trigger failed:", {
-      lessonId: input.lessonId,
-      status: response.status,
-      statusText: response.statusText,
-    });
-  }
 }

--- a/apps/main/src/data/progress/trigger-preload-target.test.ts
+++ b/apps/main/src/data/progress/trigger-preload-target.test.ts
@@ -1,0 +1,64 @@
+import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { triggerChapterGeneration } from "./trigger-chapter-generation";
+import { triggerLessonPreload } from "./trigger-lesson-preload";
+import { triggerPreloadTarget } from "./trigger-preload-target";
+
+vi.mock("@zoonk/core/auth/subscription", () => ({ hasActiveSubscription: vi.fn() }));
+vi.mock("./trigger-chapter-generation", () => ({ triggerChapterGeneration: vi.fn() }));
+vi.mock("./trigger-lesson-preload", () => ({ triggerLessonPreload: vi.fn() }));
+
+const cookieHeader = "session=test";
+const requestHeaders = new Headers({ cookie: cookieHeader });
+const hasActiveSubscriptionMock = vi.mocked(hasActiveSubscription);
+const triggerChapterGenerationMock = vi.mocked(triggerChapterGeneration);
+const triggerLessonPreloadMock = vi.mocked(triggerLessonPreload);
+
+describe(triggerPreloadTarget, () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("triggers lesson preload without checking subscription", async () => {
+    await triggerPreloadTarget({
+      cookieHeader,
+      requestHeaders,
+      target: { kind: "lesson", lessonId: "lesson-1" },
+    });
+
+    expect(triggerLessonPreloadMock).toHaveBeenCalledWith({ cookieHeader, lessonId: "lesson-1" });
+    expect(hasActiveSubscriptionMock).not.toHaveBeenCalled();
+    expect(triggerChapterGenerationMock).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger chapter generation without an active subscription", async () => {
+    hasActiveSubscriptionMock.mockResolvedValue(false);
+
+    await triggerPreloadTarget({
+      cookieHeader,
+      requestHeaders,
+      target: { chapterId: "chapter-1", kind: "chapter" },
+    });
+
+    expect(hasActiveSubscriptionMock).toHaveBeenCalledWith(requestHeaders);
+    expect(triggerChapterGenerationMock).not.toHaveBeenCalled();
+    expect(triggerLessonPreloadMock).not.toHaveBeenCalled();
+  });
+
+  it("triggers chapter generation with an active subscription", async () => {
+    hasActiveSubscriptionMock.mockResolvedValue(true);
+
+    await triggerPreloadTarget({
+      cookieHeader,
+      requestHeaders,
+      target: { chapterId: "chapter-1", kind: "chapter" },
+    });
+
+    expect(triggerChapterGenerationMock).toHaveBeenCalledWith({
+      chapterId: "chapter-1",
+      cookieHeader,
+    });
+
+    expect(triggerLessonPreloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/main/src/data/progress/trigger-preload-target.ts
+++ b/apps/main/src/data/progress/trigger-preload-target.ts
@@ -1,0 +1,52 @@
+import "server-only";
+import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { type NextPreloadTarget } from "@zoonk/core/player/commands/get-next-lesson-preload-target";
+import { triggerChapterGeneration } from "./trigger-chapter-generation";
+import { triggerLessonPreload } from "./trigger-lesson-preload";
+
+/**
+ * Lesson preloading can keep using the existing lesson workflow rules, but
+ * chapter generation is paid work at the next-chapter boundary. Checking the
+ * subscription before the chapter trigger avoids sending unpaid users into a
+ * background request that the API would reject anyway.
+ */
+async function triggerSubscribedChapterGeneration(input: {
+  chapterId: string;
+  cookieHeader: string;
+  requestHeaders: Headers;
+}): Promise<void> {
+  const hasSubscription = await hasActiveSubscription(input.requestHeaders);
+
+  if (!hasSubscription) {
+    return;
+  }
+
+  await triggerChapterGeneration({ chapterId: input.chapterId, cookieHeader: input.cookieHeader });
+}
+
+/**
+ * Dispatches the server-derived preload target to the correct workflow. The
+ * target is already trusted by the core lookup, so this helper only decides
+ * which workflow endpoint should receive it and applies the chapter-only paid
+ * subscription gate.
+ */
+export async function triggerPreloadTarget(input: {
+  cookieHeader: string;
+  requestHeaders: Headers;
+  target: NextPreloadTarget;
+}): Promise<void> {
+  if (input.target.kind === "lesson") {
+    await triggerLessonPreload({
+      cookieHeader: input.cookieHeader,
+      lessonId: input.target.lessonId,
+    });
+
+    return;
+  }
+
+  await triggerSubscribedChapterGeneration({
+    chapterId: input.target.chapterId,
+    cookieHeader: input.cookieHeader,
+    requestHeaders: input.requestHeaders,
+  });
+}

--- a/apps/main/src/data/progress/trigger-workflow.ts
+++ b/apps/main/src/data/progress/trigger-workflow.ts
@@ -1,0 +1,31 @@
+import "server-only";
+import { logError } from "@zoonk/utils/logger";
+import { API_URL } from "@zoonk/utils/url";
+
+/**
+ * Server-to-server workflow triggers all need the same POST shape and failure
+ * logging. This helper keeps the endpoint-specific wrappers small while making
+ * sure background preload failures stay observable instead of throwing into the
+ * lesson player action.
+ */
+export async function triggerWorkflow(input: {
+  body: unknown;
+  cookieHeader: string;
+  endpoint: string;
+  failureContext: Record<string, string>;
+  logPrefix: string;
+}): Promise<void> {
+  const response = await fetch(`${API_URL}${input.endpoint}`, {
+    body: JSON.stringify(input.body),
+    headers: { "Content-Type": "application/json", Cookie: input.cookieHeader },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    logError(input.logPrefix, {
+      ...input.failureContext,
+      status: response.status,
+      statusText: response.statusText,
+    });
+  }
+}

--- a/packages/core/src/player/commands/get-next-lesson-preload-target.test.ts
+++ b/packages/core/src/player/commands/get-next-lesson-preload-target.test.ts
@@ -1,11 +1,10 @@
-import { randomUUID } from "node:crypto";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { describe, expect, it } from "vitest";
-import { getNextLessonPreloadTarget } from "./get-next-lesson-preload-target";
+import { getNextPreloadTarget } from "./get-next-lesson-preload-target";
 
 type PreloadTargetVisibility = {
   chapterIsPublished?: boolean;
@@ -80,21 +79,46 @@ async function createLessonPair(params: {
   return { currentLesson, nextLesson };
 }
 
-describe(getNextLessonPreloadTarget, () => {
+describe(getNextPreloadTarget, () => {
+  it("returns the next lesson target before considering chapter generation", async () => {
+    const [user, lessons] = await Promise.all([
+      userFixture(),
+      createLessonPair({ nextLessonGenerationStatus: "pending" }),
+    ]);
+
+    const result = await getNextPreloadTarget({
+      lessonId: lessons.currentLesson.id,
+      userId: user.id,
+    });
+
+    expect(result).toStrictEqual({ kind: "lesson", lessonId: lessons.nextLesson.id });
+  });
+
   it.each(preloadGenerationStatuses)(
-    "returns the next lesson id when its generation state is %s",
-    async (nextLessonGenerationStatus) => {
-      const [user, lessons] = await Promise.all([
-        userFixture(),
-        createLessonPair({ nextLessonGenerationStatus }),
+    "returns the next chapter target when the current lesson is last and the chapter is %s",
+    async (nextChapterGenerationStatus) => {
+      const [user, context] = await Promise.all([userFixture(), createChapterContext()]);
+
+      const [currentLesson, nextChapter] = await Promise.all([
+        lessonFixture({
+          chapterId: context.chapter.id,
+          generationStatus: "completed",
+          isPublished: true,
+          organizationId: context.organization.id,
+          position: 0,
+        }),
+        chapterFixture({
+          courseId: context.chapter.courseId,
+          generationStatus: nextChapterGenerationStatus,
+          isPublished: true,
+          organizationId: context.organization.id,
+          position: 1,
+        }),
       ]);
 
-      const result = await getNextLessonPreloadTarget({
-        lessonId: lessons.currentLesson.id,
-        userId: user.id,
-      });
+      const result = await getNextPreloadTarget({ lessonId: currentLesson.id, userId: user.id });
 
-      expect(result).toBe(lessons.nextLesson.id);
+      expect(result).toStrictEqual({ chapterId: nextChapter.id, kind: "chapter" });
     },
   );
 
@@ -106,7 +130,7 @@ describe(getNextLessonPreloadTarget, () => {
         createLessonPair({ nextLessonGenerationStatus }),
       ]);
 
-      const result = await getNextLessonPreloadTarget({
+      const result = await getNextPreloadTarget({
         lessonId: lessons.currentLesson.id,
         userId: user.id,
       });
@@ -129,7 +153,7 @@ describe(getNextLessonPreloadTarget, () => {
         }),
       ]);
 
-      const result = await getNextLessonPreloadTarget({
+      const result = await getNextPreloadTarget({
         lessonId: lessons.currentLesson.id,
         userId: user.id,
       });
@@ -141,11 +165,36 @@ describe(getNextLessonPreloadTarget, () => {
   it("returns null for malformed lesson ids before querying UUID columns", async () => {
     const user = await userFixture();
 
-    const result = await getNextLessonPreloadTarget({
-      lessonId: `not-a-uuid-${randomUUID()}`,
-      userId: user.id,
-    });
+    const result = await getNextPreloadTarget({ lessonId: "not-a-uuid", userId: user.id });
 
     expect(result).toBeNull();
   });
+
+  it.each(nonPreloadGenerationStatuses)(
+    "returns null when the next chapter generation state is %s",
+    async (nextChapterGenerationStatus) => {
+      const [user, context] = await Promise.all([userFixture(), createChapterContext()]);
+
+      const [currentLesson] = await Promise.all([
+        lessonFixture({
+          chapterId: context.chapter.id,
+          generationStatus: "completed",
+          isPublished: true,
+          organizationId: context.organization.id,
+          position: 0,
+        }),
+        chapterFixture({
+          courseId: context.chapter.courseId,
+          generationStatus: nextChapterGenerationStatus,
+          isPublished: true,
+          organizationId: context.organization.id,
+          position: 1,
+        }),
+      ]);
+
+      const result = await getNextPreloadTarget({ lessonId: currentLesson.id, userId: user.id });
+
+      expect(result).toBeNull();
+    },
+  );
 });

--- a/packages/core/src/player/commands/get-next-lesson-preload-target.ts
+++ b/packages/core/src/player/commands/get-next-lesson-preload-target.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type GenerationStatus, prisma } from "@zoonk/db";
+import { type GenerationStatus, getPublishedChapterWhere, prisma } from "@zoonk/db";
 import { isUuid } from "@zoonk/utils/uuid";
 import {
   type NextLessonInCourse,
@@ -8,6 +8,36 @@ import {
 import { getCompletableLessonWhere } from "./_utils/completable-lesson";
 
 const preloadableGenerationStatuses = new Set<GenerationStatus>(["pending", "failed"]);
+
+export type NextPreloadTarget =
+  | { kind: "chapter"; chapterId: string }
+  | { kind: "lesson"; lessonId: string };
+
+/**
+ * Chapter generation should only be preloaded when the next chapter is still
+ * empty and retryable. Running chapters already have a workflow in flight, and
+ * completed chapters should expose their first lesson through the normal next
+ * lesson lookup instead of starting a second chapter workflow.
+ */
+async function getNextChapterPreloadCandidate({
+  chapterPosition,
+  courseId,
+}: {
+  chapterPosition: number;
+  courseId: string;
+}) {
+  return prisma.chapter.findFirst({
+    include: { _count: { select: { lessons: true } } },
+    orderBy: { position: "asc" },
+    where: getPublishedChapterWhere({
+      chapterWhere: { courseId, position: { gt: chapterPosition } },
+    }),
+  });
+}
+
+type NextChapterPreloadCandidate = NonNullable<
+  Awaited<ReturnType<typeof getNextChapterPreloadCandidate>>
+>;
 
 /**
  * Early preload should only enqueue work that can still become useful. Pending
@@ -25,10 +55,10 @@ function isPreloadableNextLesson(
 }
 
 /**
- * Completion already has the next lesson row loaded, so it can reuse the same
- * preload eligibility rule without doing another current-lesson lookup.
+ * Callers that already have the next lesson row can reuse the same preload
+ * eligibility rule without doing another current-lesson lookup.
  */
-export function getNextLessonPreloadId({
+function getNextLessonPreloadId({
   nextLesson,
 }: {
   nextLesson: NextLessonInCourse | null;
@@ -41,17 +71,79 @@ export function getNextLessonPreloadId({
 }
 
 /**
- * The browser only proves that a learner interacted with the current lesson.
- * This command derives the next structural lesson on the server so callers do
- * not trust a client-provided target for an expensive AI generation job.
+ * Chapter preloading is the fallback for the boundary between generated
+ * chapters: if there is no next lesson row yet, the next published chapter
+ * can be generated early so its first lesson is ready by the time the learner
+ * finishes the current chapter.
  */
-export async function getNextLessonPreloadTarget({
+function getChapterPreloadTarget(
+  nextChapter: NextChapterPreloadCandidate | null,
+): NextPreloadTarget | null {
+  if (!nextChapter) {
+    return null;
+  }
+
+  if (nextChapter._count.lessons > 0) {
+    return null;
+  }
+
+  if (!preloadableGenerationStatuses.has(nextChapter.generationStatus)) {
+    return null;
+  }
+
+  return { chapterId: nextChapter.id, kind: "chapter" };
+}
+
+/**
+ * The second-step preload entry point needs one structural decision: prefer a
+ * concrete next lesson when it exists, otherwise generate the next empty
+ * chapter if the learner is at the chapter boundary.
+ */
+async function getNextPreloadTargetAfterLessonPosition({
+  chapterId,
+  chapterPosition,
+  courseId,
+  lessonPosition,
+}: {
+  chapterId: string;
+  chapterPosition: number;
+  courseId: string;
+  lessonPosition: number;
+}): Promise<NextPreloadTarget | null> {
+  const nextLesson = await getNextLessonInCourse({
+    chapterId,
+    chapterPosition,
+    courseId,
+    lessonPosition,
+  });
+
+  const nextLessonId = getNextLessonPreloadId({ nextLesson });
+
+  if (nextLessonId) {
+    return { kind: "lesson", lessonId: nextLessonId };
+  }
+
+  if (nextLesson) {
+    return null;
+  }
+
+  const nextChapter = await getNextChapterPreloadCandidate({ chapterPosition, courseId });
+
+  return getChapterPreloadTarget(nextChapter);
+}
+
+/**
+ * The browser only proves that a learner interacted with the current lesson.
+ * This command derives the next preload target on the server so callers do not
+ * trust a client-provided lesson or chapter id for an expensive AI job.
+ */
+export async function getNextPreloadTarget({
   lessonId,
   userId,
 }: {
   lessonId: string;
   userId: string;
-}): Promise<string | null> {
+}): Promise<NextPreloadTarget | null> {
   if (!isUuid(lessonId) || !isUuid(userId)) {
     return null;
   }
@@ -65,12 +157,10 @@ export async function getNextLessonPreloadTarget({
     return null;
   }
 
-  const nextLesson = await getNextLessonInCourse({
+  return getNextPreloadTargetAfterLessonPosition({
     chapterId: lesson.chapterId,
     chapterPosition: lesson.chapter.position,
     courseId: lesson.chapter.courseId,
     lessonPosition: lesson.position,
   });
-
-  return getNextLessonPreloadId({ nextLesson });
 }

--- a/packages/core/src/player/commands/submit-player-completion.test.ts
+++ b/packages/core/src/player/commands/submit-player-completion.test.ts
@@ -27,9 +27,6 @@ const inaccessibleLessonCases: { name: string; visibility: CompletableLessonVisi
   { name: "organization", visibility: { organizationKind: "school" } },
 ];
 
-const preloadGenerationStatuses = ["pending", "failed"] as const;
-const nonPreloadGenerationStatuses = ["completed", "running"] as const;
-
 /**
  * Completion writes store a local calendar day alongside UTC timestamps so the
  * daily progress tables can aggregate by the learner's own timezone. Tests only
@@ -66,7 +63,7 @@ async function createChapterContext(params: CompletableLessonVisibility = {}) {
 /**
  * These tests exercise the shared player completion flow, so a single
  * multiple-choice step is enough to verify validation, persistence, and
- * follow-up effect planning without dragging in unrelated player variants.
+ * persistence without dragging in unrelated player variants.
  */
 async function createMultipleChoiceLesson(params: {
   chapterId: string;
@@ -324,17 +321,17 @@ async function readCompletionWrites(params: {
 }
 
 describe(submitPlayerCompletion, () => {
-  it("returns null when the submitted lesson no longer exists", async () => {
-    const result = await submitPlayerCompletion({
-      input: buildCompletionInput({ lessonId: randomUUID(), stepId: randomUUID() }),
-      userId: randomUUID(),
-    });
-
-    expect(result).toBeNull();
+  it("ignores submissions for lessons that no longer exist", async () => {
+    await expect(
+      submitPlayerCompletion({
+        input: buildCompletionInput({ lessonId: randomUUID(), stepId: randomUUID() }),
+        userId: randomUUID(),
+      }),
+    ).resolves.toBeUndefined();
   });
 
   it.each(inaccessibleLessonCases)(
-    "returns null without writing progress when the submitted $name is not publicly completable",
+    "does not write progress when the submitted $name is not publicly completable",
     async (testCase) => {
       const [user, context] = await Promise.all([
         userFixture(),
@@ -347,7 +344,7 @@ describe(submitPlayerCompletion, () => {
         organizationId: context.organization.id,
       });
 
-      const result = await submitPlayerCompletion({
+      await submitPlayerCompletion({
         input: buildCompletionInput({ lessonId: lesson.id, stepId: step.id }),
         userId: user.id,
       });
@@ -359,7 +356,6 @@ describe(submitPlayerCompletion, () => {
         userId: user.id,
       });
 
-      expect(result).toBeNull();
       expect(writes.chapterCompletion).toHaveLength(0);
       expect(writes.courseCompletion).toHaveLength(0);
       expect(writes.courseUser).toBeNull();
@@ -370,85 +366,37 @@ describe(submitPlayerCompletion, () => {
     },
   );
 
-  it.each(preloadGenerationStatuses)(
-    "persists completion and requests preloading when the next lesson is %s",
-    async (generationStatus) => {
-      const [user, { chapter, organization }] = await Promise.all([
-        userFixture(),
-        createChapterContext(),
-      ]);
+  it("persists completion for a valid interactive lesson", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
 
-      const [currentLesson, nextLesson] = await Promise.all([
-        createMultipleChoiceLesson({
-          chapterId: chapter.id,
-          organizationId: organization.id,
-          position: 0,
-        }),
-        lessonFixture({
-          chapterId: chapter.id,
-          generationStatus,
-          isPublished: true,
-          organizationId: organization.id,
-          position: 1,
-        }),
-      ]);
+    const currentLesson = await createMultipleChoiceLesson({
+      chapterId: chapter.id,
+      organizationId: organization.id,
+      position: 0,
+    });
 
-      const result = await submitPlayerCompletion({
-        input: buildCompletionInput({
-          lessonId: currentLesson.lesson.id,
-          stepId: currentLesson.step.id,
-        }),
-        userId: user.id,
-      });
+    await submitPlayerCompletion({
+      input: buildCompletionInput({
+        lessonId: currentLesson.lesson.id,
+        stepId: currentLesson.step.id,
+      }),
+      userId: user.id,
+    });
 
-      const [lessonProgress, stepAttempts] = await Promise.all([
-        prisma.lessonProgress.findUnique({
-          where: { userLesson: { lessonId: currentLesson.lesson.id, userId: user.id } },
-        }),
-        prisma.stepAttempt.findMany({ where: { stepId: currentLesson.step.id, userId: user.id } }),
-      ]);
+    const [lessonProgress, stepAttempts] = await Promise.all([
+      prisma.lessonProgress.findUnique({
+        where: { userLesson: { lessonId: currentLesson.lesson.id, userId: user.id } },
+      }),
+      prisma.stepAttempt.findMany({ where: { stepId: currentLesson.step.id, userId: user.id } }),
+    ]);
 
-      expect(nextLesson.position).toBeGreaterThan(currentLesson.lesson.position);
-      expect(result).toStrictEqual({ preloadLessonId: nextLesson.id });
-      expect(lessonProgress?.completedAt).toBeInstanceOf(Date);
-      expect(stepAttempts).toHaveLength(1);
-      expect(stepAttempts[0]?.isCorrect).toBe(true);
-    },
-  );
-
-  it.each(nonPreloadGenerationStatuses)(
-    "persists completion without requesting preloading when the next lesson is %s",
-    async (generationStatus) => {
-      const [user, { chapter, organization }] = await Promise.all([
-        userFixture(),
-        createChapterContext(),
-      ]);
-
-      const currentLesson = await createMultipleChoiceLesson({
-        chapterId: chapter.id,
-        organizationId: organization.id,
-        position: 0,
-      });
-
-      await lessonFixture({
-        chapterId: chapter.id,
-        generationStatus,
-        isPublished: true,
-        organizationId: organization.id,
-        position: 1,
-      });
-
-      const result = await submitPlayerCompletion({
-        input: buildCompletionInput({
-          lessonId: currentLesson.lesson.id,
-          stepId: currentLesson.step.id,
-        }),
-        userId: user.id,
-      });
-
-      expect(result).toStrictEqual({ preloadLessonId: null });
-    },
-  );
+    expect(lessonProgress?.completedAt).toBeInstanceOf(Date);
+    expect(stepAttempts).toHaveLength(1);
+    expect(stepAttempts[0]?.isCorrect).toBe(true);
+  });
 
   it("rejects empty answers for an interactive lesson without writing progress", async () => {
     const [user, { chapter, course, organization }] = await Promise.all([
@@ -461,7 +409,7 @@ describe(submitPlayerCompletion, () => {
       organizationId: organization.id,
     });
 
-    const result = await submitPlayerCompletion({
+    await submitPlayerCompletion({
       input: buildEmptyCompletionInput({ lessonId: lesson.id }),
       userId: user.id,
     });
@@ -473,7 +421,6 @@ describe(submitPlayerCompletion, () => {
       userId: user.id,
     });
 
-    expect(result).toBeNull();
     expect(writes.dailyProgress).toHaveLength(0);
     expect(writes.lessonProgress).toBeNull();
     expect(writes.stepAttempts).toHaveLength(0);
@@ -491,7 +438,7 @@ describe(submitPlayerCompletion, () => {
       organizationId: organization.id,
     });
 
-    const result = await submitPlayerCompletion({
+    await submitPlayerCompletion({
       input: buildCompletionInputForSteps({ lessonId: lesson.id, stepIds: [steps[0]!.id] }),
       userId: user.id,
     });
@@ -503,7 +450,6 @@ describe(submitPlayerCompletion, () => {
       userId: user.id,
     });
 
-    expect(result).toBeNull();
     expect(writes.dailyProgress).toHaveLength(0);
     expect(writes.lessonProgress).toBeNull();
     expect(writes.stepAttempts).toHaveLength(0);
@@ -521,7 +467,7 @@ describe(submitPlayerCompletion, () => {
       organizationId: organization.id,
     });
 
-    const result = await submitPlayerCompletion({
+    await submitPlayerCompletion({
       input: buildCompletionInputForSteps({
         lessonId: lesson.id,
         selectedOptionId: "b",
@@ -534,7 +480,6 @@ describe(submitPlayerCompletion, () => {
       where: { stepId: { in: steps.map((step) => step.id) }, userId: user.id },
     });
 
-    expect(result).toStrictEqual({ preloadLessonId: null });
     expect(stepAttempts).toHaveLength(2);
     expect(stepAttempts.every((attempt) => !attempt.isCorrect)).toBe(true);
   });
@@ -550,7 +495,7 @@ describe(submitPlayerCompletion, () => {
       organizationId: organization.id,
     });
 
-    const result = await submitPlayerCompletion({
+    await submitPlayerCompletion({
       input: buildEmptyCompletionInput({ lessonId: lesson.id }),
       userId: user.id,
     });
@@ -563,7 +508,6 @@ describe(submitPlayerCompletion, () => {
       prisma.stepAttempt.findMany({ where: { stepId: step.id, userId: user.id } }),
     ]);
 
-    expect(result).toStrictEqual({ preloadLessonId: null });
     expect(dailyProgress?.staticCompleted).toBe(1);
     expect(lessonProgress?.completedAt).toBeInstanceOf(Date);
     expect(stepAttempts).toHaveLength(0);
@@ -658,7 +602,7 @@ describe(submitPlayerCompletion, () => {
       ),
     );
 
-    const result = await submitPlayerCompletion({
+    await submitPlayerCompletion({
       input: buildReviewCompletionInput({
         lessonId: reviewLesson.id,
         stepIds: reviewableSteps.slice(0, 1).map((step) => step.id),
@@ -676,7 +620,6 @@ describe(submitPlayerCompletion, () => {
       }),
     ]);
 
-    expect(result).toBeNull();
     expect(dailyProgress).toBeNull();
     expect(lessonProgress).toBeNull();
     expect(stepAttempts).toHaveLength(0);
@@ -725,7 +668,7 @@ describe(submitPlayerCompletion, () => {
       position: REVIEW_TARGET_STEP_COUNT,
     });
 
-    const result = await submitPlayerCompletion({
+    await submitPlayerCompletion({
       input: buildReviewCompletionInput({
         lessonId: reviewLesson.id,
         stepIds: answerableSteps.map((step) => step.id),
@@ -740,7 +683,6 @@ describe(submitPlayerCompletion, () => {
       }),
     ]);
 
-    expect(result).toStrictEqual({ preloadLessonId: null });
     expect(stepAttempts).toHaveLength(REVIEW_TARGET_STEP_COUNT - 1);
     expect(dailyProgress?.correctAnswers).toBe(REVIEW_TARGET_STEP_COUNT - 1);
   });

--- a/packages/core/src/player/commands/submit-player-completion.ts
+++ b/packages/core/src/player/commands/submit-player-completion.ts
@@ -1,12 +1,10 @@
 import "server-only";
 import { type StepKind, prisma } from "@zoonk/db";
-import { getNextLessonInCourse } from "../../lessons/get-next-lesson-in-course";
 import { type CompletionInput } from "../contracts/completion-input-schema";
 import { computeLessonScore } from "../contracts/compute-score";
 import { countAnswerableSteps, validateAnswers } from "../contracts/validate-answers";
 import { getReviewValidationData } from "../queries/get-review-steps";
 import { getCompletableLessonWhere } from "./_utils/completable-lesson";
-import { getNextLessonPreloadId } from "./get-next-lesson-preload-target";
 import { submitLessonCompletion } from "./submit-lesson-completion";
 
 const MAX_DURATION_SECONDS = 7200;
@@ -25,8 +23,6 @@ type StepWithSentence = {
   word: { id: string } | null;
   sentence: { id: string; sentence: string } | null;
 };
-
-type PlayerCompletionEffects = { preloadLessonId: string | null };
 
 /**
  * Attaches chapter-scoped sentence translation data to steps.
@@ -65,13 +61,13 @@ function hasCompleteAnswerCoverage(params: {
 /**
  * The app shell should only orchestrate request-specific concerns such as auth,
  * cache revalidation, and background execution. This command owns the shared
- * completion workflow: validate the submission, persist authoritative progress,
- * and describe any follow-up lesson work the host app should trigger.
+ * completion workflow: validate the submission and persist authoritative
+ * progress without coupling lesson completion to generation side effects.
  */
 export async function submitPlayerCompletion(params: {
   input: CompletionInput;
   userId: string;
-}): Promise<PlayerCompletionEffects | null> {
+}): Promise<void> {
   const lessonId = params.input.lessonId;
 
   const lesson = await prisma.lesson.findFirst({
@@ -87,7 +83,7 @@ export async function submitPlayerCompletion(params: {
   });
 
   if (!lesson) {
-    return null;
+    return;
   }
 
   const validationData =
@@ -111,7 +107,7 @@ export async function submitPlayerCompletion(params: {
       validatedStepCount: stepResults.length,
     })
   ) {
-    return null;
+    return;
   }
 
   const score = computeLessonScore({ results: stepResults });
@@ -142,13 +138,4 @@ export async function submitPlayerCompletion(params: {
     stepResults: mergedStepResults,
     userId: params.userId,
   });
-
-  const nextLesson = await getNextLessonInCourse({
-    chapterId: lesson.chapterId,
-    chapterPosition: lesson.chapter.position,
-    courseId: lesson.chapter.courseId,
-    lessonPosition: lesson.position,
-  });
-
-  return { preloadLessonId: getNextLessonPreloadId({ nextLesson }) };
 }


### PR DESCRIPTION
## Summary
- derive lesson preload targets as either the next lesson or the next empty chapter
- trigger chapter generation from the second-step preload path only for active subscribers
- remove preload work from lesson completion persistence

## Verification
- pnpm --filter @zoonk/core test -- src/player/commands/get-next-lesson-preload-target.test.ts src/player/commands/submit-player-completion.test.ts
- pnpm --filter main test -- src/data/progress/trigger-preload-target.test.ts
- pnpm --filter @zoonk/core typecheck
- pnpm --filter main typecheck
- pnpm knip --production
- pnpm format
- pnpm lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preload now targets either the next lesson or the next empty chapter, and only triggers chapter generation for active subscribers. Lesson completion no longer triggers preload; it only persists progress.

- **New Features**
  - Added `getNextPreloadTarget` in `@zoonk/core` to return a lesson or chapter target based on course position and generation state.
  - Added `trigger-preload-target` to route targets: lessons use `triggerLessonPreload`; chapters use `triggerChapterGeneration` gated by `hasActiveSubscription`.
  - Introduced `trigger-workflow` to standardize server-to-server workflow POSTs and error logging.

- **Refactors**
  - Updated `preload-next-lesson-action` to use `getNextPreloadTarget` and pass `requestHeaders` for subscription checks.
  - Removed preload side effects from `submit-player-completion`; it now returns `void`.
  - Added/updated tests for preload target selection and workflow dispatch.

<sup>Written for commit e922b4ca84f681c825242a48f7e594768f15a2ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1564?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

