### PR TITLE
fix(main): preload lessons behind short language lessons

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/preload-next-lesson-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/preload-next-lesson-action.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { triggerPreloadTarget } from "@/data/progress/trigger-preload-target";
-import { getNextPreloadTarget } from "@zoonk/core/player/commands/get-next-lesson-preload-target";
+import { getNextPreloadTargets } from "@zoonk/core/player/commands/get-next-lesson-preload-target";
 import { getSession } from "@zoonk/core/users/session/get";
 import { logError } from "@zoonk/utils/logger";
 import { headers } from "next/headers";
@@ -22,17 +22,21 @@ type NextPreloadInput = {
  */
 async function triggerNextPreload(input: NextPreloadInput): Promise<void> {
   try {
-    const target = await getNextPreloadTarget({ lessonId: input.lessonId, userId: input.userId });
+    const targets = await getNextPreloadTargets({ lessonId: input.lessonId, userId: input.userId });
 
-    if (!target) {
+    if (targets.length === 0) {
       return;
     }
 
-    await triggerPreloadTarget({
-      cookieHeader: input.cookieHeader,
-      requestHeaders: input.requestHeaders,
-      target,
-    });
+    await Promise.all(
+      targets.map((target) =>
+        triggerPreloadTarget({
+          cookieHeader: input.cookieHeader,
+          requestHeaders: input.requestHeaders,
+          target,
+        }),
+      ),
+    );
   } catch (error) {
     logError("[preloadNextLesson] Failed to trigger preload:", error);
   }

--- a/packages/core/src/lessons/get-next-lesson-in-course.ts
+++ b/packages/core/src/lessons/get-next-lesson-in-course.ts
@@ -9,6 +9,7 @@ export type NextLessonInCourse = {
   lessonPosition: number;
   lessonTitle: string | null;
   chapterId: string;
+  chapterPosition: number;
   chapterSlug: string;
   chapterTitle: string;
   lessonDescription: string | null;
@@ -45,6 +46,7 @@ const cachedGetNextLesson = cache(
 
     return {
       chapterId: lesson.chapter.id,
+      chapterPosition: lesson.chapter.position,
       chapterSlug: lesson.chapter.slug,
       chapterTitle: lesson.chapter.title,
       lessonDescription: lesson.description,

--- a/packages/core/src/player/commands/get-next-lesson-preload-target.test.ts
+++ b/packages/core/src/player/commands/get-next-lesson-preload-target.test.ts
@@ -4,7 +4,7 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { describe, expect, it } from "vitest";
-import { getNextPreloadTarget } from "./get-next-lesson-preload-target";
+import { getNextPreloadTargets } from "./get-next-lesson-preload-target";
 
 type PreloadTargetVisibility = {
   chapterIsPublished?: boolean;
@@ -79,19 +79,19 @@ async function createLessonPair(params: {
   return { currentLesson, nextLesson };
 }
 
-describe(getNextPreloadTarget, () => {
+describe(getNextPreloadTargets, () => {
   it("returns the next lesson target before considering chapter generation", async () => {
     const [user, lessons] = await Promise.all([
       userFixture(),
       createLessonPair({ nextLessonGenerationStatus: "pending" }),
     ]);
 
-    const result = await getNextPreloadTarget({
+    const result = await getNextPreloadTargets({
       lessonId: lessons.currentLesson.id,
       userId: user.id,
     });
 
-    expect(result).toStrictEqual({ kind: "lesson", lessonId: lessons.nextLesson.id });
+    expect(result).toStrictEqual([{ kind: "lesson", lessonId: lessons.nextLesson.id }]);
   });
 
   it.each(preloadGenerationStatuses)(
@@ -116,26 +116,26 @@ describe(getNextPreloadTarget, () => {
         }),
       ]);
 
-      const result = await getNextPreloadTarget({ lessonId: currentLesson.id, userId: user.id });
+      const result = await getNextPreloadTargets({ lessonId: currentLesson.id, userId: user.id });
 
-      expect(result).toStrictEqual({ chapterId: nextChapter.id, kind: "chapter" });
+      expect(result).toStrictEqual([{ chapterId: nextChapter.id, kind: "chapter" }]);
     },
   );
 
   it.each(nonPreloadGenerationStatuses)(
-    "returns null when the next lesson generation state is %s",
+    "returns no targets when the next lesson generation state is %s",
     async (nextLessonGenerationStatus) => {
       const [user, lessons] = await Promise.all([
         userFixture(),
         createLessonPair({ nextLessonGenerationStatus }),
       ]);
 
-      const result = await getNextPreloadTarget({
+      const result = await getNextPreloadTargets({
         lessonId: lessons.currentLesson.id,
         userId: user.id,
       });
 
-      expect(result).toBeNull();
+      expect(result).toStrictEqual([]);
     },
   );
 
@@ -153,25 +153,25 @@ describe(getNextPreloadTarget, () => {
         }),
       ]);
 
-      const result = await getNextPreloadTarget({
+      const result = await getNextPreloadTargets({
         lessonId: lessons.currentLesson.id,
         userId: user.id,
       });
 
-      expect(result).toBeNull();
+      expect(result).toStrictEqual([]);
     },
   );
 
-  it("returns null for malformed lesson ids before querying UUID columns", async () => {
+  it("returns no targets for malformed lesson ids before querying UUID columns", async () => {
     const user = await userFixture();
 
-    const result = await getNextPreloadTarget({ lessonId: "not-a-uuid", userId: user.id });
+    const result = await getNextPreloadTargets({ lessonId: "not-a-uuid", userId: user.id });
 
-    expect(result).toBeNull();
+    expect(result).toStrictEqual([]);
   });
 
   it.each(nonPreloadGenerationStatuses)(
-    "returns null when the next chapter generation state is %s",
+    "returns no targets when the next chapter generation state is %s",
     async (nextChapterGenerationStatus) => {
       const [user, context] = await Promise.all([userFixture(), createChapterContext()]);
 
@@ -192,9 +192,174 @@ describe(getNextPreloadTarget, () => {
         }),
       ]);
 
-      const result = await getNextPreloadTarget({ lessonId: currentLesson.id, userId: user.id });
+      const result = await getNextPreloadTargets({ lessonId: currentLesson.id, userId: user.id });
 
-      expect(result).toBeNull();
+      expect(result).toStrictEqual([]);
     },
   );
+
+  it("preloads a pending translation lesson and the generated reading lesson behind it", async () => {
+    const [user, context] = await Promise.all([userFixture(), createChapterContext()]);
+
+    const lessons = await Promise.all([
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "vocabulary",
+        organizationId: context.organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "translation",
+        organizationId: context.organization.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "reading",
+        organizationId: context.organization.id,
+        position: 2,
+      }),
+    ]);
+
+    const [vocabulary, translation, reading] = lessons;
+
+    const result = await getNextPreloadTargets({ lessonId: vocabulary.id, userId: user.id });
+
+    expect(result).toStrictEqual([
+      { kind: "lesson", lessonId: translation.id },
+      { kind: "lesson", lessonId: reading.id },
+    ]);
+  });
+
+  it("preloads a pending grammar lesson and the vocabulary lesson behind it", async () => {
+    const [user, context] = await Promise.all([userFixture(), createChapterContext()]);
+
+    const lessons = await Promise.all([
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "vocabulary",
+        organizationId: context.organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "grammar",
+        organizationId: context.organization.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "vocabulary",
+        organizationId: context.organization.id,
+        position: 2,
+      }),
+    ]);
+
+    const [previousVocabulary, grammar, vocabulary] = lessons;
+
+    const result = await getNextPreloadTargets({
+      lessonId: previousVocabulary.id,
+      userId: user.id,
+    });
+
+    expect(result).toStrictEqual([
+      { kind: "lesson", lessonId: grammar.id },
+      { kind: "lesson", lessonId: vocabulary.id },
+    ]);
+  });
+
+  it("preloads the generated lesson behind an already-running listening lesson", async () => {
+    const [user, context] = await Promise.all([userFixture(), createChapterContext()]);
+
+    const lessons = await Promise.all([
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "reading",
+        organizationId: context.organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "running",
+        isPublished: true,
+        kind: "listening",
+        organizationId: context.organization.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "grammar",
+        organizationId: context.organization.id,
+        position: 2,
+      }),
+    ]);
+
+    const [reading, , grammar] = lessons;
+
+    const result = await getNextPreloadTargets({ lessonId: reading.id, userId: user.id });
+
+    expect(result).toStrictEqual([{ kind: "lesson", lessonId: grammar.id }]);
+  });
+
+  it("does not preload through a derived lesson with unfinished source content", async () => {
+    const [user, context] = await Promise.all([userFixture(), createChapterContext()]);
+
+    const lessons = await Promise.all([
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "vocabulary",
+        organizationId: context.organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        organizationId: context.organization.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "translation",
+        organizationId: context.organization.id,
+        position: 2,
+      }),
+      lessonFixture({
+        chapterId: context.chapter.id,
+        generationStatus: "pending",
+        isPublished: true,
+        kind: "reading",
+        organizationId: context.organization.id,
+        position: 3,
+      }),
+    ]);
+
+    const currentLesson = lessons[1];
+
+    const result = await getNextPreloadTargets({ lessonId: currentLesson.id, userId: user.id });
+
+    expect(result).toStrictEqual([]);
+  });
 });

--- a/packages/core/src/player/commands/get-next-lesson-preload-target.ts
+++ b/packages/core/src/player/commands/get-next-lesson-preload-target.ts
@@ -1,6 +1,12 @@
 import "server-only";
-import { type GenerationStatus, getPublishedChapterWhere, prisma } from "@zoonk/db";
+import {
+  type GenerationStatus,
+  type LessonKind,
+  getPublishedChapterWhere,
+  prisma,
+} from "@zoonk/db";
 import { isUuid } from "@zoonk/utils/uuid";
+import { getBlockingLessonGenerationPrerequisite } from "../../lessons/generation-prerequisites";
 import {
   type NextLessonInCourse,
   getNextLessonInCourse,
@@ -8,10 +14,22 @@ import {
 import { getCompletableLessonWhere } from "./_utils/completable-lesson";
 
 const preloadableGenerationStatuses = new Set<GenerationStatus>(["pending", "failed"]);
+const preloadLookaheadLessonKinds = new Set<LessonKind>(["grammar", "listening", "translation"]);
+const maxPreloadTargets = 2;
+const maxLookaheadHops = 1;
 
 export type NextPreloadTarget =
   | { kind: "chapter"; chapterId: string }
   | { kind: "lesson"; lessonId: string };
+
+type LessonPreloadCursor = {
+  chapterId: string;
+  chapterPosition: number;
+  courseId: string;
+  lessonPosition: number;
+};
+
+type LessonPreloadDecision = { shouldContinue: boolean; target: NextPreloadTarget | null };
 
 /**
  * Chapter generation should only be preloaded when the next chapter is still
@@ -55,19 +73,53 @@ function isPreloadableNextLesson(
 }
 
 /**
- * Callers that already have the next lesson row can reuse the same preload
- * eligibility rule without doing another current-lesson lookup.
+ * Some language lessons are commonly finished before the next heavy generated
+ * lesson is ready. These are the only lesson kinds this command may look
+ * through, and the shared target cap still prevents broad course generation.
  */
-function getNextLessonPreloadId({
+function isPreloadLookaheadLesson({ lessonKind }: NextLessonInCourse): boolean {
+  return preloadLookaheadLessonKinds.has(lessonKind);
+}
+
+/**
+ * Avoids starting workflow runs that the shared prerequisite guard would block
+ * anyway. This keeps lookahead generation from skipping over unfinished source
+ * lessons while still reusing the same rule the generation workflow enforces.
+ */
+async function isBlockedByGenerationPrerequisite({
   nextLesson,
 }: {
-  nextLesson: NextLessonInCourse | null;
-}): string | null {
-  if (!isPreloadableNextLesson(nextLesson)) {
-    return null;
+  nextLesson: NextLessonInCourse;
+}): Promise<boolean> {
+  const blockingPrerequisite = await getBlockingLessonGenerationPrerequisite({
+    chapterId: nextLesson.chapterId,
+    kind: nextLesson.lessonKind,
+    position: nextLesson.lessonPosition,
+  });
+
+  return Boolean(blockingPrerequisite);
+}
+
+/**
+ * Decides whether the next structural lesson should be started and whether the
+ * selector may continue behind it. Lookahead lessons can be looked through only
+ * when their own source content is already complete.
+ */
+async function getLessonPreloadDecision({
+  nextLesson,
+}: {
+  nextLesson: NextLessonInCourse;
+}): Promise<LessonPreloadDecision> {
+  if (await isBlockedByGenerationPrerequisite({ nextLesson })) {
+    return { shouldContinue: false, target: null };
   }
 
-  return nextLesson.lessonId;
+  return {
+    shouldContinue: isPreloadLookaheadLesson(nextLesson),
+    target: isPreloadableNextLesson(nextLesson)
+      ? { kind: "lesson", lessonId: nextLesson.lessonId }
+      : null,
+  };
 }
 
 /**
@@ -95,21 +147,49 @@ function getChapterPreloadTarget(
 }
 
 /**
- * The second-step preload entry point needs one structural decision: prefer a
- * concrete next lesson when it exists, otherwise generate the next empty
- * chapter if the learner is at the chapter boundary.
+ * Keeps the returned target list typed after composing the optional current
+ * lesson target with any target found behind a lookahead lesson.
  */
-async function getNextPreloadTargetAfterLessonPosition({
+function getPreloadTargets(input: {
+  laterTargets: NextPreloadTarget[];
+  target: NextPreloadTarget | null;
+}): NextPreloadTarget[] {
+  return input.target ? [input.target, ...input.laterTargets] : input.laterTargets;
+}
+
+/**
+ * Counts how many target slots remain after the current lesson decision. The
+ * cap keeps early preload from becoming broad course generation.
+ */
+function getRemainingTargetCount({
+  remainingTargets,
+  target,
+}: {
+  remainingTargets: number;
+  target: NextPreloadTarget | null;
+}): number {
+  return target ? remainingTargets - 1 : remainingTargets;
+}
+
+/**
+ * The second-step preload entry point normally starts the immediate next
+ * generated lesson. Short language lessons are special: the selector may walk
+ * one lookahead hop and start the slower generated lesson behind them too.
+ */
+async function getNextPreloadTargetsAfterLessonPosition({
   chapterId,
   chapterPosition,
   courseId,
   lessonPosition,
-}: {
-  chapterId: string;
-  chapterPosition: number;
-  courseId: string;
-  lessonPosition: number;
-}): Promise<NextPreloadTarget | null> {
+  remainingLookaheadHops,
+  remainingTargets,
+}: { remainingLookaheadHops: number; remainingTargets: number } & LessonPreloadCursor): Promise<
+  NextPreloadTarget[]
+> {
+  if (remainingTargets <= 0) {
+    return [];
+  }
+
   const nextLesson = await getNextLessonInCourse({
     chapterId,
     chapterPosition,
@@ -117,35 +197,50 @@ async function getNextPreloadTargetAfterLessonPosition({
     lessonPosition,
   });
 
-  const nextLessonId = getNextLessonPreloadId({ nextLesson });
+  if (!nextLesson) {
+    const nextChapter = await getNextChapterPreloadCandidate({ chapterPosition, courseId });
+    const target = getChapterPreloadTarget(nextChapter);
 
-  if (nextLessonId) {
-    return { kind: "lesson", lessonId: nextLessonId };
+    return target ? [target] : [];
   }
 
-  if (nextLesson) {
-    return null;
+  const decision = await getLessonPreloadDecision({ nextLesson });
+
+  const nextRemainingTargets = getRemainingTargetCount({
+    remainingTargets,
+    target: decision.target,
+  });
+
+  if (!decision.shouldContinue || remainingLookaheadHops <= 0 || nextRemainingTargets <= 0) {
+    return getPreloadTargets({ laterTargets: [], target: decision.target });
   }
 
-  const nextChapter = await getNextChapterPreloadCandidate({ chapterPosition, courseId });
+  const laterTargets = await getNextPreloadTargetsAfterLessonPosition({
+    chapterId: nextLesson.chapterId,
+    chapterPosition: nextLesson.chapterPosition,
+    courseId,
+    lessonPosition: nextLesson.lessonPosition,
+    remainingLookaheadHops: remainingLookaheadHops - 1,
+    remainingTargets: nextRemainingTargets,
+  });
 
-  return getChapterPreloadTarget(nextChapter);
+  return getPreloadTargets({ laterTargets, target: decision.target });
 }
 
 /**
  * The browser only proves that a learner interacted with the current lesson.
- * This command derives the next preload target on the server so callers do not
+ * This command derives the next preload targets on the server so callers do not
  * trust a client-provided lesson or chapter id for an expensive AI job.
  */
-export async function getNextPreloadTarget({
+export async function getNextPreloadTargets({
   lessonId,
   userId,
 }: {
   lessonId: string;
   userId: string;
-}): Promise<NextPreloadTarget | null> {
+}): Promise<NextPreloadTarget[]> {
   if (!isUuid(lessonId) || !isUuid(userId)) {
-    return null;
+    return [];
   }
 
   const lesson = await prisma.lesson.findFirst({
@@ -154,13 +249,15 @@ export async function getNextPreloadTarget({
   });
 
   if (!lesson) {
-    return null;
+    return [];
   }
 
-  return getNextPreloadTargetAfterLessonPosition({
+  return getNextPreloadTargetsAfterLessonPosition({
     chapterId: lesson.chapterId,
     chapterPosition: lesson.chapter.position,
     courseId: lesson.chapter.courseId,
     lessonPosition: lesson.position,
+    remainingLookaheadHops: maxLookaheadHops,
+    remainingTargets: maxPreloadTargets,
   });
 }


### PR DESCRIPTION
## Summary

- preload bounded lookahead targets behind short language lessons
- keep prerequisite checks in the shared preload target selector
- update preload target coverage for translation, listening, grammar, and chapter targets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloads the next generated lesson and, when the immediate next step is a short language lesson, also preloads the generated lesson behind it to reduce wait time. Adds a safe, bounded lookahead with prerequisite checks and a max of two targets.

- New Features
  - Look ahead through short lessons (grammar, listening, translation) and start the slower generated lesson behind them.
  - Reuse generation prerequisite guard to avoid starting work when source content isn’t ready.
  - Honors generation status rules; still preloads next chapter when appropriate.
  - Limits scope: 1 lookahead hop, max 2 total targets.

- Refactors
  - Replace `getNextPreloadTarget` with `getNextPreloadTargets` in `@zoonk/core/player/commands`, and trigger all targets in parallel in `preload-next-lesson-action.ts`.
  - Add `chapterPosition` to `getNextLessonInCourse` result.
  - Return `[]` instead of `null` for invalid IDs and unify target typing.
  - Expand tests to cover lookahead paths for translation, listening, grammar, and chapter targets.

<sup>Written for commit 2f1c9d29ff6108663ca81d3b0b3b3de7d544a926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

