### PR TITLE
fix(main): make lesson descriptions clickable

### DIFF
--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -40,6 +40,82 @@ test.describe("Home Page - Unauthenticated", () => {
 });
 
 test.describe("Home Page - Authenticated", () => {
+  test("continue learning lesson description navigates to the player", async ({
+    baseURL,
+    browser,
+  }) => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const [org, user] = await Promise.all([getAiOrganization(), createE2EUser(baseURL!)]);
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-description-course-${uniqueId}`,
+      title: `E2E Description Course ${uniqueId}`,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-description-chapter-${uniqueId}`,
+      title: `E2E Description Chapter ${uniqueId}`,
+    });
+
+    const lessonDescription = `E2E Description target ${uniqueId}`;
+
+    const [completedLesson, nextLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+        slug: `e2e-description-completed-${uniqueId}`,
+        title: `E2E Description Completed ${uniqueId}`,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        description: lessonDescription,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: org.id,
+        position: 1,
+        slug: `e2e-description-next-${uniqueId}`,
+        title: `E2E Description Next ${uniqueId}`,
+      }),
+    ]);
+
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date(),
+        durationSeconds: 60,
+        lessonId: completedLesson.id,
+        userId: user.id,
+      }),
+      userProgressFixture({ totalBrainPower: 100n, userId: user.id }),
+      prisma.courseUser.create({ data: { courseId: course.id, userId: user.id } }),
+    ]);
+
+    const ctx = await browser.newContext({ storageState: user.storageState });
+    const page = await ctx.newPage();
+
+    try {
+      await page.goto("/");
+
+      const descriptionLink = page.getByRole("link", { name: lessonDescription });
+
+      await expect(descriptionLink).toBeVisible();
+      await descriptionLink.click();
+
+      await expect(page).toHaveURL(
+        new RegExp(`/b/${org.slug}/c/${course.slug}/ch/${chapter.slug}/l/${nextLesson.slug}$`, "u"),
+      );
+    } finally {
+      await ctx.close();
+    }
+  });
+
   test("user with progress sees continue learning instead of hero", async ({
     authenticatedPage,
   }) => {

--- a/apps/main/src/app/(catalog)/(home)/continue-learning-card.tsx
+++ b/apps/main/src/app/(catalog)/(home)/continue-learning-card.tsx
@@ -109,7 +109,15 @@ export async function ContinueLearningCard({ item }: { item: ContinueLearningIte
           </FeatureCardSubtitle>
 
           {lessonMeta ? (
-            <FeatureCardDescription>{lessonMeta.description}</FeatureCardDescription>
+            <Link
+              className="focus-visible:ring-ring block rounded-sm focus-visible:ring-2 focus-visible:outline-none"
+              href={headerHref}
+              prefetch={prefetch}
+            >
+              <FeatureCardDescription className="hover:text-muted-foreground transition-colors hover:underline">
+                {lessonMeta.description}
+              </FeatureCardDescription>
+            </Link>
           ) : null}
         </FeatureCardBody>
       </FeatureCardContent>


### PR DESCRIPTION
## Summary

- make Continue Learning lesson descriptions link to the lesson player
- add e2e coverage for description-click navigation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Continue Learning lesson descriptions clickable, linking directly to the lesson player for quicker navigation. Adds an e2e test that clicks the description and verifies the player URL.

<sup>Written for commit df41ce50fb991f73e81aec881511d8487ef6f9c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

