### PR TITLE
feat(player): emphasize next step navigation

### DIFF
--- a/packages/player/src/components/step-navigation-button-group.tsx
+++ b/packages/player/src/components/step-navigation-button-group.tsx
@@ -23,27 +23,23 @@ export function StepNavigationButtonGroup({
   const t = useExtracted();
 
   return (
-    <div
-      className={cn("grid w-full gap-2", canNavigatePrev ? "grid-cols-2" : "grid-cols-1")}
-      data-slot="step-navigation-button-group"
-    >
+    <div className="flex w-full gap-2" data-slot="step-navigation-button-group">
       {canNavigatePrev && (
         <Button
+          aria-label={t("Previous")}
           aria-keyshortcuts="ArrowLeft"
-          className="min-w-0"
           onClick={onNavigatePrev}
-          size="lg"
+          size="icon-lg"
           type="button"
           variant="outline"
         >
-          <ChevronLeftIcon aria-hidden="true" data-icon="inline-start" />
-          <span>{t("Previous")}</span>
+          <ChevronLeftIcon aria-hidden="true" />
         </Button>
       )}
 
       <Button
         aria-keyshortcuts="ArrowRight"
-        className="min-w-0"
+        className={cn("min-w-0 flex-1", !canNavigatePrev && "w-full")}
         onClick={onNavigateNext}
         size="lg"
         type="button"


### PR DESCRIPTION
## Summary

- Make the static-step previous control icon-only while preserving its accessible label
- Let the next control fill the remaining bottom navigation space

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emphasizes Next in the player navigation: Previous is now icon-only (with aria-label), and Next expands to fill the remaining space. Keyboard shortcuts (Left/Right arrows) are unchanged.

<sup>Written for commit 03b22f1ffa5796fdbd9dbcbfa6a384a184150024. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

