### PR TITLE
feat(player): show word bank pronunciation

### DIFF
--- a/packages/core/src/player/contracts/build-word-bank-options.test.ts
+++ b/packages/core/src/player/contracts/build-word-bank-options.test.ts
@@ -98,6 +98,7 @@ describe(buildWordBankOptions, () => {
         makeDistractorWord({
           audioUrl: "/audio/dog.mp3",
           id: "dog-1",
+          pronunciation: "EE-noo",
           romanization: "inu",
           word: "犬",
         }),
@@ -107,6 +108,7 @@ describe(buildWordBankOptions, () => {
 
     expect(options.find((option) => option.word === "犬")).toStrictEqual({
       audioUrl: "/audio/dog.mp3",
+      pronunciation: "EE-noo",
       romanization: "inu",
       translation: null,
       word: "犬",
@@ -145,6 +147,7 @@ describe(buildWordBankOptions, () => {
 
     expect(options.find((option) => option.word === "noite")).toStrictEqual({
       audioUrl: null,
+      pronunciation: null,
       romanization: null,
       translation: null,
       word: "noite",
@@ -173,8 +176,20 @@ describe(buildSentenceWordOptions, () => {
     );
 
     expect(options).toStrictEqual([
-      { audioUrl: null, romanization: "guten", translation: null, word: "Guten" },
-      { audioUrl: null, romanization: "morgen", translation: null, word: "Morgen" },
+      {
+        audioUrl: null,
+        pronunciation: null,
+        romanization: "guten",
+        translation: null,
+        word: "Guten",
+      },
+      {
+        audioUrl: null,
+        pronunciation: null,
+        romanization: "morgen",
+        translation: null,
+        word: "Morgen",
+      },
     ]);
   });
 
@@ -191,13 +206,22 @@ describe(buildSentenceWordOptions, () => {
       ],
       [],
       new Map([
-        ["hola", { audioUrl: "/audio/hola-sentence.mp3", romanization: "o-la", word: "Hola" }],
+        [
+          "hola",
+          {
+            audioUrl: "/audio/hola-sentence.mp3",
+            pronunciation: "OH-lah",
+            romanization: "o-la",
+            word: "Hola",
+          },
+        ],
       ]),
     );
 
     expect(options).toStrictEqual([
       {
         audioUrl: "/audio/hola-sentence.mp3",
+        pronunciation: "OH-lah",
         romanization: "o-la",
         translation: "hello",
         word: "Hola",

--- a/packages/core/src/player/contracts/build-word-bank-options.ts
+++ b/packages/core/src/player/contracts/build-word-bank-options.ts
@@ -8,7 +8,12 @@ import {
 } from "./prepare-lesson-data";
 import { type DistractorWord } from "./translation-options";
 
-type WordDataInput = { audioUrl: string | null; romanization: string | null; word: string };
+type WordDataInput = {
+  audioUrl: string | null;
+  pronunciation: string | null;
+  romanization: string | null;
+  word: string;
+};
 
 type WordMetadata = Omit<WordBankOption, "word">;
 
@@ -31,13 +36,16 @@ function splitMultiWordEntries(lessonWord: SerializedWord): [string, WordMetadat
     return [];
   }
 
+  const pronunciationTokens = lessonWord.pronunciation?.split(" ").filter(Boolean) ?? [];
   const romanizationTokens = lessonWord.romanization?.split(" ").filter(Boolean) ?? [];
+  const canSlicePronunciation = pronunciationTokens.length === wordTokens.length;
   const canSlice = romanizationTokens.length === wordTokens.length;
 
   return wordTokens.map((token, index) => [
     normalizeWordKey(token),
     {
       audioUrl: null,
+      pronunciation: canSlicePronunciation ? (pronunciationTokens[index] ?? null) : null,
       romanization: canSlice ? (romanizationTokens[index] ?? null) : null,
       translation: null,
     },
@@ -58,6 +66,7 @@ function mergeWordMetadata({
 }): WordMetadata {
   return {
     audioUrl: incoming.audioUrl ?? current?.audioUrl ?? null,
+    pronunciation: incoming.pronunciation ?? current?.pronunciation ?? null,
     romanization: incoming.romanization ?? current?.romanization ?? null,
     translation: incoming.translation ?? current?.translation ?? null,
   };
@@ -114,6 +123,7 @@ function buildWordMetadataLookup(params: {
       normalizeWordKey(lessonWord.word),
       {
         audioUrl: lessonWord.audioUrl,
+        pronunciation: lessonWord.pronunciation,
         romanization: lessonWord.romanization,
         translation: lessonWord.translation,
       },
@@ -124,7 +134,12 @@ function buildWordMetadataLookup(params: {
     (word) =>
       [
         normalizeWordKey(word.word),
-        { audioUrl: word.audioUrl, romanization: word.romanization, translation: null },
+        {
+          audioUrl: word.audioUrl,
+          pronunciation: word.pronunciation,
+          romanization: word.romanization,
+          translation: null,
+        },
       ] as const,
   );
 
@@ -132,7 +147,12 @@ function buildWordMetadataLookup(params: {
     (word) =>
       [
         normalizeWordKey(word.word),
-        { audioUrl: word.audioUrl, romanization: word.romanization, translation: null },
+        {
+          audioUrl: word.audioUrl,
+          pronunciation: word.pronunciation,
+          romanization: word.romanization,
+          translation: null,
+        },
       ] as const,
   );
 
@@ -159,6 +179,7 @@ function createWordOptionBuilder(params: {
 
     return {
       audioUrl: metadata?.audioUrl ?? null,
+      pronunciation: metadata?.pronunciation ?? null,
       romanization: metadata?.romanization ?? null,
       translation: metadata?.translation ?? null,
       word,
@@ -171,7 +192,7 @@ function createWordOptionBuilder(params: {
  * distractors do not get target-language enrichment.
  */
 function emptyWordOption(word: string): WordBankOption {
-  return { audioUrl: null, romanization: null, translation: null, word };
+  return { audioUrl: null, pronunciation: null, romanization: null, translation: null, word };
 }
 
 /**

--- a/packages/core/src/player/contracts/prepare-lesson-data.test.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.test.ts
@@ -265,8 +265,14 @@ describe(preparePlayerLessonData, () => {
     expect(result.steps[0]?.sortOrderItems).toStrictEqual(["first", "second", "third"]);
 
     expect(result.steps[1]?.fillBlankOptions).toStrictEqual([
-      { audioUrl: null, romanization: null, translation: null, word: "sky" },
-      { audioUrl: null, romanization: "ground-rom", translation: null, word: "ground" },
+      { audioUrl: null, pronunciation: null, romanization: null, translation: null, word: "sky" },
+      {
+        audioUrl: null,
+        pronunciation: null,
+        romanization: "ground-rom",
+        translation: null,
+        word: "ground",
+      },
     ]);
 
     expect(result.steps[2]?.matchColumnsRightItems).toStrictEqual(["1", "2"]);
@@ -642,18 +648,36 @@ describe(preparePlayerLessonData, () => {
     });
 
     expect(result.steps[0]?.wordBankOptions).toStrictEqual([
-      { audioUrl: null, romanization: null, translation: null, word: "Guten" },
-      { audioUrl: null, romanization: null, translation: null, word: "Morgen," },
-      { audioUrl: null, romanization: null, translation: null, word: "Lara." },
-      { audioUrl: "/audio/abend.mp3", romanization: "abend", translation: null, word: "Abend" },
-      { audioUrl: null, romanization: null, translation: null, word: "Fenster" },
+      { audioUrl: null, pronunciation: null, romanization: null, translation: null, word: "Guten" },
+      {
+        audioUrl: null,
+        pronunciation: null,
+        romanization: null,
+        translation: null,
+        word: "Morgen,",
+      },
+      { audioUrl: null, pronunciation: null, romanization: null, translation: null, word: "Lara." },
+      {
+        audioUrl: "/audio/abend.mp3",
+        pronunciation: "abend",
+        romanization: "abend",
+        translation: null,
+        word: "Abend",
+      },
+      {
+        audioUrl: null,
+        pronunciation: null,
+        romanization: null,
+        translation: null,
+        word: "Fenster",
+      },
     ]);
 
     expect(result.steps[1]?.wordBankOptions).toStrictEqual([
-      { audioUrl: null, romanization: null, translation: null, word: "Bom" },
-      { audioUrl: null, romanization: null, translation: null, word: "dia," },
-      { audioUrl: null, romanization: null, translation: null, word: "Lara." },
-      { audioUrl: null, romanization: null, translation: null, word: "tchau" },
+      { audioUrl: null, pronunciation: null, romanization: null, translation: null, word: "Bom" },
+      { audioUrl: null, pronunciation: null, romanization: null, translation: null, word: "dia," },
+      { audioUrl: null, pronunciation: null, romanization: null, translation: null, word: "Lara." },
+      { audioUrl: null, pronunciation: null, romanization: null, translation: null, word: "tchau" },
     ]);
   });
 
@@ -681,8 +705,20 @@ describe(preparePlayerLessonData, () => {
     });
 
     expect(result.steps[0]?.sentenceWordOptions).toStrictEqual([
-      { audioUrl: null, romanization: "guten", translation: null, word: "Guten" },
-      { audioUrl: null, romanization: "morgen", translation: null, word: "Morgen" },
+      {
+        audioUrl: null,
+        pronunciation: null,
+        romanization: "guten",
+        translation: null,
+        word: "Guten",
+      },
+      {
+        audioUrl: null,
+        pronunciation: null,
+        romanization: "morgen",
+        translation: null,
+        word: "Morgen",
+      },
     ]);
   });
 
@@ -723,11 +759,18 @@ describe(preparePlayerLessonData, () => {
     expect(result.steps[0]?.sentenceWordOptions).toStrictEqual([
       {
         audioUrl: "/audio/sentence-gato.mp3",
+        pronunciation: null,
         romanization: "ga-to",
         translation: "cat (lesson)",
         word: "gato",
       },
-      { audioUrl: null, romanization: null, translation: null, word: "bonito" },
+      {
+        audioUrl: null,
+        pronunciation: null,
+        romanization: null,
+        translation: null,
+        word: "bonito",
+      },
     ]);
   });
 
@@ -784,8 +827,8 @@ describe(preparePlayerLessonData, () => {
     });
 
     expect(result.steps[0]?.wordBankOptions).toStrictEqual([
-      { audioUrl: null, romanization: null, translation: null, word: "Hola" },
-      { audioUrl: null, romanization: null, translation: null, word: "mundo" },
+      { audioUrl: null, pronunciation: null, romanization: null, translation: null, word: "Hola" },
+      { audioUrl: null, pronunciation: null, romanization: null, translation: null, word: "mundo" },
     ]);
   });
 

--- a/packages/core/src/player/contracts/prepare-lesson-data.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.ts
@@ -56,6 +56,7 @@ type SerializedSentence = {
 export type WordBankOption = {
   word: string;
   translation: string | null;
+  pronunciation: string | null;
   romanization: string | null;
   audioUrl: string | null;
 };
@@ -196,6 +197,7 @@ function buildFillBlankOptions(step: SerializedStep): WordBankOption[] {
 
   return words.map((word) => ({
     audioUrl: null,
+    pronunciation: null,
     romanization: content.romanizations?.[word] ?? null,
     translation: null,
     word,

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -7,7 +7,6 @@ msgstr ""
 "X-Crowdin-SourceKey: msgstr\n"
 
 #: src/components/alphabet-step.tsx
-#: src/use-lesson-kind-label.ts
 msgid "w0J/gv"
 msgstr "Alphabet"
 
@@ -268,7 +267,6 @@ msgid "++l7ni"
 msgstr "Not quite"
 
 #: src/components/vocabulary-step.tsx
-#: src/use-lesson-kind-label.ts
 msgid "lqtP+R"
 msgstr "Vocabulary"
 
@@ -311,43 +309,3 @@ msgstr "White"
 #: src/use-belt-color-label.ts
 msgid "5Tw3Ta"
 msgstr "Yellow"
-
-#: src/use-lesson-kind-label.ts
-msgid "PJivSX"
-msgstr "Lesson"
-
-#: src/use-lesson-kind-label.ts
-msgid "E1bF/X"
-msgstr "Explanation"
-
-#: src/use-lesson-kind-label.ts
-msgid "QzTY8x"
-msgstr "Grammar"
-
-#: src/use-lesson-kind-label.ts
-msgid "1TOMnj"
-msgstr "Listening"
-
-#: src/use-lesson-kind-label.ts
-msgid "KV+O0y"
-msgstr "Practice"
-
-#: src/use-lesson-kind-label.ts
-msgid "OuR/Ij"
-msgstr "Quiz"
-
-#: src/use-lesson-kind-label.ts
-msgid "MOK/yK"
-msgstr "Reading"
-
-#: src/use-lesson-kind-label.ts
-msgid "R+J5ox"
-msgstr "Review"
-
-#: src/use-lesson-kind-label.ts
-msgid "/vCXIP"
-msgstr "Translation"
-
-#: src/use-lesson-kind-label.ts
-msgid "Ox+Z+K"
-msgstr "Tutorial"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -7,7 +7,6 @@ msgstr ""
 "X-Crowdin-SourceKey: msgstr\n"
 
 #: src/components/alphabet-step.tsx
-#: src/use-lesson-kind-label.ts
 msgid "w0J/gv"
 msgstr "Alfabeto"
 
@@ -268,7 +267,6 @@ msgid "++l7ni"
 msgstr "No del todo"
 
 #: src/components/vocabulary-step.tsx
-#: src/use-lesson-kind-label.ts
 msgid "lqtP+R"
 msgstr "Vocabulario"
 
@@ -311,43 +309,3 @@ msgstr "Blanco"
 #: src/use-belt-color-label.ts
 msgid "5Tw3Ta"
 msgstr "Amarillo"
-
-#: src/use-lesson-kind-label.ts
-msgid "PJivSX"
-msgstr "Lección"
-
-#: src/use-lesson-kind-label.ts
-msgid "E1bF/X"
-msgstr "Explicación"
-
-#: src/use-lesson-kind-label.ts
-msgid "QzTY8x"
-msgstr "Gramática"
-
-#: src/use-lesson-kind-label.ts
-msgid "1TOMnj"
-msgstr "Escucha"
-
-#: src/use-lesson-kind-label.ts
-msgid "KV+O0y"
-msgstr "Practica"
-
-#: src/use-lesson-kind-label.ts
-msgid "OuR/Ij"
-msgstr "Cuestionario"
-
-#: src/use-lesson-kind-label.ts
-msgid "MOK/yK"
-msgstr "Lectura"
-
-#: src/use-lesson-kind-label.ts
-msgid "R+J5ox"
-msgstr "Repaso"
-
-#: src/use-lesson-kind-label.ts
-msgid "/vCXIP"
-msgstr "Traducción"
-
-#: src/use-lesson-kind-label.ts
-msgid "Ox+Z+K"
-msgstr "Tutorial"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -7,7 +7,6 @@ msgstr ""
 "X-Crowdin-SourceKey: msgstr\n"
 
 #: src/components/alphabet-step.tsx
-#: src/use-lesson-kind-label.ts
 msgid "w0J/gv"
 msgstr "Alfabeto"
 
@@ -268,7 +267,6 @@ msgid "++l7ni"
 msgstr "Não exatamente"
 
 #: src/components/vocabulary-step.tsx
-#: src/use-lesson-kind-label.ts
 msgid "lqtP+R"
 msgstr "Vocabulário"
 
@@ -311,43 +309,3 @@ msgstr "Branca"
 #: src/use-belt-color-label.ts
 msgid "5Tw3Ta"
 msgstr "Amarela"
-
-#: src/use-lesson-kind-label.ts
-msgid "PJivSX"
-msgstr "Aula"
-
-#: src/use-lesson-kind-label.ts
-msgid "E1bF/X"
-msgstr "Explicação"
-
-#: src/use-lesson-kind-label.ts
-msgid "QzTY8x"
-msgstr "Gramática"
-
-#: src/use-lesson-kind-label.ts
-msgid "1TOMnj"
-msgstr "Escuta"
-
-#: src/use-lesson-kind-label.ts
-msgid "KV+O0y"
-msgstr "Praticar"
-
-#: src/use-lesson-kind-label.ts
-msgid "OuR/Ij"
-msgstr "Quiz"
-
-#: src/use-lesson-kind-label.ts
-msgid "MOK/yK"
-msgstr "Leitura"
-
-#: src/use-lesson-kind-label.ts
-msgid "R+J5ox"
-msgstr "Revisão"
-
-#: src/use-lesson-kind-label.ts
-msgid "/vCXIP"
-msgstr "Tradução"
-
-#: src/use-lesson-kind-label.ts
-msgid "Ox+Z+K"
-msgstr "Tutorial"

--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -4,6 +4,7 @@ import {
   buildSerializedLesson,
   buildSerializedSentence,
   buildSerializedStep,
+  buildWordBankOption,
 } from "../_test-utils/player-test-data";
 import { buildAuthenticatedViewer } from "../_test-utils/player-test-viewer";
 import { renderPlayer } from "../_test-utils/render-player";
@@ -21,9 +22,9 @@ describe("player browser integration: word bank steps", () => {
               template: "The [BLANK] sat on the [BLANK]",
             },
             fillBlankOptions: [
-              { audioUrl: null, romanization: null, translation: null, word: "cat" },
-              { audioUrl: null, romanization: null, translation: null, word: "mat" },
-              { audioUrl: null, romanization: null, translation: null, word: "dog" },
+              buildWordBankOption({ word: "cat" }),
+              buildWordBankOption({ word: "mat" }),
+              buildWordBankOption({ word: "dog" }),
             ],
             kind: "fillBlank",
           }),
@@ -58,9 +59,9 @@ describe("player browser integration: word bank steps", () => {
               translation: "Hello world",
             }),
             wordBankOptions: [
-              { audioUrl: null, romanization: null, translation: null, word: "Hola" },
-              { audioUrl: null, romanization: null, translation: null, word: "mundo" },
-              { audioUrl: null, romanization: null, translation: null, word: "gato" },
+              buildWordBankOption({ pronunciation: "OH-lah", word: "Hola" }),
+              buildWordBankOption({ word: "mundo" }),
+              buildWordBankOption({ word: "gato" }),
             ],
           }),
         ],
@@ -69,8 +70,11 @@ describe("player browser integration: word bank steps", () => {
     });
 
     const wordBank = page.getByRole("group", { name: /word bank/iu });
+    const holaOption = wordBank.getByRole("button", { exact: true, name: "Hola" });
 
-    await wordBank.getByRole("button", { exact: true, name: "Hola" }).click();
+    await expect.element(holaOption.getByText("OH-lah")).toBeInTheDocument();
+
+    await holaOption.click();
     await wordBank.getByRole("button", { exact: true, name: "mundo" }).click();
     await page.getByRole("button", { name: /check/iu }).click();
 
@@ -93,9 +97,9 @@ describe("player browser integration: word bank steps", () => {
               translation: "Hello world",
             }),
             wordBankOptions: [
-              { audioUrl: null, romanization: null, translation: null, word: "Hello" },
-              { audioUrl: null, romanization: null, translation: null, word: "world" },
-              { audioUrl: null, romanization: null, translation: null, word: "bird" },
+              buildWordBankOption({ word: "Hello" }),
+              buildWordBankOption({ word: "world" }),
+              buildWordBankOption({ word: "bird" }),
             ],
           }),
         ],
@@ -130,8 +134,8 @@ describe("player browser integration: word bank steps", () => {
               template: "The sky is [BLANK]",
             },
             fillBlankOptions: [
-              { audioUrl: null, romanization: null, translation: null, word: "blue" },
-              { audioUrl: null, romanization: null, translation: null, word: "red" },
+              buildWordBankOption({ word: "blue" }),
+              buildWordBankOption({ word: "red" }),
             ],
             kind: "fillBlank",
           }),
@@ -172,9 +176,9 @@ describe("player browser integration: word bank steps", () => {
               translation: "Hello world",
             }),
             wordBankOptions: [
-              { audioUrl: null, romanization: null, translation: null, word: "mundo" },
-              { audioUrl: null, romanization: null, translation: null, word: "Hola" },
-              { audioUrl: null, romanization: null, translation: null, word: "gato" },
+              buildWordBankOption({ word: "mundo" }),
+              buildWordBankOption({ word: "Hola" }),
+              buildWordBankOption({ word: "gato" }),
             ],
           }),
         ],
@@ -211,9 +215,9 @@ describe("player browser integration: word bank steps", () => {
               translation: "Hello world",
             }),
             wordBankOptions: [
-              { audioUrl: null, romanization: null, translation: null, word: "Hello" },
-              { audioUrl: null, romanization: null, translation: null, word: "world" },
-              { audioUrl: null, romanization: null, translation: null, word: "bird" },
+              buildWordBankOption({ word: "Hello" }),
+              buildWordBankOption({ word: "world" }),
+              buildWordBankOption({ word: "bird" }),
             ],
           }),
         ],

--- a/packages/player/src/_test-utils/player-test-data.ts
+++ b/packages/player/src/_test-utils/player-test-data.ts
@@ -2,6 +2,7 @@ import {
   type SerializedLesson,
   type SerializedStep,
   type SerializedWord,
+  type WordBankOption,
 } from "@zoonk/core/player/contracts/prepare-lesson-data";
 
 type SerializedSentence = NonNullable<SerializedStep["sentence"]>;
@@ -19,6 +20,25 @@ export function buildSerializedWord(overrides: Partial<SerializedWord> = {}): Se
     romanization: null,
     translation: "Translation",
     word: "Word",
+    ...overrides,
+  };
+}
+
+/**
+ * Word-bank fixtures should default optional render metadata to null so tests can
+ * describe only the pronunciation, romanization, or audio detail that matters to
+ * the behavior under test.
+ */
+export function buildWordBankOption({
+  word,
+  ...overrides
+}: Partial<Omit<WordBankOption, "word">> & Pick<WordBankOption, "word">): WordBankOption {
+  return {
+    audioUrl: null,
+    pronunciation: null,
+    romanization: null,
+    translation: null,
+    word,
     ...overrides,
   };
 }

--- a/packages/player/src/components/arrange-words.test.tsx
+++ b/packages/player/src/components/arrange-words.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { type Mock, describe, expect, it, vi } from "vitest";
+import { buildWordBankOption } from "../_test-utils/player-test-data";
 import { ArrangeWordsInteraction } from "./arrange-words";
 
 vi.mock("next-intl", () => ({ useExtracted: () => (value: string) => value }));
@@ -26,9 +27,9 @@ describe(ArrangeWordsInteraction, () => {
         selectedAnswer={undefined}
         stepId="step-1"
         wordBankOptions={[
-          { audioUrl: null, romanization: null, translation: null, word: "Hola" },
-          { audioUrl: null, romanization: null, translation: null, word: "mundo" },
-          { audioUrl: null, romanization: null, translation: null, word: "gato" },
+          buildWordBankOption({ word: "Hola" }),
+          buildWordBankOption({ word: "mundo" }),
+          buildWordBankOption({ word: "gato" }),
         ]}
       >
         <p>Prompt</p>

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -5,7 +5,7 @@ import { arrayMove } from "@dnd-kit/sortable";
 import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { useWordAudio } from "../use-word-audio";
@@ -13,12 +13,28 @@ import { ArrangeWordsAnswerArea, type PlacedWord } from "./arrange-words-answer-
 import { RomanizationText } from "./romanization-text";
 import { InteractiveStepLayout } from "./step-layouts";
 
-function BankTileContent({ option }: { option: WordBankOption }) {
+function BankTileContent({
+  descriptionId,
+  option,
+}: {
+  descriptionId?: string;
+  option: WordBankOption;
+}) {
+  const hasDescription = Boolean(option.romanization || option.pronunciation);
+
   return (
     <>
       <span>{option.word}</span>
 
-      <RomanizationText>{option.romanization}</RomanizationText>
+      {hasDescription && (
+        <span className="flex flex-col items-center" id={descriptionId}>
+          <RomanizationText>{option.romanization}</RomanizationText>
+
+          {option.pronunciation && (
+            <span className="text-muted-foreground text-xs">{option.pronunciation}</span>
+          )}
+        </span>
+      )}
     </>
   );
 }
@@ -32,8 +48,13 @@ function BankTile({
   onPlace: () => void;
   option: WordBankOption;
 }) {
+  const descriptionId = useId();
+  const hasDescription = Boolean(option.romanization || option.pronunciation);
+
   return (
     <button
+      aria-describedby={hasDescription ? descriptionId : undefined}
+      aria-label={option.word}
       aria-disabled={isUsed}
       className={cn(
         "border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 transition-all duration-150",
@@ -45,7 +66,7 @@ function BankTile({
       tabIndex={isUsed ? -1 : 0}
       type="button"
     >
-      <BankTileContent option={option} />
+      <BankTileContent descriptionId={descriptionId} option={option} />
     </button>
   );
 }
@@ -115,7 +136,15 @@ export function ArrangeWordsInteraction({
       return result.answer.arrangedWords.map((word) => {
         const id = String(idCounter.current);
         idCounter.current += 1;
-        return { audioUrl: null, id, romanization: null, translation: null, word };
+
+        return {
+          audioUrl: null,
+          id,
+          pronunciation: null,
+          romanization: null,
+          translation: null,
+          word,
+        };
       });
     }
 

--- a/packages/player/src/components/fill-blank-step.test.tsx
+++ b/packages/player/src/components/fill-blank-step.test.tsx
@@ -2,6 +2,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { type ReactNode, StrictMode, useCallback, useState } from "react";
 import { type Mock, afterEach, describe, expect, it, vi } from "vitest";
+import { buildWordBankOption } from "../_test-utils/player-test-data";
 import { type SelectedAnswer } from "../player-reducer";
 import { FillBlankStep } from "./fill-blank-step";
 
@@ -18,9 +19,9 @@ function buildFillBlankStep(overrides: Record<string, unknown> = {}) {
       template: "Say [BLANK] then [BLANK]",
     },
     fillBlankOptions: [
-      { audioUrl: null, romanization: null, translation: null, word: "alpha" },
-      { audioUrl: null, romanization: null, translation: null, word: "beta" },
-      { audioUrl: null, romanization: null, translation: null, word: "gamma" },
+      buildWordBankOption({ word: "alpha" }),
+      buildWordBankOption({ word: "beta" }),
+      buildWordBankOption({ word: "gamma" }),
     ],
     id: "step-fb",
     kind: "fillBlank" as const,
@@ -132,9 +133,9 @@ describe("fill in the blank step", () => {
         template: "お金[BLANK]お願いします。",
       },
       fillBlankOptions: [
-        { audioUrl: null, romanization: "o", translation: null, word: "を" },
-        { audioUrl: null, romanization: "wa", translation: null, word: "は" },
-        { audioUrl: null, romanization: "ni", translation: null, word: "に" },
+        buildWordBankOption({ romanization: "o", word: "を" }),
+        buildWordBankOption({ romanization: "wa", word: "は" }),
+        buildWordBankOption({ romanization: "ni", word: "に" }),
       ],
     });
 
@@ -171,8 +172,8 @@ describe("fill in the blank step", () => {
         template: "お金[BLANK]お願いします。",
       },
       fillBlankOptions: [
-        { audioUrl: null, romanization: "o", translation: null, word: "を" },
-        { audioUrl: null, romanization: "wa", translation: null, word: "は" },
+        buildWordBankOption({ romanization: "o", word: "を" }),
+        buildWordBankOption({ romanization: "wa", word: "は" }),
       ],
     });
 
@@ -203,8 +204,8 @@ describe("fill in the blank step", () => {
         template: "[BLANK], wie geht's?",
       },
       fillBlankOptions: [
-        { audioUrl: null, romanization: null, translation: null, word: "Guten Morgen" },
-        { audioUrl: null, romanization: null, translation: null, word: "Guten Tag" },
+        buildWordBankOption({ word: "Guten Morgen" }),
+        buildWordBankOption({ word: "Guten Tag" }),
       ],
     });
 


### PR DESCRIPTION
Adds pronunciation metadata to reading word-bank options and shows it discreetly under target-language word tiles.\n\nAlso keeps listening word banks plain and updates player/core coverage for the serialized option shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show pronunciation under reading word-bank tiles to help learners say words correctly. Adds a new `pronunciation` field to `WordBankOption` and threads it through core and player; listening word banks remain plain.

- **New Features**
  - Core: Added `pronunciation` to `WordBankOption` and enriched `buildWordBankOptions` to pull it from lesson/sentence data, including per-token splits for multi-word entries. Defaults to null for distractors and fill-blank options.
  - Player: Displays pronunciation below the word (under romanization when present) with accessible `aria-describedby` and labels.

- **Migration**
  - If you construct `WordBankOption` manually, add `pronunciation` (string or null). Tests can use `buildWordBankOption()` to get sane defaults.

<sup>Written for commit de081a1427e31811eaa46af84cb3350396cb5b5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

