### PR TITLE
feat(player): add mobile audio play control

### DIFF
--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -202,6 +202,10 @@ msgstr "Lesson progress"
 msgid "tJtNzs"
 msgstr "Player screen"
 
+#: src/components/player-shell.tsx
+msgid "QmGDqt"
+msgstr "Player controls"
+
 #: src/components/reward-badges.tsx
 msgid "/Q0taG"
 msgstr "BP"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -202,6 +202,10 @@ msgstr "Progreso de la lección"
 msgid "tJtNzs"
 msgstr "Pantalla del jugador"
 
+#: src/components/player-shell.tsx
+msgid "QmGDqt"
+msgstr "Controles de la lección"
+
 #: src/components/reward-badges.tsx
 msgid "/Q0taG"
 msgstr "PM"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -202,6 +202,10 @@ msgstr "Progresso da aula"
 msgid "tJtNzs"
 msgstr "Tela do jogador"
 
+#: src/components/player-shell.tsx
+msgid "QmGDqt"
+msgstr "Controles da aula"
+
 #: src/components/reward-badges.tsx
 msgid "/Q0taG"
 msgstr "PM"

--- a/packages/player/src/_browser-tests/player-alphabet.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-alphabet.browser.test.tsx
@@ -120,13 +120,15 @@ describe("player browser integration: alphabet", () => {
       viewer: buildAuthenticatedViewer(),
     });
 
-    await page.getByRole("button", { name: /play pronunciation/iu }).click();
+    const currentCard = page.getByRole("region", { name: /alphabet: ب/iu });
+
+    await currentCard.getByRole("button", { name: /play pronunciation/iu }).click();
 
     await expect
-      .element(page.getByRole("button", { name: /pause pronunciation/iu }))
+      .element(currentCard.getByRole("button", { name: /pause pronunciation/iu }))
       .toBeInTheDocument();
 
-    await expect.element(page.getByRole("region", { name: /alphabet: ب/iu })).toBeInTheDocument();
+    await expect.element(currentCard).toBeInTheDocument();
 
     await expect
       .element(page.getByRole("region", { name: /alphabet: ت/iu }))

--- a/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { page } from "vitest/browser";
+import { runInMobilePlayerViewport } from "../_test-utils/browser-viewport";
 import {
   buildSerializedLesson,
   buildSerializedStep,
@@ -71,19 +72,73 @@ describe("player browser integration: vocabulary", () => {
       viewer: buildAuthenticatedViewer(),
     });
 
-    await page.getByRole("button", { name: /play pronunciation/iu }).click();
+    const currentCard = page.getByRole("region", { name: /vocabulary: Hola/iu });
+
+    await currentCard.getByRole("button", { name: /play pronunciation/iu }).click();
 
     await expect
-      .element(page.getByRole("button", { name: /pause pronunciation/iu }))
+      .element(currentCard.getByRole("button", { name: /pause pronunciation/iu }))
       .toBeInTheDocument();
 
-    await expect
-      .element(page.getByRole("region", { name: /vocabulary: Hola/iu }))
-      .toBeInTheDocument();
+    await expect.element(currentCard).toBeInTheDocument();
 
     await expect
       .element(page.getByRole("region", { name: /vocabulary: Adios/iu }))
       .not.toBeInTheDocument();
+  });
+
+  it("plays vocabulary audio from the mobile bottom bar", async () => {
+    await runInMobilePlayerViewport(async () => {
+      renderPlayer({
+        lesson: buildSerializedLesson({
+          kind: "vocabulary",
+          steps: [
+            buildSerializedStep({
+              content: {},
+              id: "vocab-bottom-audio-1",
+              kind: "vocabulary",
+              word: buildSerializedWord({
+                audioUrl: "https://example.com/hola.mp3",
+                id: "word-bottom-audio-1",
+                translation: "Hello",
+                word: "Hola",
+              }),
+            }),
+            buildSerializedStep({
+              content: {},
+              id: "vocab-bottom-audio-2",
+              kind: "vocabulary",
+              position: 1,
+              word: buildSerializedWord({
+                audioUrl: "https://example.com/adios.mp3",
+                id: "word-bottom-audio-2",
+                translation: "Goodbye",
+                word: "Adios",
+              }),
+            }),
+          ],
+        }),
+        navigation: buildNavigation({ nextLessonHref: null }),
+        viewer: buildAuthenticatedViewer(),
+      });
+
+      const controls = page.getByRole("toolbar", { name: /player controls/iu });
+      const currentCard = page.getByRole("region", { name: /vocabulary: Hola/iu });
+
+      await controls.getByRole("button", { name: /play pronunciation/iu }).click();
+
+      await expect
+        .element(controls.getByRole("button", { name: /pause pronunciation/iu }))
+        .toBeInTheDocument();
+
+      await expect
+        .element(currentCard.getByRole("button", { name: /pause pronunciation/iu }))
+        .toBeInTheDocument();
+
+      await expect
+        .element(page.getByRole("region", { name: /vocabulary: Adios/iu }))
+        .not.toBeInTheDocument();
+    });
   });
 
   it("navigates vocabulary cards without quiz controls", async () => {

--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { page } from "vitest/browser";
+import { runInMobilePlayerViewport } from "../_test-utils/browser-viewport";
 import {
   buildSerializedLesson,
   buildSerializedSentence,
@@ -84,41 +85,53 @@ describe("player browser integration: word bank steps", () => {
   });
 
   it("renders listening audio controls and completes from the word bank flow", async () => {
-    renderPlayer({
-      lesson: buildSerializedLesson({
-        kind: "listening",
-        steps: [
-          buildSerializedStep({
-            content: {},
-            kind: "listening",
-            sentence: buildSerializedSentence({
-              audioUrl: "https://example.com/audio.mp3",
-              sentence: "Hola mundo",
-              translation: "Hello world",
+    await runInMobilePlayerViewport(async () => {
+      renderPlayer({
+        lesson: buildSerializedLesson({
+          kind: "listening",
+          steps: [
+            buildSerializedStep({
+              content: {},
+              kind: "listening",
+              sentence: buildSerializedSentence({
+                audioUrl: "https://example.com/audio.mp3",
+                sentence: "Hola mundo",
+                translation: "Hello world",
+              }),
+              wordBankOptions: [
+                buildWordBankOption({ word: "Hello" }),
+                buildWordBankOption({ word: "world" }),
+                buildWordBankOption({ word: "bird" }),
+              ],
             }),
-            wordBankOptions: [
-              buildWordBankOption({ word: "Hello" }),
-              buildWordBankOption({ word: "world" }),
-              buildWordBankOption({ word: "bird" }),
-            ],
-          }),
-        ],
-      }),
-      viewer: buildAuthenticatedViewer(),
+          ],
+        }),
+        viewer: buildAuthenticatedViewer(),
+      });
+
+      const controls = page.getByRole("toolbar", { name: /player controls/iu });
+
+      await expect
+        .element(controls.getByRole("button", { name: /play pronunciation/iu }))
+        .toBeInTheDocument();
+
+      await expect.element(controls.getByRole("button", { name: /check/iu })).toBeDisabled();
+
+      await controls.getByRole("button", { name: /play pronunciation/iu }).click();
+
+      await expect
+        .element(controls.getByRole("button", { name: /pause pronunciation/iu }))
+        .toBeInTheDocument();
+
+      const wordBank = page.getByRole("group", { name: /word bank/iu });
+
+      await wordBank.getByRole("button", { exact: true, name: "Hello" }).click();
+      await wordBank.getByRole("button", { exact: true, name: "world" }).click();
+      await controls.getByRole("button", { name: /check/iu }).click();
+      await controls.getByRole("button", { name: /continue/iu }).click();
+
+      await expect.element(page.getByText("1/1")).toBeInTheDocument();
     });
-
-    await expect
-      .element(page.getByRole("button", { name: /play pronunciation/iu }))
-      .toBeInTheDocument();
-
-    const wordBank = page.getByRole("group", { name: /word bank/iu });
-
-    await wordBank.getByRole("button", { exact: true, name: "Hello" }).click();
-    await wordBank.getByRole("button", { exact: true, name: "world" }).click();
-    await page.getByRole("button", { name: /check/iu }).click();
-    await page.getByRole("button", { name: /continue/iu }).click();
-
-    await expect.element(page.getByText("1/1")).toBeInTheDocument();
   });
 
   it("lets learners remove fill-blank words before checking and shows the correct-answer hint", async () => {

--- a/packages/player/src/_test-utils/browser-viewport.ts
+++ b/packages/player/src/_test-utils/browser-viewport.ts
@@ -1,0 +1,19 @@
+import { page } from "vitest/browser";
+
+const DEFAULT_DESKTOP_VIEWPORT = { height: 720, width: 1280 };
+const MOBILE_PLAYER_VIEWPORT = { height: 844, width: 390 };
+
+/**
+ * Mobile player controls are intentionally hidden at desktop breakpoints. This
+ * helper makes bottom-bar tests run at a phone-sized viewport, then restores a
+ * desktop viewport so later browser tests keep their default layout assumptions.
+ */
+export async function runInMobilePlayerViewport(run: () => Promise<void>) {
+  await page.viewport(MOBILE_PLAYER_VIEWPORT.width, MOBILE_PLAYER_VIEWPORT.height);
+
+  try {
+    await run();
+  } finally {
+    await page.viewport(DEFAULT_DESKTOP_VIEWPORT.width, DEFAULT_DESKTOP_VIEWPORT.height);
+  }
+}

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -1,10 +1,48 @@
 "use client";
 
+import { Button } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { PauseIcon, Volume2Icon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { useState } from "react";
+import { useSharedPlayerAudio } from "../player-audio-context";
 import { useWordAudio } from "../use-word-audio";
+
+type PlayAudioButtonVariant = "filled" | "outline" | "text";
+
+/**
+ * Picks the shared player audio controller when this button represents the
+ * active step prompt, otherwise falls back to a local controller. That keeps
+ * duplicate prompt buttons synchronized while preserving standalone audio
+ * buttons in other contexts.
+ */
+function usePlayAudioButtonState({ audioUrl, preload }: { audioUrl: string; preload: boolean }) {
+  const sharedAudio = useSharedPlayerAudio(audioUrl);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const { pause, play } = useWordAudio({
+    onEnded: () => setIsPlaying(false),
+    preloadUrls: preload && !sharedAudio ? [audioUrl] : undefined,
+  });
+
+  if (sharedAudio) {
+    return { handleClick: sharedAudio.toggle, isPlaying: sharedAudio.isPlaying };
+  }
+
+  return {
+    handleClick: () => {
+      if (isPlaying) {
+        pause();
+        setIsPlaying(false);
+        return;
+      }
+
+      play(audioUrl);
+      setIsPlaying(true);
+    },
+    isPlaying,
+  };
+}
 
 export function PlayAudioButton({
   audioUrl,
@@ -15,25 +53,10 @@ export function PlayAudioButton({
   audioUrl: string;
   preload?: boolean;
   size?: "sm" | "md";
-  variant?: "filled" | "text";
+  variant?: PlayAudioButtonVariant;
 }) {
   const t = useExtracted();
-  const [isPlaying, setIsPlaying] = useState(false);
-
-  const { pause, play } = useWordAudio({
-    onEnded: () => setIsPlaying(false),
-    preloadUrls: preload ? [audioUrl] : undefined,
-  });
-
-  const handleClick = () => {
-    if (isPlaying) {
-      pause();
-      setIsPlaying(false);
-    } else {
-      play(audioUrl);
-      setIsPlaying(true);
-    }
-  };
+  const { handleClick, isPlaying } = usePlayAudioButtonState({ audioUrl, preload });
 
   const Icon = isPlaying ? PauseIcon : Volume2Icon;
   const label = isPlaying ? t("Pause pronunciation") : t("Play pronunciation");
@@ -48,6 +71,20 @@ export function PlayAudioButton({
         <Icon aria-hidden className="size-4" />
         {label}
       </button>
+    );
+  }
+
+  if (variant === "outline") {
+    return (
+      <Button
+        aria-label={label}
+        onClick={handleClick}
+        size={size === "md" ? "icon-lg" : "icon"}
+        type="button"
+        variant="outline"
+      >
+        <Icon aria-hidden className={size === "md" ? "size-5" : "size-4"} />
+      </Button>
     );
   }
 

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useExtracted } from "next-intl";
+import { PlayerAudioProvider } from "../player-audio-context";
 import { usePlayerRuntime } from "../player-context";
 import {
   getCurrentResult,
@@ -10,6 +11,7 @@ import {
 } from "../player-selectors";
 import { usePlayerHaptics } from "../use-player-haptics";
 import { InPlayStickyHeader } from "./in-play-sticky-header";
+import { PlayAudioButton } from "./play-audio-button";
 import { PlayerBottomBar } from "./player-bottom-bar";
 import { PlayerStage } from "./player-stage";
 import { StageContent } from "./stage-content";
@@ -25,20 +27,36 @@ import { StepNavigationButtonGroup } from "./step-navigation-button-group";
  */
 function BottomBarContent() {
   const { actions, screen } = usePlayerRuntime();
+  const audioUrl = screen.bottomBar?.audioUrl ?? null;
+  const audioAction = audioUrl ? <BottomBarAudioAction audioUrl={audioUrl} /> : null;
 
   return (
     <PlayerContentFrame>
       {screen.bottomBar?.kind === "navigation" ? (
         <StepNavigationButtonGroup
+          audioAction={audioAction}
           canNavigatePrev={screen.bottomBar.canNavigatePrev}
           onNavigateNext={actions.navigateNext}
           onNavigatePrev={actions.navigatePrev}
         />
       ) : (
-        <StepActionButton />
+        <div className="flex w-full gap-2">
+          <StepActionButton className="min-w-0 flex-1" />
+          {audioAction}
+        </div>
       )}
     </PlayerContentFrame>
   );
+}
+
+/**
+ * Renders the secondary bottom-bar audio icon only for steps with prompt audio.
+ *
+ * The center play button stays in the step content; this small duplicate gives
+ * thumb-reachable access on mobile without adding noise to non-audio steps.
+ */
+function BottomBarAudioAction({ audioUrl }: { audioUrl: string }) {
+  return <PlayAudioButton audioUrl={audioUrl} variant="outline" />;
 }
 
 /**
@@ -50,6 +68,17 @@ function BottomBarContent() {
  */
 function getStageResetKey({ screenKind, stepId }: { screenKind: string; stepId?: string }) {
   return `${stepId ?? "completion"}:${screenKind}`;
+}
+
+/**
+ * Remounts the shared audio provider when the active step changes.
+ *
+ * The provider owns the reusable audio element for duplicate prompt controls,
+ * so keying by step and URL guarantees any still-playing clip is cleaned up
+ * when the learner advances to a different prompt.
+ */
+function getAudioProviderKey({ audioUrl, stepId }: { audioUrl: string | null; stepId?: string }) {
+  return `${stepId ?? "completion"}:${audioUrl ?? "no-audio"}`;
 }
 
 export function PlayerShell() {
@@ -64,6 +93,13 @@ export function PlayerShell() {
 
   const progressValue = getProgressValue(state);
   const upcomingImages = getUpcomingImages(state);
+  const bottomBarAudioUrl = screen.bottomBar?.audioUrl ?? null;
+
+  const audioProviderKey = getAudioProviderKey({
+    audioUrl: bottomBarAudioUrl,
+    stepId: currentStep?.id,
+  });
+
   const stageResetKey = getStageResetKey({ screenKind: screen.kind, stepId: currentStep?.id });
 
   usePlayerHaptics({ current: { phase: state.phase, result: currentResult, step: currentStep } });
@@ -72,22 +108,24 @@ export function PlayerShell() {
     <main className="flex h-dvh flex-col overflow-hidden">
       {screen.showChrome && <InPlayStickyHeader progressValue={progressValue} />}
 
-      <PlayerStage
-        aria-label={t("Player screen")}
-        isFullBleed={screen.stageIsFullBleed}
-        isStatic={screen.stageIsStatic}
-        key={stageResetKey}
-        phase={state.phase}
-        scene={screen.scene}
-      >
-        <StageContent />
-      </PlayerStage>
+      <PlayerAudioProvider audioUrl={bottomBarAudioUrl} key={audioProviderKey}>
+        <PlayerStage
+          aria-label={t("Player screen")}
+          isFullBleed={screen.stageIsFullBleed}
+          isStatic={screen.stageIsStatic}
+          key={stageResetKey}
+          phase={state.phase}
+          scene={screen.scene}
+        >
+          <StageContent />
+        </PlayerStage>
 
-      {shouldShowStickyBottomBar && (
-        <PlayerBottomBar className="lg:hidden">
-          <BottomBarContent />
-        </PlayerBottomBar>
-      )}
+        {shouldShowStickyBottomBar && (
+          <PlayerBottomBar aria-label={t("Player controls")} className="lg:hidden" role="toolbar">
+            <BottomBarContent />
+          </PlayerBottomBar>
+        )}
+      </PlayerAudioProvider>
 
       <StepImagePreloader images={upcomingImages} />
     </main>

--- a/packages/player/src/components/step-navigation-button-group.tsx
+++ b/packages/player/src/components/step-navigation-button-group.tsx
@@ -6,16 +6,19 @@ import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 
 /**
- * Read-only steps need an explicit touch target because swipe gestures are
+ * Read-only steps need explicit touch targets because swipe gestures are
  * discoverable only after the learner already knows they exist. This group
  * keeps swipe navigation intact while giving mobile and tablet users a clear
- * tappable path through static, vocabulary, and alphabet screens.
+ * tappable path through static, vocabulary, and alphabet screens, plus an
+ * optional trailing control for prompt-specific actions like audio playback.
  */
 export function StepNavigationButtonGroup({
+  audioAction,
   canNavigatePrev,
   onNavigateNext,
   onNavigatePrev,
 }: {
+  audioAction?: React.ReactNode;
   canNavigatePrev: boolean;
   onNavigateNext: () => void;
   onNavigatePrev: () => void;
@@ -39,7 +42,7 @@ export function StepNavigationButtonGroup({
 
       <Button
         aria-keyshortcuts="ArrowRight"
-        className={cn("min-w-0 flex-1", !canNavigatePrev && "w-full")}
+        className={cn("min-w-0 flex-1", !canNavigatePrev && !audioAction && "w-full")}
         onClick={onNavigateNext}
         size="lg"
         type="button"
@@ -47,6 +50,8 @@ export function StepNavigationButtonGroup({
         <span>{t("Next")}</span>
         <ChevronRightIcon aria-hidden="true" data-icon="inline-end" />
       </Button>
+
+      {audioAction}
     </div>
   );
 }

--- a/packages/player/src/player-audio-context.tsx
+++ b/packages/player/src/player-audio-context.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { useWordAudio } from "./use-word-audio";
+
+type PlayerAudioContextValue = {
+  audioUrl: string | null;
+  isPlaying: boolean;
+  toggleAudio: (audioUrl: string) => void;
+};
+
+const PlayerAudioContext = createContext<PlayerAudioContextValue | null>(null);
+
+/**
+ * Shares the active step's main audio prompt between duplicate controls.
+ *
+ * Vocabulary, alphabet, and listening screens can show the same play action in
+ * the step content and in the mobile bottom bar. Keeping playback here makes
+ * those controls reflect the same playing state instead of creating two
+ * independent audio elements for one prompt.
+ */
+export function PlayerAudioProvider({
+  audioUrl,
+  children,
+}: {
+  audioUrl: string | null;
+  children: React.ReactNode;
+}) {
+  const [playingAudioUrl, setPlayingAudioUrl] = useState<string | null>(null);
+
+  const { pause, play } = useWordAudio({
+    onEnded: () => setPlayingAudioUrl(null),
+    preloadUrls: audioUrl ? [audioUrl] : undefined,
+  });
+
+  const isPlaying = Boolean(audioUrl && playingAudioUrl === audioUrl);
+
+  const toggleAudio = useCallback(
+    (targetAudioUrl: string) => {
+      if (playingAudioUrl === targetAudioUrl) {
+        pause();
+        setPlayingAudioUrl(null);
+        return;
+      }
+
+      play(targetAudioUrl);
+      setPlayingAudioUrl(targetAudioUrl);
+    },
+    [pause, play, playingAudioUrl],
+  );
+
+  const value = useMemo(
+    () => ({ audioUrl, isPlaying, toggleAudio }),
+    [audioUrl, isPlaying, toggleAudio],
+  );
+
+  return <PlayerAudioContext value={value}>{children}</PlayerAudioContext>;
+}
+
+/**
+ * Returns shared prompt-audio controls when a button targets the active step.
+ *
+ * Buttons outside the active step, such as word-bank option sounds, should keep
+ * their local playback hook. Returning null lets those buttons continue using
+ * their existing standalone behavior.
+ */
+export function useSharedPlayerAudio(audioUrl: string) {
+  const context = useContext(PlayerAudioContext);
+
+  if (context?.audioUrl !== audioUrl) {
+    return null;
+  }
+
+  return { isPlaying: context.isPlaying, toggle: () => context.toggleAudio(audioUrl) };
+}

--- a/packages/player/src/player-screen.test.ts
+++ b/packages/player/src/player-screen.test.ts
@@ -1,6 +1,7 @@
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { type LessonKind } from "@zoonk/core/steps/contract/content";
 import { describe, expect, it } from "vitest";
+import { buildSerializedSentence, buildSerializedWord } from "./_test-utils/player-test-data";
 import { type PlayerState } from "./player-reducer";
 import { getPlayerScreenModel } from "./player-screen";
 
@@ -53,7 +54,13 @@ describe(getPlayerScreenModel, () => {
     const screen = buildScreen();
 
     expect(screen.kind).toBe("step");
-    expect(screen.bottomBar).toStrictEqual({ canNavigatePrev: false, kind: "navigation" });
+
+    expect(screen.bottomBar).toStrictEqual({
+      audioUrl: null,
+      canNavigatePrev: false,
+      kind: "navigation",
+    });
+
     expect(screen.keyboard.enterAction).toBeNull();
     expect(screen.keyboard.rightAction).toBe("navigateNext");
     expect(screen.stageIsStatic).toBe(true);
@@ -72,6 +79,7 @@ describe(getPlayerScreenModel, () => {
     expect(screen.kind).toBe("step");
 
     expect(screen.bottomBar).toStrictEqual({
+      audioUrl: null,
       button: "begin",
       disabled: false,
       kind: "primaryAction",
@@ -101,6 +109,7 @@ describe(getPlayerScreenModel, () => {
     expect(screen.kind).toBe("step");
 
     expect(screen.bottomBar).toStrictEqual({
+      audioUrl: null,
       button: "check",
       disabled: true,
       kind: "primaryAction",
@@ -117,5 +126,70 @@ describe(getPlayerScreenModel, () => {
     expect(screen.bottomBar).toBeNull();
     expect(screen.keyboard.enterAction).toBe("nextOrEscape");
     expect(screen.keyboard.canRestart).toBe(true);
+  });
+
+  it("adds bottom audio to vocabulary, alphabet, and listening prompt steps", () => {
+    const vocabularyScreen = buildScreen({
+      state: buildState({
+        steps: [
+          buildStep({
+            content: {},
+            kind: "vocabulary",
+            word: buildSerializedWord({ audioUrl: "https://example.com/vocabulary.mp3" }),
+          }),
+        ],
+      }),
+    });
+
+    const alphabetScreen = buildScreen({
+      state: buildState({
+        steps: [
+          buildStep({
+            content: {
+              audioText: "あ",
+              audioUrl: "https://example.com/alphabet.mp3",
+              forms: [],
+              pronunciation: "like a in father",
+              readingAid: "a",
+              symbol: "あ",
+            },
+            kind: "alphabet",
+          }),
+        ],
+      }),
+    });
+
+    const listeningScreen = buildScreen({
+      state: buildState({
+        steps: [
+          buildStep({
+            content: {},
+            kind: "listening",
+            sentence: buildSerializedSentence({ audioUrl: "https://example.com/listening.mp3" }),
+          }),
+        ],
+      }),
+    });
+
+    expect(vocabularyScreen.kind).toBe("step");
+
+    expect(vocabularyScreen.bottomBar).toMatchObject({
+      audioUrl: "https://example.com/vocabulary.mp3",
+      kind: "navigation",
+    });
+
+    expect(alphabetScreen.kind).toBe("step");
+
+    expect(alphabetScreen.bottomBar).toMatchObject({
+      audioUrl: "https://example.com/alphabet.mp3",
+      kind: "navigation",
+    });
+
+    expect(listeningScreen.kind).toBe("step");
+
+    expect(listeningScreen.bottomBar).toMatchObject({
+      audioUrl: "https://example.com/listening.mp3",
+      kind: "primaryAction",
+    });
   });
 });

--- a/packages/player/src/player-screen.ts
+++ b/packages/player/src/player-screen.ts
@@ -1,5 +1,9 @@
 import { type PlayerState } from "./player-reducer";
-import { type PlayerStepDescriptor, describePlayerStep } from "./player-step";
+import {
+  type PlayerStepDescriptor,
+  describePlayerStep,
+  getPlayerStepAudioUrl,
+} from "./player-step";
 import {
   getPlayerStepBehavior,
   getPlayerStepScene,
@@ -13,8 +17,9 @@ type PlayerPrimaryActionRun = "check" | "continue" | "navigateNext";
 type InPlayScreenScene = "choice" | "feedback" | "read";
 
 type PlayerBottomBarModel =
-  | { canNavigatePrev: boolean; kind: "navigation" }
+  | { audioUrl: string | null; canNavigatePrev: boolean; kind: "navigation" }
   | {
+      audioUrl: string | null;
       button: PlayerPrimaryActionKind;
       disabled: boolean;
       kind: "primaryAction";
@@ -81,6 +86,25 @@ function getCompletedScreenModel(): PlayerCompletedScreenModel {
 }
 
 /**
+ * Bottom-bar audio is only useful while the learner is answering or reading
+ * the active prompt. Feedback screens should keep the bar focused on Continue
+ * so the audio button does not follow the learner into a result screen.
+ */
+function getBottomBarAudioUrl({
+  phase,
+  step,
+}: {
+  phase: PlayerState["phase"];
+  step: PlayerStepDescriptor;
+}): string | null {
+  if (phase !== "playing") {
+    return null;
+  }
+
+  return getPlayerStepAudioUrl(step);
+}
+
+/**
  * The bottom bar is the clearest description of the player's current control
  * mode. Building it in one place prevents shell and keyboard code from
  * independently re-deriving which action should be active.
@@ -97,24 +121,37 @@ function getBottomBarModel({
   step: PlayerStepDescriptor;
 }): PlayerBottomBarModel {
   const behavior = getPlayerStepBehavior(step);
+  const audioUrl = getBottomBarAudioUrl({ phase, step });
 
   if (!behavior) {
-    return { canNavigatePrev: canMovePrev, kind: "navigation" };
+    return { audioUrl, canNavigatePrev: canMovePrev, kind: "navigation" };
   }
 
   if (phase === "feedback") {
-    return { button: "continue", disabled: false, kind: "primaryAction", run: "continue" };
+    return {
+      audioUrl,
+      button: "continue",
+      disabled: false,
+      kind: "primaryAction",
+      run: "continue",
+    };
   }
 
   if (step.kind === "intro") {
-    return { button: "begin", disabled: false, kind: "primaryAction", run: "navigateNext" };
+    return {
+      audioUrl,
+      button: "begin",
+      disabled: false,
+      kind: "primaryAction",
+      run: "navigateNext",
+    };
   }
 
   if (behavior.layout === "navigable") {
-    return { canNavigatePrev: canMovePrev, kind: "navigation" };
+    return { audioUrl, canNavigatePrev: canMovePrev, kind: "navigation" };
   }
 
-  return { button: "check", disabled: !hasAnswer, kind: "primaryAction", run: "check" };
+  return { audioUrl, button: "check", disabled: !hasAnswer, kind: "primaryAction", run: "check" };
 }
 
 /**

--- a/packages/player/src/player-step.ts
+++ b/packages/player/src/player-step.ts
@@ -156,3 +156,27 @@ export function getPlayerStepImage(descriptor?: PlayerStepDescriptor | null): St
 
   return descriptor.content.image ?? null;
 }
+
+/**
+ * Returns the primary audio prompt for steps where listening is required.
+ *
+ * This intentionally excludes option-selection sounds, such as translation
+ * choices and word-bank tiles, because those sounds belong to the selected
+ * option rather than the step prompt that should be reachable from the bottom
+ * bar.
+ */
+export function getPlayerStepAudioUrl(descriptor?: PlayerStepDescriptor | null): string | null {
+  if (descriptor?.kind === "alphabet") {
+    return descriptor.content.audioUrl ?? null;
+  }
+
+  if (descriptor?.kind === "listening") {
+    return descriptor.step.sentence?.audioUrl ?? null;
+  }
+
+  if (descriptor?.kind === "vocabulary") {
+    return descriptor.step.word?.audioUrl ?? null;
+  }
+
+  return null;
+}


### PR DESCRIPTION
Adds a thumb-reachable audio control to the mobile player bottom bar for prompt-audio steps.

Also shares prompt playback state between the centered play button and bottom-bar icon, and adds mobile browser coverage for vocabulary and listening flows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a thumb-reachable play/pause control to the mobile player bottom bar for prompt audio. It stays in sync with the main play button and only shows for steps with audio.

- **New Features**
  - Mobile bottom bar adds an audio button for vocabulary, alphabet, and listening prompts; it only appears while playing a prompt and shares state with the centered button via `PlayerAudioProvider`.
  - `PlayAudioButton` gains an `outline` variant and shared-audio behavior; bottom bar is now a `role="toolbar"` with the “Player controls” label (en/es/pt i18n updated).
  - Screen model exposes `bottomBar.audioUrl` for relevant steps; tests add a mobile viewport helper and extend coverage for vocabulary and listening bottom-bar playback.

<sup>Written for commit d94d1e030516554d02566f9e28937b3e0dc29b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

