### PR TITLE
feat(main): add lesson type filters

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "node:crypto";
+import { type Browser, type Page } from "@playwright/test";
+import { getBaseURL } from "@zoonk/e2e/fixtures/base-url";
 import { createOrganization, getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { createE2EUser } from "@zoonk/e2e/fixtures/users";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
@@ -22,8 +25,37 @@ let noLessonsChapterUrl: string;
 let lessonNames: { first: string; second: string };
 let lessonDescriptions: { first: string; second: string };
 let lessonSlugs: { first: string; second: string };
+let languageChapterUrl: string;
 let ptChapterUrl: string;
 let ptLessonNames: { first: string; second: string };
+
+/**
+ * Lesson type filters are saved to the user profile, so filter tests need a
+ * dedicated user instead of the shared worker auth fixture that parallel tests
+ * may also be using.
+ */
+async function createFilterTestPage({ browser }: { browser: Browser }) {
+  const user = await createE2EUser(getBaseURL(), { orgRole: "member" });
+  const context = await browser.newContext({ storageState: user.storageState });
+  const page = await context.newPage();
+
+  return { context, page, user };
+}
+
+/**
+ * The filter menu is rendered through a portal, so tests should wait for the
+ * trigger and the menu label before checking specific checkbox items.
+ */
+async function openLessonTypeFilterMenu({ page }: { page: Page }) {
+  const filterButton = page.getByRole("button", { name: /filter lesson types/iu });
+
+  await expect(filterButton).toBeVisible();
+  await expect(filterButton).toBeEnabled();
+  await filterButton.click();
+  await expect(page.getByText(/show lesson types/iu)).toBeVisible();
+
+  return filterButton;
+}
 
 test.beforeAll(async () => {
   const org = await getAiOrganization();
@@ -86,6 +118,7 @@ test.beforeAll(async () => {
       chapterId: chapter.id,
       description: lessonDescriptions.second,
       isPublished: true,
+      kind: "quiz",
       normalizedTitle: normalizeString(lessonNames.second),
       organizationId: org.id,
       position: 1,
@@ -100,6 +133,64 @@ test.beforeAll(async () => {
       position: 2,
       slug: `e2e-unpub-lesson-${uniqueId}`,
       title: unpublishedLessonTitle,
+    }),
+  ]);
+
+  const languageCourse = await courseFixture({
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString(`E2E Language Course ${uniqueId}`),
+    organizationId: org.id,
+    slug: `e2e-language-course-${uniqueId}`,
+    targetLanguage: "es",
+    title: `E2E Language Course ${uniqueId}`,
+  });
+
+  const languageChapter = await chapterFixture({
+    courseId: languageCourse.id,
+    description: `Language learning chapter ${uniqueId}`,
+    isPublished: true,
+    normalizedTitle: normalizeString(`E2E Language Chapter ${uniqueId}`),
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-language-ch-${uniqueId}`,
+    title: `E2E Language Chapter ${uniqueId}`,
+  });
+
+  languageChapterUrl = `/b/${AI_ORG_SLUG}/c/${languageCourse.slug}/ch/${languageChapter.slug}`;
+
+  await Promise.all([
+    lessonFixture({
+      chapterId: languageChapter.id,
+      isPublished: true,
+      kind: "vocabulary",
+      organizationId: org.id,
+      position: 0,
+      title: `Spanish Words ${uniqueId}`,
+    }),
+    lessonFixture({
+      chapterId: languageChapter.id,
+      isPublished: true,
+      kind: "grammar",
+      organizationId: org.id,
+      position: 1,
+      title: `Spanish Grammar ${uniqueId}`,
+    }),
+    lessonFixture({
+      chapterId: languageChapter.id,
+      isPublished: true,
+      kind: "quiz",
+      organizationId: org.id,
+      position: 2,
+      title: `Language Quiz ${uniqueId}`,
+    }),
+    lessonFixture({
+      chapterId: languageChapter.id,
+      isPublished: true,
+      kind: "explanation",
+      organizationId: org.id,
+      position: 3,
+      title: `Language Explanation ${uniqueId}`,
     }),
   ]);
 
@@ -304,6 +395,25 @@ test.describe("Chapter Lesson Search", () => {
     ).not.toBeVisible();
   });
 
+  test("persists search in URL and survives page reload", async ({ page }) => {
+    await page.goto(chapterUrl);
+
+    await page.getByLabel(/search lessons/iu).fill("History");
+    await expect(page).toHaveURL(/\?q=History/u);
+
+    await page.reload();
+
+    await expect(page.getByLabel(/search lessons/iu)).toHaveValue("History");
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.first, "u") }),
+    ).not.toBeVisible();
+  });
+
   test("filters lessons by description", async ({ page }) => {
     await page.goto(chapterUrl);
 
@@ -371,6 +481,98 @@ test.describe("Chapter Lesson Search - Mobile", () => {
     await expect
       .poll(() => getSearchInputTop({ label: SEARCH_LESSONS_LABEL, page }))
       .toBeLessThanOrEqual(matchingTop + 1);
+  });
+});
+
+test.describe("Chapter Lesson Type Filters", () => {
+  test("lets guests hide lesson types locally without a save error", async ({ page }) => {
+    await page.goto(chapterUrl);
+
+    await openLessonTypeFilterMenu({ page });
+    await expect(page.getByRole("menuitemcheckbox", { name: /^explanation$/iu })).toBeVisible();
+    await expect(page.getByRole("menuitemcheckbox", { name: /^quiz$/iu })).toBeVisible();
+    await expect(page.getByRole("menuitemcheckbox", { name: /^grammar$/iu })).not.toBeVisible();
+    await expect(page.getByRole("menuitemcheckbox", { name: /^vocabulary$/iu })).not.toBeVisible();
+    await page.getByRole("menuitemcheckbox", { name: /^quiz$/iu }).click();
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.first, "u") }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),
+    ).not.toBeVisible();
+
+    await expect(page.getByRole("menuitem", { name: /clear filter/iu })).toBeVisible();
+    await expect(page.getByText(/could not update lesson filters/iu)).not.toBeVisible();
+  });
+
+  test("shows only language lesson types for language courses", async ({ page }) => {
+    await page.goto(languageChapterUrl);
+
+    await openLessonTypeFilterMenu({ page });
+
+    await expect(page.getByRole("menuitemcheckbox", { name: /^grammar$/iu })).toBeVisible();
+    await expect(page.getByRole("menuitemcheckbox", { name: /^vocabulary$/iu })).toBeVisible();
+    await expect(page.getByRole("menuitemcheckbox", { name: /^explanation$/iu })).not.toBeVisible();
+    await expect(page.getByRole("menuitemcheckbox", { name: /^quiz$/iu })).not.toBeVisible();
+  });
+
+  test("hides lesson types and clears filters from the filter menu", async ({ browser }) => {
+    const { context, page } = await createFilterTestPage({ browser });
+
+    await page.goto(chapterUrl);
+
+    const filterButton = await openLessonTypeFilterMenu({ page });
+    await page.getByRole("menuitemcheckbox", { name: /^quiz$/iu }).click();
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.first, "u") }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),
+    ).not.toBeVisible();
+
+    await expect(page.getByRole("menuitem", { name: /clear filter/iu })).toBeVisible();
+    await expect(filterButton).toBeEnabled();
+
+    await page.getByRole("menuitem", { name: /clear filter/iu }).click();
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),
+    ).toBeVisible();
+
+    await expect(filterButton).toBeEnabled();
+
+    await context.close();
+  });
+
+  test("persists hidden lesson types for the user", async ({ browser }) => {
+    const { context, page, user } = await createFilterTestPage({ browser });
+
+    await page.goto(chapterUrl);
+
+    const filterButton = await openLessonTypeFilterMenu({ page });
+    await page.getByRole("menuitemcheckbox", { name: /^quiz$/iu }).click();
+    await expect(filterButton).toBeEnabled();
+
+    const secondContext = await browser.newContext({ storageState: user.storageState });
+    const secondPage = await secondContext.newPage();
+
+    await secondPage.goto(chapterUrl);
+
+    await expect(
+      secondPage.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),
+    ).not.toBeVisible();
+
+    await openLessonTypeFilterMenu({ page: secondPage });
+
+    await expect(secondPage.getByRole("menuitem", { name: /clear filter/iu })).toBeVisible();
+
+    await secondPage.getByRole("menuitem", { name: /clear filter/iu }).click();
+    await expect(secondPage.getByRole("button", { name: /filter lesson types/iu })).toBeEnabled();
+    await Promise.all([context.close(), secondContext.close()]);
   });
 });
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -285,6 +285,26 @@ msgstr "This chapter hasn't been created yet."
 msgid "3IOFp2"
 msgstr "Create chapter"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "a0eayI"
+msgstr "Could not update lesson filters. Please try again."
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "d6tcJn"
+msgstr "Filter lesson types"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "kxP9GJ"
+msgstr "Types"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "wi5osl"
+msgstr "Show lesson types"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "OhgOkH"
+msgstr "Clear filter"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "orGV/i"
 msgstr "Current lesson"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -285,6 +285,26 @@ msgstr "Este capítulo aún no se ha creado."
 msgid "3IOFp2"
 msgstr "Crear capítulo"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "a0eayI"
+msgstr "No pudimos actualizar los filtros de lecciones. Inténtalo de nuevo."
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "d6tcJn"
+msgstr "Filtrar tipos de lección"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "kxP9GJ"
+msgstr "Tipos"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "wi5osl"
+msgstr "Mostrar tipos de lección"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "OhgOkH"
+msgstr "Borrar filtro"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "orGV/i"
 msgstr "Lección actual"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -285,6 +285,26 @@ msgstr "Este capítulo ainda não foi criado."
 msgid "3IOFp2"
 msgstr "Criar capítulo"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "a0eayI"
+msgstr "Não foi possível atualizar os filtros de aulas. Tente de novo."
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "d6tcJn"
+msgstr "Filtrar tipos de aula"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "kxP9GJ"
+msgstr "Tipos"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "wi5osl"
+msgstr "Mostrar tipos de aula"
+
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+msgid "OhgOkH"
+msgstr "Limpar filtro"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "orGV/i"
 msgstr "Aula atual"

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-actions.ts
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-actions.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { updateUserHiddenLessonKinds } from "@/data/users/lesson-filter-settings";
+import { type LessonKind } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
+
+/**
+ * Lesson type visibility is a user setting, so the data helper owns current
+ * session lookup before touching the shared learning-profile preferences record.
+ */
+export async function updateHiddenLessonKindsAction({
+  hiddenLessonKinds,
+}: {
+  hiddenLessonKinds: LessonKind[];
+}) {
+  const { data: result, error } = await safeAsync(() =>
+    updateUserHiddenLessonKinds({ hiddenLessonKinds }),
+  );
+
+  const updateError = error ?? result?.error;
+
+  if (updateError) {
+    logError("Error updating hidden lesson kinds:", updateError);
+    return { status: "error" as const };
+  }
+
+  if (!result?.saved) {
+    return { status: "error" as const };
+  }
+
+  return { status: "success" as const };
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import {
+  CatalogGridSearchField,
+  type CatalogGridSearchItem,
+  matchesCatalogSearchQuery,
+} from "@/components/catalog/catalog-grid";
+import { CatalogGridContext } from "@/components/catalog/catalog-grid-context";
+import {
+  type LessonKindFilterSettings,
+  getClearedHiddenLessonKinds,
+  getHiddenLessonKindsForFilter,
+  getNextHiddenLessonKinds,
+} from "@/lib/lessons/lesson-kind-filters";
+import { type LessonKind } from "@zoonk/db";
+import { Button } from "@zoonk/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@zoonk/ui/components/dropdown-menu";
+import { toast } from "@zoonk/ui/components/sonner";
+import { normalizeString } from "@zoonk/utils/string";
+import { ListFilterIcon, XIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { useQueryState } from "nuqs";
+import { type ReactNode, useState, useTransition } from "react";
+import { updateHiddenLessonKindsAction } from "./lesson-list-actions";
+
+type LessonKindOption = { kind: LessonKind; label: string };
+
+type LessonTypeFilterItem = CatalogGridSearchItem & { kind: LessonKind };
+
+/**
+ * Lesson list filtering combines URL-backed text search with durable user
+ * preferences, so this component owns the client state that has to update
+ * immediately while the server action persists the same hidden-kind array.
+ */
+export function LessonListFilters({
+  canPersistFilters,
+  children,
+  initialHiddenLessonKinds,
+  items,
+  lessonKindOptions,
+  placeholder,
+}: {
+  canPersistFilters: boolean;
+  children: ReactNode;
+  initialHiddenLessonKinds: LessonKindFilterSettings["hiddenLessonKinds"];
+  items: LessonTypeFilterItem[];
+  lessonKindOptions: LessonKindOption[];
+  placeholder: string;
+}) {
+  const t = useExtracted();
+  const [isPending, startTransition] = useTransition();
+
+  const [search, setSearch] = useQueryState("q", {
+    defaultValue: "",
+    shallow: true,
+    throttleMs: 300,
+  });
+
+  const [hiddenLessonKinds, setHiddenLessonKinds] = useState(initialHiddenLessonKinds);
+
+  const filterableLessonKinds = lessonKindOptions.map((option) => option.kind);
+
+  const activeHiddenLessonKinds = getHiddenLessonKindsForFilter({
+    filterableLessonKinds,
+    hiddenLessonKinds,
+  });
+
+  const hiddenLessonKindSet = new Set(activeHiddenLessonKinds);
+
+  const { filteredIds, isFilterActive } = getLessonFilterState({
+    activeHiddenLessonKinds,
+    hiddenLessonKindSet,
+    items,
+    search,
+  });
+
+  /**
+   * The UI updates optimistically because hiding one kind is a lightweight
+   * preference change; failed saves roll back so the visible list still matches
+   * the server-owned setting.
+   */
+  function persistHiddenLessonKinds(nextHiddenLessonKinds: LessonKind[]) {
+    const previousHiddenLessonKinds = hiddenLessonKinds;
+
+    setHiddenLessonKinds(nextHiddenLessonKinds);
+
+    if (!canPersistFilters) {
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await updateHiddenLessonKindsAction({
+        hiddenLessonKinds: nextHiddenLessonKinds,
+      });
+
+      if (result.status === "error") {
+        setHiddenLessonKinds(previousHiddenLessonKinds);
+        toast.error(t("Could not update lesson filters. Please try again."));
+      }
+    });
+  }
+
+  /**
+   * The menu is phrased as visible lesson types, while the saved preference is
+   * hidden lesson types. This adapter keeps that inversion out of the markup.
+   */
+  function updateLessonKindVisibility({
+    isVisible,
+    kind,
+  }: {
+    isVisible: boolean;
+    kind: LessonKind;
+  }) {
+    persistHiddenLessonKinds(
+      getNextHiddenLessonKinds({
+        currentHiddenLessonKinds: hiddenLessonKinds,
+        isHidden: !isVisible,
+        kind,
+      }),
+    );
+  }
+
+  const hiddenCount = activeHiddenLessonKinds.length;
+
+  return (
+    <CatalogGridContext value={{ filteredIds, isFilterActive }}>
+      <CatalogGridSearchField
+        onSearchChange={(value) => setSearch(value || null)}
+        placeholder={placeholder}
+        search={search}
+      >
+        <LessonTypeFilterMenu
+          hiddenLessonKindSet={hiddenLessonKindSet}
+          hiddenCount={hiddenCount}
+          isPending={isPending}
+          lessonKindOptions={lessonKindOptions}
+          onClear={() =>
+            persistHiddenLessonKinds(
+              getClearedHiddenLessonKinds({
+                currentHiddenLessonKinds: hiddenLessonKinds,
+                filterableLessonKinds,
+              }),
+            )
+          }
+          onVisibilityChange={updateLessonKindVisibility}
+        />
+      </CatalogGridSearchField>
+
+      {children}
+    </CatalogGridContext>
+  );
+}
+
+/**
+ * Search and type preferences both hide items, so a lesson only stays visible
+ * when it matches the text query and its kind is not in the hidden set.
+ */
+function isLessonVisibleAfterFilters({
+  hiddenLessonKindSet,
+  item,
+  query,
+}: {
+  hiddenLessonKindSet: Set<LessonKind>;
+  item: LessonTypeFilterItem;
+  query: string;
+}) {
+  if (hiddenLessonKindSet.has(item.kind)) {
+    return false;
+  }
+
+  if (!query) {
+    return true;
+  }
+
+  return matchesCatalogSearchQuery({ item, query });
+}
+
+/**
+ * Search and hidden type filters share the same visibility result, so this
+ * keeps the branching out of the component while the derived values stay plain
+ * render-time calculations instead of being hidden in memo callbacks.
+ */
+function getLessonFilterState({
+  activeHiddenLessonKinds,
+  hiddenLessonKindSet,
+  items,
+  search,
+}: {
+  activeHiddenLessonKinds: LessonKind[];
+  hiddenLessonKindSet: Set<LessonKind>;
+  items: LessonTypeFilterItem[];
+  search: string;
+}) {
+  const query = normalizeString(search);
+  const isSearchActive = Boolean(query);
+  const hasHiddenLessonKinds = activeHiddenLessonKinds.length > 0;
+
+  if (!isSearchActive && !hasHiddenLessonKinds) {
+    return { filteredIds: null, isFilterActive: false };
+  }
+
+  const matchingItems = items.filter((item) =>
+    isLessonVisibleAfterFilters({ hiddenLessonKindSet, item, query }),
+  );
+
+  return {
+    filteredIds: new Set(matchingItems.map((item) => String(item.id))),
+    isFilterActive: true,
+  };
+}
+
+/**
+ * The dropdown keeps the control compact beside search while still showing the
+ * full list of lesson kinds as regular menu checkbox items for keyboard users.
+ */
+function LessonTypeFilterMenu({
+  hiddenLessonKindSet,
+  hiddenCount,
+  isPending,
+  lessonKindOptions,
+  onClear,
+  onVisibilityChange,
+}: {
+  hiddenLessonKindSet: Set<LessonKind>;
+  hiddenCount: number;
+  isPending: boolean;
+  lessonKindOptions: LessonKindOption[];
+  onClear: () => void;
+  onVisibilityChange: (params: { isVisible: boolean; kind: LessonKind }) => void;
+}) {
+  const t = useExtracted();
+
+  if (lessonKindOptions.length === 0) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            aria-label={t("Filter lesson types")}
+            disabled={isPending}
+            size="adaptive"
+            variant={hiddenCount > 0 ? "secondary" : "outline"}
+          />
+        }
+      >
+        <ListFilterIcon aria-hidden="true" />
+        <span className="hidden sm:inline">{t("Types")}</span>
+        {hiddenCount > 0 && (
+          <>
+            <span
+              aria-hidden="true"
+              className="bg-primary ring-background absolute top-1 right-1 size-1.5 rounded-full ring-2 sm:hidden"
+            />
+            <span
+              aria-hidden="true"
+              className="bg-background/80 ml-0.5 hidden min-w-4 justify-center rounded-full px-1.5 text-xs text-current sm:inline-flex"
+            >
+              {hiddenCount}
+            </span>
+          </>
+        )}
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>{t("Show lesson types")}</DropdownMenuLabel>
+          {lessonKindOptions.map((option) => (
+            <DropdownMenuCheckboxItem
+              checked={!hiddenLessonKindSet.has(option.kind)}
+              disabled={isPending}
+              key={option.kind}
+              onCheckedChange={(checked) =>
+                onVisibilityChange({ isVisible: checked, kind: option.kind })
+              }
+            >
+              {option.label}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuGroup>
+
+        {hiddenCount > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem disabled={isPending} onClick={onClear} variant="destructive">
+              <XIcon aria-hidden="true" />
+              {t("Clear filter")}
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -2,14 +2,16 @@ import {
   CatalogGridContent,
   CatalogGridEmpty,
   CatalogGridItem,
-  CatalogGridSearch,
 } from "@/components/catalog/catalog-grid";
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { getCatalogActiveItemKey } from "@/components/catalog/catalog-item-target";
 import { getCatalogLessonProgress } from "@/data/progress/catalog-progress";
+import { getUserHiddenLessonKinds } from "@/data/users/lesson-filter-settings";
 import { getDefaultLessonImage } from "@/lib/catalog/default-images";
-import { getLessonDisplayMeta } from "@/lib/lessons";
+import { getLessonDisplayMeta, getLessonKindLabels } from "@/lib/lessons";
+import { getFilterableLessonKinds } from "@/lib/lessons/lesson-kind-filters";
 import { getActiveCatalogTarget } from "@zoonk/core/progress/active-catalog-target";
+import { getSession } from "@zoonk/core/users/session/get";
 import { type Lesson } from "@zoonk/db";
 import {
   GridGroup,
@@ -24,6 +26,7 @@ import {
 } from "@zoonk/ui/components/grid";
 import { getExtracted } from "next-intl/server";
 import { getLessonKindTone } from "./_utils/lesson-kind-tones";
+import { LessonListFilters } from "./lesson-list-filters";
 
 type LessonRow = { display: Awaited<ReturnType<typeof getLessonDisplayMeta>>; lesson: Lesson };
 
@@ -121,12 +124,14 @@ export async function LessonList({
   chapterId,
   chapterSlug,
   courseSlug,
+  isLanguageCourse,
   lessons,
 }: {
   brandSlug: string;
   chapterId: string;
   chapterSlug: string;
   courseSlug: string;
+  isLanguageCourse: boolean;
   lessons: Lesson[];
 }) {
   if (lessons.length === 0) {
@@ -135,11 +140,14 @@ export async function LessonList({
 
   const t = await getExtracted();
 
-  const [completionData, activeTarget] = await Promise.all([
+  const [completionData, activeTarget, session, hiddenLessonKinds] = await Promise.all([
     getCatalogLessonProgress(chapterId),
     getActiveCatalogTarget({ scope: { chapterId } }),
+    getSession(),
+    getUserHiddenLessonKinds(),
   ]);
 
+  const lessonKindLabels = await getLessonKindLabels();
   const completionMap = new Map(completionData.map((row) => [row.lessonId, row]));
   const lessonRows = await getLessonRows(lessons);
 
@@ -151,12 +159,29 @@ export async function LessonList({
   const searchItems = lessonRows.map(({ display, lesson }) => ({
     description: display.description,
     id: lesson.id,
+    kind: lesson.kind,
     title: display.title,
+  }));
+
+  const filterableLessonKinds = getFilterableLessonKinds({
+    isLanguageCourse,
+    lessonKinds: lessons.map((lesson) => lesson.kind),
+  });
+
+  const lessonKindOptions = filterableLessonKinds.map((kind) => ({
+    kind,
+    label: lessonKindLabels[kind],
   }));
 
   return (
     <CatalogGridContent activeItemKey={activeLessonKey} activeLabel={t("Current lesson")}>
-      <CatalogGridSearch items={searchItems} placeholder={t("Search lessons...")}>
+      <LessonListFilters
+        canPersistFilters={Boolean(session)}
+        initialHiddenLessonKinds={hiddenLessonKinds}
+        items={searchItems}
+        lessonKindOptions={lessonKindOptions}
+        placeholder={t("Search lessons...")}
+      >
         <CatalogGridEmpty>{t("No lessons found")}</CatalogGridEmpty>
         <GridGroup variant="pane">
           {lessonRows.map(({ display, lesson }) => {
@@ -178,7 +203,7 @@ export async function LessonList({
             );
           })}
         </GridGroup>
-      </CatalogGridSearch>
+      </LessonListFilters>
     </CatalogGridContent>
   );
 }

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -109,6 +109,7 @@ export default async function ChapterPage({
               chapterId={chapter.id}
               chapterSlug={chapterSlug}
               courseSlug={courseSlug}
+              isLanguageCourse={Boolean(chapter.course.targetLanguage)}
               lessons={lessons}
             />
           </Suspense>

--- a/apps/main/src/components/catalog/catalog-grid-context.tsx
+++ b/apps/main/src/components/catalog/catalog-grid-context.tsx
@@ -2,12 +2,12 @@
 
 import { createContext, use } from "react";
 
-type CatalogGridContextValue = { filteredIds: Set<string> | null; isSearchActive: boolean };
+type CatalogGridContextValue = { filteredIds: Set<string> | null; isFilterActive: boolean };
 
 export const CatalogGridContext = createContext<CatalogGridContextValue | null>(null);
 
 /**
- * Grid children read the active search filter from this hook so links and empty
+ * Grid children read the active catalog filter from this hook so links and empty
  * states can stay declarative instead of passing filtered ids through every map.
  */
 export function useCatalogGridContext() {

--- a/apps/main/src/components/catalog/catalog-grid.tsx
+++ b/apps/main/src/components/catalog/catalog-grid.tsx
@@ -13,7 +13,11 @@ import { CatalogGridBackToTop } from "./catalog-grid-back-to-top";
 import { CatalogGridContext, useCatalogGridContext } from "./catalog-grid-context";
 import { type CatalogGridItemKey, getCatalogItemTargetId } from "./catalog-item-target";
 
-type CatalogGridSearchItem = { description?: string | null; id: CatalogGridItemKey; title: string };
+export type CatalogGridSearchItem = {
+  description?: string | null;
+  id: CatalogGridItemKey;
+  title: string;
+};
 
 /**
  * Catalog search should match the text learners scan inside each tile. Generated
@@ -28,7 +32,7 @@ function getCatalogSearchText(item: CatalogGridSearchItem): string {
  * Normalizing the combined tile text once per candidate keeps chapter and lesson
  * search accent-insensitive without each page rebuilding the same rules.
  */
-function matchesCatalogSearchQuery({
+export function matchesCatalogSearchQuery({
   item,
   query,
 }: {
@@ -84,34 +88,65 @@ export function CatalogGridSearch({
     throttleMs: 300,
   });
 
-  const { filteredIds, isSearchActive } = useMemo(() => {
+  const { filteredIds, isFilterActive } = useMemo(() => {
     const query = normalizeString(search);
 
     if (!query) {
-      return { filteredIds: null, isSearchActive: false };
+      return { filteredIds: null, isFilterActive: false };
     }
 
     const matching = items.filter((item) => matchesCatalogSearchQuery({ item, query }));
-    return { filteredIds: new Set(matching.map((item) => String(item.id))), isSearchActive: true };
+    return { filteredIds: new Set(matching.map((item) => String(item.id))), isFilterActive: true };
   }, [items, search]);
 
   return (
-    <CatalogGridContext value={{ filteredIds, isSearchActive }}>
-      <div className={cn("w-full", className)} data-slot="catalog-grid-search">
-        <div className="relative">
-          <SearchIcon className="text-muted-foreground/60 absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-          <Input
-            aria-label={placeholder}
-            className="border-border/40 placeholder:text-muted-foreground/50 focus-visible:border-border h-10 bg-transparent pl-9 focus-visible:ring-0"
-            onChange={(event) => setSearch(event.target.value || null)}
-            placeholder={placeholder}
-            type="search"
-            value={search}
-          />
-        </div>
-      </div>
+    <CatalogGridContext value={{ filteredIds, isFilterActive }}>
+      <CatalogGridSearchField
+        className={className}
+        onSearchChange={(value) => setSearch(value || null)}
+        placeholder={placeholder}
+        search={search}
+      />
       {children}
     </CatalogGridContext>
+  );
+}
+
+/**
+ * Search controls keep the same icon, sizing, and responsive row behavior while
+ * letting specialized catalog pages place small filter actions beside the field.
+ */
+export function CatalogGridSearchField({
+  children,
+  className,
+  onSearchChange,
+  placeholder,
+  search,
+}: {
+  children?: ReactNode;
+  className?: string;
+  onSearchChange: (value: string) => void;
+  placeholder: string;
+  search: string;
+}) {
+  return (
+    <div
+      className={cn("flex w-full min-w-0 items-center gap-2", className)}
+      data-slot="catalog-grid-search"
+    >
+      <div className="relative min-w-0 flex-1">
+        <SearchIcon className="text-muted-foreground/60 absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+        <Input
+          aria-label={placeholder}
+          className="border-border/40 placeholder:text-muted-foreground/50 focus-visible:border-border h-10 bg-transparent pl-9 focus-visible:ring-0"
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder={placeholder}
+          type="search"
+          value={search}
+        />
+      </div>
+      {children}
+    </div>
   );
 }
 
@@ -123,9 +158,9 @@ export function CatalogGridSearch({
 export function CatalogGridEmpty({ className, ...props }: React.ComponentProps<"p">) {
   const context = useCatalogGridContext();
   const filteredIds = context?.filteredIds ?? null;
-  const isSearchActive = context?.isSearchActive ?? false;
+  const isFilterActive = context?.isFilterActive ?? false;
 
-  const isEmpty = isSearchActive && filteredIds?.size === 0;
+  const isEmpty = isFilterActive && filteredIds?.size === 0;
 
   if (!isEmpty) {
     return null;

--- a/apps/main/src/data/users/lesson-filter-settings.ts
+++ b/apps/main/src/data/users/lesson-filter-settings.ts
@@ -1,0 +1,71 @@
+import "server-only";
+import {
+  getHiddenLessonKindsFromPreferences,
+  getUpdatedLessonFilterSettings,
+} from "@/lib/lessons/lesson-kind-filters";
+import { getSession } from "@zoonk/core/users/session/get";
+import { type LessonKind, prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { logError } from "@zoonk/utils/logger";
+
+/**
+ * The chapter lesson list reads hidden kinds from the learner profile so the
+ * same filters follow the signed-in learner across devices and browser sessions.
+ */
+export async function getUserHiddenLessonKinds(): Promise<LessonKind[]> {
+  const session = await getSession();
+
+  if (!session) {
+    return [];
+  }
+
+  const { data, error } = await safeAsync(() =>
+    prisma.userLearningProfile.findUnique({ where: { userId: session.user.id } }),
+  );
+
+  if (error) {
+    logError("Error loading hidden lesson kinds:", error);
+    return [];
+  }
+
+  return getHiddenLessonKindsFromPreferences(data?.preferences);
+}
+
+/**
+ * Updating lesson filters must preserve the rest of the learning-profile JSON
+ * because future preferences can share this same durable user settings record.
+ */
+export async function updateUserHiddenLessonKinds({
+  hiddenLessonKinds,
+}: {
+  hiddenLessonKinds: LessonKind[];
+}) {
+  const session = await getSession();
+
+  if (!session) {
+    return { error: null, saved: false };
+  }
+
+  const { data: profile, error: loadError } = await safeAsync(() =>
+    prisma.userLearningProfile.findUnique({ where: { userId: session.user.id } }),
+  );
+
+  if (loadError) {
+    return { error: loadError, saved: false };
+  }
+
+  const preferences = getUpdatedLessonFilterSettings({
+    hiddenLessonKinds,
+    preferences: profile?.preferences,
+  });
+
+  const { error } = await safeAsync(() =>
+    prisma.userLearningProfile.upsert({
+      create: { preferences, userId: session.user.id },
+      update: { preferences },
+      where: { userId: session.user.id },
+    }),
+  );
+
+  return { error, saved: !error };
+}

--- a/apps/main/src/lib/lessons.ts
+++ b/apps/main/src/lib/lessons.ts
@@ -13,7 +13,7 @@ type LessonSeoInput = LessonDisplayInput & {
  * one translated map prevents the chapter list, player metadata, and SEO copy
  * from drifting when a label changes.
  */
-async function getLessonKindLabels(): Promise<Record<LessonKind, string>> {
+export async function getLessonKindLabels(): Promise<Record<LessonKind, string>> {
   const t = await getExtracted();
 
   return {

--- a/apps/main/src/lib/lessons/lesson-kind-filters.test.ts
+++ b/apps/main/src/lib/lessons/lesson-kind-filters.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  getClearedHiddenLessonKinds,
+  getFilterableLessonKinds,
+  getHiddenLessonKindsForFilter,
+  getHiddenLessonKindsFromPreferences,
+  getNextHiddenLessonKinds,
+  getUpdatedLessonFilterSettings,
+} from "./lesson-kind-filters";
+
+describe(getHiddenLessonKindsFromPreferences, () => {
+  it("keeps only supported hidden lesson kinds in canonical order", () => {
+    const result = getHiddenLessonKindsFromPreferences({
+      hiddenLessonKinds: ["quiz", "unknown", "explanation", "quiz", 42],
+    });
+
+    expect(result).toStrictEqual(["explanation", "quiz"]);
+  });
+
+  it("ignores malformed preferences", () => {
+    expect(getHiddenLessonKindsFromPreferences(null)).toStrictEqual([]);
+    expect(getHiddenLessonKindsFromPreferences({ hiddenLessonKinds: "quiz" })).toStrictEqual([]);
+  });
+});
+
+describe(getNextHiddenLessonKinds, () => {
+  it("adds or removes one hidden lesson kind without duplicating values", () => {
+    expect(
+      getNextHiddenLessonKinds({
+        currentHiddenLessonKinds: ["quiz", "quiz"],
+        isHidden: true,
+        kind: "explanation",
+      }),
+    ).toStrictEqual(["explanation", "quiz"]);
+
+    expect(
+      getNextHiddenLessonKinds({
+        currentHiddenLessonKinds: ["explanation", "quiz"],
+        isHidden: false,
+        kind: "quiz",
+      }),
+    ).toStrictEqual(["explanation"]);
+  });
+});
+
+describe(getFilterableLessonKinds, () => {
+  it("shows only present language lesson kinds for language courses", () => {
+    const filterableKinds = getFilterableLessonKinds({
+      isLanguageCourse: true,
+      lessonKinds: ["vocabulary", "grammar", "quiz", "explanation"],
+    });
+
+    expect(filterableKinds).toStrictEqual(["grammar", "vocabulary"]);
+  });
+
+  it("shows only present content lesson kinds for non-language courses", () => {
+    const filterableKinds = getFilterableLessonKinds({
+      isLanguageCourse: false,
+      lessonKinds: ["vocabulary", "grammar", "quiz", "explanation"],
+    });
+
+    expect(filterableKinds).toStrictEqual(["explanation", "quiz"]);
+  });
+});
+
+describe(getHiddenLessonKindsForFilter, () => {
+  it("returns only hidden kinds that apply to the current filter menu", () => {
+    const hiddenKinds = getHiddenLessonKindsForFilter({
+      filterableLessonKinds: ["grammar", "vocabulary"],
+      hiddenLessonKinds: ["quiz", "vocabulary"],
+    });
+
+    expect(hiddenKinds).toStrictEqual(["vocabulary"]);
+  });
+});
+
+describe(getClearedHiddenLessonKinds, () => {
+  it("clears only the hidden kinds controlled by the current menu", () => {
+    const hiddenKinds = getClearedHiddenLessonKinds({
+      currentHiddenLessonKinds: ["quiz", "vocabulary"],
+      filterableLessonKinds: ["grammar", "vocabulary"],
+    });
+
+    expect(hiddenKinds).toStrictEqual(["quiz"]);
+  });
+});
+
+describe(getUpdatedLessonFilterSettings, () => {
+  it("preserves unrelated user preferences while replacing hidden lesson kinds", () => {
+    const result = getUpdatedLessonFilterSettings({
+      hiddenLessonKinds: ["quiz"],
+      preferences: { existing: "value" },
+    });
+
+    expect(result).toStrictEqual({ existing: "value", hiddenLessonKinds: ["quiz"] });
+  });
+});

--- a/apps/main/src/lib/lessons/lesson-kind-filters.ts
+++ b/apps/main/src/lib/lessons/lesson-kind-filters.ts
@@ -1,0 +1,179 @@
+import { type LessonKind } from "@zoonk/db";
+import { type JsonObject, isJsonObject } from "@zoonk/utils/json";
+
+export type LessonKindFilterSettings = JsonObject & { hiddenLessonKinds: LessonKind[] };
+
+const LANGUAGE_COURSE_LESSON_FILTER_KINDS = [
+  "alphabet",
+  "grammar",
+  "listening",
+  "reading",
+  "review",
+  "translation",
+  "vocabulary",
+] as const satisfies readonly LessonKind[];
+
+const CONTENT_COURSE_LESSON_FILTER_KINDS = [
+  "custom",
+  "explanation",
+  "practice",
+  "quiz",
+  "review",
+  "tutorial",
+] as const satisfies readonly LessonKind[];
+
+const SUPPORTED_LESSON_FILTER_KINDS = [
+  "alphabet",
+  "custom",
+  "explanation",
+  "grammar",
+  "listening",
+  "practice",
+  "quiz",
+  "reading",
+  "review",
+  "translation",
+  "tutorial",
+  "vocabulary",
+] as const satisfies readonly LessonKind[];
+
+const SUPPORTED_LESSON_FILTER_KIND_SET = new Set<string>(SUPPORTED_LESSON_FILTER_KINDS);
+
+/**
+ * Course families have different lesson vocabularies. Showing only lesson kinds
+ * that belong to the current family and are present in the chapter keeps the
+ * menu short instead of exposing the whole database enum everywhere.
+ */
+export function getFilterableLessonKinds({
+  isLanguageCourse,
+  lessonKinds,
+}: {
+  isLanguageCourse: boolean;
+  lessonKinds: LessonKind[];
+}): LessonKind[] {
+  const presentLessonKinds = new Set(lessonKinds);
+
+  const courseKinds = isLanguageCourse
+    ? LANGUAGE_COURSE_LESSON_FILTER_KINDS
+    : CONTENT_COURSE_LESSON_FILTER_KINDS;
+
+  return courseKinds.filter((kind) => presentLessonKinds.has(kind));
+}
+
+/**
+ * Saved filter JSON can outlive enum changes, so every saved value needs to be
+ * checked against the lesson kinds this UI still knows how to filter.
+ */
+function isFilterableLessonKind(kind: unknown): kind is LessonKind {
+  return typeof kind === "string" && SUPPORTED_LESSON_FILTER_KIND_SET.has(kind);
+}
+
+/**
+ * Stored preferences come from a JSON column, so this narrows the value to the
+ * object shape the lesson filter can safely merge with without trusting arrays,
+ * null, or primitive values as user settings.
+ */
+function getPreferenceObject(preferences: unknown): JsonObject {
+  if (isJsonObject(preferences)) {
+    return preferences;
+  }
+
+  return {};
+}
+
+/**
+ * Hidden lesson kinds are stored as a user preference, but filtering must stay
+ * deterministic for hydration and tests. Returning canonical enum order removes
+ * duplicates and ignores stale values from older saved preferences.
+ */
+export function getHiddenLessonKindsFromPreferences(preferences: unknown): LessonKind[] {
+  const value = getPreferenceObject(preferences).hiddenLessonKinds;
+
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const hiddenLessonKinds = new Set(value.filter((item) => isFilterableLessonKind(item)));
+  return SUPPORTED_LESSON_FILTER_KINDS.filter((kind) => hiddenLessonKinds.has(kind));
+}
+
+/**
+ * Toggling one kind should preserve the same canonical array shape that is
+ * saved to the database, regardless of the order or duplicates in the current
+ * client state.
+ */
+export function getNextHiddenLessonKinds({
+  currentHiddenLessonKinds,
+  isHidden,
+  kind,
+}: {
+  currentHiddenLessonKinds: LessonKind[];
+  isHidden: boolean;
+  kind: LessonKind;
+}): LessonKind[] {
+  const hiddenLessonKinds = new Set(
+    currentHiddenLessonKinds.filter((item) => isFilterableLessonKind(item)),
+  );
+
+  if (isHidden) {
+    hiddenLessonKinds.add(kind);
+  } else {
+    hiddenLessonKinds.delete(kind);
+  }
+
+  return SUPPORTED_LESSON_FILTER_KINDS.filter((item) => hiddenLessonKinds.has(item));
+}
+
+/**
+ * A user preference can hide kinds from another course family. The current
+ * page should only apply hidden kinds controlled by the menu it is showing.
+ */
+export function getHiddenLessonKindsForFilter({
+  filterableLessonKinds,
+  hiddenLessonKinds,
+}: {
+  filterableLessonKinds: LessonKind[];
+  hiddenLessonKinds: LessonKind[];
+}): LessonKind[] {
+  const hiddenLessonKindSet = new Set(
+    hiddenLessonKinds.filter((item) => isFilterableLessonKind(item)),
+  );
+
+  return filterableLessonKinds.filter((kind) => hiddenLessonKindSet.has(kind));
+}
+
+/**
+ * Clearing filters on a language course should not erase a learner's saved
+ * non-language preferences, and the inverse is also true.
+ */
+export function getClearedHiddenLessonKinds({
+  currentHiddenLessonKinds,
+  filterableLessonKinds,
+}: {
+  currentHiddenLessonKinds: LessonKind[];
+  filterableLessonKinds: LessonKind[];
+}): LessonKind[] {
+  const filterableLessonKindSet = new Set(filterableLessonKinds);
+
+  return SUPPORTED_LESSON_FILTER_KINDS.filter(
+    (kind) => currentHiddenLessonKinds.includes(kind) && !filterableLessonKindSet.has(kind),
+  );
+}
+
+/**
+ * Lesson filters share the broader learning-profile preferences object, so
+ * updates replace only the hidden lesson kinds while keeping unrelated saved
+ * preferences intact.
+ */
+export function getUpdatedLessonFilterSettings({
+  hiddenLessonKinds,
+  preferences,
+}: {
+  hiddenLessonKinds: LessonKind[];
+  preferences: unknown;
+}): LessonKindFilterSettings {
+  return {
+    ...getPreferenceObject(preferences),
+    hiddenLessonKinds: getHiddenLessonKindsFromPreferences({ hiddenLessonKinds }),
+  };
+}

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -1,8 +1,11 @@
+export type JsonObject = { [key: string]: JsonValue };
+type JsonValue = JsonObject | JsonValue[] | boolean | null | number | string;
+
 /**
  * Narrows unknown JSON-like values to keyed objects so callers can safely read
  * named fields without accidentally treating arrays as records.
  */
-export function isJsonObject(value: unknown): value is Record<string, unknown> {
+export function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 


### PR DESCRIPTION
Adds lesson type filters to chapter lesson lists, with user settings persistence and scoped language/content options.\n\nAlso keeps lesson search URL-backed and covers the new filter flows in chapter-detail E2E.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add lesson type filters to chapter lesson lists so learners can hide lesson kinds and focus on what matters. Filters are saved to user settings (guests filter locally) and work alongside URL-backed search.

- New Features
  - Added a Types filter dropdown to show/hide lesson kinds and clear in one click.
  - Scoped options by course type (language: grammar/vocabulary; content: explanation/quiz).
  - Persisted filters for signed-in users with optimistic updates and error rollback via toast.
  - Combined search and type filters; empty state respects both; updates in real time.
  - Added E2E and unit tests for filter logic and flows.

- Refactors
  - Extracted reusable `CatalogGridSearchField` and renamed context flag to `isFilterActive`.
  - Exposed `matchesCatalogSearchQuery` and `getLessonKindLabels` for reuse.

<sup>Written for commit 14b3b604bad7bd56ec0d136664bd5c4883774a1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

