### PR TITLE
feat(admin): add user sorting and ai lesson filter

### DIFF
--- a/apps/admin/src/app/(private)/users/user-list.tsx
+++ b/apps/admin/src/app/(private)/users/user-list.tsx
@@ -1,16 +1,22 @@
 import { AdminPagination } from "@/components/pagination";
 import { listUsers } from "@/data/users/list-users";
 import { parseSearchParams } from "@/lib/parse-search-params";
+import { type UserSort, getUserSortQueryValue, parseUserSort } from "@/lib/user-sort";
 import { Table, TableBody, TableHead, TableHeader, TableRow } from "@zoonk/ui/components/table";
+import { ArrowDown } from "lucide-react";
 import { UserRow } from "./user-row";
+
+type SortQueryEntry = [string, string | undefined] | undefined;
 
 export async function UserList({
   searchParams,
 }: {
   searchParams: PageProps<"/users">["searchParams"];
 }) {
-  const { page, limit, offset, search } = parseSearchParams(await searchParams);
-  const { users, total } = await listUsers({ limit, offset, search });
+  const params = await searchParams;
+  const { page, limit, offset, search } = parseSearchParams(params);
+  const sort = parseUserSort(params.sort);
+  const { users, total } = await listUsers({ limit, offset, search, sort });
   const totalPages = Math.ceil(total / limit);
 
   return (
@@ -21,7 +27,20 @@ export async function UserList({
             <TableRow>
               <TableHead>User</TableHead>
               <TableHead>Username</TableHead>
-              <TableHead className="text-right">Brain Power</TableHead>
+              <SortableUserTableHead
+                align="right"
+                className="text-right"
+                label="Brain Power"
+                search={search}
+                selectedSort={sort}
+                sort="brain-power"
+              />
+              <SortableUserTableHead
+                label="Joined"
+                search={search}
+                selectedSort={sort}
+                sort="newest-signups"
+              />
               <TableHead>Subscription</TableHead>
             </TableRow>
           </TableHeader>
@@ -38,9 +57,74 @@ export async function UserList({
         basePath="/users"
         limit={limit}
         page={page}
+        queryParams={{ sort: getUserSortQueryValue(sort) }}
         search={search}
         totalPages={totalPages}
       />
     </>
   );
+}
+
+/**
+ * Sorting from the column header matches the way admins scan the table: the
+ * column label is both the data label and the control for that ordering.
+ */
+function SortableUserTableHead({
+  className,
+  align = "left",
+  label,
+  search,
+  selectedSort,
+  sort,
+}: {
+  align?: "left" | "right";
+  className?: string;
+  label: string;
+  search?: string;
+  selectedSort: UserSort;
+  sort: UserSort;
+}) {
+  const isSelected = selectedSort === sort;
+
+  const linkClassName =
+    align === "right"
+      ? "hover:text-foreground inline-flex w-full items-center justify-end gap-1 text-inherit transition-colors"
+      : "hover:text-foreground inline-flex w-full items-center justify-start gap-1 text-inherit transition-colors";
+
+  return (
+    <TableHead aria-sort={isSelected ? "descending" : undefined} className={className}>
+      <a
+        aria-current={isSelected ? "page" : undefined}
+        className={linkClassName}
+        href={buildSortHref({ search, sort })}
+      >
+        {label}
+        {isSelected ? <ArrowDown className="size-3.5" /> : null}
+      </a>
+    </TableHead>
+  );
+}
+
+/**
+ * Sorting changes should preserve search but reset pagination so a valid page
+ * number from one ordering does not land on an unexpectedly sparse result set.
+ */
+function buildSortHref({ search, sort }: { search?: string; sort: UserSort }): string {
+  const entries: SortQueryEntry[] = [
+    getUserSortQueryValue(sort) ? ["sort", sort] : undefined,
+    search ? ["search", search] : undefined,
+  ];
+
+  const params = new URLSearchParams(entries.filter((entry) => isSortQueryEntry(entry)));
+  const queryString = params.toString();
+
+  return queryString ? `/users?${queryString}` : "/users";
+}
+
+/**
+ * URLSearchParams only accepts complete string pairs. This guard keeps optional
+ * sort/search entries declarative without weakening the query-building type.
+ */
+function isSortQueryEntry(entry: SortQueryEntry): entry is [string, string] {
+  return Array.isArray(entry) && Boolean(entry[1]);
 }

--- a/apps/admin/src/app/(private)/users/user-row.tsx
+++ b/apps/admin/src/app/(private)/users/user-row.tsx
@@ -4,8 +4,8 @@ import { TableCell, TableRow } from "@zoonk/ui/components/table";
 import Link from "next/link";
 
 /**
- * The admin user list is ordered by Brain Power, so each row shows the score
- * that explains why the user appears in that position.
+ * Admins can sort users by Brain Power or signup recency, so the row keeps both
+ * values visible without making either sort mode require a separate detail page.
  */
 export function UserRow({
   user,
@@ -25,6 +25,10 @@ export function UserRow({
 
       <TableCell className="text-right tabular-nums">
         {Number(user.progress?.totalBrainPower ?? 0).toLocaleString()}
+      </TableCell>
+
+      <TableCell className="text-muted-foreground">
+        {new Date(user.createdAt).toLocaleDateString()}
       </TableCell>
 
       <TableCell>

--- a/apps/admin/src/data/lessons/list-generated-lessons.ts
+++ b/apps/admin/src/data/lessons/list-generated-lessons.ts
@@ -1,8 +1,19 @@
 import "server-only";
 import { isAdmin } from "@/lib/admin-guard";
 import { type GeneratedLessonStatus } from "@/lib/generated-lesson-status";
-import { prisma } from "@zoonk/db";
+import { type LessonKind, prisma } from "@zoonk/db";
 import { cache } from "react";
+
+const aiGeneratedLessonKinds = [
+  "alphabet",
+  "explanation",
+  "grammar",
+  "practice",
+  "quiz",
+  "reading",
+  "tutorial",
+  "vocabulary",
+] as const satisfies readonly LessonKind[];
 
 const cachedListGeneratedLessons = cache(
   async (limit: number, offset: number, status: GeneratedLessonStatus, search?: string) => {
@@ -64,11 +75,14 @@ function buildGeneratedLessonWhere({
   search?: string;
   status: GeneratedLessonStatus;
 }) {
+  const baseWhere = getAiGeneratedLessonWhere({ status });
+
   if (!search) {
-    return { generationStatus: status };
+    return baseWhere;
   }
 
   return {
+    ...baseWhere,
     OR: [
       { normalizedTitle: { contains: search, mode: "insensitive" as const } },
       { chapter: { normalizedTitle: { contains: search, mode: "insensitive" as const } } },
@@ -78,6 +92,15 @@ function buildGeneratedLessonWhere({
         },
       },
     ],
-    generationStatus: status,
   };
+}
+
+/**
+ * The generated lesson log should show lessons whose content was produced by
+ * the AI workflow. Companion rows like review, translation, and listening reuse
+ * existing generated resources, so including them makes the log look larger
+ * than the set of lessons that actually went through model-authored generation.
+ */
+function getAiGeneratedLessonWhere({ status }: { status: GeneratedLessonStatus }) {
+  return { generationStatus: status, kind: { in: [...aiGeneratedLessonKinds] } };
 }

--- a/apps/admin/src/data/users/list-users.ts
+++ b/apps/admin/src/data/users/list-users.ts
@@ -1,43 +1,68 @@
 import "server-only";
 import { findUserActiveSubscription } from "@/data/users/find-active-subscription";
 import { isAdmin } from "@/lib/admin-guard";
+import { type UserSort } from "@/lib/user-sort";
 import { type Subscription, prisma } from "@zoonk/db";
 import { cache } from "react";
 
-const cachedListUsers = cache(async (limit: number, offset: number, search?: string) => {
-  if (!(await isAdmin())) {
-    return { total: 0, users: [] };
+const cachedListUsers = cache(
+  async (limit: number, offset: number, sort: UserSort, search?: string) => {
+    if (!(await isAdmin())) {
+      return { total: 0, users: [] };
+    }
+
+    const where = getUserSearchWhere({ search });
+
+    const [users, total] = await Promise.all([
+      prisma.user.findMany({
+        include: { progress: true },
+        orderBy: getUserOrderBy({ sort }),
+        skip: offset,
+        take: limit,
+        where,
+      }),
+      prisma.user.count({ where }),
+    ]);
+
+    const userIds = users.map((user) => user.id);
+
+    const subscriptions =
+      userIds.length > 0
+        ? await prisma.subscription.findMany({ where: { referenceId: { in: userIds } } })
+        : [];
+
+    const subscriptionsByUserId = groupSubscriptionsByUser({ subscriptions });
+
+    const usersWithPlan = users.map((user) => addUserPlan({ subscriptionsByUserId, user }));
+
+    return { total, users: usersWithPlan };
+  },
+);
+
+export async function listUsers(params: {
+  limit: number;
+  offset: number;
+  search?: string;
+  sort: UserSort;
+}) {
+  return cachedListUsers(params.limit, params.offset, params.sort, params.search);
+}
+
+/**
+ * Brain Power remains the default ranking because it highlights the most
+ * engaged learners. Newest signups is an alternate operational view for launch
+ * follow-up, so it only replaces the primary ranking when the URL asks for it.
+ */
+function getUserOrderBy({ sort }: { sort: UserSort }) {
+  if (sort === "newest-signups") {
+    return [{ createdAt: "desc" as const }, { id: "asc" as const }];
   }
 
-  const where = getUserSearchWhere({ search });
-
-  const [users, total] = await Promise.all([
-    prisma.user.findMany({
-      include: { progress: true },
-      orderBy: [{ progress: { totalBrainPower: "desc" } }, { createdAt: "desc" }, { id: "asc" }],
-      skip: offset,
-      take: limit,
-      where,
-    }),
-    prisma.user.count({ where }),
-  ]);
-
-  const userIds = users.map((user) => user.id);
-
-  const subscriptions =
-    userIds.length > 0
-      ? await prisma.subscription.findMany({ where: { referenceId: { in: userIds } } })
-      : [];
-
-  const subscriptionsByUserId = groupSubscriptionsByUser({ subscriptions });
-
-  const usersWithPlan = users.map((user) => addUserPlan({ subscriptionsByUserId, user }));
-
-  return { total, users: usersWithPlan };
-});
-
-export async function listUsers(params: { limit: number; offset: number; search?: string }) {
-  return cachedListUsers(params.limit, params.offset, params.search);
+  return [
+    { progress: { totalBrainPower: "desc" as const } },
+    { createdAt: "desc" as const },
+    { id: "asc" as const },
+  ];
 }
 
 /**

--- a/apps/admin/src/lib/user-sort.ts
+++ b/apps/admin/src/lib/user-sort.ts
@@ -1,0 +1,31 @@
+const defaultUserSort = "brain-power";
+const userSorts = [defaultUserSort, "newest-signups"] as const;
+
+export type UserSort = (typeof userSorts)[number];
+
+/**
+ * User sorting is URL-driven so admins can share a filtered table state. Unknown
+ * query values should fall back to Brain Power instead of changing the table
+ * order through arbitrary user-controlled strings.
+ */
+export function parseUserSort(value: string | string[] | undefined): UserSort {
+  const sort = Array.isArray(value) ? value[0] : value;
+
+  return isUserSort(sort) ? sort : defaultUserSort;
+}
+
+/**
+ * Brain Power is the default user ranking, so omitting it from generated URLs
+ * keeps the normal admin users page clean while preserving non-default sorts.
+ */
+export function getUserSortQueryValue(sort: UserSort): string | undefined {
+  return sort === defaultUserSort ? undefined : sort;
+}
+
+/**
+ * The parser needs a runtime guard because query params arrive as untrusted
+ * strings even though the rest of the app works with a narrow sort union.
+ */
+function isUserSort(value: string | undefined): value is UserSort {
+  return userSorts.some((sort) => sort === value);
+}


### PR DESCRIPTION
## Summary

- Filter generated lesson list to AI-generated lesson kinds.
- Keep Brain Power as the default users sort and let admins sort by Joined from the table header.
- Preserve user sort state through pagination.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds sortable columns to the Admin Users table (Brain Power by default, Joined for newest signups), with sorting preserved in the URL and through pagination. Filters the generated lessons log to only AI-generated lesson kinds.

- **New Features**
  - Users: Click Brain Power or Joined to sort; URL uses ?sort=newest-signups; search is preserved; pagination resets on sort change; shows joined date in each row.
  - Lessons: Generated lessons list now includes only AI-generated kinds (alphabet, explanation, grammar, practice, quiz, reading, tutorial, vocabulary).

<sup>Written for commit 3a222afbce3ba7eae97dd9623120fa1f5353c1ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

