### PR TITLE
feat(main): add active catalog scroll shortcut

### DIFF
--- a/apps/main/e2e/catalog-active-scroll.test.ts
+++ b/apps/main/e2e/catalog-active-scroll.test.ts
@@ -1,0 +1,303 @@
+import { randomUUID } from "node:crypto";
+import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
+import { type Page, expect, test } from "./fixtures";
+
+type ScrollTarget = { title: string; url: string };
+type LessonProgressSetup = "completedPrevious" | "startedOnly";
+
+const ACTIVE_SCROLL_VIEWPORT = { height: 667, width: 375 };
+const SCROLL_TARGET_TOP_OFFSET = 180;
+
+/**
+ * The floating action changes after a real scroll event, so tests use the
+ * browser scroll API instead of reaching into React state.
+ */
+async function scrollDown(page: Page) {
+  await page.evaluate(() => globalThis.scrollBy({ behavior: "auto", top: 700 }));
+}
+
+/**
+ * Passing the active item should make the current-item shortcut disappear
+ * because jumping back down to content the learner already crossed is
+ * disorienting; the floating action should become a recovery path upward.
+ */
+async function scrollPastCatalogTarget({ page, title }: { page: Page; title: string }) {
+  const targetTop = await getCatalogLinkTop({ page, title });
+
+  await page.evaluate(
+    (scrollDistance) => globalThis.scrollBy({ behavior: "auto", top: scrollDistance }),
+    targetTop + 260,
+  );
+
+  await expect.poll(() => getCatalogLinkTop({ page, title })).toBeLessThan(0);
+}
+
+/**
+ * Semantic link lookup keeps these scroll assertions tied to what a learner can
+ * see and activate, while still letting the test inspect the rendered position.
+ */
+async function getCatalogLinkTop({ page, title }: { page: Page; title: string }) {
+  return page
+    .getByRole("link", { name: new RegExp(title, "u") })
+    .evaluate((element) => element.getBoundingClientRect().top);
+}
+
+/**
+ * The current-item action scrolls to a tile near the top of the viewport, but
+ * leaves enough room for the sticky catalog navigation.
+ */
+async function expectTargetNearTop({ page, title }: { page: Page; title: string }) {
+  await expect
+    .poll(() => getCatalogLinkTop({ page, title }))
+    .toBeLessThanOrEqual(SCROLL_TARGET_TOP_OFFSET);
+}
+
+/**
+ * Course pages need enough chapters to make the active chapter useful as a
+ * shortcut. The completed lesson sits just before the active chapter, while a
+ * later opened lesson proves incomplete progress does not move the target.
+ */
+async function createScrollableCourseTarget({
+  userId,
+}: {
+  userId?: string;
+}): Promise<ScrollTarget> {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+  const activeChapterIndex = userId ? 10 : 0;
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-active-scroll-course-${uniqueId}`,
+    title: `E2E Active Scroll Course ${uniqueId}`,
+  });
+
+  const chapters = await Promise.all(
+    Array.from({ length: 14 }, (_, position) =>
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: org.id,
+        position,
+        slug: `e2e-active-scroll-ch-${position}-${uniqueId}`,
+        title: `E2E Active Scroll Chapter ${position + 1} ${uniqueId}`,
+      }),
+    ),
+  );
+
+  const lessons = await Promise.all(
+    chapters.map((chapter, position) =>
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+        title: `E2E Active Scroll Lesson ${position + 1} ${uniqueId}`,
+      }),
+    ),
+  );
+
+  const activeChapter = chapters[activeChapterIndex];
+  const completedLesson = lessons[activeChapterIndex - 1];
+  const startedLesson = lessons[activeChapterIndex + 1];
+
+  if (!activeChapter || (userId && (!completedLesson || !startedLesson))) {
+    throw new Error("Active scroll course fixture did not create enough chapters.");
+  }
+
+  if (userId && completedLesson && startedLesson) {
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date(),
+        durationSeconds: 60,
+        lessonId: completedLesson.id,
+        userId,
+      }),
+      lessonProgressFixture({
+        completedAt: null,
+        durationSeconds: null,
+        lessonId: startedLesson.id,
+        userId,
+      }),
+    ]);
+  }
+
+  return { title: activeChapter.title, url: `/b/${AI_ORG_SLUG}/c/${course.slug}` };
+}
+
+/**
+ * Chapter pages need a long lesson list so the active lesson target proves the
+ * floating action can jump deeper into the chapter.
+ */
+async function createScrollableLessonTarget({
+  progressSetup = "completedPrevious",
+  userId,
+}: {
+  progressSetup?: LessonProgressSetup;
+  userId: string;
+}): Promise<ScrollTarget> {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+  const activeLessonIndex = 11;
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-active-scroll-lessons-course-${uniqueId}`,
+    title: `E2E Active Scroll Lessons Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-active-scroll-lessons-ch-${uniqueId}`,
+    title: `E2E Active Scroll Lessons Chapter ${uniqueId}`,
+  });
+
+  const lessons = await Promise.all(
+    Array.from({ length: 16 }, (_, position) =>
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId: org.id,
+        position,
+        title: `E2E Active Scroll Lesson ${position + 1} ${uniqueId}`,
+      }),
+    ),
+  );
+
+  const activeLesson = lessons[activeLessonIndex];
+  const completedLesson = lessons[activeLessonIndex - 1];
+
+  if (!activeLesson || !completedLesson) {
+    throw new Error("Active scroll lesson fixture did not create enough lessons.");
+  }
+
+  if (progressSetup === "completedPrevious") {
+    await lessonProgressFixture({
+      completedAt: new Date(),
+      durationSeconds: 60,
+      lessonId: completedLesson.id,
+      userId,
+    });
+  }
+
+  if (progressSetup === "startedOnly") {
+    await lessonProgressFixture({
+      completedAt: null,
+      durationSeconds: null,
+      lessonId: activeLesson.id,
+      userId,
+    });
+  }
+
+  return {
+    title: activeLesson.title ?? "",
+    url: `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`,
+  };
+}
+
+test.describe("Catalog Active Scroll", () => {
+  test.use({ viewport: ACTIVE_SCROLL_VIEWPORT });
+
+  test("course page jumps to the current chapter while scrolling down", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const target = await createScrollableCourseTarget({ userId: withProgressUser.id });
+
+    await authenticatedPage.emulateMedia({ reducedMotion: "reduce" });
+    await authenticatedPage.goto(target.url);
+    await expect(authenticatedPage.getByRole("heading", { level: 1 })).toBeVisible();
+
+    await expect(
+      authenticatedPage.getByRole("link", { name: new RegExp(target.title, "u") }),
+    ).toBeVisible();
+
+    await scrollDown(authenticatedPage);
+
+    const currentChapterLink = authenticatedPage.getByRole("link", { name: /current chapter/iu });
+    await expect(currentChapterLink).toBeVisible();
+
+    await currentChapterLink.click();
+    await expectTargetNearTop({ page: authenticatedPage, title: target.title });
+  });
+
+  test("course page keeps back-to-top when no chapter is active", async ({
+    userWithoutProgress,
+  }) => {
+    const target = await createScrollableCourseTarget({});
+
+    await userWithoutProgress.emulateMedia({ reducedMotion: "reduce" });
+    await userWithoutProgress.goto(target.url);
+    await expect(userWithoutProgress.getByRole("heading", { level: 1 })).toBeVisible();
+
+    await scrollDown(userWithoutProgress);
+
+    await expect(userWithoutProgress.getByRole("link", { name: /back to top/iu })).toBeVisible();
+    const currentChapterLink = userWithoutProgress.getByRole("link", { name: /current chapter/iu });
+    await expect(currentChapterLink).toHaveCount(0);
+  });
+
+  test("chapter page switches between current lesson and back-to-top actions", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const target = await createScrollableLessonTarget({ userId: withProgressUser.id });
+
+    await authenticatedPage.emulateMedia({ reducedMotion: "reduce" });
+    await authenticatedPage.goto(target.url);
+    await expect(authenticatedPage.getByRole("heading", { level: 1 })).toBeVisible();
+
+    await expect(
+      authenticatedPage.getByRole("link", { name: new RegExp(target.title, "u") }),
+    ).toBeVisible();
+
+    await scrollDown(authenticatedPage);
+
+    const currentLessonLink = authenticatedPage.getByRole("link", { name: /current lesson/iu });
+    await expect(currentLessonLink).toBeVisible();
+
+    await currentLessonLink.click();
+    await expectTargetNearTop({ page: authenticatedPage, title: target.title });
+
+    await scrollPastCatalogTarget({ page: authenticatedPage, title: target.title });
+
+    const backToTopAfterPassingLink = authenticatedPage.getByRole("link", {
+      name: /back to top/iu,
+    });
+
+    await expect(backToTopAfterPassingLink).toBeVisible();
+    await expect(authenticatedPage.getByRole("link", { name: /current lesson/iu })).toHaveCount(0);
+
+    await backToTopAfterPassingLink.click();
+    await expect.poll(() => authenticatedPage.evaluate(() => globalThis.scrollY)).toBe(0);
+  });
+
+  test("chapter page keeps back-to-top when only opened lesson is incomplete", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const target = await createScrollableLessonTarget({
+      progressSetup: "startedOnly",
+      userId: withProgressUser.id,
+    });
+
+    await authenticatedPage.emulateMedia({ reducedMotion: "reduce" });
+    await authenticatedPage.goto(target.url);
+    await expect(authenticatedPage.getByRole("heading", { level: 1 })).toBeVisible();
+
+    await scrollDown(authenticatedPage);
+
+    await expect(authenticatedPage.getByRole("link", { name: /back to top/iu })).toBeVisible();
+    const currentLessonLink = authenticatedPage.getByRole("link", { name: /current lesson/iu });
+    await expect(currentLessonLink).toHaveCount(0);
+  });
+});

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -286,6 +286,10 @@ msgid "3IOFp2"
 msgstr "Create chapter"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+msgid "orGV/i"
+msgstr "Current lesson"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
 msgstr "Search lessons..."
 
@@ -302,6 +306,10 @@ msgstr "Completed"
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "xTTP0x"
 msgstr "Not started"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+msgid "iRubpl"
+msgstr "Current chapter"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "3SOcGR"
@@ -1666,7 +1674,11 @@ msgstr "I didn't like it"
 msgid "G5YSJR"
 msgstr "Send feedback"
 
-#: src/components/catalog/catalog-grid.tsx
+#: src/components/catalog/catalog-grid-back-to-top.tsx
+msgid "izuy1D"
+msgstr "Current item"
+
+#: src/components/catalog/catalog-grid-back-to-top.tsx
 msgid "Gs9Kfp"
 msgstr "Back to top"
 

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -286,6 +286,10 @@ msgid "3IOFp2"
 msgstr "Crear capítulo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+msgid "orGV/i"
+msgstr "Lección actual"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
 msgstr "Buscar lecciones..."
 
@@ -302,6 +306,10 @@ msgstr "Completado"
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "xTTP0x"
 msgstr "Sin empezar"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+msgid "iRubpl"
+msgstr "Capítulo actual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "3SOcGR"
@@ -1666,7 +1674,11 @@ msgstr "No me gustó"
 msgid "G5YSJR"
 msgstr "Enviar comentarios"
 
-#: src/components/catalog/catalog-grid.tsx
+#: src/components/catalog/catalog-grid-back-to-top.tsx
+msgid "izuy1D"
+msgstr "Elemento actual"
+
+#: src/components/catalog/catalog-grid-back-to-top.tsx
 msgid "Gs9Kfp"
 msgstr "Volver arriba"
 

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -286,6 +286,10 @@ msgid "3IOFp2"
 msgstr "Criar capítulo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+msgid "orGV/i"
+msgstr "Aula atual"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
 msgstr "Buscar aulas..."
 
@@ -302,6 +306,10 @@ msgstr "Concluído"
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "xTTP0x"
 msgstr "Não começou"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+msgid "iRubpl"
+msgstr "Capítulo atual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "3SOcGR"
@@ -1666,7 +1674,11 @@ msgstr "Não gostei"
 msgid "G5YSJR"
 msgstr "Enviar opinião"
 
-#: src/components/catalog/catalog-grid.tsx
+#: src/components/catalog/catalog-grid-back-to-top.tsx
+msgid "izuy1D"
+msgstr "Item atual"
+
+#: src/components/catalog/catalog-grid-back-to-top.tsx
 msgid "Gs9Kfp"
 msgstr "Voltar ao topo"
 

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -7,6 +7,10 @@ import {
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { getDefaultLessonImage } from "@/lib/catalog/default-images";
 import { getLessonDisplayMeta } from "@/lib/lessons";
+import {
+  type ActiveCatalogTarget,
+  getActiveCatalogTarget,
+} from "@zoonk/core/progress/active-catalog-target";
 import { getLessonProgress } from "@zoonk/core/progress/lessons";
 import { type Lesson } from "@zoonk/db";
 import {
@@ -43,6 +47,21 @@ function LessonListItemStatus({
   }
 
   return <GridItemStatusIdle>{notStartedLabel}</GridItemStatusIdle>;
+}
+
+/**
+ * The active shortcut on a chapter page should land on a lesson tile. Progress
+ * resolves from the last completed lesson so opening a lesson without finishing
+ * it does not make that lesson look active.
+ */
+function getActiveLessonKey({
+  activeTarget,
+  lessons,
+}: {
+  activeTarget: ActiveCatalogTarget | null;
+  lessons: Lesson[];
+}) {
+  return lessons.find((lesson) => lesson.slug === activeTarget?.lessonSlug)?.id ?? null;
 }
 
 /**
@@ -132,9 +151,15 @@ export async function LessonList({
   }
 
   const t = await getExtracted();
-  const completionData = await getLessonProgress({ chapterId });
+
+  const [completionData, activeTarget] = await Promise.all([
+    getLessonProgress({ chapterId }),
+    getActiveCatalogTarget({ scope: { chapterId } }),
+  ]);
+
   const completionMap = new Map(completionData.map((row) => [row.lessonId, row]));
   const lessonRows = await getLessonRows(lessons);
+  const activeLessonKey = getActiveLessonKey({ activeTarget, lessons });
 
   const searchItems = lessonRows.map(({ display, lesson }) => ({
     description: display.description,
@@ -143,7 +168,7 @@ export async function LessonList({
   }));
 
   return (
-    <CatalogGridContent>
+    <CatalogGridContent activeItemKey={activeLessonKey} activeLabel={t("Current lesson")}>
       <CatalogGridSearch items={searchItems} placeholder={t("Search lessons...")}>
         <CatalogGridEmpty>{t("No lessons found")}</CatalogGridEmpty>
         <GridGroup variant="pane">

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -6,6 +6,10 @@ import {
 } from "@/components/catalog/catalog-grid";
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { type CourseChapter } from "@/data/chapters/list-course-chapters";
+import {
+  type ActiveCatalogTarget,
+  getActiveCatalogTarget,
+} from "@zoonk/core/progress/active-catalog-target";
 import { getChapterProgress } from "@zoonk/core/progress/chapters";
 import {
   GridGroup,
@@ -102,6 +106,20 @@ function ChapterListItemStatus({
 }
 
 /**
+ * The active shortcut on a course page should land on a chapter tile, even
+ * though progress is tracked at the lesson level.
+ */
+function getActiveChapterKey({
+  activeTarget,
+  chapters,
+}: {
+  activeTarget: ActiveCatalogTarget | null;
+  chapters: CourseChapter[];
+}) {
+  return chapters.find((chapter) => chapter.slug === activeTarget?.chapterSlug)?.id ?? null;
+}
+
+/**
  * A chapter tile gives the image more room than the old row, making the course
  * path easier to scan on wide screens without dropping the compact mobile flow.
  */
@@ -177,11 +195,17 @@ export async function ChapterList({
   }
 
   const t = await getExtracted();
-  const completionData = await getChapterProgress({ courseId });
+
+  const [completionData, activeTarget] = await Promise.all([
+    getChapterProgress({ courseId }),
+    getActiveCatalogTarget({ scope: { courseId } }),
+  ]);
+
   const completionMap = new Map(completionData.map((row) => [row.chapterId, row]));
+  const activeChapterKey = getActiveChapterKey({ activeTarget, chapters });
 
   return (
-    <CatalogGridContent>
+    <CatalogGridContent activeItemKey={activeChapterKey} activeLabel={t("Current chapter")}>
       <CatalogGridSearch items={chapters} placeholder={t("Search chapters...")}>
         <CatalogGridEmpty>{t("No chapters found")}</CatalogGridEmpty>
         <GridGroup variant="pane">

--- a/apps/main/src/components/catalog/catalog-grid-back-to-top.tsx
+++ b/apps/main/src/components/catalog/catalog-grid-back-to-top.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { GridBackToTop } from "@zoonk/ui/components/grid";
+import { cn } from "@zoonk/ui/lib/utils";
+import { useExtracted } from "next-intl";
+import { type MouseEvent, useEffect, useRef, useState } from "react";
+import { CATALOG_TOP_TARGET_ID } from "./catalog-top-target";
+
+export type CatalogGridItemKey = string | number | bigint;
+
+type CatalogActiveTargetPosition = "ahead" | "unavailable";
+type CatalogScrollActionMode = "active" | "top";
+type CatalogScrollDirection = "down" | "up";
+
+type CatalogScrollState = {
+  activeTargetPosition: CatalogActiveTargetPosition;
+  direction: CatalogScrollDirection;
+  isVisible: boolean;
+};
+
+const BACK_TO_TOP_VISIBLE_SCROLL_Y = 360;
+
+const DEFAULT_CATALOG_SCROLL_STATE = {
+  activeTargetPosition: "unavailable",
+  direction: "up",
+  isVisible: false,
+} satisfies CatalogScrollState;
+
+/**
+ * Catalog tiles need stable DOM anchors so the floating action can target the
+ * current chapter or lesson without coupling scroll behavior to route URLs.
+ */
+export function getCatalogItemTargetId(itemKey: CatalogGridItemKey): string {
+  return `catalog-item-${String(itemKey)}`;
+}
+
+/**
+ * The floating top action should appear only after the reader has left the
+ * page header; showing it immediately would add chrome before it can help.
+ */
+function isBackToTopVisible({ scrollY }: { scrollY: number }): boolean {
+  return scrollY > BACK_TO_TOP_VISIBLE_SCROLL_Y;
+}
+
+/**
+ * The scroll action follows the latest user intent: down means "take me to my
+ * current item", while up means "take me back to the page header".
+ */
+function getCatalogScrollDirection({
+  currentScrollY,
+  previousDirection,
+  previousScrollY,
+}: {
+  currentScrollY: number;
+  previousDirection: CatalogScrollDirection;
+  previousScrollY: number;
+}): CatalogScrollDirection {
+  if (currentScrollY > previousScrollY) {
+    return "down";
+  }
+
+  if (currentScrollY < previousScrollY) {
+    return "up";
+  }
+
+  return previousDirection;
+}
+
+/**
+ * The active target is useful only before the learner reaches it. Once its top
+ * edge is at or above the viewport, the downward shortcut would point back to
+ * content they have already reached, so the floating action should recover up.
+ */
+function isCatalogActiveTargetAhead(element: Element): boolean {
+  return element.getBoundingClientRect().top > 0;
+}
+
+/**
+ * Catalog anchors are queried through CSS selectors, so ids must be escaped
+ * before interpolation to keep unusual future keys from breaking the shortcut.
+ */
+function getCatalogScrollTargetElement(targetId: string | null) {
+  if (!targetId) {
+    return null;
+  }
+
+  return globalThis.document.querySelector(`#${globalThis.CSS.escape(targetId)}`);
+}
+
+/**
+ * Active targets are optional because anonymous users, users without progress,
+ * and filtered grids all need the same simple fallback: back to the page top.
+ */
+function getCatalogActiveTargetPosition({
+  activeTargetId,
+}: {
+  activeTargetId: string | null;
+}): CatalogActiveTargetPosition {
+  if (!activeTargetId) {
+    return "unavailable";
+  }
+
+  const activeTarget = getCatalogScrollTargetElement(activeTargetId);
+
+  if (!activeTarget) {
+    return "unavailable";
+  }
+
+  return isCatalogActiveTargetAhead(activeTarget) ? "ahead" : "unavailable";
+}
+
+/**
+ * Visibility and direction are derived together from the same browser scroll
+ * read so the floating action does not briefly show the wrong destination.
+ */
+function getCatalogScrollState({
+  activeTargetId,
+  currentScrollY,
+  direction,
+}: {
+  activeTargetId: string | null;
+  currentScrollY: number;
+  direction: CatalogScrollDirection;
+}): CatalogScrollState {
+  return {
+    activeTargetPosition: getCatalogActiveTargetPosition({ activeTargetId }),
+    direction,
+    isVisible: isBackToTopVisible({ scrollY: currentScrollY }),
+  };
+}
+
+/**
+ * React should only re-render the floating action when its visible behavior
+ * changes; scroll events can fire many times with the same useful state.
+ */
+function isSameCatalogScrollState(left: CatalogScrollState, right: CatalogScrollState): boolean {
+  return (
+    left.activeTargetPosition === right.activeTargetPosition &&
+    left.direction === right.direction &&
+    left.isVisible === right.isVisible
+  );
+}
+
+/**
+ * The active shortcut is only useful while moving down toward a target that is
+ * still ahead. Missing, reached, or passed targets keep the existing top action.
+ */
+function getCatalogScrollActionMode({
+  activeTargetPosition,
+  direction,
+}: {
+  activeTargetPosition: CatalogActiveTargetPosition;
+  direction: CatalogScrollDirection;
+}): CatalogScrollActionMode {
+  if (activeTargetPosition === "ahead" && direction === "down") {
+    return "active";
+  }
+
+  return "top";
+}
+
+/**
+ * The href and JavaScript scroll target must stay identical so the anchor still
+ * has a valid no-JS destination.
+ */
+function getCatalogScrollTargetId({
+  activeTargetId,
+  mode,
+}: {
+  activeTargetId: string | null;
+  mode: CatalogScrollActionMode;
+}) {
+  if (mode === "active" && activeTargetId) {
+    return activeTargetId;
+  }
+
+  return CATALOG_TOP_TARGET_ID;
+}
+
+/**
+ * Users who reduce motion should still get the same destination without the
+ * animated movement that can make scrolling feel uncomfortable.
+ */
+function getBackToTopScrollBehavior(): ScrollBehavior {
+  if (globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    return "auto";
+  }
+
+  return "smooth";
+}
+
+/**
+ * Search filtering can remove the active tile after the floating action has
+ * already rendered, so clicks fall back to the permanent top anchor instead of
+ * becoming a no-op.
+ */
+function getCatalogScrollDestination({ targetId }: { targetId: string }) {
+  return (
+    getCatalogScrollTargetElement(targetId) ?? getCatalogScrollTargetElement(CATALOG_TOP_TARGET_ID)
+  );
+}
+
+/**
+ * The anchor href stays as a no-JS fallback, but hydrated catalog pages can
+ * scroll smoothly so floating-action jumps do not feel harsh.
+ */
+function handleCatalogScrollActionClick({
+  event,
+  targetId,
+}: {
+  event: MouseEvent<HTMLAnchorElement>;
+  targetId: string;
+}) {
+  event.preventDefault();
+
+  const catalogScrollTarget = getCatalogScrollDestination({ targetId });
+  catalogScrollTarget?.scrollIntoView({ behavior: getBackToTopScrollBehavior(), block: "start" });
+}
+
+/**
+ * Long generated course grids need a reachable escape hatch while scrolling,
+ * so this centralized action follows the viewport instead of waiting for the
+ * user to reach the end of the collection.
+ */
+export function CatalogGridBackToTop({
+  activeItemKey,
+  activeLabel,
+}: {
+  activeItemKey?: CatalogGridItemKey | null;
+  activeLabel?: string;
+}) {
+  const t = useExtracted();
+
+  const previousDirectionRef = useRef<CatalogScrollDirection>(
+    DEFAULT_CATALOG_SCROLL_STATE.direction,
+  );
+
+  const previousScrollYRef = useRef(0);
+  const [scrollState, setScrollState] = useState<CatalogScrollState>(DEFAULT_CATALOG_SCROLL_STATE);
+
+  const activeTargetId =
+    activeItemKey === null || activeItemKey === undefined
+      ? null
+      : getCatalogItemTargetId(activeItemKey);
+
+  const actionMode = getCatalogScrollActionMode({
+    activeTargetPosition: scrollState.activeTargetPosition,
+    direction: scrollState.direction,
+  });
+
+  const targetId = getCatalogScrollTargetId({ activeTargetId, mode: actionMode });
+  const label = actionMode === "active" ? (activeLabel ?? t("Current item")) : t("Back to top");
+
+  useEffect(() => {
+    /**
+     * Scroll position lives outside React, so the listener keeps this utility
+     * visible only when it can help without forcing every grid item to know
+     * anything about viewport state.
+     */
+    function syncCatalogScrollState() {
+      const currentScrollY = globalThis.scrollY;
+
+      const direction = getCatalogScrollDirection({
+        currentScrollY,
+        previousDirection: previousDirectionRef.current,
+        previousScrollY: previousScrollYRef.current,
+      });
+
+      const nextScrollState = getCatalogScrollState({ activeTargetId, currentScrollY, direction });
+
+      previousDirectionRef.current = direction;
+      previousScrollYRef.current = currentScrollY;
+
+      setScrollState((currentScrollState) =>
+        isSameCatalogScrollState(currentScrollState, nextScrollState)
+          ? currentScrollState
+          : nextScrollState,
+      );
+    }
+
+    syncCatalogScrollState();
+    globalThis.addEventListener("scroll", syncCatalogScrollState, { passive: true });
+
+    return () => globalThis.removeEventListener("scroll", syncCatalogScrollState);
+  }, [activeTargetId]);
+
+  return (
+    <GridBackToTop
+      aria-label={label}
+      className={cn(
+        "bg-background/85 border-border/40 fixed right-4 bottom-[calc(env(safe-area-inset-bottom)+1rem)] z-30 border shadow-[0_8px_24px_rgb(0_0_0/0.08)] backdrop-blur-md transition-all duration-150 md:right-6 [&_svg]:transition-transform",
+        actionMode === "active" && "[&_svg]:rotate-180",
+        scrollState.isVisible
+          ? "pointer-events-auto translate-y-0 opacity-100"
+          : "pointer-events-none translate-y-2 opacity-0",
+      )}
+      href={`#${targetId}`}
+      onClick={(event) => handleCatalogScrollActionClick({ event, targetId })}
+      title={label}
+    >
+      <span className="hidden sm:inline">{label}</span>
+    </GridBackToTop>
+  );
+}

--- a/apps/main/src/components/catalog/catalog-grid.tsx
+++ b/apps/main/src/components/catalog/catalog-grid.tsx
@@ -1,31 +1,22 @@
 "use client";
 
-import {
-  GridBackToTop,
-  GridContent,
-  GridEmpty,
-  GridGroupItem,
-  GridItem,
-} from "@zoonk/ui/components/grid";
+import { GridContent, GridEmpty, GridGroupItem, GridItem } from "@zoonk/ui/components/grid";
 import { Input } from "@zoonk/ui/components/input";
 import { cn } from "@zoonk/ui/lib/utils";
 import { normalizeString } from "@zoonk/utils/string";
 import { SearchIcon } from "lucide-react";
 import { type Route } from "next";
-import { useExtracted } from "next-intl";
 import Link from "next/link";
 import { useQueryState } from "nuqs";
-import { type MouseEvent, type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useMemo } from "react";
+import {
+  CatalogGridBackToTop,
+  type CatalogGridItemKey,
+  getCatalogItemTargetId,
+} from "./catalog-grid-back-to-top";
 import { CatalogGridContext, useCatalogGridContext } from "./catalog-grid-context";
-import { CATALOG_TOP_TARGET_ID } from "./catalog-top-target";
 
-type CatalogGridSearchItem = {
-  description?: string | null;
-  id: string | number | bigint;
-  title: string;
-};
-
-const BACK_TO_TOP_VISIBLE_SCROLL_Y = 360;
+type CatalogGridSearchItem = { description?: string | null; id: CatalogGridItemKey; title: string };
 
 /**
  * Catalog search should match the text learners scan inside each tile. Generated
@@ -51,99 +42,25 @@ function matchesCatalogSearchQuery({
 }
 
 /**
- * The floating top action should appear only after the reader has left the
- * page header; showing it immediately would add chrome before it can help.
- */
-function isBackToTopVisible({ scrollY }: { scrollY: number }): boolean {
-  return scrollY > BACK_TO_TOP_VISIBLE_SCROLL_Y;
-}
-
-/**
- * Users who reduce motion should still get the same destination without the
- * animated movement that can make scrolling feel uncomfortable.
- */
-function getBackToTopScrollBehavior(): ScrollBehavior {
-  if (globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-    return "auto";
-  }
-
-  return "smooth";
-}
-
-/**
- * The anchor href stays as a no-JS fallback, but hydrated catalog pages should
- * scroll smoothly so the jump back to the sticky navigation does not feel harsh.
- */
-function handleBackToTopClick(event: MouseEvent<HTMLAnchorElement>) {
-  event.preventDefault();
-
-  const catalogTopTarget = globalThis.document.querySelector(`#${CATALOG_TOP_TARGET_ID}`);
-  catalogTopTarget?.scrollIntoView({ behavior: getBackToTopScrollBehavior(), block: "start" });
-}
-
-/**
- * Long generated course grids need a reachable escape hatch while scrolling,
- * so this centralized action follows the viewport instead of waiting for the
- * user to reach the end of the collection.
- */
-function CatalogGridBackToTop() {
-  const t = useExtracted();
-  const [isVisible, setIsVisible] = useState(false);
-
-  useEffect(() => {
-    /**
-     * Scroll position lives outside React, so the listener keeps this utility
-     * visible only when it can help without forcing every grid item to know
-     * anything about viewport state.
-     */
-    function syncBackToTopVisibility() {
-      const nextIsVisible = isBackToTopVisible({ scrollY: globalThis.scrollY });
-
-      setIsVisible((currentIsVisible) =>
-        currentIsVisible === nextIsVisible ? currentIsVisible : nextIsVisible,
-      );
-    }
-
-    syncBackToTopVisibility();
-    globalThis.addEventListener("scroll", syncBackToTopVisibility, { passive: true });
-
-    return () => globalThis.removeEventListener("scroll", syncBackToTopVisibility);
-  }, []);
-
-  return (
-    <GridBackToTop
-      aria-label={t("Back to top")}
-      className={cn(
-        "bg-background/85 border-border/40 fixed right-4 bottom-[calc(env(safe-area-inset-bottom)+1rem)] z-30 border shadow-[0_8px_24px_rgb(0_0_0/0.08)] backdrop-blur-md transition-all duration-150 md:right-6",
-        isVisible
-          ? "pointer-events-auto translate-y-0 opacity-100"
-          : "pointer-events-none translate-y-2 opacity-0",
-      )}
-      href={`#${CATALOG_TOP_TARGET_ID}`}
-      onClick={handleBackToTopClick}
-      title={t("Back to top")}
-    >
-      <span className="hidden sm:inline">{t("Back to top")}</span>
-    </GridBackToTop>
-  );
-}
-
-/**
  * Catalog grids share the same floating utility action so course, chapter, and
  * lesson pages can offer quick scroll recovery without duplicating viewport
  * listeners or page-specific positioning.
  */
 export function CatalogGridContent({
+  activeItemKey,
+  activeLabel,
   children,
   className,
 }: {
+  activeItemKey?: CatalogGridItemKey | null;
+  activeLabel?: string;
   children: ReactNode;
   className?: string;
 }) {
   return (
     <GridContent className={className}>
       {children}
-      <CatalogGridBackToTop />
+      <CatalogGridBackToTop activeItemKey={activeItemKey} activeLabel={activeLabel} />
     </GridContent>
   );
 }
@@ -242,7 +159,7 @@ export function CatalogGridItem<Href extends string>({
   children: ReactNode;
   className?: string;
   href: Route<Href>;
-  id: string | number | bigint;
+  id: CatalogGridItemKey;
   prefetch?: boolean;
 }) {
   const context = useCatalogGridContext();
@@ -253,7 +170,7 @@ export function CatalogGridItem<Href extends string>({
   }
 
   return (
-    <GridGroupItem>
+    <GridGroupItem id={getCatalogItemTargetId(id)}>
       <GridItem className={className} render={<Link href={href} prefetch={prefetch} />}>
         {children}
       </GridItem>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
     "./player/queries/get-review-steps": "./src/player/queries/get-review-steps.ts",
     "./player/queries/get-total-brain-power": "./src/player/queries/get-total-brain-power.ts",
     "./progress/chapters": "./src/progress/get-chapter-progress.ts",
+    "./progress/active-catalog-target": "./src/progress/get-active-catalog-target.ts",
     "./progress/lessons": "./src/progress/get-lesson-progress.ts",
     "./progress/continue-lesson-target": "./src/progress/get-continue-lesson-target.ts",
     "./progress/next-lesson-state": "./src/progress/get-next-lesson-state.ts",

--- a/packages/core/src/progress/get-active-catalog-target.test.ts
+++ b/packages/core/src/progress/get-active-catalog-target.test.ts
@@ -1,0 +1,185 @@
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { beforeAll, describe, expect, it } from "vitest";
+import { getActiveCatalogTarget } from "./get-active-catalog-target";
+
+type CourseTree = {
+  chapter: Awaited<ReturnType<typeof chapterFixture>>;
+  course: Awaited<ReturnType<typeof courseFixture>>;
+  lessons: Awaited<ReturnType<typeof lessonFixture>>[];
+};
+
+type TwoChapterCourseTree = {
+  course: Awaited<ReturnType<typeof courseFixture>>;
+  firstChapter: Awaited<ReturnType<typeof chapterFixture>>;
+  firstChapterLessons: Awaited<ReturnType<typeof lessonFixture>>[];
+  secondChapter: Awaited<ReturnType<typeof chapterFixture>>;
+  secondChapterLessons: Awaited<ReturnType<typeof lessonFixture>>[];
+};
+
+describe(getActiveCatalogTarget, () => {
+  let organization: Awaited<ReturnType<typeof organizationFixture>>;
+
+  beforeAll(async () => {
+    organization = await organizationFixture({ kind: "brand" });
+  });
+
+  /**
+   * Active-target tests need a tiny published chapter with stable lesson order
+   * so each case can focus on the progress timestamp that defines "current".
+   */
+  async function createCourseTree(): Promise<CourseTree> {
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lessons = await Promise.all(
+      [0, 1, 2].map((position) =>
+        lessonFixture({
+          chapterId: chapter.id,
+          generationStatus: "completed",
+          isPublished: true,
+          organizationId: organization.id,
+          position,
+        }),
+      ),
+    );
+
+    return { chapter, course, lessons };
+  }
+
+  /**
+   * Course-level targets must ignore lessons the learner opened but did not
+   * complete, even when that opened lesson sits in a later chapter.
+   */
+  async function createTwoChapterCourseTree(): Promise<TwoChapterCourseTree> {
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
+    const [firstChapter, secondChapter] = await Promise.all(
+      [0, 1].map((position) =>
+        chapterFixture({
+          courseId: course.id,
+          isPublished: true,
+          organizationId: organization.id,
+          position,
+        }),
+      ),
+    );
+
+    if (!firstChapter || !secondChapter) {
+      throw new Error("Active catalog target fixture did not create both chapters.");
+    }
+
+    const firstChapterLessons = await Promise.all(
+      [0, 1].map((position) =>
+        lessonFixture({
+          chapterId: firstChapter.id,
+          generationStatus: "completed",
+          isPublished: true,
+          organizationId: organization.id,
+          position,
+        }),
+      ),
+    );
+
+    const secondChapterLessons = await Promise.all(
+      [0].map((position) =>
+        lessonFixture({
+          chapterId: secondChapter.id,
+          generationStatus: "completed",
+          isPublished: true,
+          organizationId: organization.id,
+          position,
+        }),
+      ),
+    );
+
+    return { course, firstChapter, firstChapterLessons, secondChapter, secondChapterLessons };
+  }
+
+  it("uses the next lesson after completion for course-level chapter targets", async () => {
+    const [user, tree] = await Promise.all([userFixture(), createTwoChapterCourseTree()]);
+    const [completedLesson, expectedLesson] = tree.firstChapterLessons;
+    const [startedLesson] = tree.secondChapterLessons;
+
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01T10:00:00Z"),
+        durationSeconds: 60,
+        lessonId: completedLesson?.id ?? "",
+        userId: user.id,
+      }),
+      lessonProgressFixture({
+        completedAt: null,
+        durationSeconds: null,
+        lessonId: startedLesson?.id ?? "",
+        startedAt: new Date("2024-01-02T10:00:00Z"),
+        userId: user.id,
+      }),
+    ]);
+
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getActiveCatalogTarget({ headers, scope: { courseId: tree.course.id } });
+
+    expect(result).toStrictEqual({
+      chapterSlug: tree.firstChapter.slug,
+      lessonSlug: expectedLesson?.slug,
+    });
+  });
+
+  it("ignores started lessons when lesson targets require completed progress", async () => {
+    const [user, tree] = await Promise.all([userFixture(), createCourseTree()]);
+    const startedLesson = tree.lessons[2];
+
+    await lessonProgressFixture({
+      completedAt: null,
+      durationSeconds: null,
+      lessonId: startedLesson?.id ?? "",
+      startedAt: new Date("2024-01-02T10:00:00Z"),
+      userId: user.id,
+    });
+
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getActiveCatalogTarget({ headers, scope: { chapterId: tree.chapter.id } });
+
+    expect(result).toBeNull();
+  });
+
+  it("uses the next lesson after the latest completed lesson", async () => {
+    const [user, tree] = await Promise.all([userFixture(), createCourseTree()]);
+    const [completedLesson, nextLesson, startedLesson] = tree.lessons;
+
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01T10:00:00Z"),
+        durationSeconds: 60,
+        lessonId: completedLesson?.id ?? "",
+        userId: user.id,
+      }),
+      lessonProgressFixture({
+        completedAt: null,
+        durationSeconds: null,
+        lessonId: startedLesson?.id ?? "",
+        startedAt: new Date("2024-01-02T10:00:00Z"),
+        userId: user.id,
+      }),
+    ]);
+
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getActiveCatalogTarget({ headers, scope: { chapterId: tree.chapter.id } });
+
+    expect(result).toStrictEqual({ chapterSlug: tree.chapter.slug, lessonSlug: nextLesson?.slug });
+  });
+});

--- a/packages/core/src/progress/get-active-catalog-target.ts
+++ b/packages/core/src/progress/get-active-catalog-target.ts
@@ -1,0 +1,29 @@
+import { type LessonScope } from "../lessons/find-last-completed";
+import { getContinueLessonTarget } from "./get-continue-lesson-target";
+
+export type ActiveCatalogTarget = { chapterSlug: string; lessonSlug?: string };
+
+/**
+ * The active catalog shortcut follows the same completed-progress continuation
+ * target as start/continue links, but stays hidden until the learner has
+ * actually completed something in the requested scope.
+ */
+export async function getActiveCatalogTarget({
+  headers,
+  scope,
+}: {
+  headers?: Headers;
+  scope: LessonScope;
+}): Promise<ActiveCatalogTarget | null> {
+  const target = await getContinueLessonTarget({ headers, scope });
+
+  if (!target?.hasStarted) {
+    return null;
+  }
+
+  if ("lessonSlug" in target) {
+    return { chapterSlug: target.chapterSlug, lessonSlug: target.lessonSlug };
+  }
+
+  return { chapterSlug: target.chapterSlug };
+}

--- a/packages/core/src/progress/get-continue-lesson-target.ts
+++ b/packages/core/src/progress/get-continue-lesson-target.ts
@@ -1,4 +1,5 @@
 import { type LessonScope, findLastCompleted } from "@zoonk/core/lessons/last-completed";
+import { cache } from "react";
 import { getNextChapterInCourse } from "../lessons/get-next-chapter-in-course";
 import { getSession } from "../users/get-user-session";
 import { type NextLessonState, getNextLessonStateForUser } from "./get-next-lesson-state";
@@ -18,55 +19,104 @@ type ContinueLessonTarget = ContinueLessonTargetBase & {
 };
 
 type ContinueChapterTarget = ContinueLessonTargetBase & { canPrefetch: false; completed: false };
+type LessonScopeKind = "chapterId" | "courseId" | "lessonId";
+type LessonScopeParts = { id: string; kind: LessonScopeKind };
+
+/**
+ * React cache needs stable positional values. Splitting the scope union into a
+ * key and id lets the sidebar CTA and catalog active shortcut share one
+ * progress lookup when they resolve the same course, chapter, or lesson.
+ */
+function getLessonScopeParts(scope: LessonScope): LessonScopeParts {
+  if ("courseId" in scope) {
+    return { id: scope.courseId, kind: "courseId" };
+  }
+
+  if ("chapterId" in scope) {
+    return { id: scope.chapterId, kind: "chapterId" };
+  }
+
+  return { id: scope.lessonId, kind: "lessonId" };
+}
+
+/**
+ * Rebuilds the public scope union from cached primitive arguments so the
+ * learner-aware continuation code can stay object-shaped and readable.
+ */
+function getLessonScopeFromParts({ id, kind }: LessonScopeParts): LessonScope {
+  if (kind === "courseId") {
+    return { courseId: id };
+  }
+
+  if (kind === "chapterId") {
+    return { chapterId: id };
+  }
+
+  return { lessonId: id };
+}
 
 /**
  * Resolves the lesson destination that start/continue/review buttons should
  * use for a learner. This stays separate from structural course navigation
  * because it folds in session state, durable completions, and prefetch safety.
  */
-export async function getContinueLessonTarget({
-  scope,
+const cachedGetContinueLessonTarget = cache(
+  async (
+    scopeKind: LessonScopeKind,
+    scopeId: string,
+    headers?: Headers,
+  ): Promise<ContinueChapterTarget | ContinueLessonTarget | null> => {
+    const scope = getLessonScopeFromParts({ id: scopeId, kind: scopeKind });
+
+    const session = await getSession(headers);
+    const userId = session?.user.id;
+    const lastCompleted = userId ? await findLastCompleted(userId, scope) : null;
+
+    const state = await getNextLessonStateForUser({
+      after: lastCompleted
+        ? {
+            chapterPosition: lastCompleted.chapterPosition,
+            lessonId: lastCompleted.lessonId,
+            lessonPosition: lastCompleted.lessonPosition,
+          }
+        : undefined,
+      scope,
+      userId,
+    });
+
+    if (!state) {
+      return null;
+    }
+
+    const pendingChapterTarget = await getPendingChapterTarget({ scope, state });
+
+    if (pendingChapterTarget) {
+      return pendingChapterTarget;
+    }
+
+    return {
+      brandSlug: state.brandSlug,
+      canPrefetch: state.canPrefetch,
+      chapterSlug: state.chapterSlug,
+      completed: state.completed,
+      courseSlug: state.courseSlug,
+      hasStarted: state.hasStarted,
+      lessonPosition: state.lessonPosition,
+      lessonSlug: state.lessonSlug,
+    };
+  },
+);
+
+export function getContinueLessonTarget({
   headers,
+  scope,
 }: {
-  scope: LessonScope;
   headers?: Headers;
+  scope: LessonScope;
 }): Promise<ContinueChapterTarget | ContinueLessonTarget | null> {
-  const session = await getSession(headers);
-  const userId = session?.user.id;
-  const lastCompleted = userId ? await findLastCompleted(userId, scope) : null;
+  const { id, kind } = getLessonScopeParts(scope);
 
-  const state = await getNextLessonStateForUser({
-    after: lastCompleted
-      ? {
-          chapterPosition: lastCompleted.chapterPosition,
-          lessonId: lastCompleted.lessonId,
-          lessonPosition: lastCompleted.lessonPosition,
-        }
-      : undefined,
-    scope,
-    userId,
-  });
-
-  if (!state) {
-    return null;
-  }
-
-  const pendingChapterTarget = await getPendingChapterTarget({ scope, state });
-
-  if (pendingChapterTarget) {
-    return pendingChapterTarget;
-  }
-
-  return {
-    brandSlug: state.brandSlug,
-    canPrefetch: state.canPrefetch,
-    chapterSlug: state.chapterSlug,
-    completed: state.completed,
-    courseSlug: state.courseSlug,
-    hasStarted: state.hasStarted,
-    lessonPosition: state.lessonPosition,
-    lessonSlug: state.lessonSlug,
-  };
+  return cachedGetContinueLessonTarget(kind, id, headers);
 }
 
 /**


### PR DESCRIPTION
## Summary

- add active chapter/lesson shortcut behavior to catalog floating scroll action
- reuse continue-target progress logic so started-only lessons are ignored
- cover course and chapter scroll behavior with e2e coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a context-aware floating scroll shortcut to catalog pages. It jumps to the current chapter/lesson while scrolling down and switches back to "Back to top" after passing the target.

- New Features
  - Floating action now targets the active catalog item when it’s ahead; otherwise shows "Back to top".
  - Uses completed-progress via `@zoonk/core/progress/continue-lesson-target`, so started-only lessons are ignored.
  - Works with no-JS fallback and respects reduced motion.
  - Added labels: "Current chapter", "Current lesson", and "Current item" (en/es/pt).

- Refactors
  - Introduced `CatalogGridBackToTop` and stable item anchors; `CatalogGridContent` accepts `activeItemKey` and `activeLabel`.
  - Added `@zoonk/core/progress/active-catalog-target` and cached `get-continue-lesson-target`.
  - Replaced inline back-to-top logic in `catalog-grid.tsx`.
  - Added e2e coverage for course/chapter behavior and unit tests for the active target.

<sup>Written for commit b55cbe9ad64e0e4a9e4cf5371d64b92b2c64806a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

