### PR TITLE
feat(player): make practice intro images full bleed

### DIFF
--- a/packages/player/src/_browser-tests/player-practice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-practice.browser.test.tsx
@@ -1,9 +1,25 @@
+import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { page } from "vitest/browser";
 import { buildInlineImageUrl } from "../_test-utils/build-inline-image-url";
 import { buildSerializedLesson, buildSerializedStep } from "../_test-utils/player-test-data";
 import { buildAuthenticatedViewer } from "../_test-utils/player-test-viewer";
 import { buildNavigation, renderPlayer } from "../_test-utils/render-player";
+
+/**
+ * Practice intros are image-led setup screens. The image should behave like a
+ * full-stage background, not like the contained diagrams used inside regular
+ * static explanation steps.
+ */
+function expectImageToFillPlayerStage(image: HTMLElement) {
+  const playerStage = screen.getByLabelText("Player screen");
+  const imageRect = image.getBoundingClientRect();
+  const stageRect = playerStage.getBoundingClientRect();
+
+  expect(globalThis.getComputedStyle(image).objectFit).toBe("cover");
+  expect(Math.round(imageRect.width)).toBe(Math.round(stageRect.width));
+  expect(Math.round(imageRect.height)).toBe(Math.round(stageRect.height));
+}
 
 describe("player browser integration: practice lessons", () => {
   it("renders a leading static scenario step and still completes with question scoring", async () => {
@@ -73,6 +89,12 @@ describe("player browser integration: practice lessons", () => {
         ),
       )
       .toBeInTheDocument();
+
+    expectImageToFillPlayerStage(
+      screen.getByAltText(
+        /late-night support war room with a refund dashboard on a laptop and a teammate reviewing notes/iu,
+      ),
+    );
 
     await expect
       .element(

--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -391,6 +391,11 @@ describe("player browser integration: static steps", () => {
     await expect
       .element(page.getByAltText(/lantern lighting up one idea at a time/iu))
       .toBeInTheDocument();
+
+    expect(
+      globalThis.getComputedStyle(screen.getByAltText(/lantern lighting up one idea at a time/iu))
+        .objectFit,
+    ).toBe("contain");
   });
 
   it("swipes touch navigation forward on static steps", async () => {

--- a/packages/player/src/components/player-stage.tsx
+++ b/packages/player/src/components/player-stage.tsx
@@ -4,9 +4,9 @@ import { type PlayerPhase } from "../player-reducer";
 /**
  * Chooses the stage scroll/alignment mode from the screen layout flags.
  *
- * Hero screens need full-bleed mobile layout and desktop scrolling. Static read
- * screens keep overflow locked for swipe navigation, while interactive screens
- * own normal vertical scrolling.
+ * Hero screens need the child to own the whole stage at every breakpoint.
+ * Static read screens keep overflow locked for swipe navigation, while
+ * interactive screens own normal vertical scrolling.
  */
 function getStageLayoutClass({
   isFullBleed,
@@ -16,7 +16,7 @@ function getStageLayoutClass({
   isStatic?: boolean;
 }) {
   if (isFullBleed) {
-    return "items-stretch overflow-hidden lg:items-center lg:overflow-y-auto";
+    return "items-stretch overflow-hidden";
   }
 
   if (isStatic) {

--- a/packages/player/src/components/step-image.tsx
+++ b/packages/player/src/components/step-image.tsx
@@ -3,7 +3,9 @@
 import { type StepImage } from "@zoonk/core/steps/contract/image";
 import Image from "next/image";
 import { useState } from "react";
-import { STEP_IMAGE_SIZES } from "../image-config";
+import { STEP_FULL_BLEED_IMAGE_SIZES, STEP_IMAGE_SIZES } from "../image-config";
+
+type StepImageFit = "contain" | "cover";
 
 function StepImageFallback({ prompt }: { prompt: string }) {
   return (
@@ -17,11 +19,19 @@ function StepImageFallback({ prompt }: { prompt: string }) {
  * Readable lesson steps now own their illustration directly. This component
  * keeps the render/fallback behavior shared between explanation and tutorial
  * steps so a missing upload still leaves the learner with the intended prompt.
- * The player renders images contained by default so generated content is not
- * clipped by the lesson frame.
+ * Images are contained by default so diagrams and screenshots are not clipped,
+ * while image-led hero screens can opt into cover cropping when the picture is
+ * acting as the full-stage scene.
  */
-export function StepImageView({ image }: { image: StepImage }) {
+export function StepImageView({
+  fit = "contain",
+  image,
+}: {
+  fit?: StepImageFit;
+  image: StepImage;
+}) {
   const [errorUrl, setErrorUrl] = useState<string | null>(null);
+  const imageSizes = fit === "cover" ? STEP_FULL_BLEED_IMAGE_SIZES : STEP_IMAGE_SIZES;
 
   if (!image.url || errorUrl === image.url) {
     return <StepImageFallback prompt={image.prompt} />;
@@ -31,11 +41,11 @@ export function StepImageView({ image }: { image: StepImage }) {
     <div className="relative h-full w-full" data-slot="step-image-view">
       <Image
         alt={image.prompt}
-        className="object-contain"
+        className={fit === "cover" ? "object-cover" : "object-contain"}
         fill
         loading="eager"
         onError={() => setErrorUrl(image.url ?? null)}
-        sizes={STEP_IMAGE_SIZES}
+        sizes={imageSizes}
         src={image.url}
       />
     </div>

--- a/packages/player/src/components/step-intro-hero-layout.tsx
+++ b/packages/player/src/components/step-intro-hero-layout.tsx
@@ -33,19 +33,16 @@ function StepIntroHeroContent({ text, title }: { text: string; title: string }) 
 }
 
 /**
- * Hero illustrations are immersive on mobile and composed on desktop.
+ * Hero illustrations behave like the scene behind the practice setup.
  *
- * Small screens keep the image behind the bottom card. Large screens reuse the
- * feedback-screen treatment: a centered, rounded square image above the content
- * so the generated scene feels intentional instead of oversized.
+ * Practice intros need the image to fill the whole available stage because the
+ * picture is the scenario context, not a contained diagram. The readable setup
+ * stays in the overlay card so the image can keep bleeding to every edge.
  */
 function StepHeroImage({ image }: { image: StepImage }) {
   return (
-    <div
-      className="bg-muted absolute inset-0 overflow-hidden lg:relative lg:inset-auto lg:aspect-square lg:w-full lg:rounded-3xl"
-      data-slot="step-hero-image"
-    >
-      <StepImageView image={image} />
+    <div className="bg-muted absolute inset-0 overflow-hidden" data-slot="step-hero-image">
+      <StepImageView fit="cover" image={image} />
     </div>
   );
 }
@@ -53,18 +50,18 @@ function StepHeroImage({ image }: { image: StepImage }) {
 /**
  * The hero card owns the readable content and embedded CTA.
  *
- * The outer layer keeps the card pinned to the bottom and centered on larger
- * touch screens. Desktop removes the card chrome and lets the content sit
- * below the image like feedback screens.
+ * The outer layer keeps the card pinned to the bottom so the image can fill the
+ * rest of the frame. Desktop keeps the same overlay model instead of switching
+ * back to the regular static-step composition.
  */
 function StepHeroCard({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center px-0 sm:px-6 lg:pointer-events-auto lg:static lg:block lg:px-0"
+      className="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex justify-center px-0 sm:px-6 lg:px-8 lg:pb-8"
       data-slot="step-hero-card-shell"
     >
       <div
-        className="bg-background pointer-events-auto max-h-[70dvh] w-full max-w-2xl overflow-y-auto rounded-t-4xl px-5 pt-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] sm:p-8 sm:pb-[max(2rem,env(safe-area-inset-bottom))] lg:max-h-none lg:max-w-none lg:overflow-visible lg:rounded-none lg:bg-transparent lg:p-0"
+        className="bg-background pointer-events-auto max-h-[70dvh] w-full max-w-2xl overflow-y-auto rounded-t-4xl px-5 pt-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] sm:p-8 sm:pb-[max(2rem,env(safe-area-inset-bottom))] lg:max-h-[48dvh] lg:rounded-3xl lg:p-8"
         data-slot="step-hero-card"
       >
         {children}
@@ -76,9 +73,9 @@ function StepHeroCard({ children }: { children: React.ReactNode }) {
 /**
  * Shared responsive image/card frame for immersive static steps.
  *
- * Mobile uses a full-screen image with a bottom card, while desktop uses the
- * feedback-style centered image stack. Keeping that structure here prevents
- * intro and outcome screens from accumulating separate layout rules over time.
+ * Image-backed intros use one full-stage composition across breakpoints. That
+ * keeps practice scenarios visually distinct from regular static images and
+ * avoids a second desktop-only media policy.
  */
 function StepHero({ children, image }: { children: React.ReactNode; image?: StepImage | null }) {
   if (!image) {
@@ -91,7 +88,7 @@ function StepHero({ children, image }: { children: React.ReactNode; image?: Step
 
   return (
     <div
-      className="relative h-full min-h-0 w-full flex-1 self-stretch overflow-hidden lg:my-auto lg:flex lg:h-auto lg:max-w-2xl lg:flex-none lg:flex-col lg:gap-6 lg:self-center lg:overflow-visible lg:px-4 lg:py-6"
+      className="relative h-full min-h-0 w-full flex-1 self-stretch overflow-hidden"
       data-slot="step-hero-layout"
     >
       <StepHeroImage image={image} />

--- a/packages/player/src/image-config.ts
+++ b/packages/player/src/image-config.ts
@@ -7,6 +7,13 @@
 export const STEP_IMAGE_SIZES = "(max-width: 1024px) 100vw, 50vw";
 
 /**
+ * Practice intro images cover the whole player stage instead of the regular
+ * static media column, so they should request candidates sized for the full
+ * viewport on every breakpoint.
+ */
+export const STEP_FULL_BLEED_IMAGE_SIZES = "100vw";
+
+/**
  * The preloader still needs explicit dimensions because hidden Next.js images
  * cannot use `fill`. A portrait-friendly request shape better matches the new
  * player layout and avoids prefetching a tiny square derivative for imagery


### PR DESCRIPTION
## Summary
- make practice intro images cover the full player stage
- keep regular static step images contained
- add browser coverage for both image behaviors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Practice intro images now fill the entire player stage (full-bleed), while regular static step images remain contained. This makes practice setups immersive and keeps diagrams/screenshots unclipped.

- **New Features**
  - Practice intro heroes use cover-fit images that fill the stage at all breakpoints with a bottom overlay card.
  - Static steps remain contain-fit to avoid clipping.
  - `StepImageView` gains a `fit` prop (default "contain"); hero images use `STEP_FULL_BLEED_IMAGE_SIZES`.
  - Updated full-bleed stage layout and added browser tests for both behaviors.

<sup>Written for commit ec3b24e0bf1d34e51e12a77a4ffd996e94062ae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

