### PR TITLE
fix(api): allow disabling auth cookie cache

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -20,6 +20,9 @@ NEXT_PUBLIC_API_URL=http://localhost:4000
 # Better Auth base path
 NEXT_PUBLIC_AUTH_BASE_PATH=/v1/auth
 
+# Better Auth cookie cache
+AUTH_COOKIE_CACHE_ENABLED=false
+
 ### OPTIONAL VARIABLES ###
 
 # Mailer API key for email services

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -4,6 +4,7 @@ export const BETTER_AUTH_BASE_PATH = process.env.NEXT_PUBLIC_AUTH_BASE_PATH || "
 
 export const SESSION_EXPIRES_IN_DAYS = 30;
 export const COOKIE_CACHE_MINUTES = 60;
+export const IS_COOKIE_CACHE_ENABLED = process.env.AUTH_COOKIE_CACHE_ENABLED !== "false";
 
 // We don't want to limit the number of memberships or organizations
 // So we use the maximum safe integer because Better Auth doesn't support infinity.

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -19,6 +19,7 @@ import {
   AUTH_ORGANIZATION_LIMIT,
   BETTER_AUTH_BASE_PATH,
   COOKIE_CACHE_MINUTES,
+  IS_COOKIE_CACHE_ENABLED,
   SESSION_EXPIRES_IN_DAYS,
 } from "./config";
 import { ac, admin, member, owner } from "./permissions";
@@ -47,7 +48,7 @@ export const baseAuthConfig: Omit<BetterAuthOptions, "rateLimit"> = {
   database: prismaAdapter(prisma, { provider: "postgresql" }),
   experimental: { joins: true },
   session: {
-    cookieCache: { enabled: true, maxAge: 60 * COOKIE_CACHE_MINUTES },
+    cookieCache: { enabled: IS_COOKIE_CACHE_ENABLED, maxAge: 60 * COOKIE_CACHE_MINUTES },
     expiresIn: 60 * 60 * 24 * SESSION_EXPIRES_IN_DAYS,
   },
   trustedOrigins: ["https://appleid.apple.com"],

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,7 @@
     "env": [
       "AI_GATEWAY_API_KEY",
       "APPLE_*",
+      "AUTH_COOKIE_CACHE_ENABLED",
       "BETTER_AUTH_SECRET",
       "BLOB_READ_WRITE_TOKEN",
       "DATABASE_*",


### PR DESCRIPTION
## Summary

- add an auth cookie cache toggle that stays enabled by default
- disable the cache in the API app example env
- include the toggle in Turbo env tracking

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an env toggle to control auth cookie caching via `AUTH_COOKIE_CACHE_ENABLED`. Caching stays enabled by default; the API example turns it off and the var is tracked by Turbo.

- **Migration**
  - To disable caching, set `AUTH_COOKIE_CACHE_ENABLED=false` in your environment. No action needed to keep caching enabled.

<sup>Written for commit 453b94d4e41edc2dbab58a5412b48ee3022c3c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1566?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

