### PR TITLE
feat(main): update generation access contract

### DIFF
--- a/apps/api/e2e/workflows-chapter-generation.test.ts
+++ b/apps/api/e2e/workflows-chapter-generation.test.ts
@@ -21,18 +21,18 @@ test.describe("Chapter Generation Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("returns 401 when triggering chapter generation without a session", async () => {
+  test("allows first chapter generation without a session", async () => {
     const uniqueId = randomUUID().slice(0, 8);
-    const courseTitle = `E2E Chapter Auth ${uniqueId}`;
+    const courseTitle = `E2E Chapter Public ${uniqueId}`;
 
     const course = await prisma.course.create({
       data: {
-        description: "Test course for chapter generation auth",
+        description: "Test course for public first chapter generation",
         isPublished: true,
         language: "en",
         normalizedTitle: normalizeString(courseTitle),
         organizationId: aiOrgId,
-        slug: `e2e-chapter-auth-${uniqueId}`,
+        slug: `e2e-chapter-public-${uniqueId}`,
         title: courseTitle,
       },
     });
@@ -40,14 +40,14 @@ test.describe("Chapter Generation Workflow API", () => {
     const chapter = await prisma.chapter.create({
       data: {
         courseId: course.id,
-        description: "Test chapter for auth",
+        description: "Test first chapter for public generation",
         isPublished: true,
         language: "en",
-        normalizedTitle: normalizeString("Test Chapter Auth"),
+        normalizedTitle: normalizeString("Test Chapter Public"),
         organizationId: aiOrgId,
         position: 0,
-        slug: `e2e-chapter-auth-${uniqueId}`,
-        title: "Test Chapter Auth",
+        slug: `e2e-chapter-public-${uniqueId}`,
+        title: "Test Chapter Public",
       },
     });
 
@@ -57,13 +57,58 @@ test.describe("Chapter Generation Workflow API", () => {
       data: { chapterId: chapter.id },
     });
 
-    expect(response.status()).toBe(401);
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.message).toBe("Workflow started");
+    expect(body.runId).toBeDefined();
+
+    await apiContext.dispose();
+  });
+
+  test("returns 402 when later chapter generation has no session", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const courseTitle = `E2E Chapter Paid ${uniqueId}`;
+
+    const course = await prisma.course.create({
+      data: {
+        description: "Test course for paid chapter generation",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(courseTitle),
+        organizationId: aiOrgId,
+        slug: `e2e-chapter-paid-${uniqueId}`,
+        title: courseTitle,
+      },
+    });
+
+    const chapter = await prisma.chapter.create({
+      data: {
+        courseId: course.id,
+        description: "Later chapter requires subscription",
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString("Test Chapter Paid"),
+        organizationId: aiOrgId,
+        position: 1,
+        slug: `e2e-chapter-paid-${uniqueId}`,
+        title: "Test Chapter Paid",
+      },
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/chapter-generation/trigger", {
+      data: { chapterId: chapter.id },
+    });
+
+    expect(response.status()).toBe(402);
 
     const body = await response.json();
 
     expect(body.error).toBeDefined();
-    expect(body.error.code).toBe("UNAUTHORIZED");
-    expect(body.error.message).toBe("Authentication required");
+    expect(body.error.code).toBe("PAYMENT_REQUIRED");
 
     await apiContext.dispose();
   });

--- a/apps/api/e2e/workflows-course-generation.test.ts
+++ b/apps/api/e2e/workflows-course-generation.test.ts
@@ -37,12 +37,12 @@ test.describe("Course Generation Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("returns 401 when triggering course generation without a session", async () => {
+  test("starts workflow without a session", async () => {
     const uniqueId = randomUUID().slice(0, 8);
 
     const suggestion = await createCompletedCourseSuggestion({
-      slug: `e2e-unauth-course-${uniqueId}`,
-      title: `E2E Unauth Course ${uniqueId}`,
+      slug: `e2e-public-course-${uniqueId}`,
+      title: `E2E Public Course ${uniqueId}`,
     });
 
     const apiContext = await request.newContext({ baseURL });
@@ -51,13 +51,13 @@ test.describe("Course Generation Workflow API", () => {
       data: { courseSuggestionId: suggestion.id },
     });
 
-    expect(response.status()).toBe(401);
+    expect(response.status()).toBe(200);
 
     const body = await response.json();
 
-    expect(body.error).toBeDefined();
-    expect(body.error.code).toBe("UNAUTHORIZED");
-    expect(body.error.message).toBe("Authentication required");
+    expect(body.message).toBe("Workflow started");
+    expect(body.runId).toBeDefined();
+    expect(typeof body.runId).toBe("string");
 
     await apiContext.dispose();
   });

--- a/apps/api/e2e/workflows-lesson-generation.test.ts
+++ b/apps/api/e2e/workflows-lesson-generation.test.ts
@@ -17,10 +17,12 @@ import { createAuthenticatedApiContext, createSubscribedApiContext } from "./hel
 async function createAiLessonForWorkflow({
   aiOrgId,
   chapterPosition,
+  lessonPosition = 0,
   uniqueId,
 }: {
   aiOrgId: string;
   chapterPosition: number;
+  lessonPosition?: number;
   uniqueId: string;
 }) {
   const course = await courseFixture({
@@ -43,6 +45,7 @@ async function createAiLessonForWorkflow({
     isPublished: true,
     kind: "explanation",
     organizationId: aiOrgId,
+    position: lessonPosition,
     title: `E2E Lesson ${uniqueId}`,
   });
 }
@@ -62,9 +65,42 @@ test.describe("Lesson Generation Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("returns 401 when triggering lesson generation without a session", async () => {
+  test("allows unauthenticated generation through the first five first-chapter lessons", async () => {
     const uniqueId = randomUUID().slice(0, 8);
-    const lesson = await createAiLessonForWorkflow({ aiOrgId, chapterPosition: 0, uniqueId });
+
+    const lesson = await createAiLessonForWorkflow({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 4,
+      uniqueId,
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.message).toBe("Workflow started");
+    expect(body.runId).toBeDefined();
+
+    await apiContext.dispose();
+  });
+
+  test("returns 401 when unauthenticated generation needs the login-expanded preview", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const lesson = await createAiLessonForWorkflow({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 5,
+      uniqueId,
+    });
+
     const apiContext = await request.newContext({ baseURL });
 
     const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
@@ -78,6 +114,32 @@ test.describe("Lesson Generation Workflow API", () => {
     expect(body.error).toBeDefined();
     expect(body.error.code).toBe("UNAUTHORIZED");
     expect(body.error.message).toBe("Authentication required");
+
+    await apiContext.dispose();
+  });
+
+  test("returns 402 when unauthenticated generation is outside the free preview", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const lesson = await createAiLessonForWorkflow({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 10,
+      uniqueId,
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(402);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("PAYMENT_REQUIRED");
 
     await apiContext.dispose();
   });
@@ -164,10 +226,15 @@ test.describe("Lesson Generation Workflow API", () => {
     await apiContext.dispose();
   });
 
-  test("allows signed-in first chapter lesson generation without subscription", async () => {
+  test("allows signed-in first-chapter generation through lesson ten without subscription", async () => {
     const uniqueId = randomUUID().slice(0, 8);
 
-    const lesson = await createAiLessonForWorkflow({ aiOrgId, chapterPosition: 0, uniqueId });
+    const lesson = await createAiLessonForWorkflow({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 9,
+      uniqueId,
+    });
 
     const { apiContext } = await createAuthenticatedApiContext({
       baseURL,
@@ -185,6 +252,35 @@ test.describe("Lesson Generation Workflow API", () => {
     expect(body.message).toBe("Workflow started");
     expect(body.runId).toBeDefined();
     expect(typeof body.runId).toBe("string");
+
+    await apiContext.dispose();
+  });
+
+  test("returns 402 for signed-in first-chapter lesson eleven without subscription", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const lesson = await createAiLessonForWorkflow({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 10,
+      uniqueId,
+    });
+
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "lesson-eleven-no-subscription",
+    });
+
+    const response = await apiContext.post("/v1/workflows/lesson-generation/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(402);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("PAYMENT_REQUIRED");
 
     await apiContext.dispose();
   });

--- a/apps/api/e2e/workflows-lesson-preload.test.ts
+++ b/apps/api/e2e/workflows-lesson-preload.test.ts
@@ -16,10 +16,12 @@ import { createAuthenticatedApiContext } from "./helpers/auth";
 async function createAiLessonForPreload({
   aiOrgId,
   chapterPosition,
+  lessonPosition = 0,
   uniqueId,
 }: {
   aiOrgId: string;
   chapterPosition: number;
+  lessonPosition?: number;
   uniqueId: string;
 }) {
   const course = await courseFixture({
@@ -42,6 +44,7 @@ async function createAiLessonForPreload({
     isPublished: true,
     kind: "explanation",
     organizationId: aiOrgId,
+    position: lessonPosition,
     title: `E2E Preload Lesson ${uniqueId}`,
   });
 }
@@ -61,9 +64,42 @@ test.describe("Lesson Preload Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("returns 401 when triggering lesson preload without a session", async () => {
+  test("allows unauthenticated preload through the first five first-chapter lessons", async () => {
     const uniqueId = randomUUID().slice(0, 8);
-    const lesson = await createAiLessonForPreload({ aiOrgId, chapterPosition: 0, uniqueId });
+
+    const lesson = await createAiLessonForPreload({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 4,
+      uniqueId,
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.message).toBe("Workflow started");
+    expect(body.runId).toBeDefined();
+
+    await apiContext.dispose();
+  });
+
+  test("returns 401 when unauthenticated preload needs the login-expanded preview", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const lesson = await createAiLessonForPreload({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 5,
+      uniqueId,
+    });
+
     const apiContext = await request.newContext({ baseURL });
 
     const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
@@ -77,6 +113,32 @@ test.describe("Lesson Preload Workflow API", () => {
     expect(body.error).toBeDefined();
     expect(body.error.code).toBe("UNAUTHORIZED");
     expect(body.error.message).toBe("Authentication required");
+
+    await apiContext.dispose();
+  });
+
+  test("returns 402 when unauthenticated preload is outside the free preview", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const lesson = await createAiLessonForPreload({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 10,
+      uniqueId,
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(402);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("PAYMENT_REQUIRED");
 
     await apiContext.dispose();
   });
@@ -106,10 +168,15 @@ test.describe("Lesson Preload Workflow API", () => {
     await apiContext.dispose();
   });
 
-  test("allows signed-in first chapter lesson preload without subscription", async () => {
+  test("allows signed-in first-chapter preload through lesson ten without subscription", async () => {
     const uniqueId = randomUUID().slice(0, 8);
 
-    const lesson = await createAiLessonForPreload({ aiOrgId, chapterPosition: 0, uniqueId });
+    const lesson = await createAiLessonForPreload({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 9,
+      uniqueId,
+    });
 
     const { apiContext } = await createAuthenticatedApiContext({
       baseURL,
@@ -127,6 +194,35 @@ test.describe("Lesson Preload Workflow API", () => {
     expect(body.message).toBe("Workflow started");
     expect(body.runId).toBeDefined();
     expect(typeof body.runId).toBe("string");
+
+    await apiContext.dispose();
+  });
+
+  test("returns 402 for signed-in first-chapter lesson eleven without subscription", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const lesson = await createAiLessonForPreload({
+      aiOrgId,
+      chapterPosition: 0,
+      lessonPosition: 10,
+      uniqueId,
+    });
+
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "preload-eleven-no-subscription",
+    });
+
+    const response = await apiContext.post("/v1/workflows/lesson-preload/trigger", {
+      data: { lessonId: lesson.id },
+    });
+
+    expect(response.status()).toBe(402);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("PAYMENT_REQUIRED");
 
     await apiContext.dispose();
   });

--- a/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/chapter-generation/trigger/route.ts
@@ -3,7 +3,6 @@ import { parseBody } from "@/lib/body-parser";
 import { chapterGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import {
   getAiGenerationChapterForWorkflow,
-  getWorkflowAuthenticationError,
   getWorkflowSubscriptionAccessError,
   requiresSubscriptionForChapterGeneration,
 } from "@/lib/workflow-generation-access";
@@ -12,12 +11,6 @@ import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
 export async function POST(request: NextRequest) {
-  const authError = await getWorkflowAuthenticationError({ headers: request.headers });
-
-  if (authError) {
-    return authError;
-  }
-
   const parsed = await parseBody(request, chapterGenerationTriggerSchema);
 
   if (!parsed.success) {

--- a/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
@@ -1,18 +1,11 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
 import { courseGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
-import { getWorkflowAuthenticationError } from "@/lib/workflow-generation-access";
 import { courseGenerationWorkflow } from "@/workflows/course-generation/course-generation-workflow";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
 export async function POST(request: NextRequest) {
-  const accessError = await getWorkflowAuthenticationError({ headers: request.headers });
-
-  if (accessError) {
-    return accessError;
-  }
-
   const parsed = await parseBody(request, courseGenerationTriggerSchema);
 
   if (!parsed.success) {

--- a/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-generation/trigger/route.ts
@@ -3,9 +3,7 @@ import { parseBody } from "@/lib/body-parser";
 import { lessonGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import {
   getAiGenerationLessonForWorkflow,
-  getWorkflowAuthenticationError,
-  getWorkflowSubscriptionAccessError,
-  requiresSubscriptionForLessonGeneration,
+  getWorkflowLessonAccessError,
 } from "@/lib/workflow-generation-access";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
 import {
@@ -16,12 +14,6 @@ import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
 export async function POST(request: NextRequest) {
-  const authError = await getWorkflowAuthenticationError({ headers: request.headers });
-
-  if (authError) {
-    return authError;
-  }
-
   const parsed = await parseBody(request, lessonGenerationTriggerSchema);
 
   if (!parsed.success) {
@@ -34,10 +26,7 @@ export async function POST(request: NextRequest) {
     return errors.notFound();
   }
 
-  const accessError = await getWorkflowSubscriptionAccessError({
-    headers: request.headers,
-    requiresSubscription: requiresSubscriptionForLessonGeneration(lesson),
-  });
+  const accessError = await getWorkflowLessonAccessError({ headers: request.headers, lesson });
 
   if (accessError) {
     return accessError;

--- a/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/lesson-preload/trigger/route.ts
@@ -3,21 +3,13 @@ import { parseBody } from "@/lib/body-parser";
 import { lessonPreloadTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import {
   getAiGenerationLessonForWorkflow,
-  getWorkflowAuthenticationError,
-  getWorkflowSubscriptionAccessError,
-  requiresSubscriptionForLessonGeneration,
+  getWorkflowLessonAccessError,
 } from "@/lib/workflow-generation-access";
 import { lessonPreloadWorkflow } from "@/workflows/lesson-preload/lesson-preload-workflow";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
 export async function POST(request: NextRequest) {
-  const authError = await getWorkflowAuthenticationError({ headers: request.headers });
-
-  if (authError) {
-    return authError;
-  }
-
   const parsed = await parseBody(request, lessonPreloadTriggerSchema);
 
   if (!parsed.success) {
@@ -30,10 +22,7 @@ export async function POST(request: NextRequest) {
     return errors.notFound();
   }
 
-  const accessError = await getWorkflowSubscriptionAccessError({
-    headers: request.headers,
-    requiresSubscription: requiresSubscriptionForLessonGeneration(lesson),
-  });
+  const accessError = await getWorkflowLessonAccessError({ headers: request.headers, lesson });
 
   if (accessError) {
     return accessError;

--- a/apps/api/src/lib/openapi/document.ts
+++ b/apps/api/src/lib/openapi/document.ts
@@ -170,11 +170,13 @@ export const openAPIDocument = createDocument({
       "Stream lesson generation status (SSE)",
     ),
     "/workflows/lesson-generation/trigger": workflowTriggerEndpoint({
+      mayRequireAuthentication: true,
       requiresSubscription: true,
       schema: lessonGenerationTriggerSchema,
       summary: "Trigger lesson generation workflow",
     }),
     "/workflows/lesson-preload/trigger": workflowTriggerEndpoint({
+      mayRequireAuthentication: true,
       requiresSubscription: true,
       schema: lessonPreloadTriggerSchema,
       summary: "Trigger lesson preload workflow",

--- a/apps/api/src/lib/openapi/schemas/responses.ts
+++ b/apps/api/src/lib/openapi/schemas/responses.ts
@@ -38,10 +38,12 @@ const sseStreamResponse = {
 } as const;
 
 export function workflowTriggerEndpoint({
+  mayRequireAuthentication = false,
   schema,
   summary,
   requiresSubscription = false,
 }: {
+  mayRequireAuthentication?: boolean;
   schema: z.ZodType;
   summary: string;
   requiresSubscription?: boolean;
@@ -49,7 +51,9 @@ export function workflowTriggerEndpoint({
   return {
     post: {
       description: [
-        "Requires authentication.",
+        mayRequireAuthentication
+          ? "May require authentication when the expanded free preview rule applies."
+          : null,
         requiresSubscription
           ? "Requires active subscription when the free generation rule does not apply."
           : null,
@@ -60,7 +64,7 @@ export function workflowTriggerEndpoint({
       responses: {
         "200": workflowStartedResponse,
         "400": validationErrorResponse,
-        "401": unauthorizedResponse,
+        ...(mayRequireAuthentication && { "401": unauthorizedResponse }),
         ...(requiresSubscription && { "402": subscriptionRequiredResponse }),
       },
       summary,

--- a/apps/api/src/lib/workflow-generation-access.ts
+++ b/apps/api/src/lib/workflow-generation-access.ts
@@ -1,5 +1,6 @@
 import { auth } from "@zoonk/core/auth";
 import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { getLessonAccessRequirement } from "@zoonk/core/lessons/access";
 import {
   type Chapter,
   type Lesson,
@@ -23,10 +24,9 @@ export async function getAiGenerationChapterForWorkflow(params: { chapterId: str
 }
 
 /**
- * Lesson generation and preload share the same subscription exception: lessons
- * in the first course chapter are free, later chapters require a subscription.
- * Loading the chapter with the lesson keeps that rule tied to the trusted row
- * instead of accepting a client-provided course or chapter position.
+ * Lesson generation and preload share one free-tier rule. Loading the chapter
+ * with the lesson keeps that rule tied to trusted database positions instead
+ * of accepting client-provided course or chapter order.
  */
 export async function getAiGenerationLessonForWorkflow(params: {
   lessonId: string;
@@ -38,43 +38,17 @@ export async function getAiGenerationLessonForWorkflow(params: {
 }
 
 /**
- * Position 0 is the product's first-chapter marker. That chapter is the free
- * starter experience; any later chapter stays behind the subscription gate.
+ * Position 0 is the product's first-chapter marker. Only that chapter can be
+ * generated before the learner has an active subscription.
  */
 export function requiresSubscriptionForChapterGeneration(chapter: Pick<Chapter, "position">) {
   return chapter.position !== 0;
 }
 
 /**
- * Lesson access follows the parent chapter, not the lesson position. This lets
- * every lesson in the first chapter be generated or preloaded before purchase.
- */
-export function requiresSubscriptionForLessonGeneration(lesson: {
-  chapter: Pick<Chapter, "position">;
-}) {
-  return requiresSubscriptionForChapterGeneration(lesson.chapter);
-}
-
-/**
- * Workflow generation is account-bound before route-specific ids are parsed or
- * looked up. That keeps anonymous callers from probing workflow trigger inputs
- * and prevents client-only page gates from protecting expensive starts.
- */
-export async function getWorkflowAuthenticationError(params: { headers: Headers }) {
-  const session = await auth.api.getSession({ headers: params.headers });
-
-  if (!session) {
-    return errors.unauthorized();
-  }
-
-  return null;
-}
-
-/**
- * Paid-plan checks still depend on the trusted chapter or lesson row because
- * first-chapter content is free for signed-in learners. Run this only after the
- * route has loaded the AI-owned entity and knows whether the subscription rule
- * applies.
+ * Paid-plan checks depend on the trusted chapter or lesson row because first
+ * chapter generation has a free exception. Run this only after the route has
+ * loaded the AI-owned entity and knows whether the subscription rule applies.
  */
 export async function getWorkflowSubscriptionAccessError(params: {
   headers: Headers;
@@ -91,4 +65,30 @@ export async function getWorkflowSubscriptionAccessError(params: {
   }
 
   return null;
+}
+
+/**
+ * Lesson workflows have three access states: public preview, login-expanded
+ * preview, and paid access. Keeping that decision here lets generation and
+ * preload return the same 401-or-402 contract for the same lesson position.
+ */
+export async function getWorkflowLessonAccessError(params: {
+  headers: Headers;
+  lesson: LessonWithChapter;
+}) {
+  const session = await auth.api.getSession({ headers: params.headers });
+
+  const requirement = getLessonAccessRequirement({
+    isAuthenticated: Boolean(session),
+    lesson: params.lesson,
+  });
+
+  if (requirement === "authentication") {
+    return errors.unauthorized();
+  }
+
+  return getWorkflowSubscriptionAccessError({
+    headers: params.headers,
+    requiresSubscription: requirement === "subscription",
+  });
 }

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -143,7 +143,7 @@ test.describe("Command Palette - Unauthenticated", () => {
     await expect(page.getByRole("heading", { name: /explore courses/iu })).toBeVisible();
   });
 
-  test("selecting Learn asks unauthenticated users to log in", async ({ page }) => {
+  test("selecting Learn shows the course creation form", async ({ page }) => {
     await openCommandPalette(page);
 
     await page
@@ -151,7 +151,7 @@ test.describe("Command Palette - Unauthenticated", () => {
       .getByText(/learn something/iu)
       .click();
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();
   });
 });
 

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -13,7 +13,7 @@ import { expect, test } from "./fixtures";
  * Test Architecture for Chapter Generation Page
  *
  * The generation page has 3 access states:
- * 1. Unauthenticated - Shows login prompt
+ * 1. First chapter - Shows generation UI without login
  * 2. Authenticated without subscription - Shows upgrade CTA
  * 3. Authenticated with subscription - Shows generation UI
  *
@@ -163,15 +163,15 @@ async function createTestSubscription(userId: string) {
 }
 
 test.describe("Generate Chapter Page - Unauthenticated", () => {
-  test("shows login prompt with link to login page", async ({ page }) => {
+  test("shows upgrade CTA for later chapters", async ({ page }) => {
     const { chapter } = await createPendingChapter(1);
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+    await expect(page.getByText(/upgrade to create/iu)).toBeVisible();
 
-    const loginLink = page.getByRole("link", { name: /login/iu });
-    await expect(loginLink).toBeVisible();
-    await expect(loginLink).toHaveAttribute("href", "/login");
+    const upgradeLink = page.getByRole("link", { name: /upgrade/iu });
+    await expect(upgradeLink).toBeVisible();
+    await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
 });
 
@@ -187,7 +187,7 @@ test.describe("Generate Chapter Page - No Subscription", () => {
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
 
-  test("allows signed-in users to retry failed generation without subscription", async ({
+  test("requires subscription to retry failed later-chapter generation", async ({
     authenticatedPage,
   }) => {
     const { chapter } = await createPendingChapter(1);
@@ -204,8 +204,7 @@ test.describe("Generate Chapter Page - No Subscription", () => {
 
     await authenticatedPage.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(authenticatedPage.getByText(/upgrade to create/iu)).toHaveCount(0);
-    await expect(authenticatedPage.getByRole("heading", { name: chapter.title })).toBeVisible();
+    await expect(authenticatedPage.getByText(/upgrade to create/iu)).toBeVisible();
   });
 });
 
@@ -516,16 +515,18 @@ test.describe("Generate Chapter Page - With Subscription", () => {
 });
 
 test.describe("Generate Chapter Page - First Chapter Free", () => {
-  test("unauthenticated user sees login prompt for first chapter", async ({ page }) => {
+  test("unauthenticated user sees generation UI for first chapter", async ({ page }) => {
     const { chapter } = await createPendingChapter(0);
+
+    await setupMockApis(page, {
+      statusDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getChapter" }],
+    });
 
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
-
-    const loginLink = page.getByRole("link", { name: /login/iu });
-    await expect(loginLink).toBeVisible();
-    await expect(loginLink).toHaveAttribute("href", "/login");
+    await expect(page.getByText(/upgrade to create/iu)).toHaveCount(0);
+    await expect(page.getByRole("heading", { name: chapter.title })).toBeVisible();
   });
 
   test("authenticated user without subscription sees generation UI for first chapter", async ({
@@ -545,8 +546,8 @@ test.describe("Generate Chapter Page - First Chapter Free", () => {
   });
 });
 
-test.describe("Generate Chapter Page - Running Generation Requires Auth", () => {
-  test("unauthenticated user sees login prompt for non-first chapter when status is running", async ({
+test.describe("Generate Chapter Page - Running Later Chapter Requires Subscription", () => {
+  test("unauthenticated user sees upgrade CTA for non-first chapter when status is running", async ({
     page,
   }) => {
     const org = await getAiOrganization();
@@ -575,11 +576,7 @@ test.describe("Generate Chapter Page - Running Generation Requires Auth", () => 
 
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
-
-    const loginLink = page.getByRole("link", { name: /login/iu });
-    await expect(loginLink).toBeVisible();
-    await expect(loginLink).toHaveAttribute("href", "/login");
+    await expect(page.getByText(/upgrade to create/iu)).toBeVisible();
   });
 });
 

--- a/apps/main/e2e/generate-course-redirect.test.ts
+++ b/apps/main/e2e/generate-course-redirect.test.ts
@@ -64,19 +64,23 @@ test.describe("Generate Course Redirect", () => {
     });
   });
 
-  test("shows login prompt before redirecting unauthenticated users", async ({ page }) => {
+  test("redirects unauthenticated users to generate/cs/[id]", async ({ page }) => {
     const slug = `e2e-redirect-unauth-${randomUUID().slice(0, 8)}`;
 
-    await courseSuggestionFixture({
-      generationStatus: "pending",
+    const suggestion = await courseSuggestionFixture({
+      generationStatus: "running",
       language: "en",
       slug,
       title: "E2E Redirect Unauth Test",
     });
 
+    await page.route("**/v1/workflows/**", mockWorkflowApis);
+
     await page.goto(`/generate/c/${slug}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+    await page.waitForURL(`/generate/cs/${suggestion.id}`, { timeout: 10_000 });
+
+    await expect(page.getByText(/creating your course/iu)).toBeVisible({ timeout: 10_000 });
   });
 
   test("shows 404 when course suggestion does not exist", async ({ authenticatedPage }) => {

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -157,7 +157,7 @@ async function createPublishedCourseWithLesson({
 }
 
 test.describe("Generate Course Page", () => {
-  test("shows login prompt before starting course generation", async ({ page }) => {
+  test("starts course generation for unauthenticated users", async ({ page }) => {
     const slug = `e2e-unauth-course-${randomUUID().slice(0, 8)}`;
 
     const suggestion = await courseSuggestionFixture({
@@ -167,17 +167,14 @@ test.describe("Generate Course Page", () => {
       title: "E2E Unauth Course Generation",
     });
 
-    await page.route("**/v1/workflows/course-generation/**", async (route) => {
-      throw new Error(`Generation workflow should not start: ${route.request().url()}`);
+    await setupMockApis(page, {
+      statusDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getCourseSuggestion" }],
     });
 
     await page.goto(`/generate/cs/${suggestion.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
-
-    const loginLink = page.getByRole("link", { name: /login/iu });
-    await expect(loginLink).toBeVisible();
-    await expect(loginLink).toHaveAttribute("href", "/login");
+    await expect(page.getByText(/creating your course/iu)).toBeVisible({ timeout: 10_000 });
   });
 
   test.describe("Initial triggering state", () => {

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -14,7 +14,7 @@ import { expect, test } from "./fixtures";
  * Test Architecture for Lesson Generation Page
  *
  * The generation page has 4 access states:
- * 1. Unauthenticated later chapter - Shows login prompt
+ * 1. Unauthenticated free preview - Shows generation UI
  * 2. Authenticated later chapter without subscription - Shows upgrade CTA
  * 3. Authenticated first chapter - Shows generation UI without subscription
  * 4. Authenticated with subscription - Shows generation UI
@@ -114,7 +114,10 @@ async function setupMockApis(page: Page, options: MockApiOptions = {}): Promise<
 /**
  * Creates a lesson with pending generation status for testing the generation workflow.
  */
-async function createPendingLesson(chapterPosition = 0) {
+async function createPendingLesson({
+  chapterPosition = 0,
+  lessonPosition = 0,
+}: { chapterPosition?: number; lessonPosition?: number } = {}) {
   const org = await getAiOrganization();
 
   const uniqueId = randomUUID().slice(0, 8);
@@ -147,6 +150,7 @@ async function createPendingLesson(chapterPosition = 0) {
     isPublished: true,
     normalizedTitle: normalizeString(lessonTitle),
     organizationId: org.id,
+    position: lessonPosition,
     slug: `e2e-gen-lesson-${uniqueId}`,
     title: lessonTitle,
   });
@@ -235,21 +239,21 @@ async function createTestSubscription(userId: string) {
 }
 
 test.describe("Generate Lesson Page - Unauthenticated", () => {
-  test("shows login prompt with link to login page", async ({ page }) => {
-    const { lesson } = await createPendingLesson(1);
+  test("shows upgrade CTA for later chapter lessons", async ({ page }) => {
+    const { lesson } = await createPendingLesson({ chapterPosition: 1 });
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+    await expect(page.getByText(/upgrade to create/iu)).toBeVisible();
 
-    const loginLink = page.getByRole("link", { name: /login/iu });
-    await expect(loginLink).toBeVisible();
-    await expect(loginLink).toHaveAttribute("href", "/login");
+    const upgradeLink = page.getByRole("link", { name: /upgrade/iu });
+    await expect(upgradeLink).toBeVisible();
+    await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
 });
 
 test.describe("Generate Lesson Page - No Subscription", () => {
   test("shows upgrade CTA with link to subscription page", async ({ authenticatedPage }) => {
-    const { lesson } = await createPendingLesson(1);
+    const { lesson } = await createPendingLesson({ chapterPosition: 1 });
     await authenticatedPage.goto(`/generate/l/${lesson.id}`);
 
     await expect(authenticatedPage.getByText(/upgrade to create/iu)).toBeVisible();
@@ -259,10 +263,10 @@ test.describe("Generate Lesson Page - No Subscription", () => {
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
 
-  test("allows signed-in users to retry failed generation without subscription", async ({
+  test("requires subscription to retry failed later-chapter generation", async ({
     authenticatedPage,
   }) => {
-    const { lesson } = await createPendingLesson(1);
+    const { lesson } = await createPendingLesson({ chapterPosition: 1 });
 
     await prisma.lesson.update({ data: { generationStatus: "failed" }, where: { id: lesson.id } });
 
@@ -273,17 +277,28 @@ test.describe("Generate Lesson Page - No Subscription", () => {
 
     await authenticatedPage.goto(`/generate/l/${lesson.id}`);
 
-    await expect(authenticatedPage.getByText(/upgrade to create/iu)).toHaveCount(0);
-
-    await expect(
-      authenticatedPage.getByRole("heading", { name: lesson.title ?? "" }),
-    ).toBeVisible();
+    await expect(authenticatedPage.getByText(/upgrade to create/iu)).toBeVisible();
   });
 });
 
 test.describe("Generate Lesson Page - First Chapter Free", () => {
-  test("unauthenticated user sees login prompt for first chapter lesson", async ({ page }) => {
-    const { lesson } = await createPendingLesson(0);
+  test("unauthenticated user sees generation UI through lesson five", async ({ page }) => {
+    const { lesson } = await createPendingLesson({ chapterPosition: 0, lessonPosition: 4 });
+
+    await setupMockApis(page, {
+      statusDelayMs: 2500,
+      streamMessages: [{ status: "started", step: "getLesson" }],
+    });
+
+    await page.goto(`/generate/l/${lesson.id}`);
+
+    await expect(page.getByText(/upgrade to create/iu)).toHaveCount(0);
+
+    await expect(page.getByRole("heading", { name: lesson.title ?? "" })).toBeVisible();
+  });
+
+  test("unauthenticated user sees login prompt for lessons six through ten", async ({ page }) => {
+    const { lesson } = await createPendingLesson({ chapterPosition: 0, lessonPosition: 5 });
 
     await page.goto(`/generate/l/${lesson.id}`);
 
@@ -297,7 +312,7 @@ test.describe("Generate Lesson Page - First Chapter Free", () => {
   test("authenticated user without subscription sees generation UI for first chapter lesson", async ({
     authenticatedPage,
   }) => {
-    const { lesson } = await createPendingLesson(0);
+    const { lesson } = await createPendingLesson({ chapterPosition: 0, lessonPosition: 9 });
 
     await setupMockApis(authenticatedPage, {
       statusDelayMs: 2500,
@@ -311,6 +326,16 @@ test.describe("Generate Lesson Page - First Chapter Free", () => {
     await expect(
       authenticatedPage.getByRole("heading", { name: lesson.title ?? "" }),
     ).toBeVisible();
+  });
+
+  test("authenticated user without subscription sees upgrade CTA from lesson eleven", async ({
+    authenticatedPage,
+  }) => {
+    const { lesson } = await createPendingLesson({ chapterPosition: 0, lessonPosition: 10 });
+
+    await authenticatedPage.goto(`/generate/l/${lesson.id}`);
+
+    await expect(authenticatedPage.getByText(/upgrade to create/iu)).toBeVisible();
   });
 });
 
@@ -463,8 +488,8 @@ test.describe("Generate Lesson Page - With Subscription", () => {
   });
 });
 
-test.describe("Generate Lesson Page - Running Generation Requires Auth", () => {
-  test("unauthenticated user sees login prompt when status is running", async ({ page }) => {
+test.describe("Generate Lesson Page - Running Later Lesson Requires Subscription", () => {
+  test("unauthenticated user sees upgrade CTA when status is running", async ({ page }) => {
     const org = await getAiOrganization();
     const uniqueId = randomUUID().slice(0, 8);
 
@@ -482,6 +507,7 @@ test.describe("Generate Lesson Page - Running Generation Requires Auth", () => {
       isPublished: true,
       normalizedTitle: normalizeString(`E2E Running Lesson Chapter ${uniqueId}`),
       organizationId: org.id,
+      position: 1,
       slug: `e2e-running-lesson-chapter-${uniqueId}`,
       title: `E2E Running Lesson Chapter ${uniqueId}`,
     });
@@ -501,11 +527,7 @@ test.describe("Generate Lesson Page - Running Generation Requires Auth", () => {
 
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
-
-    const loginLink = page.getByRole("link", { name: /login/iu });
-    await expect(loginLink).toBeVisible();
-    await expect(loginLink).toHaveAttribute("href", "/login");
+    await expect(page.getByText(/upgrade to create/iu)).toBeVisible();
   });
 });
 

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -29,7 +29,7 @@ test.describe("Home Page - Unauthenticated", () => {
     await hero.getByRole("link", { exact: true, name: "Create a course with AI" }).click();
 
     await expect(page).toHaveURL(/\/learn$/u);
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();
   });
 
   test("does not show progress section", async ({ page }) => {

--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -80,14 +80,12 @@ test.beforeAll(async () => {
 });
 
 test.describe("Learn Form", () => {
-  test("shows form with auto-focused input", async ({ authenticatedPage }) => {
-    await authenticatedPage.goto("/learn");
+  test("shows form with auto-focused input", async ({ page }) => {
+    await page.goto("/learn");
 
-    await expect(
-      authenticatedPage.getByRole("heading", { name: /learn anything/iu }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();
 
-    const input = authenticatedPage.getByRole("textbox");
+    const input = page.getByRole("textbox");
     await expect(input).toBeFocused();
   });
 
@@ -123,19 +121,28 @@ test.describe("Learn Form", () => {
     ).toBeVisible();
   });
 
-  test("shows login prompt for unauthenticated users", async ({ page }) => {
+  test("submitting prompt navigates unauthenticated users to suggestions page", async ({
+    page,
+  }) => {
     await page.goto("/learn");
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
-    await expect(page.getByRole("link", { name: /login/iu })).toBeVisible();
+    await page.getByRole("textbox").fill(prompt);
+    await page.keyboard.press("Enter");
+
+    await expect(page.getByRole("heading", { name: /course ideas for/iu })).toBeVisible();
   });
 });
 
 test.describe("Course Suggestions", () => {
-  test("shows login prompt for unauthenticated users", async ({ page }) => {
+  test("shows suggestions to unauthenticated users", async ({ page }) => {
     await page.goto(`/learn/${encodeURIComponent(prompt)}`);
 
-    await expect(page.getByRole("alert").filter({ hasText: /logged in/iu })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`course ideas for ${prompt}`, "iu") }),
+    ).toBeVisible();
+
+    await expect(page.getByText(suggestionTitle)).toBeVisible();
+    await expect(page.getByText(suggestionDescription)).toBeVisible();
   });
 
   test("shows suggestions with title, description, and generate link", async ({
@@ -156,21 +163,17 @@ test.describe("Course Suggestions", () => {
     await expect(generateLinks.first()).toBeVisible();
   });
 
-  test("Generate link navigates signed-in users to generate page", async ({
-    authenticatedPage,
-  }) => {
-    await mockCourseGenerationWorkflow(authenticatedPage);
+  test("Generate link navigates unauthenticated users to generate page", async ({ page }) => {
+    await mockCourseGenerationWorkflow(page);
 
-    await authenticatedPage.goto(`/learn/${encodeURIComponent(prompt)}`);
+    await page.goto(`/learn/${encodeURIComponent(prompt)}`);
 
-    await expect(
-      authenticatedPage.getByRole("heading", { name: /course ideas for/iu }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: /course ideas for/iu })).toBeVisible();
 
-    const generateLink = authenticatedPage.getByRole("link", { name: /create/iu }).first();
+    const generateLink = page.getByRole("link", { name: /create/iu }).first();
     await generateLink.click();
 
-    await expect(authenticatedPage).toHaveURL(/\/generate\/cs\/[-a-f0-9]+/u);
+    await expect(page).toHaveURL(/\/generate\/cs\/[-a-f0-9]+/u);
   });
 
   test("Change subject navigates back to learn form", async ({ authenticatedPage }) => {

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -428,9 +428,12 @@ async function createDerivedListeningLesson() {
 }
 
 test.describe("Lesson Player Page", () => {
-  test("unauthenticated users can play the first lesson of the first chapter", async ({ page }) => {
+  test("unauthenticated users can play through lesson five of the first chapter", async ({
+    page,
+  }) => {
     const { chapter, course, lesson, uniqueId } = await createTestLesson({
       generationStatus: "completed",
+      lessonPosition: 4,
     });
 
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
@@ -439,10 +442,10 @@ test.describe("Lesson Player Page", () => {
     await expect(page.getByText(`Test step content ${uniqueId} #0`)).toBeVisible();
   });
 
-  test("unauthenticated users see login prompt for later lessons", async ({ page }) => {
+  test("unauthenticated users see login prompt for lessons six through ten", async ({ page }) => {
     const { chapter, course, lesson } = await createTestLesson({
       generationStatus: "completed",
-      lessonPosition: 1,
+      lessonPosition: 5,
     });
 
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
@@ -452,6 +455,49 @@ test.describe("Lesson Player Page", () => {
     const loginLink = page.getByRole("link", { name: /login/iu });
     await expect(loginLink).toBeVisible();
     await expect(loginLink).toHaveAttribute("href", "/login");
+  });
+
+  test("authenticated users without subscription can play through lesson ten", async ({
+    authenticatedPage,
+  }) => {
+    const { chapter, course, lesson, uniqueId } = await createTestLesson({
+      generationStatus: "completed",
+      lessonPosition: 9,
+    });
+
+    await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+
+    await expect(
+      authenticatedPage.getByRole("heading", { name: `Step ${uniqueId} #0` }),
+    ).toBeVisible();
+  });
+
+  test("authenticated users without subscription see upgrade CTA from lesson eleven", async ({
+    authenticatedPage,
+  }) => {
+    const { chapter, course, lesson } = await createTestLesson({
+      generationStatus: "completed",
+      lessonPosition: 10,
+    });
+
+    await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+
+    await expect(authenticatedPage.getByText(/upgrade to keep learning/iu)).toBeVisible();
+    await expect(authenticatedPage.getByRole("link", { name: /upgrade/iu })).toBeVisible();
+  });
+
+  test("authenticated users without subscription see upgrade CTA for later chapters", async ({
+    authenticatedPage,
+  }) => {
+    const { chapter, course, lesson } = await createTestLesson({
+      chapterPosition: 1,
+      generationStatus: "completed",
+      lessonPosition: 0,
+    });
+
+    await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+
+    await expect(authenticatedPage.getByText(/upgrade to keep learning/iu)).toBeVisible();
   });
 
   test("close link has correct href", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -384,20 +384,12 @@ msgid "47FYwb"
 msgstr "Cancel"
 
 #: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
-#: src/app/generate/c/[slug]/generate-course-content.tsx
-msgid "RbslnC"
-msgstr "Change subject"
-
-#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
-#: src/app/(catalog)/learn/page.tsx
-#: src/app/generate/c/[slug]/generate-course-content.tsx
-#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
-msgid "LvUoVs"
-msgstr "Create Course"
-
-#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
 msgid "7x4411"
 msgstr "Course ideas for {prompt}"
+
+#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+msgid "RbslnC"
+msgstr "Change subject"
 
 #: src/app/(catalog)/learn/[prompt]/page.tsx
 msgid "CaU/nf"
@@ -418,11 +410,6 @@ msgstr "Tell Zoonk what you want to learn and get a course created with AI. Star
 #: src/app/(catalog)/learn/page.tsx
 msgid "Zs1QEq"
 msgstr "Learn Anything with AI"
-
-#: src/app/(catalog)/learn/page.tsx
-#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
-msgid "rPgekg"
-msgstr "Back home"
 
 #: src/app/(catalog)/learn/page.tsx
 msgid "l450Bl"
@@ -1016,6 +1003,14 @@ msgstr "Create lesson"
 msgid "/N8rYN"
 msgstr "Back to chapter"
 
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+msgid "3pyC1G"
+msgstr "This lesson requires an active subscription."
+
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+msgid "xu3uCX"
+msgstr "Upgrade to keep learning"
+
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "mA7vCW"
 msgstr "Review locked"
@@ -1035,10 +1030,6 @@ msgstr "There are no practice questions to review yet."
 #: src/app/generate/ch/[id]/generate-chapter-content.tsx
 msgid "qrEiLa"
 msgstr "Back to course"
-
-#: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qNiSDe"
-msgstr "Create Chapter"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "ViO6Dt"
@@ -1118,6 +1109,10 @@ msgstr "Saving your progress..."
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JUr8Er"
 msgstr "Finishing up..."
+
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "rPgekg"
+msgstr "Back home"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -384,20 +384,12 @@ msgid "47FYwb"
 msgstr "Cancelar"
 
 #: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
-#: src/app/generate/c/[slug]/generate-course-content.tsx
-msgid "RbslnC"
-msgstr "Cambiar tema"
-
-#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
-#: src/app/(catalog)/learn/page.tsx
-#: src/app/generate/c/[slug]/generate-course-content.tsx
-#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
-msgid "LvUoVs"
-msgstr "Crear Curso"
-
-#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
 msgid "7x4411"
 msgstr "Ideas de cursos para {prompt}"
+
+#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+msgid "RbslnC"
+msgstr "Cambiar tema"
 
 #: src/app/(catalog)/learn/[prompt]/page.tsx
 msgid "CaU/nf"
@@ -418,11 +410,6 @@ msgstr "Dile a Zoonk qué quieres aprender y obtén un curso creado con IA. Empi
 #: src/app/(catalog)/learn/page.tsx
 msgid "Zs1QEq"
 msgstr "Aprende cualquier cosa con IA"
-
-#: src/app/(catalog)/learn/page.tsx
-#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
-msgid "rPgekg"
-msgstr "Volver al inicio"
 
 #: src/app/(catalog)/learn/page.tsx
 msgid "l450Bl"
@@ -1016,6 +1003,14 @@ msgstr "Crear lección"
 msgid "/N8rYN"
 msgstr "Volver al capítulo"
 
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+msgid "3pyC1G"
+msgstr "Esta lección requiere una suscripción activa."
+
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+msgid "xu3uCX"
+msgstr "Suscríbete para seguir aprendiendo"
+
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "mA7vCW"
 msgstr "Revisión bloqueada"
@@ -1035,10 +1030,6 @@ msgstr "Aún no hay preguntas para revisar."
 #: src/app/generate/ch/[id]/generate-chapter-content.tsx
 msgid "qrEiLa"
 msgstr "Volver al curso"
-
-#: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qNiSDe"
-msgstr "Crear Capítulo"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "ViO6Dt"
@@ -1118,6 +1109,10 @@ msgstr "Guardando tu progreso..."
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JUr8Er"
 msgstr "Terminando..."
+
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "rPgekg"
+msgstr "Volver al inicio"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -384,20 +384,12 @@ msgid "47FYwb"
 msgstr "Cancelar"
 
 #: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
-#: src/app/generate/c/[slug]/generate-course-content.tsx
-msgid "RbslnC"
-msgstr "Mudar assunto"
-
-#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
-#: src/app/(catalog)/learn/page.tsx
-#: src/app/generate/c/[slug]/generate-course-content.tsx
-#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
-msgid "LvUoVs"
-msgstr "Criar Curso"
-
-#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
 msgid "7x4411"
 msgstr "Ideias de cursos para {prompt}"
+
+#: src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+msgid "RbslnC"
+msgstr "Mudar assunto"
 
 #: src/app/(catalog)/learn/[prompt]/page.tsx
 msgid "CaU/nf"
@@ -418,11 +410,6 @@ msgstr "Conte ao Zoonk o que você quer aprender e receba um curso criado com IA
 #: src/app/(catalog)/learn/page.tsx
 msgid "Zs1QEq"
 msgstr "Aprenda qualquer coisa com IA"
-
-#: src/app/(catalog)/learn/page.tsx
-#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
-msgid "rPgekg"
-msgstr "Voltar para o início"
 
 #: src/app/(catalog)/learn/page.tsx
 msgid "l450Bl"
@@ -1016,6 +1003,14 @@ msgstr "Criar aula"
 msgid "/N8rYN"
 msgstr "Voltar para o capítulo"
 
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+msgid "3pyC1G"
+msgstr "Esta aula requer uma assinatura ativa."
+
+#: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+msgid "xu3uCX"
+msgstr "Assine para continuar aprendendo"
+
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "mA7vCW"
 msgstr "Revisão bloqueada"
@@ -1035,10 +1030,6 @@ msgstr "Ainda não há perguntas para revisar."
 #: src/app/generate/ch/[id]/generate-chapter-content.tsx
 msgid "qrEiLa"
 msgstr "Voltar para o curso"
-
-#: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qNiSDe"
-msgstr "Criar Capítulo"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "ViO6Dt"
@@ -1118,6 +1109,10 @@ msgstr "Salvando seu progresso..."
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JUr8Er"
 msgstr "Finalizando..."
+
+#: src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+msgid "rPgekg"
+msgstr "Voltar para o início"
 
 #: src/app/generate/cs/[id]/generation-client.tsx
 msgid "DFlapX"

--- a/apps/main/src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+++ b/apps/main/src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
@@ -1,4 +1,3 @@
-import { LoginRequired } from "@/components/auth/login-required";
 import { ContentFeedback } from "@/components/feedback/content-feedback";
 import { generateCourseSuggestions } from "@/data/courses/course-suggestions";
 import { getSession } from "@zoonk/core/users/session/get";
@@ -18,15 +17,11 @@ import { CourseSuggestionItem } from "./course-suggestion-item";
 export async function CourseSuggestions({ prompt }: { prompt: string }) {
   const locale = await getLocale();
   const t = await getExtracted();
-  const session = await getSession();
 
-  if (!session) {
-    return (
-      <LoginRequired backHref="/learn" backLabel={t("Change subject")} title={t("Create Course")} />
-    );
-  }
-
-  const { suggestions } = await generateCourseSuggestions({ language: locale, prompt });
+  const [session, { suggestions }] = await Promise.all([
+    getSession(),
+    generateCourseSuggestions({ language: locale, prompt }),
+  ]);
 
   return (
     <Container variant="narrow">

--- a/apps/main/src/app/(catalog)/learn/page.tsx
+++ b/apps/main/src/app/(catalog)/learn/page.tsx
@@ -1,5 +1,3 @@
-import { LoginRequired } from "@/components/auth/login-required";
-import { getSession } from "@zoonk/core/users/session/get";
 import { shuffle } from "@zoonk/utils/shuffle";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
@@ -21,11 +19,6 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Learn() {
   const t = await getExtracted();
-  const session = await getSession();
-
-  if (!session) {
-    return <LoginRequired backHref="/" backLabel={t("Back home")} title={t("Create Course")} />;
-  }
 
   const allSuggestions = [
     t("Computer Science"),

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -1,6 +1,9 @@
 import { LoginRequired } from "@/components/auth/login-required";
+import { UpgradeCTA } from "@/components/subscription/upgrade-cta";
 import { getLesson as getCatalogLesson } from "@/data/lessons/get-lesson";
 import { getLessonDisplayMeta, getLessonSeoMeta } from "@/lib/lessons";
+import { hasActiveSubscription } from "@zoonk/core/auth/subscription";
+import { getLessonAccessRequirement } from "@zoonk/core/lessons/access";
 import { getBlockingLessonGenerationPrerequisite } from "@zoonk/core/lessons/generation-prerequisites";
 import { getNextChapterInCourse } from "@zoonk/core/lessons/next-chapter-in-course";
 import { getNextLessonInCourse } from "@zoonk/core/lessons/next-in-course";
@@ -14,9 +17,18 @@ import { getLesson as getPlayerLesson } from "@zoonk/core/player/queries/get-les
 import { getPlayerResourceIds } from "@zoonk/core/player/queries/get-player-resource-ids";
 import { getTotalBrainPower } from "@zoonk/core/player/queries/get-total-brain-power";
 import { getSession } from "@zoonk/core/users/session/get";
+import {
+  Container,
+  ContainerBody,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import { after } from "next/server";
 import { fetchReviewLessonData } from "./lesson-data-loaders";
@@ -30,21 +42,12 @@ type LessonSession = Awaited<ReturnType<typeof getSession>>;
 type PlayerLesson = NonNullable<Awaited<ReturnType<typeof getPlayerLesson>>>;
 
 /**
- * The public lesson preview is intentionally only the first lesson in the
- * first chapter. Later lessons may include progression-dependent review,
- * preload, and completion behavior, so anonymous learners need to sign in
- * before the player loads them.
+ * Stops the player route before expensive player queries when the lesson sits
+ * outside the viewer's free window. Lessons 6-10 ask anonymous learners to log
+ * in, while lesson 11+ and later chapters require an active subscription even
+ * if the lesson content was already generated.
  */
-function canPlayWithoutSession(lesson: { position: number; chapter: { position: number } }) {
-  return lesson.chapter.position === 0 && lesson.position === 0;
-}
-
-/**
- * Keeps anonymous users out of player-only queries unless they are opening the
- * public preview lesson. The login wall needs the lesson title, so this lives
- * beside the route instead of inside a generic auth component.
- */
-async function getAnonymousLessonGate({
+async function getLessonAccessGate({
   brandSlug,
   chapterSlug,
   courseSlug,
@@ -57,7 +60,9 @@ async function getAnonymousLessonGate({
   lesson: LessonShell;
   session: LessonSession;
 }) {
-  if (session || canPlayWithoutSession(lesson)) {
+  const requirement = getLessonAccessRequirement({ isAuthenticated: Boolean(session), lesson });
+
+  if (requirement === "free") {
     return null;
   }
 
@@ -65,8 +70,40 @@ async function getAnonymousLessonGate({
   const lessonMeta = await getLessonDisplayMeta(lesson);
   const t = await getExtracted();
 
+  if (requirement === "authentication") {
+    return (
+      <LoginRequired
+        backHref={backHref}
+        backLabel={t("Back to chapter")}
+        title={lessonMeta.title}
+      />
+    );
+  }
+
+  const hasSubscription = await hasActiveSubscription(await headers());
+
+  if (hasSubscription) {
+    return null;
+  }
+
   return (
-    <LoginRequired backHref={backHref} backLabel={t("Back to chapter")} title={lessonMeta.title} />
+    <Container variant="narrow">
+      <ContainerHeader>
+        <ContainerHeaderGroup>
+          <ContainerTitle>{lessonMeta.title}</ContainerTitle>
+          <ContainerDescription>{lessonMeta.description}</ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <UpgradeCTA
+          backHref={backHref}
+          backLabel={t("Back to chapter")}
+          description={t("This lesson requires an active subscription.")}
+          title={t("Upgrade to keep learning")}
+        />
+      </ContainerBody>
+    </Container>
   );
 }
 
@@ -111,7 +148,7 @@ export default async function LessonPage({ params }: Props) {
 
   const session = await getSession();
 
-  const anonymousGate = await getAnonymousLessonGate({
+  const accessGate = await getLessonAccessGate({
     brandSlug,
     chapterSlug,
     courseSlug,
@@ -119,8 +156,8 @@ export default async function LessonPage({ params }: Props) {
     session,
   });
 
-  if (anonymousGate) {
-    return anonymousGate;
+  if (accessGate) {
+    return accessGate;
   }
 
   const [lesson, nextChapter, nextLesson, reviewLessonData, totalBrainPower] = await Promise.all([

--- a/apps/main/src/app/generate/c/[slug]/generate-course-content.tsx
+++ b/apps/main/src/app/generate/c/[slug]/generate-course-content.tsx
@@ -1,21 +1,10 @@
-import { LoginRequired } from "@/components/auth/login-required";
 import { getCourseSuggestionBySlug } from "@/data/courses/course-suggestions";
-import { getSession } from "@zoonk/core/users/session/get";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { getExtracted, getLocale } from "next-intl/server";
+import { getLocale } from "next-intl/server";
 import { notFound, redirect } from "next/navigation";
 
 export async function GenerateCourseContent({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
-  const t = await getExtracted();
-  const session = await getSession();
-
-  if (!session) {
-    return (
-      <LoginRequired backHref="/learn" backLabel={t("Change subject")} title={t("Create Course")} />
-    );
-  }
-
   const locale = await getLocale();
 
   const suggestion = await getCourseSuggestionBySlug({ language: locale, slug });

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -1,9 +1,7 @@
-import { LoginRequired } from "@/components/auth/login-required";
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import { SubscriptionGate } from "@/components/subscription/subscription-gate";
 import { getChapterForGeneration } from "@/data/chapters/get-chapter-for-generation";
 import { getInitialGenerationPageStatus } from "@/lib/workflow/get-initial-generation-page-status";
-import { getSession } from "@zoonk/core/users/session/get";
 import {
   Container,
   ContainerBody,
@@ -20,19 +18,11 @@ import { GenerationClient } from "./generation-client";
 
 export async function GenerateChapterContent({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const [session, chapter] = await Promise.all([getSession(), getChapterForGeneration(id)]);
+  const chapter = await getChapterForGeneration(id);
 
   if (!chapter) {
     notFound();
   }
-
-  const isFirstChapter = chapter.position === 0;
-
-  const bypassSubscription =
-    isFirstChapter ||
-    chapter.generationStatus === "running" ||
-    chapter.generationStatus === "failed" ||
-    chapter.generationStatus === "completed";
 
   const t = await getExtracted();
 
@@ -43,10 +33,6 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
     generationStatus: chapter.generationStatus,
     isReadyForRedirect: chapter._count.lessons > 0,
   });
-
-  if (!session) {
-    return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Chapter")} />;
-  }
 
   return (
     <Container variant="narrow">
@@ -60,7 +46,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={bypassSubscription}>
+        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={chapter.position === 0}>
           <GenerationClient
             chapterId={id}
             chapterSlug={chapter.slug}

--- a/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
+++ b/apps/main/src/app/generate/cs/[id]/generate-course-suggestion-content.tsx
@@ -1,10 +1,8 @@
-import { LoginRequired } from "@/components/auth/login-required";
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import {
   getCourseSuggestionById,
   getLinkedCourseForSuggestion,
 } from "@/data/courses/course-suggestions";
-import { getSession } from "@zoonk/core/users/session/get";
 import {
   Container,
   ContainerBody,
@@ -27,13 +25,6 @@ export async function GenerateCourseSuggestionContent({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const t = await getExtracted();
-  const session = await getSession();
-
-  if (!session) {
-    return <LoginRequired backHref="/" backLabel={t("Back home")} title={t("Create Course")} />;
-  }
-
   const suggestion = await getCourseSuggestionById(id);
 
   if (!suggestion) {
@@ -45,6 +36,8 @@ export async function GenerateCourseSuggestionContent({
   if (linkedCourse?.generationStatus === "completed") {
     redirect(`/b/${AI_ORG_SLUG}/c/${linkedCourse.slug}`);
   }
+
+  const t = await getExtracted();
 
   return (
     <Container variant="narrow">

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -4,6 +4,7 @@ import { SubscriptionGate } from "@/components/subscription/subscription-gate";
 import { getLessonForGeneration } from "@/data/lessons/get-lesson-for-generation";
 import { getLessonDisplayMeta } from "@/lib/lessons";
 import { getInitialGenerationPageStatus } from "@/lib/workflow/get-initial-generation-page-status";
+import { getLessonAccessRequirement } from "@zoonk/core/lessons/access";
 import { getBlockingLessonGenerationPrerequisite } from "@zoonk/core/lessons/generation-prerequisites";
 import { getSession } from "@zoonk/core/users/session/get";
 import { type GenerationStatus } from "@zoonk/db";
@@ -54,14 +55,6 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
     notFound();
   }
 
-  const isFirstChapter = lesson.chapter.position === 0;
-
-  const bypassSubscription =
-    isFirstChapter ||
-    lesson.generationStatus === "running" ||
-    lesson.generationStatus === "failed" ||
-    lesson.generationStatus === "completed";
-
   const t = await getExtracted();
 
   const backHref =
@@ -69,7 +62,12 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
 
   const backLabel = t("Back to chapter");
 
-  if (!session) {
+  const accessRequirement = getLessonAccessRequirement({
+    isAuthenticated: Boolean(session),
+    lesson,
+  });
+
+  if (accessRequirement === "authentication") {
     return <LoginRequired backHref={backHref} backLabel={backLabel} title={t("Create Lesson")} />;
   }
 
@@ -86,45 +84,45 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
     isReadyForRedirect: lesson.generationStatus === "completed" || lesson._count.steps > 0,
   });
 
-  if (blockingPrerequisite) {
-    return (
-      <Container variant="narrow">
-        <ContainerHeader>
-          <ContainerHeaderGroup>
-            <ContainerTitle>{lessonMeta.title}</ContainerTitle>
-            <ContainerDescription>{lessonMeta.description}</ContainerDescription>
-          </ContainerHeaderGroup>
-        </ContainerHeader>
+  const content = blockingPrerequisite ? (
+    <Empty className="border-0">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <SparklesIcon />
+        </EmptyMedia>
 
-        <ContainerBody>
-          <Empty className="border-0">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <SparklesIcon />
-              </EmptyMedia>
+        <EmptyTitle>{t("Lesson locked")}</EmptyTitle>
 
-              <EmptyTitle>{t("Lesson locked")}</EmptyTitle>
+        <EmptyDescription>{t("Create the required lesson first.")}</EmptyDescription>
+      </EmptyHeader>
 
-              <EmptyDescription>{t("Create the required lesson first.")}</EmptyDescription>
-            </EmptyHeader>
-
-            <EmptyContent>
-              <Link
-                className={buttonVariants({ variant: "outline" })}
-                href={`/generate/l/${blockingPrerequisite.lessonId}`}
-                prefetch={false}
-                rel="nofollow"
-              >
-                <SparklesIcon data-icon="inline-start" />
-                {t("Open required lesson")}
-              </Link>
-              <GenerationExitLink href={backHref}>{backLabel}</GenerationExitLink>
-            </EmptyContent>
-          </Empty>
-        </ContainerBody>
-      </Container>
-    );
-  }
+      <EmptyContent>
+        <Link
+          className={buttonVariants({ variant: "outline" })}
+          href={`/generate/l/${blockingPrerequisite.lessonId}`}
+          prefetch={false}
+          rel="nofollow"
+        >
+          <SparklesIcon data-icon="inline-start" />
+          {t("Open required lesson")}
+        </Link>
+        <GenerationExitLink href={backHref}>{backLabel}</GenerationExitLink>
+      </EmptyContent>
+    </Empty>
+  ) : (
+    <>
+      <GenerationClient
+        chapterSlug={lesson.chapter.slug}
+        courseSlug={lesson.chapter.course.slug}
+        generationRunId={lesson.generationRunId}
+        initialStatus={initialStatus}
+        lessonId={id}
+        lessonKind={lesson.kind}
+        lessonSlug={lesson.slug}
+      />
+      <GenerationExitLink href={backHref}>{backLabel}</GenerationExitLink>
+    </>
+  );
 
   return (
     <Container variant="narrow">
@@ -136,17 +134,12 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
       </ContainerHeader>
 
       <ContainerBody>
-        <SubscriptionGate backHref={backHref} backLabel={backLabel} bypass={bypassSubscription}>
-          <GenerationClient
-            chapterSlug={lesson.chapter.slug}
-            courseSlug={lesson.chapter.course.slug}
-            generationRunId={lesson.generationRunId}
-            initialStatus={initialStatus}
-            lessonId={id}
-            lessonKind={lesson.kind}
-            lessonSlug={lesson.slug}
-          />
-          <GenerationExitLink href={backHref}>{backLabel}</GenerationExitLink>
+        <SubscriptionGate
+          backHref={backHref}
+          backLabel={backLabel}
+          bypass={accessRequirement === "free"}
+        >
+          {content}
         </SubscriptionGate>
       </ContainerBody>
     </Container>

--- a/apps/main/src/components/subscription/upgrade-cta.tsx
+++ b/apps/main/src/components/subscription/upgrade-cta.tsx
@@ -16,9 +16,13 @@ import Link from "next/link";
 export async function UpgradeCTA<Href extends string>({
   backHref,
   backLabel,
+  description,
+  title,
 }: {
   backHref: Route<Href>;
   backLabel: string;
+  description?: string;
+  title?: string;
 }) {
   const t = await getExtracted();
 
@@ -29,10 +33,10 @@ export async function UpgradeCTA<Href extends string>({
           <SparklesIcon />
         </EmptyMedia>
 
-        <EmptyTitle>{t("Upgrade to create")}</EmptyTitle>
+        <EmptyTitle>{title ?? t("Upgrade to create")}</EmptyTitle>
 
         <EmptyDescription>
-          {t("Creating content with AI requires an active subscription.")}
+          {description ?? t("Creating content with AI requires an active subscription.")}
         </EmptyDescription>
       </EmptyHeader>
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "./images/optimize": "./src/images/optimize-image.ts",
     "./images/process-and-upload": "./src/images/process-and-upload-image.ts",
     "./images/upload": "./src/images/upload-image.ts",
+    "./lessons/access": "./src/lessons/access.ts",
     "./lessons/generation-prerequisites": "./src/lessons/generation-prerequisites.ts",
     "./lessons/last-completed": "./src/lessons/find-last-completed.ts",
     "./lessons/next-chapter-in-course": "./src/lessons/get-next-chapter-in-course.ts",

--- a/packages/core/src/lessons/access.test.ts
+++ b/packages/core/src/lessons/access.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { getLessonAccessRequirement } from "./access";
+
+describe(getLessonAccessRequirement, () => {
+  it("allows unauthenticated learners through the first five lessons of the first chapter", () => {
+    const requirement = getLessonAccessRequirement({
+      isAuthenticated: false,
+      lesson: { chapter: { position: 0 }, position: 4 },
+    });
+
+    expect(requirement).toBe("free");
+  });
+
+  it("asks unauthenticated learners to log in for lessons six through ten", () => {
+    const requirement = getLessonAccessRequirement({
+      isAuthenticated: false,
+      lesson: { chapter: { position: 0 }, position: 5 },
+    });
+
+    expect(requirement).toBe("authentication");
+  });
+
+  it("allows authenticated learners through the first ten lessons of the first chapter", () => {
+    const requirement = getLessonAccessRequirement({
+      isAuthenticated: true,
+      lesson: { chapter: { position: 0 }, position: 9 },
+    });
+
+    expect(requirement).toBe("free");
+  });
+
+  it("requires a subscription starting at lesson eleven in the first chapter", () => {
+    const requirement = getLessonAccessRequirement({
+      isAuthenticated: true,
+      lesson: { chapter: { position: 0 }, position: 10 },
+    });
+
+    expect(requirement).toBe("subscription");
+  });
+
+  it("requires a subscription for every lesson outside the first chapter", () => {
+    const requirement = getLessonAccessRequirement({
+      isAuthenticated: true,
+      lesson: { chapter: { position: 1 }, position: 0 },
+    });
+
+    expect(requirement).toBe("subscription");
+  });
+});

--- a/packages/core/src/lessons/access.ts
+++ b/packages/core/src/lessons/access.ts
@@ -1,0 +1,57 @@
+const FREE_UNAUTHENTICATED_FIRST_CHAPTER_LESSON_COUNT = 5;
+const FREE_AUTHENTICATED_FIRST_CHAPTER_LESSON_COUNT = 10;
+
+export type LessonAccessRequirement = "authentication" | "free" | "subscription";
+
+type LessonAccessInput = { chapter: { position: number }; position: number };
+
+/**
+ * The product treats the first chapter as the only free preview area. Keeping
+ * this check named makes every caller use the same zero-based chapter rule
+ * instead of repeating `position === 0` with slightly different meanings.
+ */
+function isFirstChapterLesson({ lesson }: { lesson: LessonAccessInput }): boolean {
+  return lesson.chapter.position === 0;
+}
+
+/**
+ * Anonymous learners get a smaller preview than signed-in learners. This helper
+ * keeps the two limits explicit so route gates can decide whether a blocked
+ * request needs login or a paid subscription.
+ */
+function getFreeFirstChapterLessonCount({ isAuthenticated }: { isAuthenticated: boolean }): number {
+  return isAuthenticated
+    ? FREE_AUTHENTICATED_FIRST_CHAPTER_LESSON_COUNT
+    : FREE_UNAUTHENTICATED_FIRST_CHAPTER_LESSON_COUNT;
+}
+
+/**
+ * Lesson gates need three outcomes, not a boolean. Lessons 6-10 in the first
+ * chapter are free after login, while lesson 11+ and every later chapter lesson
+ * require a subscription even when content has already been generated.
+ */
+export function getLessonAccessRequirement({
+  isAuthenticated,
+  lesson,
+}: {
+  isAuthenticated: boolean;
+  lesson: LessonAccessInput;
+}): LessonAccessRequirement {
+  if (!isFirstChapterLesson({ lesson })) {
+    return "subscription";
+  }
+
+  if (lesson.position < FREE_UNAUTHENTICATED_FIRST_CHAPTER_LESSON_COUNT) {
+    return "free";
+  }
+
+  if (lesson.position < getFreeFirstChapterLessonCount({ isAuthenticated })) {
+    return "free";
+  }
+
+  if (lesson.position < FREE_AUTHENTICATED_FIRST_CHAPTER_LESSON_COUNT) {
+    return "authentication";
+  }
+
+  return "subscription";
+}


### PR DESCRIPTION
## Summary

- allow unauthenticated course suggestions and course/first-chapter generation
- add shared first-chapter lesson access rules for anonymous, signed-in, and subscribed learners
- align API workflow gates and main app generation/player gates with the new contract

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens course suggestions and course/first‑chapter generation to unauthenticated users and applies a unified first‑chapter lesson access contract across API and app. Anonymous get lessons 1–5, login unlocks 6–10, and lesson 11+ or any later chapter requires a subscription.

- New Features
  - Public access: course suggestions and course generation start without a session.
  - First‑chapter generation: allowed without login; later chapters require subscription.
  - Lesson access rules centralized in `@zoonk/core/lessons/access` via `getLessonAccessRequirement` (with tests).
  - Player and generation pages follow the contract:
    - Unauth: free preview through lesson 5; lessons 6–10 prompt login; beyond that shows upgrade CTA.
    - Signed‑in (no sub): free through lesson 10; from lesson 11 or later chapters shows upgrade CTA.

- Refactors
  - API workflow triggers now align with the contract:
    - Lesson generation/preload may return 200, 401 (login‑expanded preview), or 402 (subscription).
    - Course and first‑chapter triggers start for unauthenticated users; later chapters return 402.
  - OpenAPI updated to mark lesson endpoints as “may require authentication” and to document 401/402 responses.
  - Removed login walls from `Learn`, course suggestions, and course generation routes; added upgrade CTA messaging where needed.
  - Exported `./lessons/access` from `@zoonk/core`; updated e2e and unit tests to match the new gates.

<sup>Written for commit 973c5e7b6ea20effffda6ef86f3e482ac074969b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

