### PR TITLE
fix(ui): update primary color and media card spacing

### DIFF
--- a/packages/ui/src/components/media-card.tsx
+++ b/packages/ui/src/components/media-card.tsx
@@ -153,7 +153,7 @@ export function MediaCardDescription({ children, className }: React.ComponentPro
   return (
     <p
       className={cn(
-        "text-muted-foreground mt-1.5 line-clamp-3 text-sm leading-snug text-pretty sm:text-base sm:leading-relaxed",
+        "text-muted-foreground mt-0.5 line-clamp-3 text-sm leading-snug text-pretty sm:text-base sm:leading-relaxed",
         className,
       )}
       data-slot="media-card-description"

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -169,7 +169,7 @@
     --card-foreground: var(--color-neutral-50);
     --popover: var(--color-neutral-900);
     --popover-foreground: var(--color-neutral-50);
-    --primary: var(--color-neutral-200);
+    --primary: var(--color-neutral-50);
     --primary-foreground: var(--color-neutral-900);
     --secondary: var(--color-neutral-800);
     --secondary-foreground: var(--color-neutral-50);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the UI theme to use a lighter primary color for better contrast and tightened media card description spacing to match design.
- Changed `--primary` to neutral-50.
- Reduced media card description top margin from `mt-1.5` to `mt-0.5`.

<sup>Written for commit ab5a1e97178bf82bcd9d2187643cb44f2a9773ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

