### PR TITLE
feat(main): add catalog progress to continue buttons

### DIFF
--- a/apps/main/e2e/chapter-progress.test.ts
+++ b/apps/main/e2e/chapter-progress.test.ts
@@ -83,7 +83,7 @@ async function completeLessons({ lessons, userId }: { lessons: { id: string }[];
 }
 
 test.describe("Chapter Progress Indicators", () => {
-  test("shows no indicators when user has no progress", async ({ authenticatedPage }) => {
+  test("shows zero lesson progress without card indicators", async ({ authenticatedPage }) => {
     const { chapter, course } = await createChapterProgressScenario();
 
     await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
@@ -93,6 +93,8 @@ test.describe("Chapter Progress Indicators", () => {
     ).toBeVisible();
 
     const main = authenticatedPage.getByRole("main");
+    await expect(main.getByRole("link", { name: "Start 0 of 3 lessons completed" })).toBeVisible();
+    await expect(main.getByText("0/3")).toBeVisible();
     await expect(main.getByText(/^completed$/iu)).toHaveCount(0);
     await expect(main.getByText(/\d+\/\d+ done/u)).toHaveCount(0);
   });
@@ -129,6 +131,12 @@ test.describe("Chapter Progress Indicators", () => {
     ).toBeVisible();
 
     const main = authenticatedPage.getByRole("main");
+
+    await expect(
+      main.getByRole("link", { name: "Continue 1 of 3 lessons completed" }),
+    ).toBeVisible();
+
+    await expect(main.getByText("1/3")).toBeVisible();
     await expect(main.getByText(/^completed$/iu)).toHaveCount(1);
     await expect(main.getByText(/\d+\/\d+ done/u)).toHaveCount(0);
   });

--- a/apps/main/e2e/continue-lesson-link.test.ts
+++ b/apps/main/e2e/continue-lesson-link.test.ts
@@ -4,7 +4,27 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
-import { expect, test } from "./fixtures";
+import { type Page, expect, test } from "./fixtures";
+
+type ContinueActionLabel = "Continue" | "Review" | "Start";
+
+/**
+ * Continue buttons expose the compact progress suffix in their accessible
+ * names, so route-focused tests should match the action while allowing the
+ * optional progress details appended after it.
+ */
+function getContinueActionLink({ label, page }: { label: ContinueActionLabel; page: Page }) {
+  return page.getByRole("link", { name: getContinueActionName({ label }) });
+}
+
+/**
+ * The progress suffix differs by scope: courses announce chapters while
+ * chapters announce lessons. These tests only need the CTA action, so this
+ * helper keeps that accessible-name detail in one place.
+ */
+function getContinueActionName({ label }: { label: ContinueActionLabel }) {
+  return new RegExp(`^${label}(?: \\d+ of \\d+ (?:chapters|lessons) completed)?$`, "iu");
+}
 
 async function createTestCourseWithLesson() {
   const org = await getAiOrganization();
@@ -114,7 +134,7 @@ test.describe("Continue Lesson Link", () => {
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
-    const startLink = page.getByRole("link", { name: /^start$/iu });
+    const startLink = getContinueActionLink({ label: "Start", page });
     await expect(startLink).toBeVisible();
   });
 
@@ -123,7 +143,7 @@ test.describe("Continue Lesson Link", () => {
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
-    const startLink = page.getByRole("link", { name: /^start$/iu });
+    const startLink = getContinueActionLink({ label: "Start", page });
     await expect(startLink).toBeVisible();
     await startLink.click();
 
@@ -137,7 +157,7 @@ test.describe("Continue Lesson Link", () => {
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`);
 
-    const startLink = page.getByRole("link", { name: /^start$/iu });
+    const startLink = getContinueActionLink({ label: "Start", page });
     await expect(startLink).toBeVisible();
   });
 
@@ -159,7 +179,7 @@ test.describe("Continue Lesson Link", () => {
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
-    const startLink = page.getByRole("link", { name: /^start$/iu });
+    const startLink = getContinueActionLink({ label: "Start", page });
     await expect(startLink).toBeVisible();
 
     await expect(startLink).toHaveAttribute(
@@ -173,7 +193,7 @@ test.describe("Continue Lesson Link", () => {
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`);
 
-    const startLink = page.getByRole("link", { name: /^start$/iu });
+    const startLink = getContinueActionLink({ label: "Start", page });
     await expect(startLink).toBeVisible();
 
     await expect(startLink).toHaveAttribute(
@@ -209,7 +229,7 @@ test.describe("Continue Lesson Link", () => {
 
     await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
-    const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/iu });
+    const continueLink = getContinueActionLink({ label: "Continue", page: authenticatedPage });
     await expect(continueLink).toBeVisible();
 
     await expect(continueLink).toHaveAttribute(
@@ -243,7 +263,7 @@ test.describe("Continue Lesson Link", () => {
 
     await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
-    const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/iu });
+    const continueLink = getContinueActionLink({ label: "Continue", page: authenticatedPage });
     await expect(continueLink).toBeVisible();
   });
 
@@ -273,7 +293,7 @@ test.describe("Continue Lesson Link", () => {
 
     await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
-    const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/iu });
+    const continueLink = getContinueActionLink({ label: "Continue", page: authenticatedPage });
     await expect(continueLink).toBeVisible();
 
     await expect(continueLink).toHaveAttribute(
@@ -334,7 +354,7 @@ test.describe("Continue Lesson Link", () => {
 
     await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
-    const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/iu });
+    const continueLink = getContinueActionLink({ label: "Continue", page: authenticatedPage });
     await expect(continueLink).toBeVisible();
 
     await expect(continueLink).toHaveAttribute(
@@ -404,7 +424,7 @@ test.describe("Continue Lesson Link", () => {
 
     await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter1.slug}`);
 
-    const continueLink = authenticatedPage.getByRole("link", { name: /^continue$/iu });
+    const continueLink = getContinueActionLink({ label: "Continue", page: authenticatedPage });
     await expect(continueLink).toBeVisible();
 
     await expect(continueLink).toHaveAttribute(
@@ -428,7 +448,7 @@ test.describe("Continue Lesson Link", () => {
 
     await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
-    const reviewLink = authenticatedPage.getByRole("link", { name: /^review$/iu });
+    const reviewLink = getContinueActionLink({ label: "Review", page: authenticatedPage });
     await expect(reviewLink).toBeVisible();
   });
 });

--- a/apps/main/e2e/course-progress.test.ts
+++ b/apps/main/e2e/course-progress.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -153,8 +154,8 @@ async function createCourseWithIncompleteChapter() {
 }
 
 /**
- * Direct lesson completion is the only progress signal these catalog tests
- * need. This helper keeps the setup consistent across aggregate scenarios.
+ * Chapter cards still derive their status from direct lesson completion, so
+ * this helper keeps that lower-level setup consistent across scenarios.
  */
 async function completeLessons({ lessons, userId }: { lessons: { id: string }[]; userId: string }) {
   await Promise.all(
@@ -169,8 +170,26 @@ async function completeLessons({ lessons, userId }: { lessons: { id: string }[];
   );
 }
 
+/**
+ * The course Continue button counts durable chapter completions because
+ * generated lessons are not a stable course-level unit.
+ */
+async function completeChapters({
+  chapters,
+  userId,
+}: {
+  chapters: { id: string }[];
+  userId: string;
+}) {
+  await Promise.all(
+    chapters.map((chapter) =>
+      prisma.chapterCompletion.create({ data: { chapterId: chapter.id, userId } }),
+    ),
+  );
+}
+
 test.describe("Course Progress Indicators", () => {
-  test("shows no indicators when user has no progress", async ({ authenticatedPage }) => {
+  test("shows zero chapter progress without card indicators", async ({ authenticatedPage }) => {
     const { course } = await createCourseProgressScenario();
 
     await authenticatedPage.goto(`/b/ai/c/${course.slug}`);
@@ -180,6 +199,8 @@ test.describe("Course Progress Indicators", () => {
     ).toBeVisible();
 
     const main = authenticatedPage.getByRole("main");
+    await expect(main.getByRole("link", { name: "Start 0 of 3 chapters completed" })).toBeVisible();
+    await expect(main.getByText("0/3")).toBeVisible();
     await expect(main.getByText(/^completed$/iu)).toHaveCount(0);
     await expect(main.getByText(/\d+\/\d+ done/u)).toHaveCount(0);
   });
@@ -188,9 +209,14 @@ test.describe("Course Progress Indicators", () => {
     authenticatedPage,
     withProgressUser,
   }) => {
-    const { lessons, course } = await createCourseProgressScenario();
+    const { chapter1, chapter2, chapter3, lessons, course } = await createCourseProgressScenario();
 
     await completeLessons({ lessons: Object.values(lessons), userId: withProgressUser.id });
+
+    await completeChapters({
+      chapters: [chapter1, chapter2, chapter3],
+      userId: withProgressUser.id,
+    });
 
     await authenticatedPage.goto(`/b/ai/c/${course.slug}`);
 
@@ -198,10 +224,17 @@ test.describe("Course Progress Indicators", () => {
       authenticatedPage.getByRole("heading", { level: 1, name: course.title }),
     ).toBeVisible();
 
+    const main = authenticatedPage.getByRole("main");
+
+    await expect(
+      main.getByRole("link", { name: "Review 3 of 3 chapters completed" }),
+    ).toBeVisible();
+
+    await expect(main.getByText("3/3")).toBeVisible();
     await expect(authenticatedPage.getByRole("main").getByText(/^completed$/iu)).toHaveCount(3);
   });
 
-  test("shows fraction text for partially completed chapters", async ({
+  test("shows chapter fraction even when only lessons are partially completed", async ({
     authenticatedPage,
     withProgressUser,
   }) => {
@@ -218,6 +251,13 @@ test.describe("Course Progress Indicators", () => {
       authenticatedPage.getByRole("heading", { level: 1, name: course.title }),
     ).toBeVisible();
 
+    const main = authenticatedPage.getByRole("main");
+
+    await expect(
+      main.getByRole("link", { name: "Continue 0 of 3 chapters completed" }),
+    ).toBeVisible();
+
+    await expect(main.getByText("0/3")).toBeVisible();
     await expect(authenticatedPage.getByText("1/3 done")).toBeVisible();
     await expect(authenticatedPage.getByText("1/2 done")).toBeVisible();
   });

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1683,6 +1683,14 @@ msgid "Gs9Kfp"
 msgstr "Back to top"
 
 #: src/components/catalog/continue-lesson-link.tsx
+msgid "4gKxIm"
+msgstr "{completed} of {total} chapters completed"
+
+#: src/components/catalog/continue-lesson-link.tsx
+msgid "grFxqs"
+msgstr "{completed} of {total} lessons completed"
+
+#: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"
 msgstr "Start"
 

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1683,6 +1683,14 @@ msgid "Gs9Kfp"
 msgstr "Volver arriba"
 
 #: src/components/catalog/continue-lesson-link.tsx
+msgid "4gKxIm"
+msgstr "{completed} de {total} capítulos completados"
+
+#: src/components/catalog/continue-lesson-link.tsx
+msgid "grFxqs"
+msgstr "{completed} de {total} lecciones completadas"
+
+#: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"
 msgstr "Comenzar"
 

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1683,6 +1683,14 @@ msgid "Gs9Kfp"
 msgstr "Voltar ao topo"
 
 #: src/components/catalog/continue-lesson-link.tsx
+msgid "4gKxIm"
+msgstr "{completed} de {total} capítulos concluídos"
+
+#: src/components/catalog/continue-lesson-link.tsx
+msgid "grFxqs"
+msgstr "{completed} de {total} aulas concluídas"
+
+#: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"
 msgstr "Começar"
 

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -5,13 +5,13 @@ import {
   CatalogGridSearch,
 } from "@/components/catalog/catalog-grid";
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
+import { getCatalogLessonProgress } from "@/data/progress/catalog-progress";
 import { getDefaultLessonImage } from "@/lib/catalog/default-images";
 import { getLessonDisplayMeta } from "@/lib/lessons";
 import {
   type ActiveCatalogTarget,
   getActiveCatalogTarget,
 } from "@zoonk/core/progress/active-catalog-target";
-import { getLessonProgress } from "@zoonk/core/progress/lessons";
 import { type Lesson } from "@zoonk/db";
 import {
   GridGroup,
@@ -153,7 +153,7 @@ export async function LessonList({
   const t = await getExtracted();
 
   const [completionData, activeTarget] = await Promise.all([
-    getLessonProgress({ chapterId }),
+    getCatalogLessonProgress(chapterId),
     getActiveCatalogTarget({ scope: { chapterId } }),
   ]);
 

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -6,11 +6,11 @@ import {
 } from "@/components/catalog/catalog-grid";
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { type CourseChapter } from "@/data/chapters/list-course-chapters";
+import { getCatalogChapterProgress } from "@/data/progress/catalog-progress";
 import {
   type ActiveCatalogTarget,
   getActiveCatalogTarget,
 } from "@zoonk/core/progress/active-catalog-target";
-import { getChapterProgress } from "@zoonk/core/progress/chapters";
 import {
   GridGroup,
   GridItemContent,
@@ -197,7 +197,7 @@ export async function ChapterList({
   const t = await getExtracted();
 
   const [completionData, activeTarget] = await Promise.all([
-    getChapterProgress({ courseId }),
+    getCatalogChapterProgress(courseId),
     getActiveCatalogTarget({ scope: { courseId } }),
   ]);
 

--- a/apps/main/src/components/catalog/continue-lesson-link.tsx
+++ b/apps/main/src/components/catalog/continue-lesson-link.tsx
@@ -1,3 +1,8 @@
+import {
+  type ContinueLessonProgress,
+  getChapterContinueProgress,
+  getCourseContinueProgress,
+} from "@/data/progress/catalog-progress";
 import { type LessonScope } from "@zoonk/core/lessons/last-completed";
 import { getContinueLessonTarget } from "@zoonk/core/progress/continue-lesson-target";
 import { Button, buttonVariants } from "@zoonk/ui/components/button";
@@ -6,6 +11,8 @@ import { ChevronRightIcon } from "lucide-react";
 import { type Route } from "next";
 import { getExtracted } from "next-intl/server";
 import Link from "next/link";
+
+type ContinueLessonProgressContent = { ariaLabel: string; text: string };
 
 function getScope(props: {
   chapterId?: string;
@@ -27,6 +34,74 @@ function getScope(props: {
   throw new Error("ContinueLessonLink requires a course, chapter, or lesson id.");
 }
 
+/**
+ * Progress can start at zero, but it still needs a valid total before it is
+ * worth replacing the arrow. Clamping the completed count keeps stale or
+ * duplicated completion rows from making the compact fraction impossible.
+ */
+function getVisibleProgress({ progress }: { progress?: ContinueLessonProgress | null }) {
+  if (!progress || progress.totalItems <= 0) {
+    return null;
+  }
+
+  return {
+    completedItems: Math.min(Math.max(progress.completedItems, 0), progress.totalItems),
+    totalItems: progress.totalItems,
+    unit: progress.unit,
+  };
+}
+
+/**
+ * The Continue button owns its compact progress suffix. Looking up progress
+ * from the scope keeps pages from threading promises through sibling
+ * components just to feed this small visual hint.
+ */
+function getContinueLessonProgress({ scope }: { scope: LessonScope }) {
+  if ("courseId" in scope) {
+    return getCourseContinueProgress(scope.courseId);
+  }
+
+  if ("chapterId" in scope) {
+    return getChapterContinueProgress(scope.chapterId);
+  }
+
+  return Promise.resolve(null);
+}
+
+/**
+ * The visible suffix is intentionally just a fraction so the mobile CTA stays
+ * compact, while the hidden text gives screen readers the full meaning.
+ */
+function ContinueLessonLinkContent({
+  label,
+  progress,
+}: {
+  label: string;
+  progress: ContinueLessonProgressContent | null;
+}) {
+  if (!progress) {
+    return (
+      <span className="inline-flex min-w-0 items-center justify-center gap-1.5">
+        {label}
+        <ChevronRightIcon aria-hidden="true" />
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex min-w-0 items-baseline justify-center gap-1.5 leading-none">
+      <span className="min-w-0 truncate leading-none">{label}</span>
+      <span
+        aria-hidden="true"
+        className="text-primary-foreground/65 text-[0.7rem] leading-none font-medium tabular-nums"
+      >
+        {progress.text}
+      </span>
+      <span className="sr-only">{progress.ariaLabel}</span>
+    </span>
+  );
+}
+
 export async function ContinueLessonLink<Href extends string, CompletedHref extends string>({
   chapterId,
   completedHref,
@@ -42,8 +117,30 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
 }) {
   const t = await getExtracted();
   const scope = getScope({ chapterId, courseId, lessonId });
-  const data = await getContinueLessonTarget({ scope });
+
+  const [data, resolvedProgress] = await Promise.all([
+    getContinueLessonTarget({ scope }),
+    getContinueLessonProgress({ scope }),
+  ]);
+
   const className = cn(buttonVariants(), "min-w-0 flex-1 gap-2");
+  const visibleProgress = getVisibleProgress({ progress: resolvedProgress });
+
+  const progressContent = visibleProgress
+    ? {
+        ariaLabel:
+          visibleProgress.unit === "chapters"
+            ? t("{completed} of {total} chapters completed", {
+                completed: String(visibleProgress.completedItems),
+                total: String(visibleProgress.totalItems),
+              })
+            : t("{completed} of {total} lessons completed", {
+                completed: String(visibleProgress.completedItems),
+                total: String(visibleProgress.totalItems),
+              }),
+        text: `${visibleProgress.completedItems}/${visibleProgress.totalItems}`,
+      }
+    : null;
 
   /**
    * Some catalog pages can compute a safe first-child route, while others may
@@ -57,8 +154,7 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
 
     return (
       <Link className={className} href={fallbackHref} prefetch={false}>
-        {label}
-        <ChevronRightIcon aria-hidden="true" />
+        <ContinueLessonLinkContent label={label} progress={progressContent} />
       </Link>
     );
   }
@@ -95,8 +191,7 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
   if (data.completed && completedHref) {
     return (
       <Link className={className} href={completedHref}>
-        {label}
-        <ChevronRightIcon aria-hidden="true" />
+        <ContinueLessonLinkContent label={label} progress={progressContent} />
       </Link>
     );
   }
@@ -122,8 +217,7 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
         href={`/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}`}
         prefetch={false}
       >
-        {label}
-        <ChevronRightIcon aria-hidden="true" />
+        <ContinueLessonLinkContent label={label} progress={progressContent} />
       </Link>
     );
   }
@@ -135,8 +229,7 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
         href={`/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}`}
         prefetch
       >
-        {label}
-        <ChevronRightIcon aria-hidden="true" />
+        <ContinueLessonLinkContent label={label} progress={progressContent} />
       </Link>
     );
   }
@@ -151,8 +244,7 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
       href={`/b/${data.brandSlug}/c/${data.courseSlug}/ch/${data.chapterSlug}/l/${data.lessonSlug}`}
       prefetch={false}
     >
-      {label}
-      <ChevronRightIcon aria-hidden="true" />
+      <ContinueLessonLinkContent label={label} progress={progressContent} />
     </Link>
   );
 }

--- a/apps/main/src/data/progress/catalog-progress.ts
+++ b/apps/main/src/data/progress/catalog-progress.ts
@@ -1,0 +1,112 @@
+import "server-only";
+import { getChapterProgress } from "@zoonk/core/progress/chapters";
+import { getLessonProgress } from "@zoonk/core/progress/lessons";
+import { getSession } from "@zoonk/core/users/session/get";
+import { getPublishedChapterWhere, getPublishedLessonWhere, prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { cache } from "react";
+
+export type ContinueLessonProgress = {
+  completedItems: number;
+  totalItems: number;
+  unit: "chapters" | "lessons";
+};
+
+/**
+ * Course and chapter page components can independently ask for chapter-card
+ * progress. React cache keeps repeated reads for the same course inside one
+ * server render from issuing duplicate progress queries.
+ */
+export const getCatalogChapterProgress = cache(async (courseId: string) =>
+  getChapterProgress({ courseId }),
+);
+
+/**
+ * The Continue button and lesson grid both need the same lesson completion
+ * rows on chapter pages. Caching by chapter id keeps those sibling Suspense
+ * boundaries independent without paying for the query twice in one render.
+ */
+export const getCatalogLessonProgress = cache(async (chapterId: string) =>
+  getLessonProgress({ chapterId }),
+);
+
+/**
+ * Course-level progress counts completed chapters, not generated lesson rows.
+ * Lessons are generated on demand, so chapter completions are the stable unit
+ * learners expect when scanning overall course progress.
+ */
+export const getCourseContinueProgress = cache(
+  async (courseId: string): Promise<ContinueLessonProgress> => {
+    const [completedItems, totalItems] = await Promise.all([
+      countCompletedPublishedCourseChapters(courseId),
+      countPublishedCourseChapters(courseId),
+    ]);
+
+    return { completedItems, totalItems, unit: "chapters" };
+  },
+);
+
+/**
+ * Chapter-level progress still counts lessons because chapter pages list the
+ * concrete lesson rows. Reusing cached lesson progress keeps this aligned with
+ * the status badges rendered by the lesson grid.
+ */
+export const getChapterContinueProgress = cache(
+  async (chapterId: string): Promise<ContinueLessonProgress> => {
+    const [progressRows, totalItems] = await Promise.all([
+      getCatalogLessonProgress(chapterId),
+      countPublishedChapterLessons(chapterId),
+    ]);
+
+    return {
+      completedItems: progressRows.filter((row) => row.isCompleted).length,
+      totalItems,
+      unit: "lessons",
+    };
+  },
+);
+
+/**
+ * Anonymous users have no durable completions, but the course button still
+ * needs a zero count against the visible chapter total.
+ */
+async function countCompletedPublishedCourseChapters(courseId: string) {
+  const session = await getSession();
+  const userId = session?.user.id;
+
+  if (!userId) {
+    return 0;
+  }
+
+  const { data } = await safeAsync(() =>
+    prisma.chapterCompletion.count({
+      where: { chapter: getPublishedChapterWhere({ chapterWhere: { courseId } }), userId },
+    }),
+  );
+
+  return data ?? 0;
+}
+
+/**
+ * Course progress needs the visible chapter total even when none of those
+ * chapters have generated lesson content yet.
+ */
+async function countPublishedCourseChapters(courseId: string) {
+  const { data } = await safeAsync(() =>
+    prisma.chapter.count({ where: getPublishedChapterWhere({ chapterWhere: { courseId } }) }),
+  );
+
+  return data ?? 0;
+}
+
+/**
+ * Chapter progress uses the visible lesson total so the Continue button and
+ * lesson grid agree about the same generated lesson set.
+ */
+async function countPublishedChapterLessons(chapterId: string) {
+  const { data } = await safeAsync(() =>
+    prisma.lesson.count({ where: getPublishedLessonWhere({ chapterWhere: { id: chapterId } }) }),
+  );
+
+  return data ?? 0;
+}


### PR DESCRIPTION
## Summary

- add compact progress fractions inside catalog Continue buttons
- count course progress by completed chapters and chapter progress by completed lessons
- keep progress reads inside streamed components with cached shared data helpers
- update E2E coverage for progress-aware accessible names

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add compact progress to catalog Continue buttons on course and chapter pages to show how much is done at a glance. Improves accessibility by adding clear progress to the button’s accessible name.

- **New Features**
  - Continue buttons show a compact fraction (e.g., 1/3) next to Start/Continue/Review.
  - Accessible names include full progress text: “{completed} of {total} chapters/lessons completed.”
  - Course buttons count completed chapters; chapter buttons count completed lessons.
  - Added cached server helpers for progress: `getCatalogChapterProgress`, `getCatalogLessonProgress`, `getCourseContinueProgress`, `getChapterContinueProgress`.
  - Updated E2E tests to match progress-aware accessible names and fractions.
  - Added i18n strings for en, es, and pt.

<sup>Written for commit 0dd0c908f08cfe421c25f639290b4ffe119a8b08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

