### PR TITLE
feat(main): add active catalog shortcut button

### DIFF
--- a/apps/main/e2e/catalog-active-scroll.test.ts
+++ b/apps/main/e2e/catalog-active-scroll.test.ts
@@ -57,6 +57,43 @@ async function expectTargetNearTop({ page, title }: { page: Page; title: string 
 }
 
 /**
+ * Smooth scrolling is browser behavior, so the focused assertion records the
+ * options passed to scrollIntoView instead of trying to time animation frames.
+ */
+async function recordScrollIntoViewOptions(page: Page) {
+  await page.addInitScript(() => {
+    // oxlint-disable-next-line unicorn/consistent-function-scoping -- Playwright init scripts need browser-side patches inside the serialized callback.
+    Element.prototype.scrollIntoView = function scrollIntoView(
+      options?: boolean | ScrollIntoViewOptions,
+    ) {
+      Object.assign(globalThis, { catalogScrollIntoViewOptions: options });
+    };
+  });
+}
+
+/**
+ * Toolbar shortcuts should animate for users who have not asked the browser to
+ * reduce motion.
+ */
+async function expectSmoothScrollRequest(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const options: unknown = Reflect.get(globalThis, "catalogScrollIntoViewOptions");
+
+        if (!options || typeof options !== "object") {
+          return null;
+        }
+
+        const behavior: unknown = Reflect.get(options, "behavior");
+
+        return typeof behavior === "string" ? behavior : null;
+      }),
+    )
+    .toBe("smooth");
+}
+
+/**
  * Course pages need enough chapters to make the active chapter useful as a
  * shortcut. The completed lesson sits just before the active chapter, while a
  * later opened lesson proves incomplete progress does not move the target.
@@ -223,11 +260,46 @@ test.describe("Catalog Active Scroll", () => {
 
     await scrollDown(authenticatedPage);
 
-    const currentChapterLink = authenticatedPage.getByRole("link", { name: /current chapter/iu });
+    const currentChapterLink = authenticatedPage.getByRole("link", { name: /^current chapter$/iu });
     await expect(currentChapterLink).toBeVisible();
 
     await currentChapterLink.click();
     await expectTargetNearTop({ page: authenticatedPage, title: target.title });
+  });
+
+  test("course page toolbar jumps to the current chapter", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const target = await createScrollableCourseTarget({ userId: withProgressUser.id });
+
+    await authenticatedPage.emulateMedia({ reducedMotion: "reduce" });
+    await authenticatedPage.goto(target.url);
+    await expect(authenticatedPage.getByRole("heading", { level: 1 })).toBeVisible();
+
+    const currentChapterLink = authenticatedPage.getByRole("link", {
+      name: /^go to current chapter$/iu,
+    });
+
+    await expect(currentChapterLink).toBeVisible();
+
+    await currentChapterLink.click();
+    await expectTargetNearTop({ page: authenticatedPage, title: target.title });
+  });
+
+  test("course page toolbar uses smooth scrolling", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const target = await createScrollableCourseTarget({ userId: withProgressUser.id });
+
+    await recordScrollIntoViewOptions(authenticatedPage);
+    await authenticatedPage.goto(target.url);
+    await expect(authenticatedPage.getByRole("heading", { level: 1 })).toBeVisible();
+
+    await authenticatedPage.getByRole("link", { name: /^go to current chapter$/iu }).click();
+
+    await expectSmoothScrollRequest(authenticatedPage);
   });
 
   test("course page keeps back-to-top when no chapter is active", async ({
@@ -262,7 +334,7 @@ test.describe("Catalog Active Scroll", () => {
 
     await scrollDown(authenticatedPage);
 
-    const currentLessonLink = authenticatedPage.getByRole("link", { name: /current lesson/iu });
+    const currentLessonLink = authenticatedPage.getByRole("link", { name: /^current lesson$/iu });
     await expect(currentLessonLink).toBeVisible();
 
     await currentLessonLink.click();
@@ -275,10 +347,33 @@ test.describe("Catalog Active Scroll", () => {
     });
 
     await expect(backToTopAfterPassingLink).toBeVisible();
-    await expect(authenticatedPage.getByRole("link", { name: /current lesson/iu })).toHaveCount(0);
+
+    await expect(authenticatedPage.getByRole("link", { name: /^current lesson$/iu })).toHaveCount(
+      0,
+    );
 
     await backToTopAfterPassingLink.click();
     await expect.poll(() => authenticatedPage.evaluate(() => globalThis.scrollY)).toBe(0);
+  });
+
+  test("chapter page toolbar jumps to the current lesson", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const target = await createScrollableLessonTarget({ userId: withProgressUser.id });
+
+    await authenticatedPage.emulateMedia({ reducedMotion: "reduce" });
+    await authenticatedPage.goto(target.url);
+    await expect(authenticatedPage.getByRole("heading", { level: 1 })).toBeVisible();
+
+    const currentLessonLink = authenticatedPage.getByRole("link", {
+      name: /^go to current lesson$/iu,
+    });
+
+    await expect(currentLessonLink).toBeVisible();
+
+    await currentLessonLink.click();
+    await expectTargetNearTop({ page: authenticatedPage, title: target.title });
   });
 
   test("chapter page keeps back-to-top when only opened lesson is incomplete", async ({

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1674,6 +1674,14 @@ msgstr "I didn't like it"
 msgid "G5YSJR"
 msgstr "Send feedback"
 
+#: src/components/catalog/catalog-active-shortcut-link.tsx
+msgid "PAKDzS"
+msgstr "Go to current chapter"
+
+#: src/components/catalog/catalog-active-shortcut-link.tsx
+msgid "Js2dT3"
+msgstr "Go to current lesson"
+
 #: src/components/catalog/catalog-grid-back-to-top.tsx
 msgid "izuy1D"
 msgstr "Current item"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1674,6 +1674,14 @@ msgstr "No me gustó"
 msgid "G5YSJR"
 msgstr "Enviar comentarios"
 
+#: src/components/catalog/catalog-active-shortcut-link.tsx
+msgid "PAKDzS"
+msgstr "Ir al capítulo actual"
+
+#: src/components/catalog/catalog-active-shortcut-link.tsx
+msgid "Js2dT3"
+msgstr "Ir a la lección actual"
+
 #: src/components/catalog/catalog-grid-back-to-top.tsx
 msgid "izuy1D"
 msgstr "Elemento actual"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1674,6 +1674,14 @@ msgstr "Não gostei"
 msgid "G5YSJR"
 msgstr "Enviar opinião"
 
+#: src/components/catalog/catalog-active-shortcut-link.tsx
+msgid "PAKDzS"
+msgstr "Ir para o capítulo atual"
+
+#: src/components/catalog/catalog-active-shortcut-link.tsx
+msgid "Js2dT3"
+msgstr "Ir para a aula atual"
+
 #: src/components/catalog/catalog-grid-back-to-top.tsx
 msgid "izuy1D"
 msgstr "Item atual"

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -5,13 +5,11 @@ import {
   CatalogGridSearch,
 } from "@/components/catalog/catalog-grid";
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
+import { getCatalogActiveItemKey } from "@/components/catalog/catalog-item-target";
 import { getCatalogLessonProgress } from "@/data/progress/catalog-progress";
 import { getDefaultLessonImage } from "@/lib/catalog/default-images";
 import { getLessonDisplayMeta } from "@/lib/lessons";
-import {
-  type ActiveCatalogTarget,
-  getActiveCatalogTarget,
-} from "@zoonk/core/progress/active-catalog-target";
+import { getActiveCatalogTarget } from "@zoonk/core/progress/active-catalog-target";
 import { type Lesson } from "@zoonk/db";
 import {
   GridGroup,
@@ -47,21 +45,6 @@ function LessonListItemStatus({
   }
 
   return <GridItemStatusIdle>{notStartedLabel}</GridItemStatusIdle>;
-}
-
-/**
- * The active shortcut on a chapter page should land on a lesson tile. Progress
- * resolves from the last completed lesson so opening a lesson without finishing
- * it does not make that lesson look active.
- */
-function getActiveLessonKey({
-  activeTarget,
-  lessons,
-}: {
-  activeTarget: ActiveCatalogTarget | null;
-  lessons: Lesson[];
-}) {
-  return lessons.find((lesson) => lesson.slug === activeTarget?.lessonSlug)?.id ?? null;
 }
 
 /**
@@ -159,7 +142,11 @@ export async function LessonList({
 
   const completionMap = new Map(completionData.map((row) => [row.lessonId, row]));
   const lessonRows = await getLessonRows(lessons);
-  const activeLessonKey = getActiveLessonKey({ activeTarget, lessons });
+
+  const activeLessonKey = getCatalogActiveItemKey({
+    activeSlug: activeTarget?.lessonSlug,
+    items: lessons,
+  });
 
   const searchItems = lessonRows.map(({ display, lesson }) => ({
     description: display.description,

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -1,4 +1,5 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
+import { CatalogActiveShortcutLink } from "@/components/catalog/catalog-active-shortcut-link";
 import { CatalogDetailLayout } from "@/components/catalog/catalog-detail-layout";
 import { CatalogGridSkeleton } from "@/components/catalog/catalog-skeletons";
 import {
@@ -78,6 +79,13 @@ export default async function ChapterPage({
                   chapterId={chapter.id}
                   completedHref={completedHref}
                   fallbackHref={fallbackHref}
+                />
+              </Suspense>
+              <Suspense fallback={null}>
+                <CatalogActiveShortcutLink
+                  items={lessons}
+                  kind="lesson"
+                  scope={{ chapterId: chapter.id }}
                 />
               </Suspense>
               <CatalogActions

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -5,12 +5,10 @@ import {
   CatalogGridSearch,
 } from "@/components/catalog/catalog-grid";
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
+import { getCatalogActiveItemKey } from "@/components/catalog/catalog-item-target";
 import { type CourseChapter } from "@/data/chapters/list-course-chapters";
 import { getCatalogChapterProgress } from "@/data/progress/catalog-progress";
-import {
-  type ActiveCatalogTarget,
-  getActiveCatalogTarget,
-} from "@zoonk/core/progress/active-catalog-target";
+import { getActiveCatalogTarget } from "@zoonk/core/progress/active-catalog-target";
 import {
   GridGroup,
   GridItemContent,
@@ -106,20 +104,6 @@ function ChapterListItemStatus({
 }
 
 /**
- * The active shortcut on a course page should land on a chapter tile, even
- * though progress is tracked at the lesson level.
- */
-function getActiveChapterKey({
-  activeTarget,
-  chapters,
-}: {
-  activeTarget: ActiveCatalogTarget | null;
-  chapters: CourseChapter[];
-}) {
-  return chapters.find((chapter) => chapter.slug === activeTarget?.chapterSlug)?.id ?? null;
-}
-
-/**
  * A chapter tile gives the image more room than the old row, making the course
  * path easier to scan on wide screens without dropping the compact mobile flow.
  */
@@ -202,7 +186,11 @@ export async function ChapterList({
   ]);
 
   const completionMap = new Map(completionData.map((row) => [row.chapterId, row]));
-  const activeChapterKey = getActiveChapterKey({ activeTarget, chapters });
+
+  const activeChapterKey = getCatalogActiveItemKey({
+    activeSlug: activeTarget?.chapterSlug,
+    items: chapters,
+  });
 
   return (
     <CatalogGridContent activeItemKey={activeChapterKey} activeLabel={t("Current chapter")}>

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -1,4 +1,5 @@
 import { CatalogActions } from "@/components/catalog/catalog-actions";
+import { CatalogActiveShortcutLink } from "@/components/catalog/catalog-active-shortcut-link";
 import { CatalogDetailLayout } from "@/components/catalog/catalog-detail-layout";
 import { CatalogGridSkeleton } from "@/components/catalog/catalog-skeletons";
 import {
@@ -68,6 +69,13 @@ export default async function CoursePage({ params }: PageProps<"/b/[brandSlug]/c
           <GridToolbar>
             <Suspense fallback={<ContinueLessonLinkSkeleton />}>
               <ContinueLessonLink courseId={course.id} fallbackHref={fallbackHref} />
+            </Suspense>
+            <Suspense fallback={null}>
+              <CatalogActiveShortcutLink
+                items={chapters}
+                kind="chapter"
+                scope={{ courseId: course.id }}
+              />
             </Suspense>
             <CatalogActions
               defaultEmail={session?.user.email}

--- a/apps/main/src/components/catalog/catalog-active-shortcut-link.tsx
+++ b/apps/main/src/components/catalog/catalog-active-shortcut-link.tsx
@@ -1,0 +1,78 @@
+import { type LessonScope } from "@zoonk/core/lessons/last-completed";
+import {
+  type ActiveCatalogTarget,
+  getActiveCatalogTarget,
+} from "@zoonk/core/progress/active-catalog-target";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { ArrowDownIcon } from "lucide-react";
+import { getExtracted } from "next-intl/server";
+import {
+  type CatalogGridItemKey,
+  getCatalogActiveItemKey,
+  getCatalogItemTargetId,
+} from "./catalog-item-target";
+import { CatalogSmoothScrollLink } from "./catalog-smooth-scroll-link";
+
+type CatalogActiveShortcutKind = "chapter" | "lesson";
+type CatalogActiveShortcutItem = { id: CatalogGridItemKey; slug: string };
+
+/**
+ * Course pages jump to chapters, while chapter pages jump to lessons. Keeping
+ * that mapping named here prevents each page from reinterpreting the same
+ * progress target differently.
+ */
+function getActiveShortcutSlug({
+  activeTarget,
+  kind,
+}: {
+  activeTarget: ActiveCatalogTarget | null;
+  kind: CatalogActiveShortcutKind;
+}) {
+  if (!activeTarget) {
+    return null;
+  }
+
+  if (kind === "chapter") {
+    return activeTarget.chapterSlug;
+  }
+
+  return activeTarget.lessonSlug ?? null;
+}
+
+/**
+ * The sidebar shortcut is a quiet icon-only anchor for learners who want to
+ * jump to the next relevant tile without first scrolling far enough to reveal
+ * the floating action.
+ */
+export async function CatalogActiveShortcutLink({
+  items,
+  kind,
+  scope,
+}: {
+  items: readonly CatalogActiveShortcutItem[];
+  kind: CatalogActiveShortcutKind;
+  scope: LessonScope;
+}) {
+  const activeTarget = await getActiveCatalogTarget({ scope });
+  const activeSlug = getActiveShortcutSlug({ activeTarget, kind });
+  const activeItemKey = getCatalogActiveItemKey({ activeSlug, items });
+
+  if (activeItemKey === null) {
+    return null;
+  }
+
+  const t = await getExtracted();
+  const label = kind === "chapter" ? t("Go to current chapter") : t("Go to current lesson");
+  const targetId = getCatalogItemTargetId(activeItemKey);
+
+  return (
+    <CatalogSmoothScrollLink
+      className={buttonVariants({ size: "icon", variant: "outline" })}
+      targetId={targetId}
+      title={label}
+    >
+      <ArrowDownIcon aria-hidden="true" />
+      <span className="sr-only">{label}</span>
+    </CatalogSmoothScrollLink>
+  );
+}

--- a/apps/main/src/components/catalog/catalog-grid-back-to-top.tsx
+++ b/apps/main/src/components/catalog/catalog-grid-back-to-top.tsx
@@ -4,9 +4,8 @@ import { GridBackToTop } from "@zoonk/ui/components/grid";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { type MouseEvent, useEffect, useRef, useState } from "react";
+import { type CatalogGridItemKey, getCatalogItemTargetId } from "./catalog-item-target";
 import { CATALOG_TOP_TARGET_ID } from "./catalog-top-target";
-
-export type CatalogGridItemKey = string | number | bigint;
 
 type CatalogActiveTargetPosition = "ahead" | "unavailable";
 type CatalogScrollActionMode = "active" | "top";
@@ -25,14 +24,6 @@ const DEFAULT_CATALOG_SCROLL_STATE = {
   direction: "up",
   isVisible: false,
 } satisfies CatalogScrollState;
-
-/**
- * Catalog tiles need stable DOM anchors so the floating action can target the
- * current chapter or lesson without coupling scroll behavior to route URLs.
- */
-export function getCatalogItemTargetId(itemKey: CatalogGridItemKey): string {
-  return `catalog-item-${String(itemKey)}`;
-}
 
 /**
  * The floating top action should appear only after the reader has left the

--- a/apps/main/src/components/catalog/catalog-grid.tsx
+++ b/apps/main/src/components/catalog/catalog-grid.tsx
@@ -9,12 +9,9 @@ import { type Route } from "next";
 import Link from "next/link";
 import { useQueryState } from "nuqs";
 import { type ReactNode, useMemo } from "react";
-import {
-  CatalogGridBackToTop,
-  type CatalogGridItemKey,
-  getCatalogItemTargetId,
-} from "./catalog-grid-back-to-top";
+import { CatalogGridBackToTop } from "./catalog-grid-back-to-top";
 import { CatalogGridContext, useCatalogGridContext } from "./catalog-grid-context";
+import { type CatalogGridItemKey, getCatalogItemTargetId } from "./catalog-item-target";
 
 type CatalogGridSearchItem = { description?: string | null; id: CatalogGridItemKey; title: string };
 

--- a/apps/main/src/components/catalog/catalog-item-target.ts
+++ b/apps/main/src/components/catalog/catalog-item-target.ts
@@ -1,0 +1,27 @@
+export type CatalogGridItemKey = string | number | bigint;
+
+type CatalogActiveItem = { id: CatalogGridItemKey; slug: string };
+
+/**
+ * Catalog tiles need stable DOM anchors so both floating and toolbar shortcuts
+ * can jump to the same chapter or lesson without coupling scroll behavior to
+ * route URLs.
+ */
+export function getCatalogItemTargetId(itemKey: CatalogGridItemKey): string {
+  return `catalog-item-${String(itemKey)}`;
+}
+
+/**
+ * Active catalog targets are resolved by slug because progress logic lives
+ * outside the rendered grid; converting that slug back to the tile id keeps the
+ * DOM anchor source of truth in the visible item collection.
+ */
+export function getCatalogActiveItemKey({
+  activeSlug,
+  items,
+}: {
+  activeSlug?: string | null;
+  items: readonly CatalogActiveItem[];
+}): CatalogGridItemKey | null {
+  return items.find((item) => item.slug === activeSlug)?.id ?? null;
+}

--- a/apps/main/src/components/catalog/catalog-smooth-scroll-link.tsx
+++ b/apps/main/src/components/catalog/catalog-smooth-scroll-link.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { type MouseEvent } from "react";
+
+/**
+ * Catalog anchors are queried through CSS selectors, so ids must be escaped
+ * before interpolation to keep unusual future keys from breaking shortcuts.
+ */
+function getCatalogScrollTargetElement(targetId: string) {
+  return globalThis.document.querySelector(`#${globalThis.CSS.escape(targetId)}`);
+}
+
+/**
+ * Users who reduce motion should still get the same destination without the
+ * animated movement that can make scrolling feel uncomfortable.
+ */
+function getCatalogScrollBehavior(): ScrollBehavior {
+  if (globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    return "auto";
+  }
+
+  return "smooth";
+}
+
+/**
+ * Catalog shortcut links keep a normal hash href as their no-JS fallback, but
+ * hydrated clicks use controlled scrolling so sidebar and floating shortcuts
+ * feel consistent.
+ */
+function handleCatalogSmoothScrollClick({
+  event,
+  targetId,
+}: {
+  event: MouseEvent<HTMLAnchorElement>;
+  targetId: string;
+}) {
+  const catalogScrollTarget = getCatalogScrollTargetElement(targetId);
+
+  if (!catalogScrollTarget) {
+    return;
+  }
+
+  event.preventDefault();
+  catalogScrollTarget.scrollIntoView({ behavior: getCatalogScrollBehavior(), block: "start" });
+}
+
+export function CatalogSmoothScrollLink({
+  children,
+  targetId,
+  ...props
+}: Omit<React.ComponentProps<"a">, "href" | "onClick"> & { targetId: string }) {
+  return (
+    <a
+      href={`#${targetId}`}
+      onClick={(event) => handleCatalogSmoothScrollClick({ event, targetId })}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}


### PR DESCRIPTION
Adds an outline icon shortcut beside the Continue action on course and chapter pages.\n\nThe shortcut jumps smoothly to the current chapter or lesson using the same active catalog target as the floating scroll action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small outline icon next to Continue on course and chapter pages that jumps to your current chapter or lesson. The jump uses smooth scrolling and respects reduced motion for accessibility.

- **New Features**
  - Added `CatalogActiveShortcutLink` beside Continue to jump to the active chapter or lesson.
  - Smooth scrolling with a no-JS hash fallback; honors `prefers-reduced-motion`.
  - Accessible, localized labels: “Go to current chapter” / “Go to current lesson” (en/es/pt).
  - Introduced `CatalogSmoothScrollLink` for consistent, controlled scrolling.

- **Refactors**
  - Centralized item anchor helpers in `catalog-item-target` and removed duplicated logic in chapter/lesson lists.
  - Unified active item key resolution and target id generation for toolbar and floating shortcuts.
  - Expanded e2e coverage for toolbar jumps and smooth-scroll behavior.

<sup>Written for commit dce6d120f4eb9d247a2b388c0d4ddb3d064e5f82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

