### PR TITLE
feat(admin): add learner milestone stats

### DIFF
--- a/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
@@ -18,10 +18,15 @@ import { LessonBreakdownTable } from "./lesson-breakdown-table";
 export async function EngagementMetrics({
   searchParams,
 }: {
-  searchParams: Promise<{ period?: string; offset?: string }>;
+  searchParams: {
+    completedLessons?: string | string[];
+    learningDays?: string | string[];
+    offset?: string | string[];
+    period?: string | string[];
+  };
 }) {
-  const { period: rawPeriod, offset: rawOffset } = await searchParams;
-  const period = validatePeriod(rawPeriod ?? "month");
+  const { period: rawPeriod, offset: rawOffset } = searchParams;
+  const period = validatePeriod(String(rawPeriod ?? "month"));
   const offset = validateOffset(rawOffset);
   const { current, previous } = calculateDateRanges(period, offset);
 

--- a/apps/admin/src/app/(private)/stats/engagement/learner-milestones.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learner-milestones.tsx
@@ -1,0 +1,226 @@
+import { getLearnerMilestoneSummary } from "@/data/stats/get-learner-milestones";
+import {
+  DEFAULT_COMPLETED_LESSONS_THRESHOLD,
+  DEFAULT_LEARNING_DAYS_THRESHOLD,
+  type LearnerMilestoneKind,
+  buildLearnerMilestoneUsersHref,
+  getLearnerMilestoneCopy,
+  parseLearnerMilestoneThreshold,
+} from "@/lib/learner-milestone-filters";
+import { Button } from "@zoonk/ui/components/button";
+import { Input } from "@zoonk/ui/components/input";
+import { Label } from "@zoonk/ui/components/label";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { BookCheckIcon, CalendarDaysIcon } from "lucide-react";
+import Link from "next/link";
+import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
+
+type EngagementSearchParams = {
+  completedLessons?: string | string[];
+  learningDays?: string | string[];
+  offset?: string | string[];
+  period?: string | string[];
+};
+
+/**
+ * Learner milestones are all-time threshold questions, so they live as a quiet
+ * engagement subsection with URL-backed inputs and linked counts.
+ */
+export async function LearnerMilestones({
+  searchParams,
+}: {
+  searchParams: EngagementSearchParams;
+}) {
+  const completedLessonsThreshold = parseLearnerMilestoneThreshold({
+    defaultValue: DEFAULT_COMPLETED_LESSONS_THRESHOLD,
+    value: searchParams.completedLessons,
+  });
+
+  const learningDaysThreshold = parseLearnerMilestoneThreshold({
+    defaultValue: DEFAULT_LEARNING_DAYS_THRESHOLD,
+    value: searchParams.learningDays,
+  });
+
+  const summary = await getLearnerMilestoneSummary(
+    completedLessonsThreshold,
+    learningDaysThreshold,
+  );
+
+  return (
+    <section className="flex flex-col gap-4">
+      <LearnerMilestoneForm
+        completedLessonsThreshold={completedLessonsThreshold}
+        learningDaysThreshold={learningDaysThreshold}
+        offset={searchParams.offset}
+        period={searchParams.period}
+      />
+
+      <div className="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-2">
+        <LearnerMilestoneCard
+          count={summary.completedLessonsUsers}
+          icon={<BookCheckIcon />}
+          kind="completedLessons"
+          threshold={completedLessonsThreshold}
+        />
+
+        <LearnerMilestoneCard
+          count={summary.learningDaysUsers}
+          icon={<CalendarDaysIcon />}
+          kind="learningDays"
+          threshold={learningDaysThreshold}
+        />
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The threshold form updates the engagement page with a plain GET request, so
+ * admins can bookmark or share the exact thresholds they are inspecting.
+ */
+function LearnerMilestoneForm({
+  completedLessonsThreshold,
+  learningDaysThreshold,
+  offset,
+  period,
+}: {
+  completedLessonsThreshold: number;
+  learningDaysThreshold: number;
+  offset?: string | string[];
+  period?: string | string[];
+}) {
+  return (
+    <form action="/stats/engagement" className="flex flex-col gap-4">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-base font-semibold tracking-tight">Learner Milestones</h3>
+          <p className="text-muted-foreground text-sm">
+            All-time learner counts for completion depth and return days.
+          </p>
+        </div>
+
+        <Button className="self-start" type="submit" variant="outline">
+          Apply
+        </Button>
+      </header>
+
+      <div className="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2">
+        <HiddenInput name="period" value={period} />
+        <HiddenInput name="offset" value={offset} />
+
+        <MilestoneThresholdField
+          defaultValue={completedLessonsThreshold}
+          id="completed-lessons-threshold"
+          label="Completed lessons"
+          name="completedLessons"
+        />
+
+        <MilestoneThresholdField
+          defaultValue={learningDaysThreshold}
+          id="learning-days-threshold"
+          label="Learning days"
+          name="learningDays"
+        />
+      </div>
+    </form>
+  );
+}
+
+/**
+ * Threshold inputs share bounds and layout, but each writes to a different
+ * query key so both milestone questions can be tuned independently.
+ */
+function MilestoneThresholdField({
+  defaultValue,
+  id,
+  label,
+  name,
+}: {
+  defaultValue: number;
+  id: string;
+  label: string;
+  name: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <Input defaultValue={defaultValue} id={id} min={1} name={name} type="number" />
+    </div>
+  );
+}
+
+/**
+ * Form submissions should preserve the selected stats period, but repeated
+ * query params still need to collapse to one hidden input value.
+ */
+function HiddenInput({ name, value }: { name: string; value?: string | string[] }) {
+  const firstValue = Array.isArray(value) ? value[0] : value;
+
+  if (!firstValue) {
+    return null;
+  }
+
+  return <input name={name} type="hidden" value={firstValue} />;
+}
+
+/**
+ * The linked card is the bridge from "how many?" to "who are they?" while
+ * keeping the visual treatment consistent with the rest of the stats page.
+ */
+function LearnerMilestoneCard({
+  count,
+  icon,
+  kind,
+  threshold,
+}: {
+  count: number;
+  icon: React.ReactNode;
+  kind: LearnerMilestoneKind;
+  threshold: number;
+}) {
+  const copy = getLearnerMilestoneCopy({ kind, threshold });
+
+  return (
+    <Link
+      className="hover:bg-muted/50 rounded-lg p-2 transition-colors"
+      href={buildLearnerMilestoneUsersHref({ kind, threshold })}
+    >
+      <AdminMetricCard
+        description="Open user list"
+        help={copy.help}
+        icon={icon}
+        title={copy.pageTitle}
+        value={count.toLocaleString()}
+      />
+    </Link>
+  );
+}
+
+/**
+ * The milestone section fetches independently from the period metrics, so its
+ * skeleton mirrors only the threshold controls and two linked counts.
+ */
+export function LearnerMilestonesSkeleton() {
+  return (
+    <section className="flex flex-col gap-4">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-80 max-w-full" />
+        </div>
+
+        <Skeleton className="h-9 w-20 rounded-4xl" />
+      </header>
+
+      <div className="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2">
+        <Skeleton className="h-16 flex-1 rounded-lg" />
+        <Skeleton className="h-16 flex-1 rounded-lg" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-2">
+        <AdminMetricCardSkeleton />
+        <AdminMetricCardSkeleton />
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-threshold-form.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-threshold-form.tsx
@@ -1,0 +1,42 @@
+import { type LearnerMilestoneKind } from "@/lib/learner-milestone-filters";
+import { Button } from "@zoonk/ui/components/button";
+import { Input } from "@zoonk/ui/components/input";
+import { Label } from "@zoonk/ui/components/label";
+
+/**
+ * The drill-down page keeps the threshold editable so admins can move from one
+ * cohort size to another without going back to the engagement overview.
+ */
+export function LearnerMilestoneThresholdForm({
+  inputLabel,
+  kind,
+  threshold,
+}: {
+  inputLabel: string;
+  kind: LearnerMilestoneKind;
+  threshold: number;
+}) {
+  return (
+    <form
+      action="/stats/engagement/learners"
+      className="flex max-w-md flex-col gap-3 sm:flex-row sm:items-end"
+    >
+      <input name="kind" type="hidden" value={kind} />
+
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <Label htmlFor="milestone-threshold">{inputLabel}</Label>
+        <Input
+          defaultValue={threshold}
+          id="milestone-threshold"
+          min={1}
+          name="threshold"
+          type="number"
+        />
+      </div>
+
+      <Button type="submit" variant="outline">
+        Apply
+      </Button>
+    </form>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-users-table.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-users-table.tsx
@@ -1,0 +1,154 @@
+import { type LearnerMilestoneUser } from "@/data/stats/get-learner-milestones";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
+import Link from "next/link";
+
+const SKELETON_ROW_COUNT = 5;
+
+/**
+ * The table focuses on the metrics that explain why each learner matched the
+ * selected milestone, while the user name remains the link into account detail.
+ */
+export function LearnerMilestoneUsersTable({
+  emptyMessage,
+  users,
+}: {
+  emptyMessage: string;
+  users: LearnerMilestoneUser[];
+}) {
+  if (users.length === 0) {
+    return <p className="text-muted-foreground text-sm">{emptyMessage}</p>;
+  }
+
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <TableCaption className="sr-only">Learners matching the selected milestone</TableCaption>
+        <LearnerMilestoneUsersTableHeader />
+
+        <TableBody>
+          {users.map((user) => (
+            <LearnerMilestoneUserRow key={user.id} user={user} />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+/**
+ * The skeleton reuses the real header so column labels stay in one place while
+ * placeholder rows mimic the loaded table body.
+ */
+export function LearnerMilestoneUsersTableSkeleton() {
+  return (
+    <div className="rounded-lg border">
+      <Table>
+        <LearnerMilestoneUsersTableHeader />
+
+        <TableBody>
+          {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
+            // oxlint-disable-next-line react/no-array-index-key -- Skeleton rows are static placeholders.
+            <LearnerMilestoneSkeletonRow key={index} />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+/**
+ * The loaded table and skeleton need identical columns. Sharing the header
+ * avoids maintaining copy and alignment in two separate render paths.
+ */
+function LearnerMilestoneUsersTableHeader() {
+  return (
+    <TableHeader>
+      <TableRow>
+        <TableHead>User</TableHead>
+        <TableHead className="text-right">Lessons</TableHead>
+        <TableHead className="text-right">Days</TableHead>
+        <TableHead className="text-right">Brain Power</TableHead>
+        <TableHead>Last completed</TableHead>
+        <TableHead>Joined</TableHead>
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+/**
+ * A separate row component keeps the skeleton table readable without deep JSX
+ * nesting in the fallback wrapper.
+ */
+function LearnerMilestoneSkeletonRow() {
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-48" />
+        </div>
+      </TableCell>
+      <TableCell>
+        <Skeleton className="ml-auto h-4 w-10" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="ml-auto h-4 w-10" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="ml-auto h-4 w-16" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-20" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-20" />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+/**
+ * Rows make the user identity clickable and keep the milestone numbers aligned
+ * for fast scanning across the two related completion metrics.
+ */
+function LearnerMilestoneUserRow({ user }: { user: LearnerMilestoneUser }) {
+  return (
+    <TableRow>
+      <TableCell>
+        <Link className="block" href={`/users/${user.id}`}>
+          <span className="font-medium">{user.name || "—"}</span>
+          <span className="text-muted-foreground block text-xs">{user.email}</span>
+        </Link>
+      </TableCell>
+
+      <TableCell className="text-right tabular-nums">
+        {user.completedLessons.toLocaleString()}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {user.learningDays.toLocaleString()}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {user.totalBrainPower.toLocaleString()}
+      </TableCell>
+      <TableCell className="text-muted-foreground">{formatDate(user.lastCompletedAt)}</TableCell>
+      <TableCell className="text-muted-foreground">{formatDate(user.createdAt)}</TableCell>
+    </TableRow>
+  );
+}
+
+/**
+ * Admin tables use compact date-only formatting because the surrounding column
+ * label already explains which timestamp is being shown.
+ */
+function formatDate(date: Date) {
+  return new Date(date).toLocaleDateString();
+}

--- a/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-users.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-users.tsx
@@ -1,0 +1,58 @@
+import { AdminPagination } from "@/components/pagination";
+import { listLearnerMilestoneUsers } from "@/data/stats/get-learner-milestones";
+import { type LearnerMilestoneKind } from "@/lib/learner-milestone-filters";
+import { parseSearchParams } from "@/lib/parse-search-params";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import {
+  LearnerMilestoneUsersTable,
+  LearnerMilestoneUsersTableSkeleton,
+} from "./learner-milestone-users-table";
+
+/**
+ * The user list is the slowest part of the drill-down page, so it streams after
+ * the page title and threshold controls are already available.
+ */
+export async function LearnerMilestoneUsers({
+  emptyMessage,
+  kind,
+  params,
+  threshold,
+}: {
+  emptyMessage: string;
+  kind: LearnerMilestoneKind;
+  params: Awaited<PageProps<"/stats/engagement/learners">["searchParams"]>;
+  threshold: number;
+}) {
+  const { limit, offset, page } = parseSearchParams(params);
+  const { total, users } = await listLearnerMilestoneUsers(kind, threshold, limit, offset);
+  const totalPages = Math.ceil(total / limit);
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm">{total.toLocaleString()} matching users.</p>
+
+      <LearnerMilestoneUsersTable emptyMessage={emptyMessage} users={users} />
+
+      <AdminPagination
+        basePath="/stats/engagement/learners"
+        limit={limit}
+        page={page}
+        queryParams={{ kind, threshold: threshold.toString() }}
+        totalPages={totalPages}
+      />
+    </>
+  );
+}
+
+/**
+ * The drill-down fallback keeps the count and table footprint stable while the
+ * grouped user query runs.
+ */
+export function LearnerMilestoneUsersSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Skeleton className="h-4 w-32" />
+      <LearnerMilestoneUsersTableSkeleton />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/engagement/learners/page.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learners/page.tsx
@@ -1,0 +1,59 @@
+import {
+  getDefaultLearnerMilestoneThreshold,
+  getLearnerMilestoneCopy,
+  parseLearnerMilestoneKind,
+  parseLearnerMilestoneThreshold,
+} from "@/lib/learner-milestone-filters";
+import { type Metadata } from "next";
+import { Suspense } from "react";
+import { StatsPageLayout } from "../../_components/stats-page-layout";
+import { LearnerMilestoneThresholdForm } from "./learner-milestone-threshold-form";
+import { LearnerMilestoneUsers, LearnerMilestoneUsersSkeleton } from "./learner-milestone-users";
+
+export const metadata: Metadata = { title: "Learner Milestones" };
+
+export default async function LearnerMilestoneUsersPage({
+  searchParams,
+}: PageProps<"/stats/engagement/learners">) {
+  const params = await searchParams;
+  const kind = parseLearnerMilestoneKind(params.kind);
+
+  const threshold = parseLearnerMilestoneThreshold({
+    defaultValue: getDefaultLearnerMilestoneThreshold({ kind }),
+    value: params.threshold,
+  });
+
+  const copy = getLearnerMilestoneCopy({ kind, threshold });
+
+  return (
+    <StatsPageLayout
+      breadcrumbItems={[
+        { href: "/stats/engagement", label: "Engagement & Learning" },
+        { label: "Learner Milestones" },
+      ]}
+      showPeriodTabs={false}
+      title={copy.pageTitle}
+    >
+      <div className="flex flex-col gap-6">
+        <header className="flex flex-col gap-1">
+          <p className="text-muted-foreground text-sm">{copy.tableCaption}</p>
+        </header>
+
+        <LearnerMilestoneThresholdForm
+          inputLabel={copy.inputLabel}
+          kind={kind}
+          threshold={threshold}
+        />
+
+        <Suspense fallback={<LearnerMilestoneUsersSkeleton />} key={`${kind}-${threshold}`}>
+          <LearnerMilestoneUsers
+            emptyMessage={copy.emptyMessage}
+            kind={kind}
+            params={params}
+            threshold={threshold}
+          />
+        </Suspense>
+      </div>
+    </StatsPageLayout>
+  );
+}

--- a/apps/admin/src/app/(private)/stats/engagement/page.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/page.tsx
@@ -5,11 +5,13 @@ import { Suspense } from "react";
 import { AdminPeriodNavigation } from "../_components/admin-period-navigation";
 import { StatsPageLayout } from "../_components/stats-page-layout";
 import { EngagementMetrics, EngagementMetricsSkeleton } from "./engagement-metrics";
+import { LearnerMilestones, LearnerMilestonesSkeleton } from "./learner-milestones";
 
 export const metadata: Metadata = { title: "Engagement & Learning" };
 
 export default async function EngagementPage({ searchParams }: PageProps<"/stats/engagement">) {
-  const { period: rawPeriod, offset: rawOffset } = await searchParams;
+  const params = await searchParams;
+  const { period: rawPeriod, offset: rawOffset } = params;
   const period = validatePeriod(String(rawPeriod ?? "month"));
   const offset = validateOffset(rawOffset);
   const { current } = calculateDateRanges(period, offset);
@@ -24,9 +26,15 @@ export default async function EngagementPage({ searchParams }: PageProps<"/stats
       }
       title="Engagement & Learning"
     >
-      <Suspense fallback={<EngagementMetricsSkeleton />} key={`${period}-${offset}`}>
-        <EngagementMetrics searchParams={searchParams} />
-      </Suspense>
+      <div className="flex flex-col gap-8">
+        <Suspense fallback={<EngagementMetricsSkeleton />} key={`${period}-${offset}`}>
+          <EngagementMetrics searchParams={params} />
+        </Suspense>
+
+        <Suspense fallback={<LearnerMilestonesSkeleton />}>
+          <LearnerMilestones searchParams={params} />
+        </Suspense>
+      </div>
     </StatsPageLayout>
   );
 }

--- a/apps/admin/src/app/(private)/stats/page.tsx
+++ b/apps/admin/src/app/(private)/stats/page.tsx
@@ -30,7 +30,7 @@ const sections = [
   },
   {
     description:
-      "Active learners, accuracy rate, time per lesson, learning time trends, and lesson breakdown.",
+      "Active learners, learner milestones, accuracy rate, time per lesson, and lesson breakdown.",
     href: "/stats/engagement",
     icon: BookOpenIcon,
     title: "Engagement & Learning",

--- a/apps/admin/src/data/stats/get-learner-milestones.ts
+++ b/apps/admin/src/data/stats/get-learner-milestones.ts
@@ -1,0 +1,192 @@
+import "server-only";
+import { adminStatsCache as cache } from "@/data/stats/_utils/admin-stats-cache";
+import { type LearnerMilestoneKind } from "@/lib/learner-milestone-filters";
+import { type Sql, prisma, sql } from "@zoonk/db";
+
+type LearnerMilestoneUserRow = {
+  completedLessons: bigint;
+  createdAt: Date;
+  email: string;
+  id: string;
+  lastCompletedAt: Date;
+  learningDays: bigint;
+  name: string;
+  totalBrainPower: bigint;
+  username: string | null;
+};
+
+type LearnerMilestoneQueryParts = { havingFilter: Sql; primaryOrder: Sql };
+
+export type LearnerMilestoneUser = {
+  completedLessons: number;
+  createdAt: Date;
+  email: string;
+  id: string;
+  lastCompletedAt: Date;
+  learningDays: number;
+  name: string;
+  totalBrainPower: number;
+  username: string | null;
+};
+
+/**
+ * The engagement page needs the two milestone counts together so it can answer
+ * the threshold questions without making each card own a separate data path.
+ */
+export const getLearnerMilestoneSummary = cache(
+  async (completedLessonsThreshold: number, learningDaysThreshold: number) => {
+    const [completedLessonsUsers, learningDaysUsers] = await Promise.all([
+      countUsersByLearnerMilestone({
+        queryParts: getLearnerMilestoneQueryParts({
+          kind: "completedLessons",
+          threshold: completedLessonsThreshold,
+        }),
+      }),
+      countUsersByLearnerMilestone({
+        queryParts: getLearnerMilestoneQueryParts({
+          kind: "learningDays",
+          threshold: learningDaysThreshold,
+        }),
+      }),
+    ]);
+
+    return { completedLessonsUsers, learningDaysUsers };
+  },
+);
+
+/**
+ * The drill-down page uses one route for both learner milestone questions. The
+ * kind decides which threshold rule filters users, while each row still shows
+ * both completion totals for context.
+ */
+export const listLearnerMilestoneUsers = cache(
+  async (kind: LearnerMilestoneKind, threshold: number, limit: number, offset: number) => {
+    const queryParts = getLearnerMilestoneQueryParts({ kind, threshold });
+
+    const [rows, total] = await Promise.all([
+      listUsersByLearnerMilestone({ limit, offset, queryParts }),
+      countUsersByLearnerMilestone({ queryParts }),
+    ]);
+
+    const users = rows.map((row) => serializeLearnerMilestoneUser({ row }));
+
+    return { total, users };
+  },
+);
+
+/**
+ * Raw SQL cannot parameterize aggregate expressions or order columns, so the
+ * supported milestone rules are explicitly whitelisted before being composed
+ * into the shared learner-progress query.
+ */
+function getLearnerMilestoneQueryParts({
+  kind,
+  threshold,
+}: {
+  kind: LearnerMilestoneKind;
+  threshold: number;
+}): LearnerMilestoneQueryParts {
+  if (kind === "learningDays") {
+    return {
+      havingFilter: sql`COUNT(DISTINCT completed_at::date) >= ${threshold}`,
+      primaryOrder: sql`learner_progress.learning_days DESC, learner_progress.completed_lessons DESC`,
+    };
+  }
+
+  return {
+    havingFilter: sql`COUNT(*) >= ${threshold}`,
+    primaryOrder: sql`learner_progress.completed_lessons DESC, learner_progress.learning_days DESC`,
+  };
+}
+
+/**
+ * Counting inside a grouped subquery lets Postgres apply the milestone rule per
+ * user before the outer count turns the qualifying user set into one metric.
+ */
+async function countUsersByLearnerMilestone({
+  queryParts,
+}: {
+  queryParts: LearnerMilestoneQueryParts;
+}) {
+  const result = await prisma.$queryRaw<[{ count: bigint }]>`
+    SELECT COUNT(*) AS count
+    FROM (
+      SELECT user_id
+      FROM lesson_progress
+      WHERE completed_at IS NOT NULL
+      GROUP BY user_id
+      HAVING ${queryParts.havingFilter}
+    ) qualifying_users
+  `;
+
+  return Number(result[0].count);
+}
+
+/**
+ * The user list shares one learner-progress subquery for both milestones. The
+ * whitelisted query parts decide which users qualify and which metric sorts
+ * first, while every row still exposes both completion counts.
+ */
+async function listUsersByLearnerMilestone({
+  limit,
+  offset,
+  queryParts,
+}: {
+  limit: number;
+  offset: number;
+  queryParts: LearnerMilestoneQueryParts;
+}) {
+  return prisma.$queryRaw<LearnerMilestoneUserRow[]>`
+    SELECT
+      users.id,
+      users.name,
+      users.email,
+      users.username,
+      users.created_at AS "createdAt",
+      COALESCE(user_progress.total_brain_power, 0)::bigint AS "totalBrainPower",
+      learner_progress.completed_lessons AS "completedLessons",
+      learner_progress.learning_days AS "learningDays",
+      learner_progress.last_completed_at AS "lastCompletedAt"
+    FROM (
+      SELECT
+        user_id,
+        COUNT(*) AS completed_lessons,
+        COUNT(DISTINCT completed_at::date) AS learning_days,
+        MAX(completed_at) AS last_completed_at
+      FROM lesson_progress
+      WHERE completed_at IS NOT NULL
+      GROUP BY user_id
+      HAVING ${queryParts.havingFilter}
+    ) learner_progress
+    JOIN users ON users.id = learner_progress.user_id
+    LEFT JOIN user_progress ON user_progress.user_id = users.id
+    ORDER BY
+      ${queryParts.primaryOrder},
+      learner_progress.last_completed_at DESC,
+      users.created_at DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+  `;
+}
+
+/**
+ * Raw SQL returns bigint values for counts and Brain Power. Converting them at
+ * the data boundary keeps table components free from database numeric details.
+ */
+function serializeLearnerMilestoneUser({
+  row,
+}: {
+  row: LearnerMilestoneUserRow;
+}): LearnerMilestoneUser {
+  return {
+    completedLessons: Number(row.completedLessons),
+    createdAt: row.createdAt,
+    email: row.email,
+    id: row.id,
+    lastCompletedAt: row.lastCompletedAt,
+    learningDays: Number(row.learningDays),
+    name: row.name,
+    totalBrainPower: Number(row.totalBrainPower),
+    username: row.username,
+  };
+}

--- a/apps/admin/src/lib/learner-milestone-filters.ts
+++ b/apps/admin/src/lib/learner-milestone-filters.ts
@@ -1,0 +1,123 @@
+export const DEFAULT_COMPLETED_LESSONS_THRESHOLD = 10;
+export const DEFAULT_LEARNING_DAYS_THRESHOLD = 3;
+
+const MAX_THRESHOLD = 1000;
+const MIN_THRESHOLD = 1;
+
+type SearchParamValue = string | string[] | undefined;
+
+export type LearnerMilestoneKind = "completedLessons" | "learningDays";
+
+/**
+ * Milestone drill-down links need stable query values instead of page copy.
+ * Keeping the URL vocabulary here prevents the summary cards and user list
+ * page from drifting when labels change.
+ */
+export function parseLearnerMilestoneKind(value: SearchParamValue): LearnerMilestoneKind {
+  const firstValue = getFirstSearchParam(value);
+
+  return isLearnerMilestoneKind(firstValue) ? firstValue : "completedLessons";
+}
+
+/**
+ * Admin thresholds are typed into URL-backed number inputs. Clamping here keeps
+ * every milestone query finite and avoids accidental unbounded grouping from a
+ * hand-edited query string.
+ */
+export function parseLearnerMilestoneThreshold({
+  defaultValue,
+  value,
+}: {
+  defaultValue: number;
+  value: SearchParamValue;
+}) {
+  const firstValue = getFirstSearchParam(value);
+  const trimmedValue = firstValue?.trim();
+
+  if (!trimmedValue) {
+    return defaultValue;
+  }
+
+  const parsedValue = Number(trimmedValue);
+
+  if (!Number.isFinite(parsedValue)) {
+    return defaultValue;
+  }
+
+  return Math.min(Math.max(Math.trunc(parsedValue), MIN_THRESHOLD), MAX_THRESHOLD);
+}
+
+/**
+ * Direct visits to the learner list only provide the milestone kind. The
+ * default threshold needs to match the summary card that links to that list.
+ */
+export function getDefaultLearnerMilestoneThreshold({ kind }: { kind: LearnerMilestoneKind }) {
+  if (kind === "learningDays") {
+    return DEFAULT_LEARNING_DAYS_THRESHOLD;
+  }
+
+  return DEFAULT_COMPLETED_LESSONS_THRESHOLD;
+}
+
+/**
+ * Summary cards and drill-down pages describe the same milestone. Centralizing
+ * the copy keeps the count, page title, and empty state aligned.
+ */
+export function getLearnerMilestoneCopy({
+  kind,
+  threshold,
+}: {
+  kind: LearnerMilestoneKind;
+  threshold: number;
+}) {
+  if (kind === "learningDays") {
+    return {
+      emptyMessage: `No users have completed lessons on ${threshold} or more days yet.`,
+      help: `Users who completed lessons on at least ${threshold} different days, all time`,
+      inputLabel: "Learning days",
+      pageTitle: `${threshold}+ Learning Days`,
+      tableCaption: `Users who completed lessons on at least ${threshold} different days.`,
+    };
+  }
+
+  return {
+    emptyMessage: `No users have completed ${threshold} or more lessons yet.`,
+    help: `Users who completed at least ${threshold} lessons, all time`,
+    inputLabel: "Completed lessons",
+    pageTitle: `${threshold}+ Completed Lessons`,
+    tableCaption: `Users who completed at least ${threshold} lessons.`,
+  };
+}
+
+/**
+ * The milestone cards link to the same list route with different query values.
+ * URLSearchParams handles encoding while this helper keeps the route shape in
+ * one place.
+ */
+export function buildLearnerMilestoneUsersHref({
+  kind,
+  threshold,
+}: {
+  kind: LearnerMilestoneKind;
+  threshold: number;
+}) {
+  const params = new URLSearchParams({ kind, threshold: threshold.toString() });
+
+  return `/stats/engagement/learners?${params.toString()}`;
+}
+
+/**
+ * Runtime URL values are plain strings. This guard narrows them to the finite
+ * milestone modes that the SQL loaders know how to query.
+ */
+function isLearnerMilestoneKind(value: string | undefined): value is LearnerMilestoneKind {
+  return value === "completedLessons" || value === "learningDays";
+}
+
+/**
+ * Next.js returns repeated query params as arrays. Milestone filters only use
+ * one value per key, so the first entry is the canonical value.
+ */
+function getFirstSearchParam(value: SearchParamValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}


### PR DESCRIPTION
## Summary
- add learner milestone stats to the admin engagement dashboard
- add threshold controls for completed lessons and learning days
- add a drill-down user list that links to user detail pages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds learner milestone stats to the admin Engagement & Learning page with configurable thresholds and a drill-down user list. This shows how many learners reached X completed lessons or Y learning days and who they are.

- **New Features**
  - New “Learner Milestones” section with two cards (X+ completed lessons, Y+ learning days); thresholds persist in the URL and update via a GET “Apply”.
  - Drill-down at `/stats/engagement/learners` lists matching users with pagination and an editable threshold; rows link to user detail pages.
  - Cached SQL loaders (`apps/admin/src/data/stats/get-learner-milestones.ts`) using `@zoonk/db` compute counts and user lists, including last completed date and total Brain Power.
  - Search params now accept `completedLessons` and `learningDays`; `period`/`offset` handling normalized to strings and preserved on form submit.
  - Added lightweight skeletons for the milestone section and the user table; sensible defaults: 10 lessons, 3 learning days.

<sup>Written for commit 32384651ddac6d9d68ee506629b7dd3dd7eaa7e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

