### PR TITLE
feat(main): add catalog open graph images

### DIFF
--- a/apps/main/e2e/opengraph-image.test.ts
+++ b/apps/main/e2e/opengraph-image.test.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+import { type APIRequestContext } from "@playwright/test";
+import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { normalizeString } from "@zoonk/utils/string";
+import { type Page, expect, test } from "./fixtures";
+
+const OPEN_GRAPH_IMAGE_SIZE = { height: 630, width: 1200 };
+
+/**
+ * The generated route returns PNG bytes, so this reads the PNG header directly
+ * instead of depending on browser rendering details or snapshot files.
+ */
+function getPngSize(image: Buffer): { height: number; width: number } {
+  return { height: image.readUInt32BE(20), width: image.readUInt32BE(16) };
+}
+
+/**
+ * Catalog pages need route-specific social cards, so the simplest end-to-end
+ * proof is asking the metadata route for an image and checking the actual bytes.
+ */
+async function expectGeneratedOpenGraphImage({
+  path,
+  request,
+}: {
+  path: string;
+  request: APIRequestContext;
+}) {
+  const response = await request.get(path);
+  const image = await response.body();
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("image/png");
+  expect(image.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
+  expect(getPngSize(image)).toStrictEqual(OPEN_GRAPH_IMAGE_SIZE);
+}
+
+/**
+ * Next fingerprints generated metadata routes, so tests need to read the
+ * concrete image URL from the page head instead of guessing the file route.
+ */
+async function getOpenGraphImagePath({ page, path }: { page: Page; path: string }) {
+  await page.goto(path);
+
+  const imageUrl = await page.evaluate(
+    () => document.querySelector<HTMLMetaElement>("meta[property='og:image']")?.content ?? "",
+  );
+
+  const url = new URL(imageUrl, "http://localhost");
+  return `${url.pathname}${url.search}`;
+}
+
+test("generates route-specific open graph images for catalog pages", async ({ page, request }) => {
+  const uniqueId = randomUUID().slice(0, 8);
+  const org = await getAiOrganization();
+  const courseTitle = `E2E Open Graph Course ${uniqueId}`;
+  const chapterTitle = `E2E Open Graph Chapter ${uniqueId}`;
+  const lessonTitle = `E2E Open Graph Lesson ${uniqueId}`;
+
+  const course = await courseFixture({
+    description: `A social sharing course ${uniqueId}`,
+    imageUrl: "/catalog/chapters/tech.webp",
+    isPublished: true,
+    normalizedTitle: normalizeString(courseTitle),
+    organizationId: org.id,
+    slug: `e2e-og-course-${uniqueId}`,
+    title: courseTitle,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    description: `A social sharing chapter ${uniqueId}`,
+    imageUrl: "/catalog/chapters/science.webp",
+    isPublished: true,
+    normalizedTitle: normalizeString(chapterTitle),
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-og-chapter-${uniqueId}`,
+    title: chapterTitle,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    description: `A social sharing lesson ${uniqueId}`,
+    imageUrl: "/catalog/lessons/explanation.webp",
+    isPublished: true,
+    kind: "explanation",
+    normalizedTitle: normalizeString(lessonTitle),
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-og-lesson-${uniqueId}`,
+    title: lessonTitle,
+  });
+
+  const coursePath = `/b/${org.slug}/c/${course.slug}`;
+  const chapterPath = `${coursePath}/ch/${chapter.slug}`;
+  const lessonPath = `${chapterPath}/l/${lesson.slug}`;
+
+  const courseImagePath = await getOpenGraphImagePath({ page, path: coursePath });
+  const chapterImagePath = await getOpenGraphImagePath({ page, path: chapterPath });
+  const lessonImagePath = await getOpenGraphImagePath({ page, path: lessonPath });
+
+  await Promise.all([
+    expectGeneratedOpenGraphImage({ path: courseImagePath, request }),
+    expectGeneratedOpenGraphImage({ path: chapterImagePath, request }),
+    expectGeneratedOpenGraphImage({ path: lessonImagePath, request }),
+  ]);
+});

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/opengraph-image.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/opengraph-image.tsx
@@ -1,0 +1,37 @@
+import { getChapter } from "@/data/chapters/get-chapter";
+import { getDefaultChapterImage } from "@/lib/catalog/default-images";
+import {
+  catalogOpenGraphImageContentType,
+  catalogOpenGraphImageSize,
+  createCatalogOpenGraphImage,
+} from "@/lib/metadata/catalog-opengraph-image";
+
+type Props = { params: Promise<{ brandSlug: string; chapterSlug: string; courseSlug: string }> };
+
+export const alt = "Zoonk chapter preview";
+export const contentType = catalogOpenGraphImageContentType;
+export const size = catalogOpenGraphImageSize;
+
+/**
+ * Chapter shares should still feel anchored to the parent course, so the card
+ * combines chapter artwork with the course title and course categories.
+ */
+export default async function Image({ params }: Props) {
+  const { brandSlug, chapterSlug, courseSlug } = await params;
+  const chapter = await getChapter({ brandSlug, chapterSlug, courseSlug });
+
+  if (!chapter) {
+    return createCatalogOpenGraphImage({
+      description: null,
+      fallbackImagePath: "/catalog/chapters/general.webp",
+      title: "Zoonk",
+    });
+  }
+
+  return createCatalogOpenGraphImage({
+    description: chapter.course.description,
+    fallbackImagePath: getDefaultChapterImage({ categories: chapter.course.categories }),
+    imageUrl: chapter.imageUrl,
+    title: chapter.course.title,
+  });
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/opengraph-image.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/opengraph-image.tsx
@@ -1,0 +1,37 @@
+import { getCourse } from "@/data/courses/get-course";
+import { getDefaultChapterImage } from "@/lib/catalog/default-images";
+import {
+  catalogOpenGraphImageContentType,
+  catalogOpenGraphImageSize,
+  createCatalogOpenGraphImage,
+} from "@/lib/metadata/catalog-opengraph-image";
+
+type Props = { params: Promise<{ brandSlug: string; courseSlug: string }> };
+
+export const alt = "Zoonk course preview";
+export const contentType = catalogOpenGraphImageContentType;
+export const size = catalogOpenGraphImageSize;
+
+/**
+ * Course pages are the top-level catalog share target, so their preview uses
+ * the course thumbnail when available and falls back to category-aligned art.
+ */
+export default async function Image({ params }: Props) {
+  const { brandSlug, courseSlug } = await params;
+  const course = await getCourse({ brandSlug, courseSlug });
+
+  if (!course) {
+    return createCatalogOpenGraphImage({
+      description: null,
+      fallbackImagePath: "/catalog/chapters/general.webp",
+      title: "Zoonk",
+    });
+  }
+
+  return createCatalogOpenGraphImage({
+    description: course.description,
+    fallbackImagePath: getDefaultChapterImage({ categories: course.categories }),
+    imageUrl: course.imageUrl,
+    title: course.title,
+  });
+}

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/opengraph-image.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/opengraph-image.tsx
@@ -1,0 +1,44 @@
+import { getLesson } from "@/data/lessons/get-lesson";
+import { getDefaultLessonImage } from "@/lib/catalog/default-images";
+import {
+  catalogOpenGraphImageContentType,
+  catalogOpenGraphImageSize,
+  createCatalogOpenGraphImage,
+} from "@/lib/metadata/catalog-opengraph-image";
+
+type Props = {
+  params: Promise<{
+    brandSlug: string;
+    chapterSlug: string;
+    courseSlug: string;
+    lessonSlug: string;
+  }>;
+};
+
+export const alt = "Zoonk lesson preview";
+export const contentType = catalogOpenGraphImageContentType;
+export const size = catalogOpenGraphImageSize;
+
+/**
+ * Lesson shares should promote the course, not the internal lesson metadata, so
+ * the card keeps the lesson image but uses the parent course copy.
+ */
+export default async function Image({ params }: Props) {
+  const { brandSlug, chapterSlug, courseSlug, lessonSlug } = await params;
+  const lesson = await getLesson({ brandSlug, chapterSlug, courseSlug, lessonSlug });
+
+  if (!lesson) {
+    return createCatalogOpenGraphImage({
+      description: null,
+      fallbackImagePath: "/catalog/lessons/explanation.webp",
+      title: "Zoonk",
+    });
+  }
+
+  return createCatalogOpenGraphImage({
+    description: lesson.chapter.course.description,
+    fallbackImagePath: getDefaultLessonImage(lesson.kind),
+    imageUrl: lesson.imageUrl,
+    title: lesson.chapter.course.title,
+  });
+}

--- a/apps/main/src/lib/metadata/catalog-opengraph-image.tsx
+++ b/apps/main/src/lib/metadata/catalog-opengraph-image.tsx
@@ -1,0 +1,296 @@
+import "server-only";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { optimizeImage } from "@zoonk/core/images/optimize";
+import { safeAsync } from "@zoonk/utils/error";
+import { ImageResponse } from "next/og";
+
+const ROOT_OPEN_GRAPH_IMAGE_PATH = "src/app/opengraph-image.png";
+const DESCRIPTION_LINE_HEIGHT = 1.35;
+const DESCRIPTION_LINE_COUNT = 5;
+const DESCRIPTION_FONT_SIZE = 30;
+const MAX_DESCRIPTION_LENGTH = 112;
+const MAX_TITLE_LENGTH = 76;
+const LONG_TITLE_LENGTH = 58;
+const MEDIUM_TITLE_LENGTH = 38;
+const LONG_TITLE_FONT_SIZE = 52;
+const MEDIUM_TITLE_FONT_SIZE = 60;
+const SHORT_TITLE_FONT_SIZE = 68;
+
+export const catalogOpenGraphImageSize = { height: 630, width: 1200 };
+export const catalogOpenGraphImageContentType = "image/png";
+
+type CatalogOpenGraphImageParams = {
+  description?: string | null;
+  fallbackImagePath: string;
+  imageUrl?: string | null;
+  title: string;
+};
+
+type CatalogImageSource =
+  | { kind: "public"; path: string }
+  | { kind: "remote"; url: string }
+  | { kind: "root" };
+
+/**
+ * Builds the shared catalog Open Graph image with only the course image, title,
+ * and description so share cards stay clean and cache-safe.
+ */
+export async function createCatalogOpenGraphImage(params: CatalogOpenGraphImageParams) {
+  const imageSrc = await getRenderableImageSrc({
+    fallbackImagePath: params.fallbackImagePath,
+    imageUrl: params.imageUrl,
+  });
+
+  return new ImageResponse(<CatalogOpenGraphImage imageSrc={imageSrc} {...params} />, {
+    ...catalogOpenGraphImageSize,
+  });
+}
+
+/**
+ * Keeps long generated titles inside the fixed social-card canvas instead of
+ * letting one unusually long course or lesson title overflow the image.
+ */
+function truncateText({ maxLength, text }: { maxLength: number; text: string }): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, maxLength - 1).trimEnd()}...`;
+}
+
+/**
+ * Longer titles need a smaller fixed type size because Open Graph images have a
+ * single target canvas and cannot rely on responsive browser layout.
+ */
+function getTitleFontSize(title: string): number {
+  if (title.length > LONG_TITLE_LENGTH) {
+    return LONG_TITLE_FONT_SIZE;
+  }
+
+  if (title.length > MEDIUM_TITLE_LENGTH) {
+    return MEDIUM_TITLE_FONT_SIZE;
+  }
+
+  return SHORT_TITLE_FONT_SIZE;
+}
+
+/**
+ * Optional image URLs flow through conditional arrays, so this narrows them
+ * before the fallback loader receives an ordered list of concrete sources.
+ */
+function isImageSource(source: CatalogImageSource | null): source is CatalogImageSource {
+  return Boolean(source);
+}
+
+/**
+ * Stored image URLs may be remote uploads or app-public fallback paths. Keeping
+ * them typed avoids dynamic filesystem joins that make the build trace too much.
+ */
+function getImageSource(source: string | null | undefined): CatalogImageSource | null {
+  if (!source) {
+    return null;
+  }
+
+  if (source.startsWith("https://") || source.startsWith("http://")) {
+    return { kind: "remote", url: source };
+  }
+
+  if (source.startsWith("/")) {
+    return { kind: "public", path: source.slice(1) };
+  }
+
+  return null;
+}
+
+/**
+ * Thumbnail URLs can be remote blob URLs or local public fallback paths. The
+ * renderer tries the content image first, then the route fallback, then the
+ * root static share image so metadata generation never fails over artwork.
+ */
+async function getRenderableImageSrc({
+  fallbackImagePath,
+  imageUrl,
+}: {
+  fallbackImagePath: string;
+  imageUrl?: string | null;
+}): Promise<string> {
+  const sources = [
+    getImageSource(imageUrl),
+    getImageSource(fallbackImagePath),
+    { kind: "root" } as const,
+  ].filter((source) => isImageSource(source));
+
+  return getFirstRenderableImageSrc(sources);
+}
+
+/**
+ * The first usable image should win because generated thumbnails are more
+ * specific than fallback art, but a broken upload should still leave a card.
+ */
+async function getFirstRenderableImageSrc(sources: CatalogImageSource[]): Promise<string> {
+  const [source, ...remainingSources] = sources;
+
+  if (!source) {
+    return "";
+  }
+
+  const image = await readImageBytes(source);
+  const dataUrl = image ? await getPngDataUrl({ image }) : null;
+
+  if (dataUrl) {
+    return dataUrl;
+  }
+
+  return getFirstRenderableImageSrc(remainingSources);
+}
+
+/**
+ * `next/og` renders PNG data URLs reliably, while the generated catalog art is
+ * stored as WebP. Converting at the metadata boundary keeps the stored assets
+ * unchanged and avoids blank share previews.
+ */
+async function getPngDataUrl({ image }: { image: Buffer }): Promise<string | null> {
+  const { data } = await optimizeImage({ format: "png", image, quality: 92 });
+
+  if (!data) {
+    return null;
+  }
+
+  return `data:image/png;base64,${data.toString("base64")}`;
+}
+
+/**
+ * Keeps remote and local image loading behind one boundary so the renderer does
+ * not need to know where a thumbnail came from.
+ */
+async function readImageBytes(source: CatalogImageSource): Promise<Buffer | null> {
+  if (source.kind === "remote") {
+    return fetchRemoteImage(source.url);
+  }
+
+  if (source.kind === "public") {
+    return readLocalImage(join(process.cwd(), "public", source.path));
+  }
+
+  return readLocalImage(join(process.cwd(), ROOT_OPEN_GRAPH_IMAGE_PATH));
+}
+
+/**
+ * Remote thumbnails are user-facing content, so failures should degrade to the
+ * next fallback image instead of breaking the metadata route.
+ */
+async function fetchRemoteImage(url: string): Promise<Buffer | null> {
+  const { data } = await safeAsync(async () => {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`Image request failed with ${response.status}`);
+    }
+
+    return Buffer.from(await response.arrayBuffer());
+  });
+
+  return data;
+}
+
+/**
+ * Local fallback art lives in the app project so tests and previews do not need
+ * production network access when a course has no generated thumbnail.
+ */
+async function readLocalImage(path: string): Promise<Buffer | null> {
+  const { data } = await safeAsync(() => readFile(path));
+  return data;
+}
+
+/**
+ * The card follows a quiet course-preview layout: one image block and one text
+ * block, with no labels or metadata that would compete with the course copy.
+ */
+function CatalogOpenGraphImage({
+  description,
+  imageSrc,
+  title,
+}: CatalogOpenGraphImageParams & { imageSrc: string }) {
+  const safeTitle = truncateText({ maxLength: MAX_TITLE_LENGTH, text: title });
+
+  const safeDescription = description
+    ? truncateText({ maxLength: MAX_DESCRIPTION_LENGTH, text: description })
+    : "";
+
+  return (
+    <div
+      style={{
+        alignItems: "center",
+        background: "#ffffff",
+        color: "#111111",
+        display: "flex",
+        fontFamily: "Arial, Helvetica, sans-serif",
+        gap: 96,
+        height: "100%",
+        justifyContent: "center",
+        padding: "72px 96px",
+        width: "100%",
+      }}
+    >
+      <div
+        style={{
+          background: "#ffffff",
+          border: "1px solid rgba(17, 17, 17, 0.12)",
+          borderRadius: 32,
+          display: "flex",
+          flexShrink: 0,
+          height: 360,
+          justifyContent: "center",
+          overflow: "hidden",
+          padding: 36,
+          width: 360,
+        }}
+      >
+        {/* oxlint-disable-next-line next/no-img-element -- ImageResponse renders plain img elements, not next/image. */}
+        <img
+          alt=""
+          src={imageSrc}
+          style={{ height: "100%", objectFit: "contain", width: "100%" }}
+        />
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 28,
+          justifyContent: "center",
+          minWidth: 0,
+          width: 560,
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: getTitleFontSize(safeTitle),
+            fontWeight: 800,
+            lineHeight: 1.04,
+          }}
+        >
+          {safeTitle}
+        </div>
+
+        {safeDescription && (
+          <div
+            style={{
+              color: "#4a4a4a",
+              display: "flex",
+              fontSize: DESCRIPTION_FONT_SIZE,
+              lineHeight: DESCRIPTION_LINE_HEIGHT,
+              maxHeight: DESCRIPTION_FONT_SIZE * DESCRIPTION_LINE_HEIGHT * DESCRIPTION_LINE_COUNT,
+              overflow: "hidden",
+            }}
+          >
+            {safeDescription}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add dynamic Open Graph image routes for catalog course, chapter, and lesson pages.
- Share a clean next/og renderer that uses the relevant thumbnail plus course title and description.
- Cover generated OG images with focused main E2E coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dynamic Open Graph images for catalog course, chapter, and lesson pages using a shared `next/og` renderer. Improves social share cards with clean thumbnails, course copy, and reliable PNG output with E2E coverage.

- New Features
  - Added OG image routes for course, chapter, and lesson pages.
  - Shared renderer builds cards from the thumbnail plus course title and description; lessons use course copy.
  - Falls back to category-aligned art and a root image; converts WebP to PNG for consistent rendering.
  - E2E test reads the `og:image` URL from the page head and validates the PNG header, content type, and 1200×630 size.

<sup>Written for commit 6ac719bf184d93ad2aac871f8464b5cdbdc89202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1567?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

