### PR TITLE
feat(admin): sort course suggestions

### DIFF
--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/course-suggestion.ts
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/_actions/course-suggestion.ts
@@ -1,11 +1,179 @@
 "use server";
 
 import { assertAdmin } from "@/lib/admin-guard";
-import { prisma } from "@zoonk/db";
+import { type TransactionClient, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
 import { toSlug } from "@zoonk/utils/string";
 import { revalidatePath } from "next/cache";
+
+type CourseSuggestionMoveDirection = "up" | "down";
+type PositionUpdate = { id: string; position: number };
+
+const COURSE_SUGGESTION_LINK_ORDER = [
+  { position: "asc" as const },
+  { createdAt: "asc" as const },
+  { id: "asc" as const },
+];
+
+/**
+ * Reordering is submitted from plain HTML forms, so the server action must
+ * reject anything outside the two movements the UI exposes.
+ */
+function parseMoveDirection(value: string | null): CourseSuggestionMoveDirection | null {
+  if (value === "up" || value === "down") {
+    return value;
+  }
+
+  return null;
+}
+
+/**
+ * Boundary moves should keep the current order instead of throwing. That lets
+ * stale forms remain harmless when another admin has already moved an item.
+ */
+function getAdjacentIndex({
+  currentIndex,
+  direction,
+  itemCount,
+}: {
+  currentIndex: number;
+  direction: CourseSuggestionMoveDirection;
+  itemCount: number;
+}): number | null {
+  if (currentIndex === -1) {
+    return null;
+  }
+
+  if (direction === "up" && currentIndex > 0) {
+    return currentIndex - 1;
+  }
+
+  if (direction === "down" && currentIndex < itemCount - 1) {
+    return currentIndex + 1;
+  }
+
+  return null;
+}
+
+/**
+ * The database stores numeric positions, but the UI operation is "swap this
+ * item with its neighbor". Keeping that rule pure makes the transaction only
+ * responsible for reading and writing the final order.
+ */
+function moveIdByDirection({
+  currentId,
+  direction,
+  ids,
+}: {
+  currentId: string;
+  direction: CourseSuggestionMoveDirection;
+  ids: string[];
+}): string[] {
+  const currentIndex = ids.indexOf(currentId);
+  const adjacentIndex = getAdjacentIndex({ currentIndex, direction, itemCount: ids.length });
+
+  if (adjacentIndex === null) {
+    return ids;
+  }
+
+  return ids.map((id, index) =>
+    getMovedIdAtIndex({ adjacentIndex, currentIndex, fallbackId: id, ids, index }),
+  );
+}
+
+/**
+ * The swap helper keeps branching out of the array callback and makes each
+ * index rule explicit: current takes neighbor, neighbor takes current, the
+ * rest keep their existing IDs.
+ */
+function getMovedIdAtIndex({
+  adjacentIndex,
+  currentIndex,
+  fallbackId,
+  ids,
+  index,
+}: {
+  adjacentIndex: number;
+  currentIndex: number;
+  fallbackId: string;
+  ids: string[];
+  index: number;
+}): string {
+  if (index === currentIndex) {
+    return ids[adjacentIndex] ?? fallbackId;
+  }
+
+  if (index === adjacentIndex) {
+    return ids[currentIndex] ?? fallbackId;
+  }
+
+  return fallbackId;
+}
+
+/**
+ * After any reorder, positions are rewritten from zero so older gaps or
+ * duplicate positions cannot keep affecting future review order.
+ */
+function buildPositionUpdates(ids: string[]): PositionUpdate[] {
+  return ids.map((id, position) => ({ id, position }));
+}
+
+/**
+ * SearchPromptSuggestion has no unique position constraint, so updating every
+ * row to its normalized position is the simplest reliable reorder operation.
+ */
+async function updateSearchPromptSuggestionPositions({
+  tx,
+  updates,
+}: {
+  tx: TransactionClient;
+  updates: PositionUpdate[];
+}) {
+  await Promise.all(
+    updates.map((update) =>
+      tx.searchPromptSuggestion.update({
+        data: { position: update.position },
+        where: { id: update.id },
+      }),
+    ),
+  );
+}
+
+/**
+ * Sorting belongs to the prompt-suggestion link, not the reusable course
+ * suggestion record, because the same suggestion can appear under many prompts.
+ */
+async function moveSearchPromptSuggestion({
+  courseSuggestionId,
+  direction,
+  searchPromptId,
+  tx,
+}: {
+  courseSuggestionId: string;
+  direction: CourseSuggestionMoveDirection;
+  searchPromptId: string;
+  tx: TransactionClient;
+}) {
+  const links = await tx.searchPromptSuggestion.findMany({
+    orderBy: COURSE_SUGGESTION_LINK_ORDER,
+    where: { searchPromptId },
+  });
+
+  const currentLink = links.find((link) => link.courseSuggestionId === courseSuggestionId);
+
+  if (!currentLink) {
+    return;
+  }
+
+  const sortedIds = moveIdByDirection({
+    currentId: currentLink.id,
+    direction,
+    ids: links.map((link) => link.id),
+  });
+
+  await updateSearchPromptSuggestionPositions({ tx, updates: buildPositionUpdates(sortedIds) });
+}
 
 export async function updateCourseSuggestionAction(formData: FormData) {
   await assertAdmin();
@@ -69,25 +237,51 @@ export async function addCourseSuggestionAction(formData: FormData) {
   }
 
   const { error } = await safeAsync(async () => {
-    const maxPosition = await prisma.searchPromptSuggestion.aggregate({
-      _max: { position: true },
-      where: { searchPromptId },
-    });
-
-    const position = (maxPosition._max.position ?? -1) + 1;
-
     const slug = toSlug(title);
 
-    const suggestion = await prisma.courseSuggestion.upsert({
-      create: { description, language, slug, targetLanguage: targetLanguage || null, title },
-      update: { description, title },
-      where: { languageSlug: { language, slug } },
-    });
+    await prisma.$transaction(async (tx) => {
+      const suggestion = await tx.courseSuggestion.upsert({
+        create: { description, language, slug, targetLanguage: targetLanguage || null, title },
+        update: { description, title },
+        where: { languageSlug: { language, slug } },
+      });
 
-    await prisma.searchPromptSuggestion.create({
-      data: { courseSuggestionId: suggestion.id, position, searchPromptId },
+      await tx.searchPromptSuggestion.updateMany({
+        data: { position: { increment: 1 } },
+        where: { searchPromptId },
+      });
+
+      await tx.searchPromptSuggestion.upsert({
+        create: { courseSuggestionId: suggestion.id, position: 0, searchPromptId },
+        update: { position: 0 },
+        where: { promptSuggestion: { courseSuggestionId: suggestion.id, searchPromptId } },
+      });
     });
   });
+
+  if (error) {
+    throw error;
+  }
+
+  revalidatePath("/review");
+}
+
+export async function moveCourseSuggestionAction(formData: FormData) {
+  await assertAdmin();
+
+  const searchPromptId = parseFormField(formData, "searchPromptId");
+  const courseSuggestionId = parseFormField(formData, "courseSuggestionId");
+  const direction = parseMoveDirection(parseFormField(formData, "direction"));
+
+  if (!searchPromptId || !courseSuggestionId || !direction) {
+    throw new Error("Invalid form data");
+  }
+
+  const { error } = await safeAsync(() =>
+    prisma.$transaction((tx) =>
+      moveSearchPromptSuggestion({ courseSuggestionId, direction, searchPromptId, tx }),
+    ),
+  );
 
   if (error) {
     throw error;

--- a/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/course-suggestion-edit.tsx
+++ b/apps/admin/src/app/(private)/review/[group]/[task]/[entityId]/course-suggestion-edit.tsx
@@ -1,10 +1,13 @@
 import { type getCourseSuggestionReview } from "@/data/review/get-review-item";
 import { Badge } from "@zoonk/ui/components/badge";
+import { Button } from "@zoonk/ui/components/button";
 import { Input } from "@zoonk/ui/components/input";
 import { Textarea } from "@zoonk/ui/components/textarea";
 import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
+import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
 import {
   addCourseSuggestionAction,
+  moveCourseSuggestionAction,
   updateCourseSuggestionAction,
 } from "./_actions/course-suggestion";
 import { RemoveSuggestionButton } from "./remove-suggestion-button";
@@ -13,16 +16,87 @@ type CourseSuggestionReviewData = NonNullable<
   Awaited<ReturnType<typeof getCourseSuggestionReview>>
 >;
 
-function SuggestionForm({
-  suggestion,
+type SuggestionLink = CourseSuggestionReviewData["suggestions"][number];
+
+/**
+ * Suggestions are sorted by their prompt-specific link, so each move form must
+ * submit both IDs instead of updating the reusable course suggestion directly.
+ */
+function SortButton({
+  courseSuggestionId,
+  direction,
+  disabled,
+  label,
   searchPromptId,
 }: {
-  suggestion: CourseSuggestionReviewData["suggestions"][number]["courseSuggestion"];
+  courseSuggestionId: string;
+  direction: "up" | "down";
+  disabled: boolean;
+  label: string;
   searchPromptId: string;
 }) {
+  const Icon = direction === "up" ? ArrowUpIcon : ArrowDownIcon;
+
   return (
-    <div className="flex flex-col gap-3 border-b pb-4 last:border-b-0">
-      <form action={updateCourseSuggestionAction} className="flex flex-col gap-3">
+    <form action={moveCourseSuggestionAction}>
+      <input type="hidden" name="searchPromptId" value={searchPromptId} />
+      <input type="hidden" name="courseSuggestionId" value={courseSuggestionId} />
+      <input type="hidden" name="direction" value={direction} />
+
+      <Button
+        aria-label={label}
+        disabled={disabled}
+        size="icon-sm"
+        title={label}
+        type="submit"
+        variant="outline"
+      >
+        <Icon />
+      </Button>
+    </form>
+  );
+}
+
+function SuggestionForm({
+  canMoveDown,
+  canMoveUp,
+  position,
+  suggestionLink,
+  searchPromptId,
+}: {
+  canMoveDown: boolean;
+  canMoveUp: boolean;
+  position: number;
+  suggestionLink: SuggestionLink;
+  searchPromptId: string;
+}) {
+  const suggestion = suggestionLink.courseSuggestion;
+
+  return (
+    <div className="flex gap-3 border-b pb-4 last:border-b-0">
+      <div className="flex flex-col items-center gap-1 pt-1">
+        <span className="text-muted-foreground w-8 text-center text-xs tabular-nums">
+          {position}
+        </span>
+
+        <SortButton
+          courseSuggestionId={suggestion.id}
+          direction="up"
+          disabled={!canMoveUp}
+          label={`Move ${suggestion.title} up`}
+          searchPromptId={searchPromptId}
+        />
+
+        <SortButton
+          courseSuggestionId={suggestion.id}
+          direction="down"
+          disabled={!canMoveDown}
+          label={`Move ${suggestion.title} down`}
+          searchPromptId={searchPromptId}
+        />
+      </div>
+
+      <form action={updateCourseSuggestionAction} className="flex min-w-0 flex-1 flex-col gap-3">
         <input type="hidden" name="suggestionId" value={suggestion.id} />
 
         <Input name="title" defaultValue={suggestion.title} aria-label="Title" />
@@ -88,10 +162,13 @@ export function CourseSuggestionEdit({ item }: { item: CourseSuggestionReviewDat
           Suggestions ({item.suggestions.length})
         </h3>
 
-        {item.suggestions.map(({ courseSuggestion }) => (
+        {item.suggestions.map((suggestionLink, index) => (
           <SuggestionForm
-            key={courseSuggestion.id}
-            suggestion={courseSuggestion}
+            key={suggestionLink.courseSuggestion.id}
+            canMoveDown={index < item.suggestions.length - 1}
+            canMoveUp={index > 0}
+            position={index + 1}
+            suggestionLink={suggestionLink}
             searchPromptId={item.id}
           />
         ))}

--- a/apps/admin/src/data/review/get-review-item.ts
+++ b/apps/admin/src/data/review/get-review-item.ts
@@ -9,7 +9,12 @@ export const getCourseSuggestionReview = cache(async (entityId: string) => {
   }
 
   return prisma.searchPrompt.findUnique({
-    include: { suggestions: { include: { courseSuggestion: true }, orderBy: { position: "asc" } } },
+    include: {
+      suggestions: {
+        include: { courseSuggestion: true },
+        orderBy: [{ position: "asc" }, { createdAt: "asc" }, { id: "asc" }],
+      },
+    },
     where: { id: entityId },
   });
 });


### PR DESCRIPTION
Adds prompt-specific sorting controls for admin course suggestion reviews.

Newly added suggestions now appear first by shifting existing prompt suggestions down, and review loading uses deterministic ordering for ties.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-prompt sorting for admin course suggestions with up/down controls. New suggestions appear first, and list ordering is now deterministic.

- **New Features**
  - Up/down sort buttons on each suggestion row; moves are scoped to the prompt link.
  - New server action to move suggestions; swaps positions and normalizes order in a transaction.
  - Adding a suggestion inserts it at position 0 and shifts existing items down.

- **Bug Fixes**
  - Deterministic ordering for ties: position, then createdAt, then id.
  - Boundary moves become no-ops to avoid errors from stale forms.

<sup>Written for commit cd51186a66f42336f7ded5f386a9ebac6374e2fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1571?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

