### PR TITLE
fix(core): limit player word bank distractors

### DIFF
--- a/packages/core/src/player/contracts/build-word-bank-options.test.ts
+++ b/packages/core/src/player/contracts/build-word-bank-options.test.ts
@@ -5,7 +5,9 @@ import { type DistractorWord } from "./translation-options";
 
 type SerializedSentence = NonNullable<SerializedStep["sentence"]>;
 
-vi.mock("@zoonk/utils/shuffle", () => ({ shuffle: <T>(items: T[]) => items }));
+const shuffleMock = vi.hoisted(() => vi.fn((items: readonly unknown[]) => [...items]));
+
+vi.mock("@zoonk/utils/shuffle", () => ({ shuffle: shuffleMock }));
 
 function makeLessonWord(overrides: Partial<SerializedWord> = {}): SerializedWord {
   return {
@@ -85,8 +87,8 @@ describe(buildWordBankOptions, () => {
       "Guten",
       "Morgen,",
       "Anna!",
-      "Abend",
-      "Fenster",
+      "abend",
+      "fenster",
     ]);
   });
 
@@ -141,7 +143,7 @@ describe(buildWordBankOptions, () => {
       "Boa",
       "tarde,",
       "Lara.",
-      "Bom",
+      "bom",
       "noite",
     ]);
 
@@ -154,6 +156,85 @@ describe(buildWordBankOptions, () => {
     });
   });
 
+  it("limits reading word banks to four distractors", () => {
+    const options = buildWordBankOptions(
+      makeStep(
+        "reading",
+        makeSentence({
+          distractors: ["uno", "dos", "tres", "cuatro", "cinco"],
+          sentence: "Hola mundo",
+        }),
+      ),
+      [],
+      [],
+      new Map(),
+    );
+
+    expect(options.map((option) => option.word)).toStrictEqual([
+      "Hola",
+      "mundo",
+      "uno",
+      "dos",
+      "tres",
+      "cuatro",
+    ]);
+  });
+
+  it("shuffles reading distractors before applying the visible cap", () => {
+    shuffleMock
+      .mockImplementationOnce((items: readonly unknown[]) => [...items].toReversed())
+      .mockImplementationOnce((items: readonly unknown[]) => [...items]);
+
+    const options = buildWordBankOptions(
+      makeStep(
+        "reading",
+        makeSentence({
+          distractors: ["uno", "dos", "tres", "cuatro", "cinco"],
+          sentence: "Hola mundo",
+        }),
+      ),
+      [],
+      [],
+      new Map(),
+    );
+
+    expect(options.map((option) => option.word)).toStrictEqual([
+      "Hola",
+      "mundo",
+      "cinco",
+      "cuatro",
+      "tres",
+      "dos",
+    ]);
+  });
+
+  it("lowercases listening distractors before display", () => {
+    const options = buildWordBankOptions(
+      makeStep(
+        "listening",
+        makeSentence({
+          sentence: "Como você está?",
+          translation: "Hi, how are you?",
+          translationDistractors: ["Farewell", "Thanks", "Goodbye", "Please"],
+        }),
+      ),
+      [],
+      [],
+      new Map(),
+    );
+
+    expect(options.map((option) => option.word)).toStrictEqual([
+      "Hi,",
+      "how",
+      "are",
+      "you?",
+      "farewell",
+      "thanks",
+      "goodbye",
+      "please",
+    ]);
+  });
+
   it("shows fewer distractors when sanitation removes entries", () => {
     const options = buildWordBankOptions(
       makeStep("reading", makeSentence({ distractors: ["Hola", "Salut"], sentence: "Hola mundo" })),
@@ -162,7 +243,7 @@ describe(buildWordBankOptions, () => {
       new Map(),
     );
 
-    expect(options.map((option) => option.word)).toStrictEqual(["Hola", "mundo", "Salut"]);
+    expect(options.map((option) => option.word)).toStrictEqual(["Hola", "mundo", "salut"]);
   });
 });
 

--- a/packages/core/src/player/contracts/build-word-bank-options.ts
+++ b/packages/core/src/player/contracts/build-word-bank-options.ts
@@ -17,6 +17,8 @@ type WordDataInput = {
 
 type WordMetadata = Omit<WordBankOption, "word">;
 
+const WORD_BANK_DISTRACTOR_LIMIT = 4;
+
 /**
  * Word-bank lookups should ignore punctuation and casing so the same visible token resolves
  * to one metadata entry regardless of where it came from.
@@ -254,6 +256,26 @@ function removeCanonicalWordCollisions(distractors: string[], correctWords: stri
 }
 
 /**
+ * Lowercase visible distractors so generated capitalization cannot identify
+ * which word-bank tiles are extra options.
+ */
+function normalizeDistractorCasing(distractor: string): string {
+  return distractor.toLocaleLowerCase();
+}
+
+/**
+ * `prepareLessonData` is the boundary that turns generated lesson resources
+ * into the player payload. Capping here keeps the stored AI distractor set
+ * intact while sending the UI four varied extra tiles instead of always taking
+ * the first generated distractors.
+ */
+function getVisibleDistractors(distractors: string[]): string[] {
+  return shuffle(distractors)
+    .slice(0, WORD_BANK_DISTRACTOR_LIMIT)
+    .map((distractor) => normalizeDistractorCasing(distractor));
+}
+
+/**
  * Builds the final arrange-words option list from canonical tokens plus stored direct
  * distractors. There is no semantic filtering, fallback lesson lookup, or local top-up.
  */
@@ -269,7 +291,10 @@ export function buildWordBankOptions(
     return [];
   }
 
-  const distractors = removeCanonicalWordCollisions(config.distractors, config.correctWords);
+  const distractors = getVisibleDistractors(
+    removeCanonicalWordCollisions(config.distractors, config.correctWords),
+  );
+
   const words = shuffle([...config.correctWords, ...distractors]);
 
   const buildOption = config.usesTargetLanguageMetadata

--- a/packages/core/src/player/contracts/prepare-lesson-data.test.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.test.ts
@@ -662,14 +662,14 @@ describe(preparePlayerLessonData, () => {
         pronunciation: "abend",
         romanization: "abend",
         translation: null,
-        word: "Abend",
+        word: "abend",
       },
       {
         audioUrl: null,
         pronunciation: null,
         romanization: null,
         translation: null,
-        word: "Fenster",
+        word: "fenster",
       },
     ]);
 


### PR DESCRIPTION
Limits reading and listening word-bank payloads to four visible distractors while preserving generated distractor storage.\n\nAlso shuffles the distractor pool before slicing and lowercases visible distractors so capitalization does not reveal the extra options.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits reading and listening word-bank payloads to four visible distractors to streamline the UI and reduce confusion. Shuffles the distractor pool before capping and lowercases visible distractors to avoid capitalization giveaways, while keeping the full generated set stored.

- **Bug Fixes**
  - Cap visible distractors at 4 for reading and listening word banks.
  - Shuffle distractors before capping for variety.
  - Lowercase visible distractors to prevent capitalization revealing extras.

<sup>Written for commit 16d53f0cff6f59b32de299fbcf7221907ba5b110. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

