### PR TITLE
feat(admin): sort users by brain power

### DIFF
--- a/apps/admin/src/app/(private)/users/[id]/page.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/page.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { UserAccount } from "./user-account";
+import { UserCourses } from "./user-courses";
 import { UserHeader } from "./user-header";
 import { UserLesson } from "./user-lesson";
 import { UserSubscription } from "./user-subscription";
@@ -76,7 +77,7 @@ export default async function UserDetailPage({ params }: PageProps<"/users/[id]"
         </ContainerHeaderGroup>
       </ContainerHeader>
 
-      <ContainerBody className="max-w-2xl gap-8">
+      <ContainerBody className="max-w-4xl gap-8">
         <Suspense fallback={<HeaderSkeleton />}>
           <UserHeader userId={userId} />
         </Suspense>
@@ -91,6 +92,10 @@ export default async function UserDetailPage({ params }: PageProps<"/users/[id]"
 
         <Suspense fallback={<SectionSkeleton />}>
           <UserLesson userId={userId} />
+        </Suspense>
+
+        <Suspense fallback={<SectionSkeleton />}>
+          <UserCourses userId={userId} />
         </Suspense>
       </ContainerBody>
     </Container>

--- a/apps/admin/src/app/(private)/users/[id]/user-courses.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-courses.tsx
@@ -1,0 +1,74 @@
+import {
+  type UserStartedCourse,
+  listUserStartedCourses,
+} from "@/data/users/list-user-started-courses";
+import { Separator } from "@zoonk/ui/components/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
+
+/**
+ * User details need the courses a learner actually started, ordered by the
+ * course update timestamp so support can quickly find the freshest course rows.
+ */
+export async function UserCourses({ userId }: { userId: string }) {
+  const courses = await listUserStartedCourses({ userId });
+
+  return (
+    <section>
+      <h3 className="mb-2 text-sm font-semibold">Started courses</h3>
+      <Separator />
+
+      {courses.length > 0 ? (
+        <div className="mt-3 overflow-x-auto rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Course</TableHead>
+                <TableHead>Organization</TableHead>
+                <TableHead>Last updated</TableHead>
+                <TableHead>Started</TableHead>
+              </TableRow>
+            </TableHeader>
+
+            <TableBody>
+              {courses.map((course) => (
+                <UserCourseRow course={course} key={course.id} />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      ) : (
+        <p className="text-muted-foreground mt-2 text-sm">No started courses.</p>
+      )}
+    </section>
+  );
+}
+
+/**
+ * Keeping the row renderer separate keeps the section focused on empty-state
+ * vs table rendering, while the row owns the date and number formatting.
+ */
+function UserCourseRow({ course }: { course: UserStartedCourse }) {
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{course.course.title}</TableCell>
+      <TableCell>{course.course.organization?.name ?? "—"}</TableCell>
+      <TableCell className="text-muted-foreground">{formatDate(course.course.updatedAt)}</TableCell>
+      <TableCell className="text-muted-foreground">{formatDate(course.startedAt)}</TableCell>
+    </TableRow>
+  );
+}
+
+/**
+ * Admin tables use a compact date-only display because the surrounding columns
+ * already make the timestamp meaning clear.
+ */
+function formatDate(date: Date | null) {
+  return date ? new Date(date).toLocaleDateString() : "—";
+}

--- a/apps/admin/src/app/(private)/users/user-list.tsx
+++ b/apps/admin/src/app/(private)/users/user-list.tsx
@@ -21,6 +21,7 @@ export async function UserList({
             <TableRow>
               <TableHead>User</TableHead>
               <TableHead>Username</TableHead>
+              <TableHead className="text-right">Brain Power</TableHead>
               <TableHead>Subscription</TableHead>
             </TableRow>
           </TableHeader>

--- a/apps/admin/src/app/(private)/users/user-row.tsx
+++ b/apps/admin/src/app/(private)/users/user-row.tsx
@@ -3,6 +3,10 @@ import { Badge } from "@zoonk/ui/components/badge";
 import { TableCell, TableRow } from "@zoonk/ui/components/table";
 import Link from "next/link";
 
+/**
+ * The admin user list is ordered by Brain Power, so each row shows the score
+ * that explains why the user appears in that position.
+ */
 export function UserRow({
   user,
 }: {
@@ -18,6 +22,10 @@ export function UserRow({
       </TableCell>
 
       <TableCell>{user.username || "—"}</TableCell>
+
+      <TableCell className="text-right tabular-nums">
+        {Number(user.progress?.totalBrainPower ?? 0).toLocaleString()}
+      </TableCell>
 
       <TableCell>
         <Badge variant={user.plan === "free" ? "secondary" : "outline"} className="capitalize">

--- a/apps/admin/src/data/users/list-user-started-courses.ts
+++ b/apps/admin/src/data/users/list-user-started-courses.ts
@@ -1,0 +1,36 @@
+import "server-only";
+import { isAdmin } from "@/lib/admin-guard";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+export type UserStartedCourse = Awaited<ReturnType<typeof findUserStartedCourseRows>>[number];
+
+const cachedListUserStartedCourses = cache(async (userId: string) => {
+  if (!(await isAdmin())) {
+    return [];
+  }
+
+  return findUserStartedCourseRows({ userId });
+});
+
+/**
+ * The detail page passes route params through a cached primitive value so
+ * repeated sections can reuse the same database read without object identity
+ * breaking React's cache lookup.
+ */
+export async function listUserStartedCourses(params: { userId: string }) {
+  return cachedListUserStartedCourses(params.userId);
+}
+
+/**
+ * CourseUser is the durable "started this course" record. Sorting by the
+ * course's own update timestamp keeps this admin view simple and avoids
+ * computing lesson-level progress for a support-oriented course list.
+ */
+function findUserStartedCourseRows({ userId }: { userId: string }) {
+  return prisma.courseUser.findMany({
+    include: { course: { include: { organization: true } } },
+    orderBy: [{ course: { updatedAt: "desc" } }, { startedAt: "desc" }, { id: "asc" }],
+    where: { userId },
+  });
+}

--- a/apps/admin/src/data/users/list-users.ts
+++ b/apps/admin/src/data/users/list-users.ts
@@ -9,18 +9,16 @@ const cachedListUsers = cache(async (limit: number, offset: number, search?: str
     return { total: 0, users: [] };
   }
 
-  const where = search
-    ? {
-        OR: [
-          { name: { contains: search, mode: "insensitive" as const } },
-          { email: { contains: search, mode: "insensitive" as const } },
-          { username: { contains: search, mode: "insensitive" as const } },
-        ],
-      }
-    : undefined;
+  const where = getUserSearchWhere({ search });
 
   const [users, total] = await Promise.all([
-    prisma.user.findMany({ orderBy: { createdAt: "desc" }, skip: offset, take: limit, where }),
+    prisma.user.findMany({
+      include: { progress: true },
+      orderBy: [{ progress: { totalBrainPower: "desc" } }, { createdAt: "desc" }, { id: "asc" }],
+      skip: offset,
+      take: limit,
+      where,
+    }),
     prisma.user.count({ where }),
   ]);
 
@@ -33,16 +31,50 @@ const cachedListUsers = cache(async (limit: number, offset: number, search?: str
 
   const subscriptionsByUserId = groupSubscriptionsByUser({ subscriptions });
 
-  const usersWithPlan = users.map((user) => ({
-    ...user,
-    plan: findUserActiveSubscription(subscriptionsByUserId.get(user.id) ?? [])?.plan ?? "free",
-  }));
+  const usersWithPlan = users.map((user) => addUserPlan({ subscriptionsByUserId, user }));
 
   return { total, users: usersWithPlan };
 });
 
 export async function listUsers(params: { limit: number; offset: number; search?: string }) {
   return cachedListUsers(params.limit, params.offset, params.search);
+}
+
+/**
+ * The user table needs the same search shape for both the paginated id query
+ * and the total count. Keeping the Prisma filter in one helper prevents the
+ * visible page count from drifting away from the rows shown in the table.
+ */
+function getUserSearchWhere({ search }: { search?: string }) {
+  if (!search) {
+    return;
+  }
+
+  return {
+    OR: [
+      { name: { contains: search, mode: "insensitive" as const } },
+      { email: { contains: search, mode: "insensitive" as const } },
+      { username: { contains: search, mode: "insensitive" as const } },
+    ],
+  };
+}
+
+/**
+ * Plan lookup is derived data for the admin table. Keeping it in one helper
+ * makes the row mapping a simple projection and keeps the active-subscription
+ * rule shared with the detail page.
+ */
+function addUserPlan<TUser extends { id: string }>({
+  subscriptionsByUserId,
+  user,
+}: {
+  subscriptionsByUserId: Map<string, Subscription[]>;
+  user: TUser;
+}) {
+  return {
+    ...user,
+    plan: findUserActiveSubscription(subscriptionsByUserId.get(user.id) ?? [])?.plan ?? "free",
+  };
 }
 
 /**

--- a/apps/main/src/data/progress/get-belt-level.test.ts
+++ b/apps/main/src/data/progress/get-belt-level.test.ts
@@ -40,21 +40,13 @@ describe("authenticated users", () => {
     });
   });
 
-  it("returns white belt level 1 for zero brain power", async () => {
+  it("returns null for zeroed placeholder progress", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
 
     await prisma.userProgress.create({ data: { totalBrainPower: BigInt(0), userId: user.id } });
 
     const result = await getBeltLevel(headers);
-
-    expect(result).toStrictEqual({
-      bpPerLevel: 250,
-      bpToNextLevel: 250,
-      color: "white",
-      isMaxLevel: false,
-      level: 1,
-      progressInLevel: 0,
-    });
+    expect(result).toBeNull();
   });
 });

--- a/apps/main/src/data/progress/get-belt-level.ts
+++ b/apps/main/src/data/progress/get-belt-level.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { hasUserLearningProgress } from "@zoonk/core/progress/user-progress";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { type BeltLevelResult, calculateBeltLevel } from "@zoonk/utils/belt-level";
@@ -18,7 +19,7 @@ export const getBeltLevel = cache(async (headers?: Headers): Promise<BeltLevelRe
     prisma.userProgress.findUnique({ where: { userId } }),
   );
 
-  if (error || !progress) {
+  if (error || !hasUserLearningProgress(progress)) {
     return null;
   }
 

--- a/apps/main/src/data/progress/get-energy-level.test.ts
+++ b/apps/main/src/data/progress/get-energy-level.test.ts
@@ -20,6 +20,16 @@ describe("authenticated users", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null for zeroed placeholder progress", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    await prisma.userProgress.create({ data: { userId: user.id } });
+
+    const result = await getEnergyLevel(headers);
+    expect(result).toBeNull();
+  });
+
   it("returns energy unchanged when lastActiveAt is today", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);

--- a/apps/main/src/data/progress/get-energy-level.ts
+++ b/apps/main/src/data/progress/get-energy-level.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { hasUserLearningProgress } from "@zoonk/core/progress/user-progress";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { computeDecayedEnergy } from "@zoonk/utils/energy";
@@ -19,7 +20,7 @@ export const getEnergyLevel = cache(
       prisma.userProgress.findUnique({ where: { userId } }),
     );
 
-    if (error || !progress) {
+    if (error || !hasUserLearningProgress(progress)) {
       return null;
     }
 

--- a/packages/auth/src/db-hooks.ts
+++ b/packages/auth/src/db-hooks.ts
@@ -1,0 +1,19 @@
+import { prisma } from "@zoonk/db";
+import { type BetterAuthOptions } from "better-auth/types";
+
+type UserCreateAfterHook = NonNullable<
+  NonNullable<NonNullable<BetterAuthOptions["databaseHooks"]>["user"]>["create"]
+>["after"];
+
+/**
+ * Better Auth owns account creation, but learner stats live in our app schema.
+ * Creating the zeroed progress row in the auth hook keeps every user sortable by
+ * brain power without making admin queries handle a missing progress relation.
+ */
+export const ensureUserProgressAfterAuthCreate: UserCreateAfterHook = async (user) => {
+  await prisma.userProgress.upsert({
+    create: { lastActiveAt: user.createdAt ?? new Date(), userId: user.id },
+    update: {},
+    where: { userId: user.id },
+  });
+};

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -22,6 +22,7 @@ import {
   IS_COOKIE_CACHE_ENABLED,
   SESSION_EXPIRES_IN_DAYS,
 } from "./config";
+import { ensureUserProgressAfterAuthCreate } from "./db-hooks";
 import { ac, admin, member, owner } from "./permissions";
 import { sendVerificationOTP } from "./plugins/otp";
 import { trustedOriginPlugin } from "./plugins/trusted-origin";
@@ -46,6 +47,7 @@ export const baseAuthConfig: Omit<BetterAuthOptions, "rateLimit"> = {
     protocol: isLocalhostSupported() ? "http" : "https",
   },
   database: prismaAdapter(prisma, { provider: "postgresql" }),
+  databaseHooks: { user: { create: { after: ensureUserProgressAfterAuthCreate } } },
   experimental: { joins: true },
   session: {
     cookieCache: { enabled: IS_COOKIE_CACHE_ENABLED, maxAge: 60 * COOKIE_CACHE_MINUTES },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,7 @@
     "./progress/lessons": "./src/progress/get-lesson-progress.ts",
     "./progress/continue-lesson-target": "./src/progress/get-continue-lesson-target.ts",
     "./progress/next-lesson-state": "./src/progress/get-next-lesson-state.ts",
+    "./progress/user-progress": "./src/progress/user-progress.ts",
     "./steps/content-image": "./src/steps/step-content-image.ts",
     "./steps/contract/content": "./src/steps/contract/content.ts",
     "./steps/contract/image": "./src/steps/contract/image.ts",

--- a/packages/core/src/player/commands/submit-lesson-completion.test.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.test.ts
@@ -241,6 +241,40 @@ describe(submitLessonCompletion, () => {
     expect(userProgress?.currentEnergy).toBeCloseTo(0.2);
   });
 
+  it("does not fill decay gaps for a zeroed UserProgress placeholder", async () => {
+    const user = await userFixture();
+    const userId = user.id;
+    const localDate = todayLocalDate();
+    const fiveDaysBefore = new Date(parseLocalDate(localDate).getTime() - 5 * 86_400_000);
+
+    await userProgressFixture({
+      currentEnergy: 0,
+      lastActiveAt: fiveDaysBefore,
+      totalBrainPower: 0n,
+      userId,
+    });
+
+    await submitLessonCompletion({
+      durationSeconds: 10,
+      lessonId: lesson.id,
+
+      localDate,
+      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+      startedAt: new Date(Date.now() - 10_000),
+      stepResults: [stepResult(true)],
+      userId,
+    });
+
+    const dailyRecords = await prisma.dailyProgress.findMany({
+      orderBy: { date: "asc" },
+      where: { userId },
+    });
+
+    expect(dailyRecords).toHaveLength(1);
+    expect(dailyRecords[0]?.date).toStrictEqual(parseLocalDate(localDate));
+    expect(dailyRecords[0]?.energyAtEnd).toBeCloseTo(0.2);
+  });
+
   it("creates DailyProgress with correct counters", async () => {
     const user = await userFixture();
     const userId = user.id;

--- a/packages/core/src/player/commands/submit-lesson-completion.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { prisma } from "@zoonk/db";
+import { type UserProgress, prisma } from "@zoonk/db";
 import { type BeltLevelResult, calculateBeltLevel } from "@zoonk/utils/belt-level";
 import { MS_PER_DAY, parseLocalDate } from "@zoonk/utils/date";
 import { clampEnergy, computeDecayedEnergy, toUTCMidnight } from "@zoonk/utils/energy";
@@ -8,6 +8,22 @@ import { fillDecayGaps, getCompletionField, upsertDailyProgress } from "./_utils
 import { syncDurableCurriculumCompletion } from "./_utils/durable-curriculum-completion";
 
 const MAX_LOCAL_DATE_DRIFT_MS = 2 * MS_PER_DAY;
+
+/**
+ * UserProgress can now exist before the learner completes anything because
+ * auth creation and data backfills create zeroed placeholder rows. Those rows
+ * make admin sorting simple, but they should not make the first lesson after
+ * signup look like the learner was inactive for every day since account
+ * creation. A real completion always adds brain power, so any positive brain
+ * power or energy means the row represents actual learning history.
+ */
+function hasLearningProgress(progress: UserProgress | null): progress is UserProgress {
+  if (!progress) {
+    return false;
+  }
+
+  return progress.totalBrainPower > 0n || progress.currentEnergy > 0;
+}
 
 export async function submitLessonCompletion(input: {
   durationSeconds: number;
@@ -87,13 +103,14 @@ export async function submitLessonCompletion(input: {
 
     // Find existing UserProgress to apply decay
     const existingProgress = await tx.userProgress.findUnique({ where: { userId: input.userId } });
+    const shouldApplyDecay = hasLearningProgress(existingProgress);
 
-    const decayedBase = existingProgress
+    const decayedBase = shouldApplyDecay
       ? computeDecayedEnergy(existingProgress.currentEnergy, existingProgress.lastActiveAt, today)
       : 0;
 
     // Fill DailyProgress records for inactive days
-    if (existingProgress) {
+    if (shouldApplyDecay) {
       const lastActiveDate = toUTCMidnight(existingProgress.lastActiveAt);
 
       await fillDecayGaps({

--- a/packages/core/src/player/commands/submit-lesson-completion.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.ts
@@ -1,29 +1,14 @@
 import "server-only";
-import { type UserProgress, prisma } from "@zoonk/db";
+import { prisma } from "@zoonk/db";
 import { type BeltLevelResult, calculateBeltLevel } from "@zoonk/utils/belt-level";
 import { MS_PER_DAY, parseLocalDate } from "@zoonk/utils/date";
 import { clampEnergy, computeDecayedEnergy, toUTCMidnight } from "@zoonk/utils/energy";
+import { hasUserLearningProgress } from "../../progress/user-progress";
 import { type ScoreResult } from "../contracts/compute-score";
 import { fillDecayGaps, getCompletionField, upsertDailyProgress } from "./_utils/daily-progress";
 import { syncDurableCurriculumCompletion } from "./_utils/durable-curriculum-completion";
 
 const MAX_LOCAL_DATE_DRIFT_MS = 2 * MS_PER_DAY;
-
-/**
- * UserProgress can now exist before the learner completes anything because
- * auth creation and data backfills create zeroed placeholder rows. Those rows
- * make admin sorting simple, but they should not make the first lesson after
- * signup look like the learner was inactive for every day since account
- * creation. A real completion always adds brain power, so any positive brain
- * power or energy means the row represents actual learning history.
- */
-function hasLearningProgress(progress: UserProgress | null): progress is UserProgress {
-  if (!progress) {
-    return false;
-  }
-
-  return progress.totalBrainPower > 0n || progress.currentEnergy > 0;
-}
 
 export async function submitLessonCompletion(input: {
   durationSeconds: number;
@@ -103,7 +88,7 @@ export async function submitLessonCompletion(input: {
 
     // Find existing UserProgress to apply decay
     const existingProgress = await tx.userProgress.findUnique({ where: { userId: input.userId } });
-    const shouldApplyDecay = hasLearningProgress(existingProgress);
+    const shouldApplyDecay = hasUserLearningProgress(existingProgress);
 
     const decayedBase = shouldApplyDecay
       ? computeDecayedEnergy(existingProgress.currentEnergy, existingProgress.lastActiveAt, today)

--- a/packages/core/src/progress/user-progress.ts
+++ b/packages/core/src/progress/user-progress.ts
@@ -1,0 +1,18 @@
+import { type UserProgress } from "@zoonk/db";
+
+/**
+ * Auth sign-up and migrations can create zeroed UserProgress rows before a
+ * learner completes anything. Progress surfaces should treat those rows like
+ * empty state, and lesson completion should not apply inactivity decay to them.
+ * Any positive brain power or energy means the row represents real learning
+ * history instead of a placeholder.
+ */
+export function hasUserLearningProgress<
+  TProgress extends Pick<UserProgress, "currentEnergy" | "totalBrainPower">,
+>(progress: TProgress | null): progress is TProgress {
+  if (!progress) {
+    return false;
+  }
+
+  return progress.totalBrainPower > 0n || progress.currentEnergy > 0;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -39,6 +39,7 @@ export type {
   Sentence,
   Subscription,
   StepKind,
+  UserProgress,
   Word,
   WordPronunciation,
 } from "./generated/prisma/client";

--- a/packages/db/src/prisma/migrations/20260528174735_backfill_user_progress/migration.sql
+++ b/packages/db/src/prisma/migrations/20260528174735_backfill_user_progress/migration.sql
@@ -1,0 +1,8 @@
+INSERT INTO "user_progress" ("user_id", "current_energy", "total_brain_power", "last_active_at")
+SELECT "users"."id", 0, 0, "users"."created_at"
+FROM "users"
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "user_progress"
+  WHERE "user_progress"."user_id" = "users"."id"
+);

--- a/packages/testing/src/fixtures/progress.ts
+++ b/packages/testing/src/fixtures/progress.ts
@@ -1,5 +1,10 @@
 import { prisma } from "@zoonk/db";
 
+/**
+ * Create daily progress rows in bulk for tests that need chart or history data.
+ * The helper keeps per-row defaults in one place so test setup can focus on the
+ * dates and counters that matter for the behavior under test.
+ */
 export async function dailyProgressFixtureMany(
   inputs: {
     brainPowerEarned?: number;
@@ -25,18 +30,27 @@ export async function dailyProgressFixtureMany(
 
 const DEFAULT_ENERGY = 50;
 
+/**
+ * Set the singleton UserProgress row for a test user.
+ * Auth-created users already have a zeroed progress row, while lower-level
+ * tests often create users directly without one. Upserting lets callers express
+ * the desired progress state without caring which path created the user.
+ */
 export async function userProgressFixture(attrs: {
   currentEnergy?: number;
   lastActiveAt?: Date;
   totalBrainPower?: bigint;
   userId: string;
 }) {
-  return prisma.userProgress.create({
-    data: {
-      currentEnergy: attrs.currentEnergy ?? DEFAULT_ENERGY,
-      lastActiveAt: attrs.lastActiveAt ?? new Date(),
-      totalBrainPower: attrs.totalBrainPower ?? 0n,
-      userId: attrs.userId,
-    },
+  const data = {
+    currentEnergy: attrs.currentEnergy ?? DEFAULT_ENERGY,
+    lastActiveAt: attrs.lastActiveAt ?? new Date(),
+    totalBrainPower: attrs.totalBrainPower ?? 0n,
+  };
+
+  return prisma.userProgress.upsert({
+    create: { ...data, userId: attrs.userId },
+    update: data,
+    where: { userId: attrs.userId },
   });
 }


### PR DESCRIPTION
## Summary
- sort admin users by brain power using Prisma relations
- add started courses to the user detail page, sorted by course update time
- create/backfill UserProgress rows so users without progress no longer sort unexpectedly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admin now sorts users by Brain Power (highest first) and shows the score. The user page lists started courses, and progress APIs ignore placeholder rows to prevent fake decay and levels.

- **New Features**
  - Sort users by Brain Power and display a Brain Power column.
  - Add a “Started courses” table on the user page, ordered by course updated time.
  - Create a zeroed progress row on signup and upsert `userProgressFixture` for stable tests.
  - Treat zeroed progress as empty: return null for belt/energy and skip decay/backfill until real activity.

- **Migration**
  - Run the DB migration to backfill zeroed progress rows for existing users.

<sup>Written for commit 512d0bca9d21af2d19e9cc1a2b27c0fa9f0a11d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1569?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

