### PR TITLE
fix(main): pass app locale to stripe billing

### DIFF
--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from "node:crypto";
-import { type Browser } from "@playwright/test";
+import { type Browser, type Page } from "@playwright/test";
 import { prisma } from "@zoonk/db";
 import { request } from "@zoonk/e2e/fixtures";
+import { setLocale } from "@zoonk/e2e/fixtures/locale";
 import { expect, test } from "./fixtures";
 
 type TestSubscriptionProvider = "apple" | "google" | "stripe" | "zoonk";
+
+type StripeSubscriptionActionPath =
+  | "/api/auth/subscription/billing-portal"
+  | "/api/auth/subscription/upgrade";
 
 /**
  * Billing page tests need to create subscriptions owned by different billing
@@ -80,6 +85,47 @@ function getStripeSubscriptionFields({
   };
 }
 
+/**
+ * Capture the billing handoff before it reaches Stripe's fake E2E API key.
+ * This test only needs the request body sent by the subscription UI, so the
+ * route responds locally and avoids turning a locale assertion into a Stripe
+ * integration test.
+ */
+async function captureStripeActionRequest({
+  page,
+  path,
+}: {
+  page: Page;
+  path: StripeSubscriptionActionPath;
+}) {
+  await page.route(`**${path}`, async (route) => {
+    await route.fulfill({
+      body: JSON.stringify({ url: "/subscription" }),
+      contentType: "application/json",
+      status: 200,
+    });
+  });
+
+  return page
+    .waitForRequest(
+      (actionRequest) => actionRequest.method() === "POST" && actionRequest.url().endsWith(path),
+    )
+    .then((actionRequest) => actionRequest.postDataJSON() as unknown);
+}
+
+/**
+ * Drive checkout through the visible plan controls because the locale is added
+ * by the client-side Better Auth call, not by the server-rendered plan page.
+ */
+async function requestHobbyCheckout({ page }: { page: Page }) {
+  const requestBody = captureStripeActionRequest({ page, path: "/api/auth/subscription/upgrade" });
+
+  await page.getByRole("radio", { name: /hobby/iu }).click();
+  await page.getByRole("button", { name: /hobby/iu }).click();
+
+  return requestBody;
+}
+
 test.describe("Subscription Page - Unauthenticated", () => {
   test("shows login prompt with link to login page", async ({ page }) => {
     await page.goto("/subscription");
@@ -149,6 +195,37 @@ test.describe("Subscription Page - No Subscription", () => {
     await expect(
       authenticatedPage.getByRole("button", { name: /upgrade to pro/iu }),
     ).not.toBeVisible();
+  });
+});
+
+test.describe("Subscription Page - Stripe Locale", () => {
+  test("passes Spanish locale to Stripe checkout", async ({ authenticatedPage }) => {
+    await setLocale(authenticatedPage, "es");
+    await authenticatedPage.goto("/subscription");
+
+    await expect(requestHobbyCheckout({ page: authenticatedPage })).resolves.toMatchObject({
+      locale: "es",
+    });
+  });
+
+  test("passes Portuguese locale as Brazilian Portuguese to Stripe checkout", async ({
+    authenticatedPage,
+  }) => {
+    await setLocale(authenticatedPage, "pt");
+    await authenticatedPage.goto("/subscription");
+
+    await expect(requestHobbyCheckout({ page: authenticatedPage })).resolves.toMatchObject({
+      locale: "pt-BR",
+    });
+  });
+
+  test("keeps English Stripe checkout locale unset", async ({ authenticatedPage }) => {
+    await setLocale(authenticatedPage, "en");
+    await authenticatedPage.goto("/subscription");
+
+    const requestBody = await requestHobbyCheckout({ page: authenticatedPage });
+
+    expect(requestBody).not.toHaveProperty("locale");
   });
 });
 

--- a/apps/main/src/app/(settings)/subscription/plan-list.tsx
+++ b/apps/main/src/app/(settings)/subscription/plan-list.tsx
@@ -15,7 +15,7 @@ import { Tabs, TabsList, TabsTrigger } from "@zoonk/ui/components/tabs";
 import { type PriceInfo, formatPrice } from "@zoonk/utils/currency";
 import { FREE_PLAN, getPlanTier } from "@zoonk/utils/subscription";
 import { Loader2Icon } from "lucide-react";
-import { useExtracted } from "next-intl";
+import { useExtracted, useLocale } from "next-intl";
 import { useState } from "react";
 
 type PlanData = {
@@ -28,6 +28,7 @@ type PlanData = {
 };
 
 type BillingPeriod = "monthly" | "yearly";
+type StripeLocaleOverride = "es" | "pt-BR";
 
 function isBillingPeriod(value: unknown): value is BillingPeriod {
   return value === "monthly" || value === "yearly";
@@ -51,6 +52,8 @@ export function PlanList({
   const [selectedPlan, setSelectedPlan] = useState(currentPlanName);
   const [state, setState] = useState<"error" | "idle" | "loading">("idle");
   const t = useExtracted();
+  const locale = useLocale();
+  const stripeLocale = getStripeLocaleOverride(locale);
 
   const fallback: PlanData = { ...FREE_PLAN, monthlyPrice: null, yearlyPrice: null };
   const selected = plans.find((plan) => plan.name === selectedPlan) ?? fallback;
@@ -77,7 +80,10 @@ export function PlanList({
       const action =
         selectedPlan === "free"
           ? authClient.subscription.cancel({ returnUrl: "/subscription" })
-          : authClient.subscription.billingPortal({ returnUrl: "/subscription" });
+          : authClient.subscription.billingPortal({
+              locale: stripeLocale,
+              returnUrl: "/subscription",
+            });
 
       const { error } = await action;
 
@@ -91,6 +97,7 @@ export function PlanList({
     const { error } = await authClient.subscription.upgrade({
       annual: period === "yearly",
       cancelUrl: "/subscription",
+      locale: stripeLocale,
       plan: selectedPlan,
       successUrl: "/subscription?stripe_checkout=complete",
     });
@@ -208,6 +215,25 @@ function getPriceLabel(planName: string, price: PriceInfo | null): string {
   }
 
   return formatPrice(price.amount, price.currency);
+}
+
+/**
+ * Stripe can auto-detect the browser language when we omit `locale`, which is
+ * still the best behavior for English and any app locale we do not explicitly
+ * support in billing yet. Spanish and Portuguese need explicit overrides
+ * because Stripe expects `es` for Spanish and `pt-BR` for Brazilian Portuguese,
+ * while the app stores Portuguese as the shorter `pt` locale.
+ */
+function getStripeLocaleOverride(locale: string): StripeLocaleOverride | undefined {
+  if (locale === "es") {
+    return "es";
+  }
+
+  if (locale === "pt") {
+    return "pt-BR";
+  }
+
+  return undefined;
 }
 
 function getCTAAction(


### PR DESCRIPTION
## Summary
- Map app locales to Stripe billing locales for subscription checkout and billing portal
- Add E2E request-capture coverage for Spanish, Portuguese, and English checkout locale behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the app locale to Stripe checkout and billing portal so users see billing in their language. Map `es` and `pt` to Stripe’s expected locales and keep English unset to let Stripe auto-detect.

- **Bug Fixes**
  - Read the app locale via `next-intl` and pass it as `locale` to `authClient.subscription.upgrade` and `authClient.subscription.billingPortal`.
  - Added `getStripeLocaleOverride`: `es` -> `es`, `pt` -> `pt-BR`, others undefined to use Stripe auto-detect.
  - Added E2E tests that intercept `/api/auth/subscription/upgrade` and `billing-portal` to assert request bodies for Spanish, Portuguese, and English without hitting Stripe.

<sup>Written for commit 11642b460eef48ef81c10d3d6002823af451cb40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

