### PR TITLE
feat(player): improve step navigation access

### DIFF
--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -72,6 +72,7 @@ msgstr "Try again"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
+#: src/components/step-navigation-button-group.tsx
 msgid "9+Ddtu"
 msgstr "Next"
 
@@ -229,6 +230,10 @@ msgstr "Check"
 #: src/components/step-action-button.tsx
 msgid "acrOoz"
 msgstr "Continue"
+
+#: src/components/step-navigation-button-group.tsx
+msgid "JJNc3c"
+msgstr "Previous"
 
 #: src/components/swipe-navigable-step-layout.tsx
 msgid "aNzy1T"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -72,6 +72,7 @@ msgstr "Intentar de nuevo"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
+#: src/components/step-navigation-button-group.tsx
 msgid "9+Ddtu"
 msgstr "Siguiente"
 
@@ -229,6 +230,10 @@ msgstr "Revisar"
 #: src/components/step-action-button.tsx
 msgid "acrOoz"
 msgstr "Continuar"
+
+#: src/components/step-navigation-button-group.tsx
+msgid "JJNc3c"
+msgstr "Anterior"
 
 #: src/components/swipe-navigable-step-layout.tsx
 msgid "aNzy1T"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -72,6 +72,7 @@ msgstr "Tentar de novo"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
+#: src/components/step-navigation-button-group.tsx
 msgid "9+Ddtu"
 msgstr "Próxima"
 
@@ -229,6 +230,10 @@ msgstr "Verificar"
 #: src/components/step-action-button.tsx
 msgid "acrOoz"
 msgstr "Continuar"
+
+#: src/components/step-navigation-button-group.tsx
+msgid "JJNc3c"
+msgstr "Anterior"
 
 #: src/components/swipe-navigable-step-layout.tsx
 msgid "aNzy1T"

--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -139,7 +139,7 @@ function getScrollableAncestor(element: HTMLElement | null): HTMLElement | null 
 }
 
 describe("player browser integration: static steps", () => {
-  it("shows desktop arrows while preserving keyboard navigation", async () => {
+  it("shows explicit navigation controls while preserving keyboard navigation", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         kind: "explanation",
@@ -160,15 +160,12 @@ describe("player browser integration: static steps", () => {
     });
 
     await expect.element(page.getByRole("heading", { name: "First step" })).toBeInTheDocument();
+    await expect.element(page.getByRole("button", { name: /^Previous$/u })).not.toBeInTheDocument();
 
-    await expect
-      .element(page.getByRole("button", { name: /previous step/iu }))
-      .not.toBeInTheDocument();
-
-    await page.getByRole("button", { name: /next step/iu }).click();
+    await page.getByRole("button", { name: /^Next$/u }).click();
     await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();
 
-    await page.getByRole("button", { name: /previous step/iu }).click();
+    await page.getByRole("button", { name: /^Previous$/u }).click();
     await expect.element(page.getByRole("heading", { name: "First step" })).toBeInTheDocument();
 
     fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
@@ -178,6 +175,38 @@ describe("player browser integration: static steps", () => {
     await expect.element(page.getByRole("status")).toBeInTheDocument();
 
     await page.getByRole("button", { name: /try again/iu }).click();
+    await expect.element(page.getByRole("heading", { name: "First step" })).toBeInTheDocument();
+  });
+
+  it("shows tappable mobile navigation controls on static steps", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "explanation",
+        steps: [
+          buildSerializedStep({
+            content: { text: "First body", title: "First step", variant: "text" as const },
+            id: "static-mobile-nav-1",
+          }),
+          buildSerializedStep({
+            content: { text: "Second body", title: "Second step", variant: "text" as const },
+            id: "static-mobile-nav-2",
+            position: 1,
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await expect.element(page.getByRole("heading", { name: "First step" })).toBeInTheDocument();
+    await expect.element(page.getByRole("button", { name: /^Previous$/u })).not.toBeInTheDocument();
+
+    await page.getByRole("button", { name: /^Next$/u }).click();
+
+    await expect.element(page.getByRole("heading", { name: "Second step" })).toBeInTheDocument();
+
+    await page.getByRole("button", { name: /^Previous$/u }).click();
+
     await expect.element(page.getByRole("heading", { name: "First step" })).toBeInTheDocument();
   });
 

--- a/packages/player/src/components/player-bottom-bar.tsx
+++ b/packages/player/src/components/player-bottom-bar.tsx
@@ -5,8 +5,8 @@ import { cn } from "@zoonk/ui/lib/utils";
 /**
  * Fixed bottom bar for the player's action buttons on mobile and tablet.
  *
- * Read-only step navigation now happens via swipe and keyboard, so this shell
- * only needs to anchor the primary action row above the device safe area.
+ * It anchors primary actions and explicit read-step navigation above the
+ * device safe area so touch users always have a visible way to continue.
  */
 export function PlayerBottomBar({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -16,16 +16,27 @@ import { StageContent } from "./stage-content";
 import { StepActionButton } from "./step-action-button";
 import { StepImagePreloader } from "./step-image-preloader";
 import { PlayerContentFrame } from "./step-layouts";
+import { StepNavigationButtonGroup } from "./step-navigation-button-group";
 
 /**
- * The mobile bottom bar only exists for primary actions like Check or Continue.
- * Navigable read screens now rely on swipe and keyboard input instead of a
- * second row of visible navigation controls.
+ * The mobile bottom bar owns the explicit controls that are easy to miss when
+ * they only exist as gestures or keyboard shortcuts. Primary-action screens
+ * render Check/Continue, while read-only screens render Previous/Next buttons.
  */
 function BottomBarContent() {
+  const { actions, screen } = usePlayerRuntime();
+
   return (
     <PlayerContentFrame>
-      <StepActionButton />
+      {screen.bottomBar?.kind === "navigation" ? (
+        <StepNavigationButtonGroup
+          canNavigatePrev={screen.bottomBar.canNavigatePrev}
+          onNavigateNext={actions.navigateNext}
+          onNavigatePrev={actions.navigatePrev}
+        />
+      ) : (
+        <StepActionButton />
+      )}
     </PlayerContentFrame>
   );
 }
@@ -49,7 +60,7 @@ export function PlayerShell() {
   const currentStep = getCurrentStep(state);
 
   const shouldShowStickyBottomBar =
-    screen.showChrome && screen.bottomBar?.kind === "primaryAction" && !screen.stageIsFullBleed;
+    screen.showChrome && Boolean(screen.bottomBar) && !screen.stageIsFullBleed;
 
   const progressValue = getProgressValue(state);
   const upcomingImages = getUpcomingImages(state);

--- a/packages/player/src/components/step-navigation-button-group.tsx
+++ b/packages/player/src/components/step-navigation-button-group.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
+
+/**
+ * Read-only steps need an explicit touch target because swipe gestures are
+ * discoverable only after the learner already knows they exist. This group
+ * keeps swipe navigation intact while giving mobile and tablet users a clear
+ * tappable path through static, vocabulary, and alphabet screens.
+ */
+export function StepNavigationButtonGroup({
+  canNavigatePrev,
+  onNavigateNext,
+  onNavigatePrev,
+}: {
+  canNavigatePrev: boolean;
+  onNavigateNext: () => void;
+  onNavigatePrev: () => void;
+}) {
+  const t = useExtracted();
+
+  return (
+    <div
+      className={cn("grid w-full gap-2", canNavigatePrev ? "grid-cols-2" : "grid-cols-1")}
+      data-slot="step-navigation-button-group"
+    >
+      {canNavigatePrev && (
+        <Button
+          aria-keyshortcuts="ArrowLeft"
+          className="min-w-0"
+          onClick={onNavigatePrev}
+          size="lg"
+          type="button"
+          variant="outline"
+        >
+          <ChevronLeftIcon aria-hidden="true" data-icon="inline-start" />
+          <span>{t("Previous")}</span>
+        </Button>
+      )}
+
+      <Button
+        aria-keyshortcuts="ArrowRight"
+        className="min-w-0"
+        onClick={onNavigateNext}
+        size="lg"
+        type="button"
+      >
+        <span>{t("Next")}</span>
+        <ChevronRightIcon aria-hidden="true" data-icon="inline-end" />
+      </Button>
+    </div>
+  );
+}

--- a/packages/player/src/components/swipe-navigable-step-layout.tsx
+++ b/packages/player/src/components/swipe-navigable-step-layout.tsx
@@ -49,12 +49,13 @@ function DesktopNavigationButton({
   return (
     <Button
       aria-label={ariaLabel}
+      aria-keyshortcuts={side === "previous" ? "ArrowLeft" : "ArrowRight"}
       className={cn(
-        "bg-background/70 text-muted-foreground/70 hover:bg-background hover:text-foreground border-border/40 absolute top-1/2 z-20 flex -translate-y-1/2 opacity-55 shadow-sm backdrop-blur-md transition-[background-color,border-color,color,opacity,scale] hover:opacity-100 focus-visible:opacity-100 pointer-coarse:hidden",
-        side === "previous" ? "left-3 xl:left-6" : "right-3 xl:right-6",
+        "bg-background/95 text-foreground border-border/70 ring-border/30 hover:bg-background hover:border-border absolute top-1/2 z-20 hidden size-11 -translate-y-1/2 opacity-95 shadow-lg ring-1 shadow-black/5 backdrop-blur-md transition-[background-color,border-color,color,opacity,scale,box-shadow] hover:opacity-100 hover:shadow-xl focus-visible:opacity-100 lg:flex pointer-coarse:hidden [&_svg]:size-5",
+        side === "previous" ? "left-4 xl:left-6" : "right-4 xl:right-6",
       )}
       onClick={onClick}
-      size="icon"
+      size="icon-lg"
       type="button"
       variant="outline"
     >


### PR DESCRIPTION
Adds explicit Previous/Next controls for navigable player steps on smaller screens and improves desktop arrow visibility.\n\nUpdates player browser coverage and translations for the new navigation labels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit Previous/Next buttons for read-only steps on mobile and tablet, and makes desktop arrows clearer and more accessible. Updates tests and i18n for the new labels.

- **New Features**
  - Adds `StepNavigationButtonGroup` in the mobile bottom bar to show Previous/Next on read-only steps; primary-action screens still show Check/Continue.
  - Shows the sticky bottom bar for navigation screens to ensure a visible tap target; swipe and keyboard still work.
  - Improves desktop arrows (larger, higher contrast) and adds ArrowLeft/ArrowRight shortcuts.
  - Updates browser tests for explicit controls and adds i18n strings for "Previous"/"Next" in `en`, `es`, and `pt`.

<sup>Written for commit ea07a60da6de0f2b49f09eee1d54dd0eaae5263b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1568?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

