### PR TITLE
fix(main): clarify progress metric explanations

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -660,16 +660,24 @@ msgid "tqJIUh"
 msgstr "About Energy"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "/1gcM1"
-msgstr "Energy reflects your learning consistency. It increases with correct answers, decreases with wrong answers, and drops for each inactive day."
+msgid "OWC2V9"
+msgstr "Energy is a score from 0% to 100%. The goal is to keep it near 100%."
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "5oXyw+"
+msgstr "It goes up when you answer correctly and goes down when you answer incorrectly or go a day without studying."
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "okV1HG"
+msgstr "It is not a streak. Missing a day does not reset Energy to zero. It drops a little, and you can recover it when you return."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "1IwE3q"
-msgstr "Track your energy over time and see how your learning consistency affects your progress."
+msgid "AZMpf3"
+msgstr "Energy is a 0% to 100% score based on recent activity and accuracy."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "7Rfk+O"
-msgstr "Track your learning energy over time"
+msgid "rsIaGW"
+msgstr "A 0% to 100% score for recent activity and accuracy"
 
 #: src/app/(progress)/level/level-chart-client.tsx
 msgid "GA8RuL"
@@ -684,20 +692,20 @@ msgid "tDbspx"
 msgstr "Total Brain Power earned: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "l2jnwA"
-msgstr "About Levels"
+msgid "aAScNr"
+msgstr "About Brain Power"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "C6bCZT"
-msgstr "Brain Power (BP) represents your knowledge growth. Unlike energy, BP never decreases - it only grows as you learn more."
+msgid "hRYALR"
+msgstr "Brain Power is your reputation. You earn Brain Power after each lesson you complete. It never goes down because knowledge is not something anyone can take from you."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "0kiEdE"
-msgstr "Every time you complete a lesson, you earn Brain Power. As you accumulate BP, you progress through 10 belt colors, each with 10 levels."
+msgid "YhaJIG"
+msgstr "You do not lose Brain Power when your Energy drops or when you miss days."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "J60fb6"
-msgstr "Belt colors in order: White, Yellow, Orange, Green, Blue, Purple, Brown, Red, Gray, and Black. Keep learning to reach the highest level!"
+msgid "98M49A"
+msgstr "Brain Power is like martial arts for your mind: the more you study, the stronger it gets. You start as a white belt and can work your way up to black belt."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "VHH0kD"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -188,11 +188,11 @@ msgstr "Continúa aprendiendo"
 
 #: src/app/(catalog)/(home)/energy.tsx
 msgid "soDmlG"
-msgstr "Sigue aprendiendo para aumentarlo"
+msgstr "Sigue aprendiendo para aumentarla"
 
 #: src/app/(catalog)/(home)/energy.tsx
 msgid "WgeB0r"
-msgstr "Sigue aprendiendo para mantenerlo"
+msgstr "Sigue aprendiendo para mantenerla"
 
 #: src/app/(catalog)/(home)/energy.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
@@ -660,16 +660,24 @@ msgid "tqJIUh"
 msgstr "Acerca de la energía"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "/1gcM1"
-msgstr "La energía refleja tu consistencia de aprendizaje. Aumenta con respuestas correctas, disminuye con respuestas incorrectas y baja por cada día inactivo."
+msgid "OWC2V9"
+msgstr "La energía es una puntuación de 0% a 100%. El objetivo es mantenerla cerca del 100%."
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "5oXyw+"
+msgstr "Sube cuando respondes correctamente y baja cuando respondes mal o pasas un día sin estudiar."
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "okV1HG"
+msgstr "No es una racha. Pasar un día sin estudiar no pone la energía en cero. Baja un poco, pero puedes recuperarla cuando vuelves."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "1IwE3q"
-msgstr "Rastrea tu energía a lo largo del tiempo y ve cómo tu constancia de aprendizaje afecta tu progreso."
+msgid "AZMpf3"
+msgstr "La energía es una puntuación de 0% a 100% basada en tu actividad y precisión recientes."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "7Rfk+O"
-msgstr "Rastrea tu energía de aprendizaje a lo largo del tiempo"
+msgid "rsIaGW"
+msgstr "Una puntuación de 0% a 100% para actividad y precisión recientes"
 
 #: src/app/(progress)/level/level-chart-client.tsx
 msgid "GA8RuL"
@@ -684,20 +692,20 @@ msgid "tDbspx"
 msgstr "Poder Mental total ganado: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "l2jnwA"
-msgstr "Sobre Niveles"
+msgid "aAScNr"
+msgstr "Sobre el Poder Mental"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "C6bCZT"
-msgstr "El Poder Mental (PM) representa tu crecimiento de conocimiento. A diferencia de la energía, el PM nunca disminuye, solo crece a medida que aprendes más."
+msgid "hRYALR"
+msgstr "El Poder Mental es tu reputación. Ganas Poder Mental después de cada lección que completas. Nunca baja porque el conocimiento es algo que nadie te puede quitar."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "0kiEdE"
-msgstr "Cada vez que completas una lección, ganas poder mental. A medida que acumulas PM, avanzas por 10 colores de cinturón, cada uno con 10 niveles."
+msgid "YhaJIG"
+msgstr "No pierdes Poder Mental cuando baja la energía o cuando pasas un día sin estudiar."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "J60fb6"
-msgstr "Colores de cinturón en orden: blanco, amarillo, naranja, verde, azul, morado, marrón, rojo, gris y negro. ¡Sigue aprendiendo para alcanzar el nivel más alto!"
+msgid "98M49A"
+msgstr "El Poder Mental es como artes marciales para tu mente: cuanto más estudias, más fuerte se vuelve. Empiezas como cinturón blanco y puedes avanzar hasta cinturón negro."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "VHH0kD"
@@ -737,11 +745,11 @@ msgstr "{value} PM ganado"
 
 #: src/app/(progress)/level/page.tsx
 msgid "4+USpX"
-msgstr "Sigue el progreso de tu nivel y ve cómo avanzas."
+msgstr "Sigue tu progreso de nivel y ve cómo avanzas."
 
 #: src/app/(progress)/level/page.tsx
 msgid "L9hqMH"
-msgstr "Sigue el progreso de tu nivel"
+msgstr "Sigue tu progreso de nivel"
 
 #: src/app/(progress)/score/page.tsx
 msgid "qHWZBu"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -188,11 +188,11 @@ msgstr "Continue aprendendo"
 
 #: src/app/(catalog)/(home)/energy.tsx
 msgid "soDmlG"
-msgstr "Continue aprendendo para aumentá-lo"
+msgstr "Continue aprendendo para aumentá-la"
 
 #: src/app/(catalog)/(home)/energy.tsx
 msgid "WgeB0r"
-msgstr "Continue aprendendo para mantê-lo"
+msgstr "Continue aprendendo para mantê-la"
 
 #: src/app/(catalog)/(home)/energy.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
@@ -660,16 +660,24 @@ msgid "tqJIUh"
 msgstr "Sobre energia"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "/1gcM1"
-msgstr "A energia reflete a sua consistência de aprendizado. Ela aumenta com respostas corretas, diminui com respostas erradas e cai a cada dia inativo."
+msgid "OWC2V9"
+msgstr "Energia é uma pontuação de 0% a 100%. O objetivo é mantê-la perto de 100%."
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "5oXyw+"
+msgstr "Ela sobe quando você responde corretamente e cai quando você responde errado ou fica um dia sem estudar."
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "okV1HG"
+msgstr "Não é uma sequência. Ficar um dia sem estudar não zera a energia. Ela cai um pouquinho, mas você consegue recuperar quando voltar."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "1IwE3q"
-msgstr "Acompanhe sua energia ao longo do tempo e veja como sua consistência de aprendizado afeta seu progresso."
+msgid "AZMpf3"
+msgstr "Energia é uma pontuação de 0% a 100% baseada em atividade e precisão recentes."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "7Rfk+O"
-msgstr "Acompanhe sua energia de aprendizado ao longo do tempo"
+msgid "rsIaGW"
+msgstr "Uma pontuação de 0% a 100% para atividade e precisão recentes"
 
 #: src/app/(progress)/level/level-chart-client.tsx
 msgid "GA8RuL"
@@ -684,20 +692,20 @@ msgid "tDbspx"
 msgstr "Total de Poder Mental ganho: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "l2jnwA"
-msgstr "Sobre Níveis"
+msgid "aAScNr"
+msgstr "Sobre Poder Mental"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "C6bCZT"
-msgstr "Poder Mental (PM) representa seu crescimento de conhecimento. Diferente da energia, o PM nunca diminui - ele só cresce conforme você aprende mais."
+msgid "hRYALR"
+msgstr "Poder Mental é a sua reputação. Você ganha Poder Mental após cada aula que completa. Ele nunca cai porque conhecimento é algo que ninguém tira de você."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "0kiEdE"
-msgstr "Toda vez que você conclui uma aula, você ganha poder mental. À medida que acumula PM, você avança por 10 cores de faixa, cada uma com 10 níveis."
+msgid "YhaJIG"
+msgstr "Você não perde Poder Mental quando a energia cai ou quando fica um dia sem estudar."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "J60fb6"
-msgstr "Cores das faixas em ordem: Branca, Amarela, Laranja, Verde, Azul, Roxa, Marrom, Vermelha, Cinza e Preta. Continue aprendendo pra alcançar o nível mais alto!"
+msgid "98M49A"
+msgstr "O Poder Mental é como artes marciais para a sua mente: quanto mais você estuda, mais forte fica. Você começa como faixa branca e pode evoluir até faixa preta."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "VHH0kD"
@@ -737,11 +745,11 @@ msgstr "{value} PM ganho"
 
 #: src/app/(progress)/level/page.tsx
 msgid "4+USpX"
-msgstr "Acompanhe o progresso do seu nível e veja como você avança."
+msgstr "Acompanhe seu progresso de nível e veja como você avança."
 
 #: src/app/(progress)/level/page.tsx
 msgid "L9hqMH"
-msgstr "Acompanhe o progresso do seu nível"
+msgstr "Acompanhe seu progresso de nível"
 
 #: src/app/(progress)/score/page.tsx
 msgid "qHWZBu"

--- a/apps/main/src/app/(progress)/energy/energy-content.tsx
+++ b/apps/main/src/app/(progress)/energy/energy-content.tsx
@@ -66,8 +66,9 @@ export function EnergyContentSkeleton() {
 
       <div className="flex flex-col gap-2">
         <Skeleton className="h-4 w-36" />
-        <Skeleton className="h-5 w-64" />
+        <Skeleton className="h-4 w-72 max-w-full" />
         <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-4/5" />
       </div>
     </div>
   );

--- a/apps/main/src/app/(progress)/energy/energy-explanation.tsx
+++ b/apps/main/src/app/(progress)/energy/energy-explanation.tsx
@@ -17,9 +17,19 @@ export async function EnergyExplanation() {
         <ExplanationTitle>{t("About Energy")}</ExplanationTitle>
       </ExplanationHeader>
 
-      <ExplanationText className="leading-relaxed">
+      <ExplanationText>
+        {t("Energy is a score from 0% to 100%. The goal is to keep it near 100%.")}
+      </ExplanationText>
+
+      <ExplanationText>
         {t(
-          "Energy reflects your learning consistency. It increases with correct answers, decreases with wrong answers, and drops for each inactive day.",
+          "It goes up when you answer correctly and goes down when you answer incorrectly or go a day without studying.",
+        )}
+      </ExplanationText>
+
+      <ExplanationText>
+        {t(
+          "It is not a streak. Missing a day does not reset Energy to zero. It drops a little, and you can recover it when you return.",
         )}
       </ExplanationText>
     </Explanation>

--- a/apps/main/src/app/(progress)/energy/page.tsx
+++ b/apps/main/src/app/(progress)/energy/page.tsx
@@ -15,9 +15,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted();
 
   return {
-    description: t(
-      "Track your energy over time and see how your learning consistency affects your progress.",
-    ),
+    description: t("Energy is a 0% to 100% score based on recent activity and accuracy."),
     title: t("Energy"),
   };
 }
@@ -30,7 +28,9 @@ export default async function EnergyPage({ searchParams }: PageProps<"/energy">)
       <ContainerHeader>
         <ContainerHeaderGroup>
           <ContainerTitle>{t("Energy")}</ContainerTitle>
-          <ContainerDescription>{t("Track your learning energy over time")}</ContainerDescription>
+          <ContainerDescription>
+            {t("A 0% to 100% score for recent activity and accuracy")}
+          </ContainerDescription>
         </ContainerHeaderGroup>
       </ContainerHeader>
 

--- a/apps/main/src/app/(progress)/level/level-content.tsx
+++ b/apps/main/src/app/(progress)/level/level-content.tsx
@@ -72,8 +72,9 @@ export function LevelContentSkeleton() {
 
       <div className="flex flex-col gap-2">
         <Skeleton className="h-4 w-36" />
-        <Skeleton className="h-5 w-64" />
+        <Skeleton className="h-4 w-72 max-w-full" />
         <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-4/5" />
       </div>
     </div>
   );

--- a/apps/main/src/app/(progress)/level/level-explanation.tsx
+++ b/apps/main/src/app/(progress)/level/level-explanation.tsx
@@ -5,24 +5,22 @@ export async function LevelExplanation() {
   const t = await getExtracted();
 
   return (
-    <Explanation>
-      <ExplanationTitle>{t("About Levels")}</ExplanationTitle>
+    <Explanation className="gap-1 border-t pt-6">
+      <ExplanationTitle>{t("About Brain Power")}</ExplanationTitle>
 
       <ExplanationText>
         {t(
-          "Brain Power (BP) represents your knowledge growth. Unlike energy, BP never decreases - it only grows as you learn more.",
+          "Brain Power is your reputation. You earn Brain Power after each lesson you complete. It never goes down because knowledge is not something anyone can take from you.",
         )}
       </ExplanationText>
 
       <ExplanationText>
-        {t(
-          "Every time you complete a lesson, you earn Brain Power. As you accumulate BP, you progress through 10 belt colors, each with 10 levels.",
-        )}
+        {t("You do not lose Brain Power when your Energy drops or when you miss days.")}
       </ExplanationText>
 
       <ExplanationText>
         {t(
-          "Belt colors in order: White, Yellow, Orange, Green, Blue, Purple, Brown, Red, Gray, and Black. Keep learning to reach the highest level!",
+          "Brain Power is like martial arts for your mind: the more you study, the stronger it gets. You start as a white belt and can work your way up to black belt.",
         )}
       </ExplanationText>
     </Explanation>

--- a/packages/ui/src/components/explanation.tsx
+++ b/packages/ui/src/components/explanation.tsx
@@ -29,7 +29,7 @@ function ExplanationTitle({ className, ...props }: React.ComponentProps<"h3">) {
 function ExplanationText({ className, ...props }: React.ComponentProps<"p">) {
   return (
     <p
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-muted-foreground text-sm leading-relaxed", className)}
       data-slot="explanation-text"
       {...props}
     />


### PR DESCRIPTION
Updates the Energy and Brain Power explanations with clearer, more natural copy. Also updates translations and moves relaxed explanation text spacing into the shared UI component.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified Energy and Brain Power explanations with simpler, more direct copy and a consistent UI. Also updated en/es/pt translations and moved text spacing into the shared `ExplanationText` component.

- **Refactors**
  - Energy: clearer explanation (0–100 score, not a streak) and updated page description.
  - Brain Power: renamed to “About Brain Power” with reputation-based copy.
  - Centralized relaxed line-height in `ExplanationText` and adjusted skeleton placeholders to fit new text.
  - Updated translations (en/es/pt), including minor grammar fixes.

<sup>Written for commit f2cc02789bb56e734050aa83da288db4234a451b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1570?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

