### PR TITLE
chore(main): update lesson descriptions

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1960,52 +1960,52 @@ msgid "lqtP+R"
 msgstr "Vocabulary"
 
 #: src/lib/lessons.ts
-msgid "KWi2PI"
-msgstr "Learn the alphabet and writing system with focused practice."
+msgid "22k1CY"
+msgstr "Learn how letters and sounds work in this writing system."
 
 #: src/lib/lessons.ts
-msgid "1h+4hA"
-msgstr "Work through a guided lesson."
+msgid "LZC7R9"
+msgstr "Work through a lesson created for your goal."
 
 #: src/lib/lessons.ts
-msgid "yGskby"
-msgstr "Understand the key ideas before applying them."
+msgid "fOfLbt"
+msgstr "Understand the key ideas using everyday language and practical examples."
 
 #: src/lib/lessons.ts
 msgid "dHmgw1"
 msgstr "Practice grammar patterns with examples and exercises."
 
 #: src/lib/lessons.ts
-msgid "kvq0XW"
-msgstr "Listen to sentences built from the latest vocabulary."
+msgid "AetsPy"
+msgstr "Listen to sentences using words you recently learned."
 
 #: src/lib/lessons.ts
-msgid "4dAUaa"
-msgstr "Apply the previous explanations in a guided problem."
+msgid "6oNgY9"
+msgstr "Use what you learned in the previous lesson to solve real-world problems."
 
 #: src/lib/lessons.ts
-msgid "t+ekBV"
-msgstr "Check your understanding with a short quiz."
+msgid "vO6aLm"
+msgstr "Check what you understood with a short quiz."
 
 #: src/lib/lessons.ts
-msgid "nuMTc1"
-msgstr "Read sentences built from the latest vocabulary."
+msgid "OIim7M"
+msgstr "Read sentences using words you recently learned."
 
 #: src/lib/lessons.ts
 msgid "pwrprO"
 msgstr "Review this chapter with practice based on your mistakes."
 
 #: src/lib/lessons.ts
-msgid "Gm85VV"
-msgstr "Translate the words from the previous vocabulary lesson."
+msgid "IQOJhk"
+msgstr "Translate words from your previous vocabulary lesson."
 
 #: src/lib/lessons.ts
 msgid "9XByXq"
 msgstr "Follow a guided step-by-step tutorial."
 
 #: src/lib/lessons.ts
-msgid "DfYRbN"
-msgstr "Learn new words with focused vocabulary practice."
+msgid "IHSVS5"
+msgstr "Learn new words and practice using them."
 
 #: src/lib/lessons.ts
 msgid "OjyuQ+"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1960,52 +1960,52 @@ msgid "lqtP+R"
 msgstr "Vocabulario"
 
 #: src/lib/lessons.ts
-msgid "KWi2PI"
-msgstr "Aprende el alfabeto y el sistema de escritura con práctica enfocada."
+msgid "22k1CY"
+msgstr "Entiende cómo funcionan las letras y los sonidos en este sistema de escritura."
 
 #: src/lib/lessons.ts
-msgid "1h+4hA"
-msgstr "Trabaja en una lección guiada."
+msgid "LZC7R9"
+msgstr "Avanza por una lección creada para tu objetivo."
 
 #: src/lib/lessons.ts
-msgid "yGskby"
-msgstr "Entiende las ideas clave antes de aplicarlas."
+msgid "fOfLbt"
+msgstr "Entiende las ideas clave con lenguaje claro y ejemplos prácticos."
 
 #: src/lib/lessons.ts
 msgid "dHmgw1"
 msgstr "Practica estructuras gramaticales con ejemplos y ejercicios."
 
 #: src/lib/lessons.ts
-msgid "kvq0XW"
-msgstr "Escucha oraciones construidas con el vocabulario más reciente."
+msgid "AetsPy"
+msgstr "Escucha oraciones con palabras que acabas de aprender."
 
 #: src/lib/lessons.ts
-msgid "4dAUaa"
-msgstr "Aplica las explicaciones anteriores en un problema guiado."
+msgid "6oNgY9"
+msgstr "Usa lo que aprendiste en la lección anterior para resolver problemas en situaciones reales."
 
 #: src/lib/lessons.ts
-msgid "t+ekBV"
-msgstr "Comprueba tu comprensión con un cuestionario breve."
+msgid "vO6aLm"
+msgstr "Comprueba lo que entendiste con un cuestionario breve."
 
 #: src/lib/lessons.ts
-msgid "nuMTc1"
-msgstr "Lee oraciones construidas con el vocabulario más reciente."
+msgid "OIim7M"
+msgstr "Lee oraciones con palabras que acabas de aprender."
 
 #: src/lib/lessons.ts
 msgid "pwrprO"
 msgstr "Repasa este capítulo con práctica basada en tus errores."
 
 #: src/lib/lessons.ts
-msgid "Gm85VV"
-msgstr "Traduce las palabras de la lección anterior de vocabulario."
+msgid "IQOJhk"
+msgstr "Traduce palabras de tu lección anterior de vocabulario."
 
 #: src/lib/lessons.ts
 msgid "9XByXq"
 msgstr "Sigue un tutorial guiado paso a paso."
 
 #: src/lib/lessons.ts
-msgid "DfYRbN"
-msgstr "Aprende palabras nuevas con práctica enfocada de vocabulario."
+msgid "IHSVS5"
+msgstr "Aprende palabras nuevas y practica cómo usarlas."
 
 #: src/lib/lessons.ts
 msgid "OjyuQ+"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1960,52 +1960,52 @@ msgid "lqtP+R"
 msgstr "Vocabulário"
 
 #: src/lib/lessons.ts
-msgid "KWi2PI"
-msgstr "Aprenda o alfabeto e o sistema de escrita com prática focada."
+msgid "22k1CY"
+msgstr "Entenda como as letras e os sons funcionam neste sistema de escrita."
 
 #: src/lib/lessons.ts
-msgid "1h+4hA"
-msgstr "Trabalhe em uma aula guiada."
+msgid "LZC7R9"
+msgstr "Faça uma aula criada para o seu objetivo."
 
 #: src/lib/lessons.ts
-msgid "yGskby"
-msgstr "Entenda as ideias principais antes de aplicá-las."
+msgid "fOfLbt"
+msgstr "Entenda as ideias principais com linguagem simples e exemplos práticos."
 
 #: src/lib/lessons.ts
 msgid "dHmgw1"
 msgstr "Pratique padrões de gramática com exemplos e exercícios."
 
 #: src/lib/lessons.ts
-msgid "kvq0XW"
-msgstr "Ouça frases montadas com o vocabulário mais recente."
+msgid "AetsPy"
+msgstr "Ouça frases com palavras que você acabou de aprender."
 
 #: src/lib/lessons.ts
-msgid "4dAUaa"
-msgstr "Aplique as explicações anteriores em um problema guiado."
+msgid "6oNgY9"
+msgstr "Use o que você aprendeu na aula anterior para resolver problemas em situações reais."
 
 #: src/lib/lessons.ts
-msgid "t+ekBV"
-msgstr "Veja se você entendeu com um quiz curto."
+msgid "vO6aLm"
+msgstr "Veja o que você entendeu com um quiz curto."
 
 #: src/lib/lessons.ts
-msgid "nuMTc1"
-msgstr "Leia frases montadas com o vocabulário mais recente."
+msgid "OIim7M"
+msgstr "Leia frases com palavras que você acabou de aprender."
 
 #: src/lib/lessons.ts
 msgid "pwrprO"
 msgstr "Revise este capítulo com prática baseada nos seus erros."
 
 #: src/lib/lessons.ts
-msgid "Gm85VV"
-msgstr "Traduza as palavras da aula anterior de vocabulário."
+msgid "IQOJhk"
+msgstr "Traduza palavras da sua aula anterior de vocabulário."
 
 #: src/lib/lessons.ts
 msgid "9XByXq"
 msgstr "Siga um tutorial guiado passo a passo."
 
 #: src/lib/lessons.ts
-msgid "DfYRbN"
-msgstr "Aprenda palavras novas com prática focada de vocabulário."
+msgid "IHSVS5"
+msgstr "Aprenda palavras novas e pratique como usá-las."
 
 #: src/lib/lessons.ts
 msgid "OjyuQ+"

--- a/apps/main/src/lib/lessons.ts
+++ b/apps/main/src/lib/lessons.ts
@@ -57,18 +57,18 @@ export async function getLessonDisplayMeta(
     }
 
     const descriptions: Record<LessonKind, string> = {
-      alphabet: t("Learn the alphabet and writing system with focused practice."),
-      custom: t("Work through a guided lesson."),
-      explanation: t("Understand the key ideas before applying them."),
+      alphabet: t("Learn how letters and sounds work in this writing system."),
+      custom: t("Work through a lesson created for your goal."),
+      explanation: t("Understand the key ideas using everyday language and practical examples."),
       grammar: t("Practice grammar patterns with examples and exercises."),
-      listening: t("Listen to sentences built from the latest vocabulary."),
-      practice: t("Apply the previous explanations in a guided problem."),
-      quiz: t("Check your understanding with a short quiz."),
-      reading: t("Read sentences built from the latest vocabulary."),
+      listening: t("Listen to sentences using words you recently learned."),
+      practice: t("Use what you learned in the previous lesson to solve real-world problems."),
+      quiz: t("Check what you understood with a short quiz."),
+      reading: t("Read sentences using words you recently learned."),
       review: t("Review this chapter with practice based on your mistakes."),
-      translation: t("Translate the words from the previous vocabulary lesson."),
+      translation: t("Translate words from your previous vocabulary lesson."),
       tutorial: t("Follow a guided step-by-step tutorial."),
-      vocabulary: t("Learn new words with focused vocabulary practice."),
+      vocabulary: t("Learn new words and practice using them."),
     };
 
     return descriptions[lesson.kind];


### PR DESCRIPTION
Updates lesson kind fallback descriptions in the main app to make them more natural and specific across English, Portuguese, and Spanish.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated lesson kind fallback descriptions to clearer, more specific copy, localized in English, Spanish, and Portuguese. Covers alphabet, custom, explanation, listening, practice, quiz, reading, translation, and vocabulary; updated code and .po files with no behavior changes.

<sup>Written for commit a1442247e0317e6500323dde6c4a0da88ac7e162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

