### PR TITLE
feat(admin): add user learning stats

### DIFF
--- a/apps/admin/src/app/(private)/users/[id]/user-courses.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-courses.tsx
@@ -31,6 +31,7 @@ export async function UserCourses({ userId }: { userId: string }) {
               <TableRow>
                 <TableHead>Course</TableHead>
                 <TableHead>Organization</TableHead>
+                <TableHead className="text-right">Completed chapters</TableHead>
                 <TableHead>Last updated</TableHead>
                 <TableHead>Started</TableHead>
               </TableRow>
@@ -59,6 +60,10 @@ function UserCourseRow({ course }: { course: UserStartedCourse }) {
     <TableRow>
       <TableCell className="font-medium">{course.course.title}</TableCell>
       <TableCell>{course.course.organization?.name ?? "—"}</TableCell>
+      <TableCell className="text-right tabular-nums">
+        {course.completedChapterCount.toLocaleString()} /{" "}
+        {course.course._count.chapters.toLocaleString()}
+      </TableCell>
       <TableCell className="text-muted-foreground">{formatDate(course.course.updatedAt)}</TableCell>
       <TableCell className="text-muted-foreground">{formatDate(course.startedAt)}</TableCell>
     </TableRow>

--- a/apps/admin/src/app/(private)/users/[id]/user-lesson.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-lesson.tsx
@@ -1,9 +1,30 @@
 import { getUser } from "@/data/users/get-user";
+import {
+  type UserLearningKindStat,
+  getUserLearningStats,
+} from "@/data/users/get-user-learning-stats";
+import { formatDuration } from "@/lib/format-duration";
+import { getAdminLessonKindLabel } from "@/lib/lesson-label";
 import { Separator } from "@zoonk/ui/components/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
 import { DetailField } from "./detail-field";
 
+/**
+ * The admin user detail page combines account progress with durable lesson
+ * completion stats so support can answer learning-history questions in one view.
+ */
 export async function UserLesson({ userId }: { userId: string }) {
-  const user = await getUser(userId);
+  const [user, learningStats] = await Promise.all([
+    getUser(userId),
+    getUserLearningStats({ userId }),
+  ]);
 
   if (!user) {
     return null;
@@ -13,7 +34,7 @@ export async function UserLesson({ userId }: { userId: string }) {
 
   return (
     <section>
-      <h3 className="mb-2 text-sm font-semibold">Lesson</h3>
+      <h3 className="mb-2 text-sm font-semibold">Learning</h3>
       <Separator />
 
       <dl className="mt-2">
@@ -22,6 +43,18 @@ export async function UserLesson({ userId }: { userId: string }) {
         </DetailField>
 
         <DetailField label="Current energy">{progress?.currentEnergy ?? 0}</DetailField>
+
+        <DetailField label="Total learning time">
+          {formatDuration(learningStats.totalLearningSeconds)}
+        </DetailField>
+
+        <DetailField label="Learning days">
+          {learningStats.learningDays.toLocaleString()}
+        </DetailField>
+
+        <DetailField label="Completed lessons">
+          {learningStats.completedLessons.toLocaleString()}
+        </DetailField>
 
         <DetailField label="Last active">
           {progress?.lastActiveAt ? new Date(progress.lastActiveAt).toLocaleDateString() : "—"}
@@ -35,6 +68,68 @@ export async function UserLesson({ userId }: { userId: string }) {
             : "—"}
         </DetailField>
       </dl>
+
+      <LessonKindBreakdown rows={learningStats.lessonKinds} />
     </section>
   );
+}
+
+/**
+ * The breakdown is hidden for learners with no completions so the section stays
+ * compact while still showing the zero-value summary fields above.
+ */
+function LessonKindBreakdown({ rows }: { rows: UserLearningKindStat[] }) {
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-4 overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Lesson kind</TableHead>
+            <TableHead className="text-right">Completed</TableHead>
+            <TableHead className="text-right">Avg time</TableHead>
+            <TableHead className="text-right">Total time</TableHead>
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          {rows.map((row) => (
+            <LessonKindBreakdownRow key={row.kind} row={row} />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+/**
+ * Formatting happens in the row so the table structure stays focused on
+ * semantics and each duration column handles missing historical telemetry.
+ */
+function LessonKindBreakdownRow({ row }: { row: UserLearningKindStat }) {
+  return (
+    <TableRow>
+      <TableCell className="font-medium">{getAdminLessonKindLabel(row.kind)}</TableCell>
+      <TableCell className="text-right tabular-nums">
+        {row.completedLessons.toLocaleString()}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {formatOptionalDuration(row.avgDurationSeconds)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {formatDuration(row.totalDurationSeconds)}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+/**
+ * Null averages mean the learner completed that kind before duration data was
+ * available, so an em dash is more honest than a zero-second lesson.
+ */
+function formatOptionalDuration(durationSeconds: number | null) {
+  return durationSeconds === null ? "—" : formatDuration(durationSeconds);
 }

--- a/apps/admin/src/data/users/get-user-learning-stats.ts
+++ b/apps/admin/src/data/users/get-user-learning-stats.ts
@@ -1,0 +1,210 @@
+import "server-only";
+import { isAdmin } from "@/lib/admin-guard";
+import { type LessonKind, prisma } from "@zoonk/db";
+import { cache } from "react";
+
+type CompletedLessonRow = Awaited<ReturnType<typeof findUserCompletedLessonRows>>[number];
+type LearningDayRow = Awaited<ReturnType<typeof findUserLearningDayRows>>[number];
+
+type LessonKindTotals = {
+  completedLessons: number;
+  durationSampleCount: number;
+  totalDurationSeconds: number;
+};
+
+export type UserLearningKindStat = {
+  avgDurationSeconds: number | null;
+  completedLessons: number;
+  kind: LessonKind;
+  totalDurationSeconds: number;
+};
+
+export type UserLearningStats = {
+  completedLessons: number;
+  learningDays: number;
+  lessonKinds: UserLearningKindStat[];
+  totalLearningSeconds: number;
+};
+
+const emptyUserLearningStats: UserLearningStats = {
+  completedLessons: 0,
+  learningDays: 0,
+  lessonKinds: [],
+  totalLearningSeconds: 0,
+};
+
+const cachedGetUserLearningStats = cache(async (userId: string): Promise<UserLearningStats> => {
+  if (!(await isAdmin())) {
+    return emptyUserLearningStats;
+  }
+
+  const [completedLessons, learningDays] = await Promise.all([
+    findUserCompletedLessonRows({ userId }),
+    findUserLearningDayRows({ userId }),
+  ]);
+
+  return buildUserLearningStats({ completedLessons, learningDays });
+});
+
+/**
+ * User detail sections pass route params as primitive cache keys so React can
+ * dedupe the admin-only progress queries across one request.
+ */
+export async function getUserLearningStats(params: { userId: string }) {
+  return cachedGetUserLearningStats(params.userId);
+}
+
+/**
+ * LessonProgress is the source of truth for completed lesson counts and
+ * duration by kind because each completion row points at the exact lesson type.
+ */
+function findUserCompletedLessonRows({ userId }: { userId: string }) {
+  return prisma.lessonProgress.findMany({
+    include: { lesson: { select: { kind: true } } },
+    orderBy: [{ completedAt: "asc" }, { id: "asc" }],
+    where: { completedAt: { not: null }, userId },
+  });
+}
+
+/**
+ * DailyProgress stores the learner's client-local completion date, so it is the
+ * best source for counting calendar learning days and total app learning time.
+ */
+function findUserLearningDayRows({ userId }: { userId: string }) {
+  return prisma.dailyProgress.findMany({
+    orderBy: [{ date: "asc" }, { id: "asc" }],
+    where: { OR: [{ interactiveCompleted: { gt: 0 } }, { staticCompleted: { gt: 0 } }], userId },
+  });
+}
+
+/**
+ * The user page needs one compact object for the summary fields and the lesson
+ * kind breakdown, while each source table answers a different part of that view.
+ */
+function buildUserLearningStats({
+  completedLessons,
+  learningDays,
+}: {
+  completedLessons: CompletedLessonRow[];
+  learningDays: LearningDayRow[];
+}): UserLearningStats {
+  return {
+    completedLessons: completedLessons.length,
+    learningDays: learningDays.length,
+    lessonKinds: buildLessonKindStats({ rows: completedLessons }),
+    totalLearningSeconds: sumLearningTime({ rows: learningDays }),
+  };
+}
+
+/**
+ * DailyProgress may contain decay-only rows, so callers filter to learning days
+ * first and this helper can stay a simple duration sum.
+ */
+function sumLearningTime({ rows }: { rows: LearningDayRow[] }) {
+  return rows.reduce((total, row) => total + row.timeSpentSeconds, 0);
+}
+
+/**
+ * Grouping by lesson kind lets support compare how this learner spends time
+ * across explanations, practice, quizzes, and language companion lessons.
+ */
+function buildLessonKindStats({ rows }: { rows: CompletedLessonRow[] }) {
+  const grouped = groupCompletedLessonsByKind({ rows });
+
+  return Array.from(grouped.entries(), ([kind, totals]) =>
+    buildLessonKindStat({ kind, totals }),
+  ).toSorted(sortLessonKindStats);
+}
+
+/**
+ * Duration can be missing on historical completions, so each kind tracks both
+ * total completions and the number of rows that can safely contribute to an average.
+ */
+function groupCompletedLessonsByKind({ rows }: { rows: CompletedLessonRow[] }) {
+  const grouped = new Map<LessonKind, LessonKindTotals>();
+
+  for (const row of rows) {
+    const kind = row.lesson.kind;
+    const totals = grouped.get(kind) ?? createEmptyLessonKindTotals();
+
+    grouped.set(
+      kind,
+      addCompletedLessonToKindTotals({ durationSeconds: row.durationSeconds, totals }),
+    );
+  }
+
+  return grouped;
+}
+
+/**
+ * A fresh totals object avoids sharing mutable state between lesson-kind groups.
+ */
+function createEmptyLessonKindTotals(): LessonKindTotals {
+  return { completedLessons: 0, durationSampleCount: 0, totalDurationSeconds: 0 };
+}
+
+/**
+ * Completed rows without a duration still count as completed lessons, but they
+ * should not pull the average duration down to zero.
+ */
+function addCompletedLessonToKindTotals({
+  durationSeconds,
+  totals,
+}: {
+  durationSeconds: number | null;
+  totals: LessonKindTotals;
+}): LessonKindTotals {
+  if (durationSeconds === null) {
+    return { ...totals, completedLessons: totals.completedLessons + 1 };
+  }
+
+  return {
+    completedLessons: totals.completedLessons + 1,
+    durationSampleCount: totals.durationSampleCount + 1,
+    totalDurationSeconds: totals.totalDurationSeconds + durationSeconds,
+  };
+}
+
+/**
+ * The UI displays null averages as empty data, which is clearer than showing
+ * zero seconds for old completions that simply lack duration telemetry.
+ */
+function buildLessonKindStat({
+  kind,
+  totals,
+}: {
+  kind: LessonKind;
+  totals: LessonKindTotals;
+}): UserLearningKindStat {
+  return {
+    avgDurationSeconds: getAverageDurationSeconds({ totals }),
+    completedLessons: totals.completedLessons,
+    kind,
+    totalDurationSeconds: totals.totalDurationSeconds,
+  };
+}
+
+/**
+ * Average lesson time should only use rows that actually recorded time spent.
+ */
+function getAverageDurationSeconds({ totals }: { totals: LessonKindTotals }) {
+  if (totals.durationSampleCount === 0) {
+    return null;
+  }
+
+  return Math.round(totals.totalDurationSeconds / totals.durationSampleCount);
+}
+
+/**
+ * Admins usually scan for the most-used lesson kinds first, with a stable
+ * alphabetical fallback when two kinds have the same completion count.
+ */
+function sortLessonKindStats(first: UserLearningKindStat, second: UserLearningKindStat) {
+  const completedLessonDifference = second.completedLessons - first.completedLessons;
+
+  if (completedLessonDifference !== 0) {
+    return completedLessonDifference;
+  }
+
+  return first.kind.localeCompare(second.kind);
+}

--- a/apps/admin/src/data/users/list-user-started-courses.ts
+++ b/apps/admin/src/data/users/list-user-started-courses.ts
@@ -3,14 +3,22 @@ import { isAdmin } from "@/lib/admin-guard";
 import { prisma } from "@zoonk/db";
 import { cache } from "react";
 
-export type UserStartedCourse = Awaited<ReturnType<typeof findUserStartedCourseRows>>[number];
+type UserStartedCourseRow = Awaited<ReturnType<typeof findUserStartedCourseRows>>[number];
+
+type UserCompletedCourseChapter = Awaited<
+  ReturnType<typeof findUserCompletedCourseChapters>
+>[number];
+
+export type UserStartedCourse = UserStartedCourseRow & { completedChapterCount: number };
 
 const cachedListUserStartedCourses = cache(async (userId: string) => {
   if (!(await isAdmin())) {
     return [];
   }
 
-  return findUserStartedCourseRows({ userId });
+  const courses = await findUserStartedCourseRows({ userId });
+
+  return addCompletedChapterCounts({ courses, userId });
 });
 
 /**
@@ -23,14 +31,89 @@ export async function listUserStartedCourses(params: { userId: string }) {
 }
 
 /**
- * CourseUser is the durable "started this course" record. Sorting by the
- * course's own update timestamp keeps this admin view simple and avoids
- * computing lesson-level progress for a support-oriented course list.
+ * CourseUser is the durable "started this course" record. Including the total
+ * chapter count here lets the row show completed chapters with useful context.
  */
 function findUserStartedCourseRows({ userId }: { userId: string }) {
   return prisma.courseUser.findMany({
-    include: { course: { include: { organization: true } } },
+    include: {
+      course: {
+        include: {
+          _count: { select: { chapters: { where: { isPublished: true } } } },
+          organization: true,
+        },
+      },
+    },
     orderBy: [{ course: { updatedAt: "desc" } }, { startedAt: "desc" }, { id: "asc" }],
     where: { userId },
   });
+}
+
+/**
+ * ChapterCompletion stores durable chapter rollups, so counting those rows is
+ * cheaper and more faithful than recomputing every lesson inside every course.
+ */
+async function addCompletedChapterCounts({
+  courses,
+  userId,
+}: {
+  courses: UserStartedCourseRow[];
+  userId: string;
+}): Promise<UserStartedCourse[]> {
+  if (courses.length === 0) {
+    return [];
+  }
+
+  const completions = await findUserCompletedCourseChapters({
+    courseIds: courses.map((course) => course.courseId),
+    userId,
+  });
+
+  const completedChaptersByCourseId = countCompletedChaptersByCourse({ completions });
+
+  return courses.map((course) => ({
+    ...course,
+    completedChapterCount: completedChaptersByCourseId.get(course.courseId) ?? 0,
+  }));
+}
+
+/**
+ * Fetching only completions for the visible course rows keeps the detail page
+ * bounded even for learners with progress across many unrelated courses.
+ */
+function findUserCompletedCourseChapters({
+  courseIds,
+  userId,
+}: {
+  courseIds: string[];
+  userId: string;
+}) {
+  return prisma.chapterCompletion.findMany({
+    include: { chapter: { select: { courseId: true } } },
+    where: {
+      chapter: { course: { isPublished: true }, courseId: { in: courseIds }, isPublished: true },
+      userId,
+    },
+  });
+}
+
+/**
+ * The course table renders one row per course, so chapter completion rows are
+ * grouped once by course id before the render data is assembled.
+ */
+function countCompletedChaptersByCourse({
+  completions,
+}: {
+  completions: UserCompletedCourseChapter[];
+}) {
+  const countsByCourseId = new Map<string, number>();
+
+  for (const completion of completions) {
+    const courseId = completion.chapter.courseId;
+    const completedCount = countsByCourseId.get(courseId) ?? 0;
+
+    countsByCourseId.set(courseId, completedCount + 1);
+  }
+
+  return countsByCourseId;
 }


### PR DESCRIPTION
## Summary
- add per-user learning time, learning days, and lesson-kind breakdown to admin user details
- show completed chapter counts in each started course row
- source stats from durable lesson, daily, and chapter progress rows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add user learning stats to the admin user detail page to give support a clear view of a learner’s history. Shows total learning time, learning days, completed lessons, a lesson-kind breakdown with averages, and completed chapters per started course.

- **New Features**
  - Aggregate stats from durable `lessonProgress`, `dailyProgress`, and `chapterCompletion`; averages ignore missing durations and the breakdown hides when empty.
  - Cache per-user results with React `cache` and enforce `isAdmin` guard.
  - Course rows now display completed chapters as X / total using chapter completions and course `_count`.

<sup>Written for commit 73cf564aaa50f994d12ac905da2bf81bb86f1cb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

