### PR TITLE
fix(api): report workflow save failures

### DIFF
--- a/apps/api/src/workflows/_shared/capture-workflow-failure.ts
+++ b/apps/api/src/workflows/_shared/capture-workflow-failure.ts
@@ -1,0 +1,60 @@
+import { captureException, flush } from "@sentry/nextjs";
+import { logError } from "@zoonk/utils/logger";
+import { type WorkflowErrorLog } from "./workflow-error";
+
+type WorkflowFailureEntity = "chapter" | "course" | "lesson";
+
+type WorkflowFailureInput = {
+  entity: WorkflowFailureEntity;
+  entityId: string;
+  error?: WorkflowErrorLog;
+  workflowName: string;
+};
+
+const sentryFlushTimeoutMs = 2000;
+
+/**
+ * Gives Sentry a real Error instance even though Workflow failure handlers pass
+ * serialized error data across step boundaries.
+ */
+function buildWorkflowFailureError(error?: WorkflowErrorLog): Error {
+  const failure = new Error(error?.message ?? "Workflow failed without a serialized error");
+  failure.name = error?.name ?? "WorkflowError";
+
+  if (error?.stack) {
+    failure.stack = error.stack;
+  }
+
+  return failure;
+}
+
+/**
+ * Reports background Workflow failures explicitly because Next's
+ * `onRequestError` hook only observes request handling errors, not final
+ * durable-step failures recorded by Workflow itself.
+ */
+export async function captureWorkflowFailure({
+  entity,
+  entityId,
+  error,
+  workflowName,
+}: WorkflowFailureInput): Promise<void> {
+  try {
+    captureException(buildWorkflowFailureError(error), {
+      contexts: {
+        workflow: { entity, entityId, name: workflowName, serializedError: error ?? null },
+      },
+      tags: {
+        "workflow.entity": entity,
+        "workflow.entity_id": entityId,
+        "workflow.name": workflowName,
+      },
+    });
+
+    await flush(sentryFlushTimeoutMs);
+  } catch (captureError) {
+    // Sentry is best-effort here. Rethrowing would hide the original workflow
+    // failure and could prevent the failure handler from updating local state.
+    logError("[Workflow Sentry Capture Failure]", captureError);
+  }
+}

--- a/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/handle-failure-step.ts
@@ -1,3 +1,4 @@
+import { captureWorkflowFailure } from "@/workflows/_shared/capture-workflow-failure";
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type WorkflowErrorLog, serializeWorkflowError } from "@/workflows/_shared/workflow-error";
 import { type CourseWorkflowStepName, WORKFLOW_ERROR_STEP } from "@zoonk/core/workflows/steps";
@@ -21,6 +22,13 @@ export async function handleCourseFailureStep(input: {
   const { courseId, courseSuggestionId } = input;
 
   logError("[Course Workflow Failure]", { courseId, courseSuggestionId, error: input.error });
+
+  await captureWorkflowFailure({
+    entity: "course",
+    entityId: courseId ?? courseSuggestionId,
+    error: input.error,
+    workflowName: "courseGenerationWorkflow",
+  });
 
   if (courseId) {
     const results = await Promise.allSettled([
@@ -75,6 +83,13 @@ export async function handleChapterFailureStep(input: {
   "use step";
 
   logError("[Chapter Workflow Failure]", { chapterId: input.chapterId, error: input.error });
+
+  await captureWorkflowFailure({
+    entity: "chapter",
+    entityId: input.chapterId,
+    error: input.error,
+    workflowName: "chapterGenerationWorkflow",
+  });
 
   await prisma.chapter.update({
     data: { generationRunId: null, generationStatus: "failed" },

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.test.ts
@@ -1,10 +1,12 @@
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
+import { captureException, flush } from "@sentry/nextjs";
 import { prisma } from "@zoonk/db";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createLessonContext } from "./_test-utils/create-lesson-context";
 import { handleLessonFailureStep } from "./handle-failure-step";
 
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn(), flush: vi.fn() }));
 vi.mock("@zoonk/utils/logger", () => ({ logError: vi.fn() }));
 
 describe(handleLessonFailureStep, () => {
@@ -36,5 +38,27 @@ describe(handleLessonFailureStep, () => {
         }),
       ]),
     );
+
+    const capturedError = vi.mocked(captureException).mock.calls[0]?.[0] as Error;
+
+    expect(capturedError.message).toBe("AI failed");
+    expect(capturedError.name).toBe("Error");
+    expect(capturedError.stack).toBe("stack");
+
+    expect(captureException).toHaveBeenCalledWith(
+      capturedError,
+      expect.objectContaining({
+        contexts: expect.objectContaining({
+          workflow: expect.objectContaining({
+            entity: "lesson",
+            entityId: lesson.id,
+            name: "lessonGenerationWorkflow",
+          }),
+        }),
+        tags: expect.objectContaining({ "workflow.name": "lessonGenerationWorkflow" }),
+      }),
+    );
+
+    expect(flush).toHaveBeenCalledWith(2000);
   });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/handle-failure-step.ts
@@ -1,3 +1,4 @@
+import { captureWorkflowFailure } from "@/workflows/_shared/capture-workflow-failure";
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type WorkflowErrorLog } from "@/workflows/_shared/workflow-error";
 import { WORKFLOW_ERROR_STEP } from "@zoonk/core/workflows/steps";
@@ -18,6 +19,13 @@ export async function handleLessonFailureStep(input: {
   await using stream = createStepStream();
 
   logError("[Lesson Workflow Failure]", { error: input.error, lessonId: input.lessonId });
+
+  await captureWorkflowFailure({
+    entity: "lesson",
+    entityId: input.lessonId,
+    error: input.error,
+    workflowName: "lessonGenerationWorkflow",
+  });
 
   await prisma.lesson.update({
     data: { generationStatus: "failed" },

--- a/apps/api/src/workflows/lesson-generation/steps/save-static-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-static-lesson-step.test.ts
@@ -67,4 +67,32 @@ describe(saveExplanationLessonStep, () => {
       ]),
     );
   });
+
+  it("normalizes malformed JSON backslash escapes before saving static content", async () => {
+    const context = await createLessonContext({ kind: "explanation", organizationId });
+
+    const malformedLatexText = JSON.parse(
+      String.raw`"FE preservada, geralmente \u00005c(\\ge 50\\%\\), não fecha diagnóstico sozinha."`,
+    ) as string;
+
+    const image = {
+      prompt: "A chart showing preserved ejection fraction.",
+      url: "https://example.com/heart.webp",
+    };
+
+    await saveExplanationLessonStep({
+      context,
+      images: [image],
+      steps: [{ text: malformedLatexText, title: "FE normal não basta" }],
+    });
+
+    const step = await prisma.step.findFirstOrThrow({ where: { lessonId: context.id } });
+
+    expect(step.content).toStrictEqual({
+      image,
+      text: String.raw`FE preservada, geralmente \(\ge 50\%\), não fecha diagnóstico sozinha.`,
+      title: "FE normal não basta",
+      variant: "text",
+    });
+  });
 });

--- a/packages/core/src/steps/contract/content.test.ts
+++ b/packages/core/src/steps/contract/content.test.ts
@@ -40,6 +40,31 @@ describe("step content contracts", () => {
     });
   });
 
+  it("normalizes malformed generated unicode escapes in nested text fields", () => {
+    const malformedLatexText = JSON.parse(
+      String.raw`"FE preservada, geralmente \u00005c(\\ge 50\\%\\), não fecha."`,
+    ) as string;
+
+    const content = parseStepContent("multipleChoice", {
+      context: malformedLatexText,
+      options: [{ feedback: "Correct", id: "a", isCorrect: true, text: malformedLatexText }],
+      question: "What is correct?",
+    });
+
+    expect(content).toStrictEqual({
+      context: String.raw`FE preservada, geralmente \(\ge 50\%\), não fecha.`,
+      options: [
+        {
+          feedback: "Correct",
+          id: "a",
+          isCorrect: true,
+          text: String.raw`FE preservada, geralmente \(\ge 50\%\), não fecha.`,
+        },
+      ],
+      question: "What is correct?",
+    });
+  });
+
   it("rejects multipleChoice options with extra fields", () => {
     expect(() =>
       parseStepContent("multipleChoice", {

--- a/packages/core/src/steps/contract/content.ts
+++ b/packages/core/src/steps/contract/content.ts
@@ -1,3 +1,4 @@
+import { isJsonObject } from "@zoonk/utils/json";
 import { z } from "zod";
 import {
   type FillBlankStepContent,
@@ -54,6 +55,9 @@ const stepContentSchemas = {
   vocabulary: vocabularyContentSchema,
 } as const;
 
+const malformedJsonBackslashEscape = "\u00005c";
+const postgresUnsupportedNullCharacter = "\u0000";
+
 export type SupportedStepKind = keyof typeof stepContentSchemas;
 
 type AlphabetStepContent = z.infer<typeof alphabetContentSchema>;
@@ -80,6 +84,61 @@ export function isSupportedStepKind(kind: string): kind is SupportedStepKind {
   return Object.hasOwn(stepContentSchemas, kind);
 }
 
+/**
+ * Repairs malformed JSON escapes that models sometimes emit when they meant a
+ * literal backslash for LaTeX, then removes any remaining NULs because
+ * PostgreSQL JSONB cannot store U+0000 inside text values.
+ */
+function normalizeStepContentString(value: string): string {
+  return value
+    .replaceAll(malformedJsonBackslashEscape, "\\")
+    .replaceAll(postgresUnsupportedNullCharacter, "");
+}
+
+/**
+ * Normalizes one object entry while keeping object keys untouched because only
+ * generated string values need this database-safe repair.
+ */
+function normalizeStepContentEntry([key, value]: [string, unknown]): [string, unknown] {
+  return [key, normalizeStepContentValue(value)];
+}
+
+/**
+ * Recurses through array content so nested options, pairs, forms, and image
+ * prompts follow the same JSONB-safe string contract as top-level fields.
+ */
+function normalizeStepContentArray(value: unknown[]): unknown[] {
+  return value.map((item) => normalizeStepContentValue(item));
+}
+
+/**
+ * Recurses through parsed step-content objects without mutating the Zod output
+ * object, which keeps validation and normalization as separate operations.
+ */
+function normalizeStepContentObject(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).map((entry) => normalizeStepContentEntry(entry)));
+}
+
+/**
+ * Walks validated step content and repairs only string leaves. Non-string JSON
+ * values are already safe for Postgres and should pass through unchanged.
+ */
+function normalizeStepContentValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return normalizeStepContentString(value);
+  }
+
+  if (Array.isArray(value)) {
+    return normalizeStepContentArray(value);
+  }
+
+  if (isJsonObject(value)) {
+    return normalizeStepContentObject(value);
+  }
+
+  return value;
+}
+
 export function parseStepContent(kind: "alphabet", content: unknown): AlphabetStepContent;
 export function parseStepContent(kind: "fillBlank", content: unknown): FillBlankStepContent;
 export function parseStepContent(kind: "listening", content: unknown): ListeningStepContent;
@@ -99,7 +158,7 @@ export function parseStepContent(
   content: unknown,
 ): StepContentByKind[SupportedStepKind];
 export function parseStepContent(kind: SupportedStepKind, content: unknown) {
-  return stepContentSchemas[kind].parse(content);
+  return normalizeStepContentValue(stepContentSchemas[kind].parse(content));
 }
 
 export function assertStepContent(kind: "alphabet", content: unknown): AlphabetStepContent;


### PR DESCRIPTION
## Summary

- normalize malformed generated Unicode escapes before saving step JSON
- report final workflow failures to Sentry from failure handlers
- add regression coverage for malformed lesson content and Sentry capture

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow save failures by normalizing malformed Unicode backslash escapes in step content and by explicitly reporting final workflow errors to Sentry. This prevents JSONB write errors and gives visibility into background failures.

- **Bug Fixes**
  - Normalize malformed backslash `\u00005c` and strip NUL `\u0000` in all step content strings; applied recursively during `parseStepContent`.
  - Add regression tests for malformed LaTeX and nested fields.

- **New Features**
  - Report final course/chapter/lesson workflow failures to `@sentry/nextjs` with workflow context and tags.
  - Flush within 2s and avoid throwing if capture fails; unit tests cover capture and flush.

<sup>Written for commit 0f753cf871065a4f265b7e9d1a738a2ca05fd384. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

