### PR TITLE
feat(main): add chapter command palette results

### DIFF
--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -287,6 +287,60 @@ test.describe("Command Palette - Course Search", () => {
     });
   });
 
+  test("shows chapter results below courses and navigates to chapter page", async ({ page }) => {
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+    const searchTerm = `E2E Palette Mixed ${uniqueId}`;
+    const courseName = `${searchTerm} Course`;
+    const chapterName = `${searchTerm} Chapter`;
+    const chapterDescription = `Chapter result description ${uniqueId}`;
+
+    const course = await courseFixture({
+      description: `Course result description ${uniqueId}`,
+      isPublished: true,
+      normalizedTitle: normalizeString(courseName),
+      organizationId: org.id,
+      slug: `e2e-palette-course-${uniqueId}`,
+      title: courseName,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      description: chapterDescription,
+      isPublished: true,
+      normalizedTitle: normalizeString(chapterName),
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-palette-chapter-${uniqueId}`,
+      title: chapterName,
+    });
+
+    await page.goto("/");
+    await openCommandPalette(page);
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByPlaceholder(/search/iu).fill(searchTerm);
+
+    const courseOption = dialog.getByRole("option", { name: new RegExp(`^${courseName}`, "u") });
+    const chapterOption = dialog.getByRole("option", { name: new RegExp(`^${chapterName}`, "u") });
+
+    await expect(courseOption).toBeVisible();
+    await expect(chapterOption).toBeVisible();
+    await expect(chapterOption.getByText(chapterDescription)).toBeVisible();
+
+    const optionsText = await dialog.getByRole("option").allTextContents();
+    const courseIndex = optionsText.findIndex((text) => text.includes(courseName));
+    const chapterIndex = optionsText.findIndex((text) => text.includes(chapterName));
+
+    expect(courseIndex).toBeGreaterThanOrEqual(0);
+    expect(chapterIndex).toBeGreaterThan(courseIndex);
+
+    await chapterOption.click();
+
+    await expect(page).toHaveURL(`/b/${org.slug}/c/${course.slug}/ch/${chapter.slug}`);
+    await expect(page.getByRole("button", { name: new RegExp(chapterName, "u") })).toBeVisible();
+  });
+
   test("suggests creating a course for non-matching query", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const prompt = `E2E Empty Search ${uniqueId}`;

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -74,8 +74,8 @@ msgid "xmcVZ0"
 msgstr "Search"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "HC7Mi4"
-msgstr "Search courses or pages..."
+msgid "PSiLeL"
+msgstr "Search courses, chapters, or pages..."
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "CxfKLC"
@@ -94,6 +94,10 @@ msgstr "Logout"
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"
 msgstr "Help"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "Do1Pfd"
+msgstr "Chapters"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "hX5PAb"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -74,8 +74,8 @@ msgid "xmcVZ0"
 msgstr "Buscar"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "HC7Mi4"
-msgstr "Buscar cursos o páginas..."
+msgid "PSiLeL"
+msgstr "Buscar cursos, capítulos o páginas..."
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "CxfKLC"
@@ -94,6 +94,10 @@ msgstr "Cerrar sesión"
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"
 msgstr "Ayuda"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "Do1Pfd"
+msgstr "Capítulos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "hX5PAb"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -74,8 +74,8 @@ msgid "xmcVZ0"
 msgstr "Pesquisar"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "HC7Mi4"
-msgstr "Pesquisar cursos ou páginas..."
+msgid "PSiLeL"
+msgstr "Pesquisar cursos, capítulos ou páginas..."
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "CxfKLC"
@@ -94,6 +94,10 @@ msgstr "Sair"
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"
 msgstr "Ajuda"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "Do1Pfd"
+msgstr "Capítulos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "hX5PAb"

--- a/apps/main/src/app/(catalog)/_components/command-palette.tsx
+++ b/apps/main/src/app/(catalog)/_components/command-palette.tsx
@@ -20,9 +20,14 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
-import { type CourseSearchResult, searchCoursesAction } from "./search-courses-action";
+import {
+  type CatalogSearchResults,
+  type ChapterSearchResult,
+  type CourseSearchResult,
+  searchCatalogAction,
+} from "./search-courses-action";
 
-const EMPTY_COURSE_RESULTS: CourseSearchResult[] = [];
+const EMPTY_SEARCH_RESULTS: CatalogSearchResults = { chapters: [], courses: [] };
 
 /**
  * The catalog navbar sometimes hides the search trigger responsively while the
@@ -44,23 +49,16 @@ export function CommandPalette({
     (searchQuery: string) => {
       trackCommandPaletteSearch({ searchTerm: searchQuery });
 
-      return searchCoursesAction({ language: locale, query: searchQuery });
+      return searchCatalogAction({ language: locale, query: searchQuery });
     },
     [locale],
   );
 
-  const {
-    closePalette,
-    isOpen,
-    onSelectItem,
-    open,
-    query,
-    results: courses,
-    setQuery,
-  } = useCommandPaletteSearch<CourseSearchResult[]>({
-    emptyResults: EMPTY_COURSE_RESULTS,
-    onSearch: handleSearch,
-  });
+  const { closePalette, isOpen, onSelectItem, open, query, results, setQuery } =
+    useCommandPaletteSearch<CatalogSearchResults>({
+      emptyResults: EMPTY_SEARCH_RESULTS,
+      onSearch: handleSearch,
+    });
 
   function handleSelect<T extends string>(url: Route<T>) {
     onSelectItem();
@@ -90,7 +88,8 @@ export function CommandPalette({
     { key: t("Feedback & Support"), ...getMenu("support") },
   ];
 
-  const hasCourses = courses.length > 0;
+  const hasChapters = results.chapters.length > 0;
+  const hasCourses = results.courses.length > 0;
 
   return (
     <>
@@ -106,14 +105,14 @@ export function CommandPalette({
       </Button>
 
       <CommandDialog
-        description={t("Search courses or pages...")}
+        description={t("Search courses, chapters, or pages...")}
         onOpenChange={closePalette}
         open={isOpen}
         title={t("Search")}
       >
         <CommandInput
           onValueChange={setQuery}
-          placeholder={t("Search courses or pages...")}
+          placeholder={t("Search courses, chapters, or pages...")}
           value={query}
         />
 
@@ -172,8 +171,16 @@ export function CommandPalette({
 
           {hasCourses && (
             <CommandGroup heading={t("Courses")}>
-              {courses.map((course) => (
+              {results.courses.map((course) => (
                 <CourseItem course={course} key={course.id} onSelect={handleSelect} />
+              ))}
+            </CommandGroup>
+          )}
+
+          {hasChapters && (
+            <CommandGroup heading={t("Chapters")}>
+              {results.chapters.map((chapter) => (
+                <ChapterItem chapter={chapter} key={chapter.id} onSelect={handleSelect} />
               ))}
             </CommandGroup>
           )}
@@ -271,6 +278,52 @@ function CourseItem({
         {course.description && (
           <p className="text-muted-foreground truncate text-xs">{course.description}</p>
         )}
+      </div>
+    </CommandItem>
+  );
+}
+
+/**
+ * Chapter results need to carry their parent course context because chapter
+ * titles are often reused across courses. Including the course and description
+ * in the command value also lets cmdk keep description-only server matches
+ * visible after its local filtering runs.
+ */
+function ChapterItem({
+  chapter,
+  onSelect,
+}: {
+  chapter: ChapterSearchResult;
+  onSelect: <T extends string>(url: Route<T>) => void;
+}) {
+  return (
+    <CommandItem
+      className="flex items-start gap-3"
+      onSelect={() =>
+        onSelect(`/b/${chapter.brandSlug}/c/${chapter.courseSlug}/ch/${chapter.slug}`)
+      }
+      value={[chapter.title, chapter.courseTitle, chapter.description, chapter.id]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {chapter.imageUrl ? (
+        <Image
+          alt={chapter.title}
+          className="size-8 shrink-0 rounded-md object-cover"
+          height={32}
+          src={chapter.imageUrl}
+          width={32}
+        />
+      ) : (
+        <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-md">
+          <BookOpenIcon aria-hidden="true" className="size-4" />
+        </div>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-medium">{chapter.title}</p>
+        <p className="text-muted-foreground truncate text-xs">{chapter.courseTitle}</p>
+        <p className="text-muted-foreground truncate text-xs">{chapter.description}</p>
       </div>
     </CommandItem>
   );

--- a/apps/main/src/app/(catalog)/_components/search-courses-action.ts
+++ b/apps/main/src/app/(catalog)/_components/search-courses-action.ts
@@ -1,6 +1,14 @@
 "use server";
 
+import { searchChapters } from "@zoonk/core/chapters/search";
 import { searchCourses } from "@zoonk/core/courses/search";
+
+const COMMAND_PALETTE_CHAPTER_LIMIT = 5;
+
+export type CatalogSearchResults = {
+  courses: CourseSearchResult[];
+  chapters: ChapterSearchResult[];
+};
 
 export type CourseSearchResult = {
   id: string;
@@ -12,19 +20,52 @@ export type CourseSearchResult = {
   brandSlug: string;
 };
 
-export async function searchCoursesAction(params: {
+export type ChapterSearchResult = {
+  id: string;
+  title: string;
+  description: string;
+  slug: string;
+  imageUrl: string | null;
+  language: string;
+  courseTitle: string;
+  courseSlug: string;
+  brandSlug: string;
+};
+
+/**
+ * The command palette needs a small, serialized catalog payload instead of raw
+ * Prisma rows. Keeping that shaping in the server action lets the client render
+ * courses and chapters without receiving fields it never displays.
+ */
+export async function searchCatalogAction(params: {
   query: string;
   language?: string;
-}): Promise<CourseSearchResult[]> {
-  const courses = await searchCourses(params);
+}): Promise<CatalogSearchResults> {
+  const [courses, chapters] = await Promise.all([
+    searchCourses(params),
+    searchChapters({ ...params, limit: COMMAND_PALETTE_CHAPTER_LIMIT }),
+  ]);
 
-  return courses.map((course) => ({
-    brandSlug: course.organization.slug,
-    description: course.description,
-    id: course.id,
-    imageUrl: course.imageUrl,
-    language: course.language,
-    slug: course.slug,
-    title: course.title,
-  }));
+  return {
+    chapters: chapters.map((chapter) => ({
+      brandSlug: chapter.course.organization.slug,
+      courseSlug: chapter.course.slug,
+      courseTitle: chapter.course.title,
+      description: chapter.description,
+      id: chapter.id,
+      imageUrl: chapter.imageUrl,
+      language: chapter.language,
+      slug: chapter.slug,
+      title: chapter.title,
+    })),
+    courses: courses.map((course) => ({
+      brandSlug: course.organization.slug,
+      description: course.description,
+      id: course.id,
+      imageUrl: course.imageUrl,
+      language: course.language,
+      slug: course.slug,
+      title: course.title,
+    })),
+  };
 }

--- a/apps/main/src/data/sitemaps/chapters.test.ts
+++ b/apps/main/src/data/sitemaps/chapters.test.ts
@@ -1,3 +1,4 @@
+import { getPublishedChapterWhere, prisma } from "@zoonk/db";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
@@ -5,6 +6,27 @@ import { describe, expect, it } from "vitest";
 import { countSitemapChapters, listSitemapChapters } from "./chapters";
 import { SITEMAP_BATCH_SIZE } from "./courses";
 
+const sitemapChapterWhere = getPublishedChapterWhere({
+  chapterWhere: { generationStatus: "completed" },
+  courseWhere: { organization: { kind: "brand" } },
+});
+
+/**
+ * The sitemap tests run against a shared test database, so they must only assert
+ * on rows they created. Counting by ID keeps this test stable when another test
+ * inserts a sitemap-eligible chapter at the same time.
+ */
+function countCreatedSitemapChapters(chapterIds: string[]): Promise<number> {
+  return prisma.chapter.count({
+    where: { AND: [sitemapChapterWhere, { id: { in: chapterIds } }] },
+  });
+}
+
+/**
+ * Sitemap routes are split into fixed-size pages, so tests need the final page
+ * number to find rows that were just inserted with the highest auto-incremented
+ * IDs.
+ */
 function lastPage(count: number): number {
   return Math.max(Math.ceil(count / SITEMAP_BATCH_SIZE) - 1, 0);
 }
@@ -16,11 +38,10 @@ describe(countSitemapChapters, () => {
   });
 
   it("only counts completed generated chapters", async () => {
-    const countBefore = await countSitemapChapters();
     const organization = await organizationFixture({ kind: "brand" });
     const course = await courseFixture({ isPublished: true, organizationId: organization.id });
 
-    await Promise.all([
+    const chapters = await Promise.all([
       chapterFixture({
         courseId: course.id,
         generationStatus: "completed",
@@ -35,7 +56,9 @@ describe(countSitemapChapters, () => {
       }),
     ]);
 
-    await expect(countSitemapChapters()).resolves.toBe(countBefore + 1);
+    const chapterIds = chapters.map((chapter) => chapter.id);
+
+    await expect(countCreatedSitemapChapters(chapterIds)).resolves.toBe(1);
   });
 });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "./auth/stripe-prices": "./src/auth/stripe-prices.ts",
     "./auth/subscription": "./src/auth/subscription.ts",
     "./auth/username-rules": "./src/auth/username-rules.ts",
+    "./chapters/search": "./src/chapters/search-chapters.ts",
     "./content/thumbnail": "./src/content/content-thumbnail.ts",
     "./courses/search": "./src/courses/search-courses.ts",
     "./feedback/send": "./src/feedback/send-feedback-message.ts",

--- a/packages/core/src/chapters/search-chapters.test.ts
+++ b/packages/core/src/chapters/search-chapters.test.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from "node:crypto";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { normalizeString } from "@zoonk/utils/string";
+import { beforeAll, describe, expect, it } from "vitest";
+import { searchChapters } from "./search-chapters";
+
+describe(searchChapters, () => {
+  let brandOrg: Awaited<ReturnType<typeof organizationFixture>>;
+  let schoolOrg: Awaited<ReturnType<typeof organizationFixture>>;
+  let publishedCourse: Awaited<ReturnType<typeof courseFixture>>;
+  let draftCourse: Awaited<ReturnType<typeof courseFixture>>;
+  let schoolCourse: Awaited<ReturnType<typeof courseFixture>>;
+
+  beforeAll(async () => {
+    [brandOrg, schoolOrg] = await Promise.all([
+      organizationFixture({ kind: "brand" }),
+      organizationFixture({ kind: "school" }),
+    ]);
+
+    [publishedCourse, draftCourse, schoolCourse] = await Promise.all([
+      courseFixture({ isPublished: true, organizationId: brandOrg.id }),
+      courseFixture({ isPublished: false, organizationId: brandOrg.id }),
+      courseFixture({ isPublished: true, organizationId: schoolOrg.id }),
+    ]);
+  });
+
+  it("returns chapters matching partial titles and descriptions", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const titleSearchTerm = `chaptertitle${uniqueId}`;
+    const descriptionSearchTerm = `chapterdescription${uniqueId}`;
+
+    const [titleMatch, descriptionMatch] = await Promise.all([
+      chapterFixture({
+        courseId: publishedCourse.id,
+        description: `Teaches a different topic ${uniqueId}`,
+        isPublished: true,
+        normalizedTitle: normalizeString(`Advanced ${titleSearchTerm}`),
+        organizationId: brandOrg.id,
+        title: `Advanced ${titleSearchTerm}`,
+      }),
+      chapterFixture({
+        courseId: publishedCourse.id,
+        description: `Teaches ${descriptionSearchTerm} without using it in the title`,
+        isPublished: true,
+        normalizedTitle: normalizeString(`Unrelated chapter ${uniqueId}`),
+        organizationId: brandOrg.id,
+        title: `Unrelated chapter ${uniqueId}`,
+      }),
+    ]);
+
+    const titleResult = await searchChapters({ language: "en", query: titleSearchTerm });
+
+    const descriptionResult = await searchChapters({
+      language: "en",
+      query: descriptionSearchTerm,
+    });
+
+    expect(titleResult.map((chapter) => chapter.id)).toContain(titleMatch.id);
+    expect(descriptionResult.map((chapter) => chapter.id)).toContain(descriptionMatch.id);
+  });
+
+  it("returns exact chapter title matches first", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const searchTerm = `chapterexact${uniqueId}`;
+
+    const [descriptionMatch, partialTitleMatch, exactTitleMatch] = await Promise.all([
+      chapterFixture({
+        courseId: publishedCourse.id,
+        description: `Mentions ${searchTerm} in the description`,
+        isPublished: true,
+        normalizedTitle: normalizeString(`Description only ${uniqueId}`),
+        organizationId: brandOrg.id,
+        title: `Description only ${uniqueId}`,
+      }),
+      chapterFixture({
+        courseId: publishedCourse.id,
+        description: `Partial title match ${uniqueId}`,
+        isPublished: true,
+        normalizedTitle: normalizeString(`Advanced ${searchTerm}`),
+        organizationId: brandOrg.id,
+        title: `Advanced ${searchTerm}`,
+      }),
+      chapterFixture({
+        courseId: publishedCourse.id,
+        description: `Exact title match ${uniqueId}`,
+        isPublished: true,
+        normalizedTitle: normalizeString(searchTerm),
+        organizationId: brandOrg.id,
+        title: searchTerm,
+      }),
+    ]);
+
+    const result = await searchChapters({ language: "en", query: searchTerm });
+    const ids = result.map((chapter) => chapter.id);
+
+    expect(ids).toContain(descriptionMatch.id);
+    expect(ids).toContain(partialTitleMatch.id);
+    expect(ids).toContain(exactTitleMatch.id);
+    expect(result[0]?.id).toBe(exactTitleMatch.id);
+  });
+
+  it("limits chapter results to five by default", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const searchTerm = `chapterlimit${uniqueId}`;
+
+    await Promise.all(
+      Array.from({ length: 7 }, (_, index) =>
+        chapterFixture({
+          courseId: publishedCourse.id,
+          description: `Limit test chapter ${index}`,
+          isPublished: true,
+          normalizedTitle: normalizeString(`${searchTerm} ${index}`),
+          organizationId: brandOrg.id,
+          position: index,
+          slug: `chapter-limit-${uniqueId}-${index}`,
+          title: `${searchTerm} ${index}`,
+        }),
+      ),
+    );
+
+    const result = await searchChapters({ language: "en", query: searchTerm });
+
+    expect(result).toHaveLength(5);
+  });
+
+  it("returns only published chapters from published brand courses", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const searchTerm = `chaptervisibility${uniqueId}`;
+
+    const [publishedChapter, draftCourseChapter, schoolCourseChapter, unpublishedChapter] =
+      await Promise.all([
+        chapterFixture({
+          courseId: publishedCourse.id,
+          isPublished: true,
+          normalizedTitle: normalizeString(searchTerm),
+          organizationId: brandOrg.id,
+          title: searchTerm,
+        }),
+        chapterFixture({
+          courseId: draftCourse.id,
+          isPublished: true,
+          normalizedTitle: normalizeString(`${searchTerm} draft`),
+          organizationId: brandOrg.id,
+          title: `${searchTerm} draft`,
+        }),
+        chapterFixture({
+          courseId: schoolCourse.id,
+          isPublished: true,
+          normalizedTitle: normalizeString(`${searchTerm} school`),
+          organizationId: schoolOrg.id,
+          title: `${searchTerm} school`,
+        }),
+        chapterFixture({
+          courseId: publishedCourse.id,
+          isPublished: false,
+          normalizedTitle: normalizeString(`${searchTerm} unpublished`),
+          organizationId: brandOrg.id,
+          title: `${searchTerm} unpublished`,
+        }),
+      ]);
+
+    const result = await searchChapters({ language: "en", query: searchTerm });
+    const ids = result.map((chapter) => chapter.id);
+
+    expect(ids).toContain(publishedChapter.id);
+    expect(ids).not.toContain(draftCourseChapter.id);
+    expect(ids).not.toContain(schoolCourseChapter.id);
+    expect(ids).not.toContain(unpublishedChapter.id);
+  });
+});

--- a/packages/core/src/chapters/search-chapters.ts
+++ b/packages/core/src/chapters/search-chapters.ts
@@ -1,0 +1,198 @@
+import "server-only";
+import {
+  type ChapterGetPayload,
+  type Organization,
+  getPublishedChapterWhere,
+  prisma,
+} from "@zoonk/db";
+import { clampQueryItems } from "@zoonk/db/utils";
+import { normalizeString } from "@zoonk/utils/string";
+
+type ChapterFindManyArgs = NonNullable<Parameters<typeof prisma.chapter.findMany>[0]>;
+type ChapterSearchWhere = ChapterFindManyArgs["where"];
+
+type ChapterSearchRow = ChapterGetPayload<{
+  include: { course: { include: { organization: true } } };
+}>;
+
+type ChapterWithCourse = ChapterSearchRow & {
+  course: ChapterSearchRow["course"] & { organization: Organization };
+};
+
+const DEFAULT_CHAPTER_SEARCH_LIMIT = 5;
+
+/**
+ * Command palette search treats chapters as secondary catalog results. The
+ * query returns only published chapters from published brand courses, then
+ * ranks exact title matches ahead of partial title and description matches.
+ */
+export async function searchChapters(params: {
+  query: string;
+  language?: string;
+  limit?: number;
+}): Promise<ChapterWithCourse[]> {
+  const limit = clampQueryItems(params.limit ?? DEFAULT_CHAPTER_SEARCH_LIMIT);
+  const normalizedSearch = normalizeString(params.query);
+
+  if (!normalizedSearch) {
+    return [];
+  }
+
+  const baseWhere = getPublishedChapterWhere({
+    courseWhere: { organization: { kind: "brand" } as const },
+  });
+
+  const [exactTitleMatches, titleMatches, descriptionMatches] = await Promise.all([
+    findChapterSearchMatches({ limit, where: { ...baseWhere, normalizedTitle: normalizedSearch } }),
+    findChapterSearchMatches({
+      limit,
+      where: { ...baseWhere, normalizedTitle: { contains: normalizedSearch, mode: "insensitive" } },
+    }),
+    findChapterSearchMatches({
+      limit,
+      where: {
+        ...baseWhere,
+        ...getChapterDescriptionWhere({ normalizedSearch, query: params.query }),
+      },
+    }),
+  ]);
+
+  return mergeChapterResults({
+    descriptionMatches: descriptionMatches.filter((chapter) =>
+      hasChapterCourseOrganization(chapter),
+    ),
+    exactTitleMatches: exactTitleMatches.filter((chapter) => hasChapterCourseOrganization(chapter)),
+    language: params.language,
+    limit,
+    titleMatches: titleMatches.filter((chapter) => hasChapterCourseOrganization(chapter)),
+  });
+}
+
+/**
+ * Chapter search always needs parent course and brand data to build catalog
+ * URLs. Centralizing that include keeps the title and description match queries
+ * from drifting as the command palette result shape changes.
+ */
+async function findChapterSearchMatches({
+  limit,
+  where,
+}: {
+  limit: number;
+  where: ChapterSearchWhere;
+}): Promise<ChapterSearchRow[]> {
+  const chapters = await prisma.chapter.findMany({
+    include: { course: { include: { organization: true } } },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    where,
+  });
+
+  return chapters as ChapterSearchRow[];
+}
+
+/**
+ * Chapter descriptions are not stored in normalized form, so description
+ * search checks both the learner's original text and the normalized query.
+ * That keeps exact typed text working while still allowing ASCII-only
+ * descriptions to match the same normalized term used for titles.
+ */
+function getChapterDescriptionWhere({
+  normalizedSearch,
+  query,
+}: {
+  normalizedSearch: string;
+  query: string;
+}) {
+  const searchTerms = getDescriptionSearchTerms({ normalizedSearch, query });
+
+  return {
+    OR: searchTerms.map((searchTerm) => ({
+      description: { contains: searchTerm, mode: "insensitive" as const },
+    })),
+  };
+}
+
+/**
+ * Prisma cannot infer that filtering through course.organization guarantees
+ * the included organization exists. This guard keeps the public return type
+ * honest before the command palette builds brand-scoped links.
+ */
+function hasChapterCourseOrganization(chapter: ChapterSearchRow): chapter is ChapterWithCourse {
+  return chapter.course.organization !== null;
+}
+
+/**
+ * Search terms can collapse to the same value after normalization. Removing
+ * duplicates avoids asking Prisma to evaluate the same description predicate
+ * twice for common ASCII queries.
+ */
+function getDescriptionSearchTerms({
+  normalizedSearch,
+  query,
+}: {
+  normalizedSearch: string;
+  query: string;
+}) {
+  return [...new Set([query.trim(), normalizedSearch].filter(Boolean))];
+}
+
+/**
+ * The command palette needs chapters after courses, but chapter ranking still
+ * matters inside that group: exact title matches should beat fuzzy title
+ * matches, and title matches should beat description-only matches.
+ */
+function mergeChapterResults({
+  descriptionMatches,
+  exactTitleMatches,
+  language,
+  limit,
+  titleMatches,
+}: {
+  descriptionMatches: ChapterWithCourse[];
+  exactTitleMatches: ChapterWithCourse[];
+  language?: string;
+  limit: number;
+  titleMatches: ChapterWithCourse[];
+}) {
+  const rankedResults = [
+    ...sortByLanguagePreference({ items: exactTitleMatches, language }),
+    ...sortByLanguagePreference({ items: titleMatches, language }),
+    ...sortByLanguagePreference({ items: descriptionMatches, language }),
+  ];
+
+  return keepFirstResultPerId(rankedResults).slice(0, limit);
+}
+
+/**
+ * Learners usually search in their active app language. Keeping that language
+ * first within each rank mirrors course search without letting language
+ * preference push description-only matches ahead of exact chapter titles.
+ */
+function sortByLanguagePreference<TItem extends { language: string }>({
+  items,
+  language,
+}: {
+  items: TItem[];
+  language?: string;
+}) {
+  if (!language) {
+    return items;
+  }
+
+  return items.toSorted((a, b) => {
+    const aMatch = a.language === language ? 0 : 1;
+    const bMatch = b.language === language ? 0 : 1;
+    return aMatch - bMatch;
+  });
+}
+
+/**
+ * A chapter can match in more than one bucket, especially exact titles because
+ * they also satisfy the contains query. Keeping the first occurrence preserves
+ * the highest-ranked bucket for every chapter.
+ */
+function keepFirstResultPerId<TItem extends { id: string }>(items: TItem[]) {
+  return items.filter(
+    (item, index) => items.findIndex((result) => result.id === item.id) === index,
+  );
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -45,6 +45,7 @@ export type {
 } from "./generated/prisma/client";
 
 export type { ChapterCreateManyInput } from "./generated/prisma/models/Chapter";
+export type { ChapterGetPayload } from "./generated/prisma/models/Chapter";
 export type { CourseGetPayload } from "./generated/prisma/models/Course";
 export type { LessonCreateManyInput } from "./generated/prisma/models/Lesson";
 


### PR DESCRIPTION
## Summary
- Add chapter matches to the main command palette search below course results
- Search chapter titles and descriptions with exact title matches ranked first
- Cover chapter command palette results with core and e2e tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add chapter results to the main command palette so users can jump straight to chapters. We search chapter titles and descriptions, rank exact title matches first, and show chapters below courses; covered by core and e2e tests.

- **New Features**
  - Server: new `@zoonk/core/chapters/search` returns published chapters from published brand courses; limit 5; prefers active language; ranks exact title > partial title > description.
  - API: replaced `searchCoursesAction` with `searchCatalogAction` that returns `{ courses, chapters }`.
  - UI: added a "Chapters" group with course context and thumbnail; updated placeholder to "Search courses, chapters, or pages..."; selecting a chapter navigates to `/b/:brand/c/:course/ch/:chapter`.

- **Bug Fixes**
  - Stabilized sitemap chapter count test to only count rows created by the test, preventing flakiness in shared DB runs.

<sup>Written for commit 62691cac1e6b5c2c3eef934b0b50a4261673e5c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

