### PR TITLE
fix(api): claim chapter generation before planning

### DIFF
--- a/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
+++ b/apps/api/src/workflows/chapter-generation/chapter-generation-workflow.ts
@@ -88,7 +88,11 @@ export async function chapterGenerationWorkflow(chapterId: string): Promise<void
   }
 
   // Mark chapter as running
-  await setChapterAsRunningStep({ chapterId, workflowRunId });
+  const isClaimed = await setChapterAsRunningStep({ chapterId, workflowRunId });
+
+  if (!isClaimed) {
+    return;
+  }
 
   // Chapter-specific work with failure handling
   const createdLessons = await generateLessonsAndCompleteChapter({ context, workflowRunId }).catch(

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.test.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.test.ts
@@ -22,12 +22,15 @@ describe(setChapterAsRunningStep, () => {
     vi.clearAllMocks();
   });
 
-  it("throws without streaming error when chapter does not exist", async () => {
-    await expect(
-      setChapterAsRunningStep({ chapterId: randomUUID(), workflowRunId: "run-id" }),
-    ).rejects.toThrow();
+  it("returns false when chapter does not exist", async () => {
+    const result = await setChapterAsRunningStep({
+      chapterId: randomUUID(),
+      workflowRunId: "run-id",
+    });
 
     const events = getStreamedEvents();
+
+    expect(result).toBe(false);
 
     expect(events).not.toContainEqual(
       expect.objectContaining({ status: "error", step: "setChapterAsRunning" }),
@@ -37,16 +40,18 @@ describe(setChapterAsRunningStep, () => {
   it("updates chapter generation status to running with run ID", async () => {
     const chapter = await chapterFixture({
       courseId,
+      generationStatus: "pending",
       organizationId,
       title: `Set Running Chapter ${randomUUID()}`,
     });
 
     const workflowRunId = `run-${randomUUID()}`;
 
-    await setChapterAsRunningStep({ chapterId: chapter.id, workflowRunId });
+    const result = await setChapterAsRunningStep({ chapterId: chapter.id, workflowRunId });
 
     const updated = await prisma.chapter.findUniqueOrThrow({ where: { id: chapter.id } });
 
+    expect(result).toBe(true);
     expect(updated.generationStatus).toBe("running");
     expect(updated.generationRunId).toBe(workflowRunId);
 
@@ -59,5 +64,26 @@ describe(setChapterAsRunningStep, () => {
     expect(events).toContainEqual(
       expect.objectContaining({ status: "completed", step: "setChapterAsRunning" }),
     );
+  });
+
+  it("does not overwrite a chapter already claimed by another workflow", async () => {
+    const chapter = await chapterFixture({
+      courseId,
+      generationRunId: "workflow-running-1",
+      generationStatus: "running",
+      organizationId,
+      title: `Already Running Chapter ${randomUUID()}`,
+    });
+
+    const result = await setChapterAsRunningStep({
+      chapterId: chapter.id,
+      workflowRunId: "workflow-running-2",
+    });
+
+    const updated = await prisma.chapter.findUniqueOrThrow({ where: { id: chapter.id } });
+
+    expect(result).toBe(false);
+    expect(updated.generationRunId).toBe("workflow-running-1");
+    expect(updated.generationStatus).toBe("running");
   });
 });

--- a/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
+++ b/apps/api/src/workflows/chapter-generation/steps/set-chapter-as-running-step.ts
@@ -2,19 +2,40 @@ import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type ChapterStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 
+/**
+ * Chapter generation can be started by both course generation and the chapter
+ * waiting page. Updating only claimable rows makes this step the ownership
+ * boundary: one workflow gets to move the chapter into `running`, and any
+ * duplicate workflow must stop before creating a second lesson plan.
+ */
+async function claimChapterGeneration(input: {
+  chapterId: string;
+  workflowRunId: string;
+}): Promise<boolean> {
+  const claim = await prisma.chapter.updateMany({
+    data: { generationRunId: input.workflowRunId, generationStatus: "running" },
+    where: { generationStatus: { in: ["pending", "failed"] }, id: input.chapterId },
+  });
+
+  if (claim.count > 0) {
+    return true;
+  }
+
+  return false;
+}
+
 export async function setChapterAsRunningStep(input: {
   chapterId: string;
   workflowRunId: string;
-}): Promise<void> {
+}): Promise<boolean> {
   "use step";
 
   await using stream = createStepStream<ChapterStepName>();
   await stream.status({ status: "started", step: "setChapterAsRunning" });
 
-  await prisma.chapter.update({
-    data: { generationRunId: input.workflowRunId, generationStatus: "running" },
-    where: { id: input.chapterId },
-  });
+  const isClaimed = await claimChapterGeneration(input);
 
   await stream.status({ status: "completed", step: "setChapterAsRunning" });
+
+  return isClaimed;
 }


### PR DESCRIPTION
## Summary

- Claim chapter generation atomically before lesson planning starts
- Stop duplicate chapter workflows before they can create a second lesson plan
- Cover the already-claimed chapter path in workflow step tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Atomically claim chapter generation before lesson planning to prevent duplicate lesson plans. Duplicate workflows now exit early if the chapter is already claimed.

- **Bug Fixes**
  - Claim chapter by updating only claimable rows (`pending` or `failed`) and setting `generationRunId` + `running`.
  - Return early when claim fails (already claimed or missing), avoiding a second lesson plan.
  - Tests cover non-existent chapters (returns false), successful claims, and no overwrite when already claimed.

<sup>Written for commit 7a397f78e27fc79832bbc3a648a61f68d80a6453. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

