### PR TITLE
feat(player): add reading word translation hints

### DIFF
--- a/packages/core/src/player/contracts/build-word-bank-options.test.ts
+++ b/packages/core/src/player/contracts/build-word-bank-options.test.ts
@@ -293,6 +293,37 @@ describe(buildSentenceWordOptions, () => {
             audioUrl: "/audio/hola-sentence.mp3",
             pronunciation: "OH-lah",
             romanization: "o-la",
+            translation: "hello from sentence",
+            word: "Hola",
+          },
+        ],
+      ]),
+    );
+
+    expect(options).toStrictEqual([
+      {
+        audioUrl: "/audio/hola-sentence.mp3",
+        pronunciation: "OH-lah",
+        romanization: "o-la",
+        translation: "hello",
+        word: "Hola",
+      },
+    ]);
+  });
+
+  it("uses sentence word translations when lesson words do not provide one", () => {
+    const options = buildSentenceWordOptions(
+      "Hola",
+      [],
+      [],
+      new Map([
+        [
+          "hola",
+          {
+            audioUrl: "/audio/hola-sentence.mp3",
+            pronunciation: "OH-lah",
+            romanization: "o-la",
+            translation: "hello",
             word: "Hola",
           },
         ],

--- a/packages/core/src/player/contracts/build-word-bank-options.ts
+++ b/packages/core/src/player/contracts/build-word-bank-options.ts
@@ -12,6 +12,7 @@ type WordDataInput = {
   audioUrl: string | null;
   pronunciation: string | null;
   romanization: string | null;
+  translation: string;
   word: string;
 };
 
@@ -55,9 +56,9 @@ function splitMultiWordEntries(lessonWord: SerializedWord): [string, WordMetadat
 }
 
 /**
- * Sentence-level token metadata is more precise for audio and romanization, but it does
- * not carry translations. Preserve any existing translation when a later source only
- * contributes render metadata.
+ * Sentence-level token metadata is more precise for audio and romanization and can now
+ * fill reading prompt hints. Existing lesson-word translations still win because those
+ * are attached to the explicit lesson resource the learner is practicing.
  */
 function mergeWordMetadata({
   current,
@@ -70,7 +71,7 @@ function mergeWordMetadata({
     audioUrl: incoming.audioUrl ?? current?.audioUrl ?? null,
     pronunciation: incoming.pronunciation ?? current?.pronunciation ?? null,
     romanization: incoming.romanization ?? current?.romanization ?? null,
-    translation: incoming.translation ?? current?.translation ?? null,
+    translation: current?.translation ?? incoming.translation ?? null,
   };
 }
 
@@ -153,7 +154,7 @@ function buildWordMetadataLookup(params: {
           audioUrl: word.audioUrl,
           pronunciation: word.pronunciation,
           romanization: word.romanization,
-          translation: null,
+          translation: word.translation || null,
         },
       ] as const,
   );

--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -84,6 +84,42 @@ describe("player browser integration: word bank steps", () => {
     await expect.element(page.getByText("1/1")).toBeInTheDocument();
   });
 
+  it("shows reading word translations from the prompt sentence", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "reading",
+        steps: [
+          buildSerializedStep({
+            content: {},
+            kind: "reading",
+            sentence: buildSerializedSentence({
+              sentence: "Hola mundo",
+              translation: "Hello world",
+            }),
+            sentenceWordOptions: [
+              buildWordBankOption({ translation: "Hello", word: "Hola" }),
+              buildWordBankOption({ translation: "world", word: "mundo" }),
+            ],
+            wordBankOptions: [
+              buildWordBankOption({ word: "Hola" }),
+              buildWordBankOption({ word: "mundo" }),
+              buildWordBankOption({ word: "gato" }),
+            ],
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await page.getByRole("button", { exact: true, name: "Hello" }).click();
+
+    const translationPopover = page.getByRole("dialog", { name: "Hola" });
+
+    await expect.element(translationPopover).toBeInTheDocument();
+
+    await expect.element(translationPopover.getByText("Hola", { exact: true })).toBeInTheDocument();
+  });
+
   it("renders listening audio controls and completes from the word bank flow", async () => {
     await runInMobilePlayerViewport(async () => {
       renderPlayer({

--- a/packages/player/src/components/_utils/reading-prompt-word-hints.test.ts
+++ b/packages/player/src/components/_utils/reading-prompt-word-hints.test.ts
@@ -1,0 +1,66 @@
+import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { describe, expect, it } from "vitest";
+import { buildReadingPromptWordHints } from "./reading-prompt-word-hints";
+
+/**
+ * Builds the smallest word-option shape needed by prompt hint tests.
+ */
+function makeOption(overrides: Partial<WordBankOption>): WordBankOption {
+  return {
+    audioUrl: null,
+    pronunciation: null,
+    romanization: null,
+    translation: null,
+    word: "word",
+    ...overrides,
+  };
+}
+
+describe(buildReadingPromptWordHints, () => {
+  it("inverts target sentence word translations onto visible prompt words", () => {
+    const hints = buildReadingPromptWordHints({
+      prompt: "Oi, como você está?",
+      sentenceWordOptions: [
+        makeOption({ translation: "oi", word: "Hi," }),
+        makeOption({ translation: "como", word: "how" }),
+        makeOption({ translation: "são", word: "are" }),
+        makeOption({ translation: "você", word: "you?" }),
+      ],
+    });
+
+    expect(hints).toStrictEqual([
+      { translation: "Hi", word: "Oi," },
+      { translation: "how", word: "como" },
+      { translation: "you", word: "você" },
+      { translation: "are", word: "está?" },
+    ]);
+  });
+
+  it("matches prompt words without punctuation or accents", () => {
+    const hints = buildReadingPromptWordHints({
+      prompt: "Olá!",
+      sentenceWordOptions: [makeOption({ translation: "ola", word: "Hello!" })],
+    });
+
+    expect(hints).toStrictEqual([{ translation: "Hello", word: "Olá!" }]);
+  });
+
+  it("only falls back to remaining target words after exact matches", () => {
+    const hints = buildReadingPromptWordHints({
+      prompt: "Tenha um bom dia!",
+      sentenceWordOptions: [
+        makeOption({ translation: "ter", word: "Have" }),
+        makeOption({ translation: "um", word: "a" }),
+        makeOption({ translation: "legal", word: "nice" }),
+        makeOption({ translation: "dia", word: "day!" }),
+      ],
+    });
+
+    expect(hints).toStrictEqual([
+      { translation: "Have", word: "Tenha" },
+      { translation: "a", word: "um" },
+      { translation: "nice", word: "bom" },
+      { translation: "day", word: "dia!" },
+    ]);
+  });
+});

--- a/packages/player/src/components/_utils/reading-prompt-word-hints.test.ts
+++ b/packages/player/src/components/_utils/reading-prompt-word-hints.test.ts
@@ -45,6 +45,21 @@ describe(buildReadingPromptWordHints, () => {
     expect(hints).toStrictEqual([{ translation: "Hello", word: "Olá!" }]);
   });
 
+  it("uses each repeated direct match once", () => {
+    const hints = buildReadingPromptWordHints({
+      prompt: "um um",
+      sentenceWordOptions: [
+        makeOption({ translation: "um", word: "a" }),
+        makeOption({ translation: "um", word: "one" }),
+      ],
+    });
+
+    expect(hints).toStrictEqual([
+      { translation: "a", word: "um" },
+      { translation: "one", word: "um" },
+    ]);
+  });
+
   it("only falls back to remaining target words after exact matches", () => {
     const hints = buildReadingPromptWordHints({
       prompt: "Tenha um bom dia!",

--- a/packages/player/src/components/_utils/reading-prompt-word-hints.ts
+++ b/packages/player/src/components/_utils/reading-prompt-word-hints.ts
@@ -1,0 +1,187 @@
+import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { normalizeString, segmentWords, stripPunctuation } from "@zoonk/utils/string";
+
+type TargetWordHint = { key: string; translation: string };
+
+export type ReadingPromptWordHint = { translation: string | null; word: string };
+
+/**
+ * Removes sentence punctuation from a word shown inside a tiny definition
+ * popover while preserving internal connectors such as apostrophes.
+ */
+function stripEdgePunctuation(word: string): string {
+  return word.replaceAll(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, "");
+}
+
+/**
+ * Converts visible prompt words and stored word translations into the same
+ * lookup key so accents, case, and punctuation do not block a reliable match.
+ */
+function getPromptWordKey(word?: string | null): string {
+  return normalizeString(stripPunctuation(word ?? ""));
+}
+
+/**
+ * Converts a target sentence word option into a compact hint candidate.
+ *
+ * Reading generation stores target-word metadata as target word plus
+ * learner-language translation. The prompt shows the learner-language sentence,
+ * so this helper inverts that metadata for prompt-word popovers.
+ */
+function toTargetWordHint(option: WordBankOption): TargetWordHint | null {
+  const key = getPromptWordKey(option.translation);
+  const translation = stripEdgePunctuation(option.word);
+
+  if (!key || !translation) {
+    return null;
+  }
+
+  return { key, translation };
+}
+
+/**
+ * Returns only the usable target-word hint candidates from the serialized
+ * sentence metadata.
+ */
+function getTargetWordHints(sentenceWordOptions: WordBankOption[]): TargetWordHint[] {
+  return sentenceWordOptions.flatMap((option) => {
+    const hint = toTargetWordHint(option);
+    return hint ? [hint] : [];
+  });
+}
+
+/**
+ * Finds the strongest target-word hint for one visible prompt word.
+ *
+ * Exact translation matches are preferred because they are explicit generated
+ * metadata. Position fallback is only used for remaining words so common
+ * language-order flips, such as "você está" -> "are you", still get a useful
+ * hint when one word did not match exactly.
+ */
+function getPromptTranslation({
+  directTargetIndexes,
+  fallbackTargetIndexes,
+  promptIndex,
+  targetHints,
+}: {
+  directTargetIndexes: (number | null)[];
+  fallbackTargetIndexes: Map<number, number>;
+  promptIndex: number;
+  targetHints: TargetWordHint[];
+}): string | null {
+  const targetIndex = directTargetIndexes[promptIndex] ?? fallbackTargetIndexes.get(promptIndex);
+
+  if (targetIndex === undefined || targetIndex === null) {
+    return null;
+  }
+
+  return targetHints[targetIndex]?.translation ?? null;
+}
+
+/**
+ * Matches a prompt word against generated target-word translations.
+ */
+function getDirectTargetIndex({
+  targetHints,
+  word,
+}: {
+  targetHints: TargetWordHint[];
+  word: string;
+}): number | null {
+  const key = getPromptWordKey(word);
+  const index = targetHints.findIndex((hint) => hint.key === key);
+
+  if (index === -1) {
+    return null;
+  }
+
+  return index;
+}
+
+/**
+ * Returns the indexes of target hints that were already consumed by exact
+ * prompt-word matches.
+ */
+function getUsedTargetIndexes(directTargetIndexes: (number | null)[]): Set<number> {
+  return new Set(directTargetIndexes.flatMap((index) => (index === null ? [] : [index])));
+}
+
+/**
+ * Returns the target indexes that are still available for order-based fallback
+ * matching after exact matches are removed.
+ */
+function getFallbackTargetIndexes({
+  directTargetIndexes,
+  targetHints,
+}: {
+  directTargetIndexes: (number | null)[];
+  targetHints: TargetWordHint[];
+}): number[] {
+  const usedTargetIndexes = getUsedTargetIndexes(directTargetIndexes);
+  return targetHints.flatMap((_hint, index) => (usedTargetIndexes.has(index) ? [] : [index]));
+}
+
+/**
+ * Returns the prompt indexes that still need an order-based fallback hint.
+ */
+function getFallbackPromptIndexes(directTargetIndexes: (number | null)[]): number[] {
+  return directTargetIndexes.flatMap((index, promptIndex) => (index === null ? [promptIndex] : []));
+}
+
+/**
+ * Pairs unmatched prompt words with unmatched target words in order.
+ *
+ * This fallback is intentionally conservative: it only fills gaps left after
+ * exact translation matches, so obvious generated metadata always wins.
+ */
+function buildFallbackTargetIndexMap({
+  directTargetIndexes,
+  targetHints,
+}: {
+  directTargetIndexes: (number | null)[];
+  targetHints: TargetWordHint[];
+}): Map<number, number> {
+  const fallbackTargetIndexes = getFallbackTargetIndexes({ directTargetIndexes, targetHints });
+  const fallbackPromptIndexes = getFallbackPromptIndexes(directTargetIndexes);
+
+  return new Map(
+    fallbackPromptIndexes.flatMap((promptIndex, index) => {
+      const targetIndex = fallbackTargetIndexes[index];
+      return targetIndex === undefined ? [] : [[promptIndex, targetIndex]];
+    }),
+  );
+}
+
+/**
+ * Builds the prompt sentence tokens used by the reading UI.
+ *
+ * The player already has target-word metadata, but learners tap the visible
+ * prompt sentence. This helper bridges those shapes without changing the
+ * serialized lesson contract.
+ */
+export function buildReadingPromptWordHints({
+  prompt,
+  sentenceWordOptions,
+}: {
+  prompt: string;
+  sentenceWordOptions: WordBankOption[];
+}): ReadingPromptWordHint[] {
+  const promptWords = segmentWords(prompt);
+  const targetHints = getTargetWordHints(sentenceWordOptions);
+
+  const directTargetIndexes = promptWords.map((word) =>
+    getDirectTargetIndex({ targetHints, word }),
+  );
+
+  const fallbackTargetIndexes = buildFallbackTargetIndexMap({ directTargetIndexes, targetHints });
+
+  return promptWords.map((word, promptIndex) => ({
+    translation: getPromptTranslation({
+      directTargetIndexes,
+      fallbackTargetIndexes,
+      promptIndex,
+      targetHints,
+    }),
+    word,
+  }));
+}

--- a/packages/player/src/components/_utils/reading-prompt-word-hints.ts
+++ b/packages/player/src/components/_utils/reading-prompt-word-hints.ts
@@ -3,6 +3,11 @@ import { normalizeString, segmentWords, stripPunctuation } from "@zoonk/utils/st
 
 type TargetWordHint = { key: string; translation: string };
 
+type DirectTargetIndexAssignment = {
+  directTargetIndexes: (number | null)[];
+  usedTargetIndexes: Set<number>;
+};
+
 export type ReadingPromptWordHint = { translation: string | null; word: string };
 
 /**
@@ -79,23 +84,86 @@ function getPromptTranslation({
 }
 
 /**
- * Matches a prompt word against generated target-word translations.
+ * Matches a prompt word against the first generated target-word translation
+ * that has not already powered an earlier prompt word.
+ *
+ * Repeated prompt words can share a lookup key while still mapping to distinct
+ * target sentence words. Consuming each target hint once keeps those repeated
+ * words from all pointing at the first matching hint.
  */
-function getDirectTargetIndex({
+function getUnusedDirectTargetIndex({
   targetHints,
+  usedTargetIndexes,
   word,
 }: {
   targetHints: TargetWordHint[];
+  usedTargetIndexes: Set<number>;
   word: string;
 }): number | null {
   const key = getPromptWordKey(word);
-  const index = targetHints.findIndex((hint) => hint.key === key);
+
+  const index = targetHints.findIndex(
+    (hint, targetIndex) => hint.key === key && !usedTargetIndexes.has(targetIndex),
+  );
 
   if (index === -1) {
     return null;
   }
 
   return index;
+}
+
+/**
+ * Adds one prompt word's exact match while preserving target hints that were
+ * already assigned to earlier visible words.
+ */
+function appendDirectTargetIndex({
+  assignment,
+  targetHints,
+  word,
+}: {
+  assignment: DirectTargetIndexAssignment;
+  targetHints: TargetWordHint[];
+  word: string;
+}): DirectTargetIndexAssignment {
+  const index = getUnusedDirectTargetIndex({
+    targetHints,
+    usedTargetIndexes: assignment.usedTargetIndexes,
+    word,
+  });
+
+  return {
+    directTargetIndexes: [...assignment.directTargetIndexes, index],
+    usedTargetIndexes:
+      index === null
+        ? assignment.usedTargetIndexes
+        : new Set([...assignment.usedTargetIndexes, index]),
+  };
+}
+
+/**
+ * Assigns exact prompt-word matches from left to right before the looser
+ * position fallback runs.
+ */
+function getDirectTargetIndexes({
+  promptWords,
+  targetHints,
+}: {
+  promptWords: string[];
+  targetHints: TargetWordHint[];
+}): (number | null)[] {
+  const initialAssignment: DirectTargetIndexAssignment = {
+    directTargetIndexes: [],
+    usedTargetIndexes: new Set(),
+  };
+
+  const assignment = promptWords.reduce(
+    (currentAssignment, word) =>
+      appendDirectTargetIndex({ assignment: currentAssignment, targetHints, word }),
+    initialAssignment,
+  );
+
+  return assignment.directTargetIndexes;
 }
 
 /**
@@ -169,9 +237,7 @@ export function buildReadingPromptWordHints({
   const promptWords = segmentWords(prompt);
   const targetHints = getTargetWordHints(sentenceWordOptions);
 
-  const directTargetIndexes = promptWords.map((word) =>
-    getDirectTargetIndex({ targetHints, word }),
-  );
+  const directTargetIndexes = getDirectTargetIndexes({ promptWords, targetHints });
 
   const fallbackTargetIndexes = buildFallbackTargetIndexMap({ directTargetIndexes, targetHints });
 

--- a/packages/player/src/components/reading-step.tsx
+++ b/packages/player/src/components/reading-step.tsx
@@ -4,12 +4,90 @@ import {
   buildAcceptedArrangeWordSequences,
   getAcceptedArrangeWordLengths,
 } from "@zoonk/core/player/contracts/arrange-words-answers";
-import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import {
+  type SerializedStep,
+  type WordBankOption,
+} from "@zoonk/core/player/contracts/prepare-lesson-data";
+import {
+  Popover,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@zoonk/ui/components/popover";
 import { useExtracted } from "next-intl";
+import { Fragment } from "react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
+import { useReplaceName } from "../user-name-context";
+import {
+  type ReadingPromptWordHint,
+  buildReadingPromptWordHints,
+} from "./_utils/reading-prompt-word-hints";
+import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
 import { ArrangeWordsInteraction } from "./arrange-words";
 import { QuestionText } from "./question-text";
 import { SectionLabel } from "./section-label";
+
+/**
+ * One prompt word can either be plain text or a small translation trigger.
+ *
+ * Reading learners tap the sentence they are translating, not the answer bank,
+ * so the interactive affordance belongs on these prompt words.
+ */
+function ReadingPromptWord({ hint }: { hint: ReadingPromptWordHint }) {
+  if (!hint.translation) {
+    return <span>{hint.word}</span>;
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger className="focus-visible:border-ring focus-visible:ring-ring/50 decoration-foreground/30 hover:text-foreground inline rounded-sm border-0 bg-transparent p-0 font-[inherit] text-inherit underline decoration-dotted underline-offset-4 transition-colors outline-none focus-visible:ring-[3px]">
+        {hint.word}
+      </PopoverTrigger>
+
+      <PopoverContent
+        className="w-fit max-w-none min-w-0 gap-0 rounded-xl px-3 py-2"
+        sideOffset={8}
+      >
+        <PopoverHeader className="gap-0.5">
+          <PopoverTitle className="text-base">{hint.translation}</PopoverTitle>
+        </PopoverHeader>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * Renders the visible reading prompt as tappable word tokens.
+ *
+ * The serialized lesson stores target-word metadata, while the prompt sentence
+ * is learner-language text. `buildReadingPromptWordHints` aligns those two
+ * shapes so this component can stay focused on rendering.
+ */
+function ReadingPromptText({
+  sentence,
+  sentenceWordOptions,
+}: {
+  sentence: string;
+  sentenceWordOptions: WordBankOption[];
+}) {
+  const replaceName = useReplaceName();
+  const prompt = stripWrappingQuotes(replaceName(sentence));
+  const hints = buildReadingPromptWordHints({ prompt, sentenceWordOptions });
+  const hasWordSpaces = prompt.includes(" ");
+
+  return (
+    <span>
+      {hints.map((hint, index) => (
+        // oxlint-disable-next-line react/no-array-index-key -- Prompt words can repeat in generated sentences, no unique ID.
+        <Fragment key={`${hint.word}-${hint.translation ?? "none"}-${index}`}>
+          {index > 0 && hasWordSpaces ? " " : null}
+          <ReadingPromptWord hint={hint} />
+        </Fragment>
+      ))}
+    </span>
+  );
+}
 
 export function ReadingStep({
   onSelectAnswer,
@@ -45,7 +123,12 @@ export function ReadingStep({
     >
       <div className="flex flex-col gap-2">
         <SectionLabel>{t("Translate this sentence:")}</SectionLabel>
-        <QuestionText>{step.sentence.translation}</QuestionText>
+        <QuestionText>
+          <ReadingPromptText
+            sentence={step.sentence.translation}
+            sentenceWordOptions={step.sentenceWordOptions}
+          />
+        </QuestionText>
       </div>
     </ArrangeWordsInteraction>
   );


### PR DESCRIPTION
Adds subtle word-level translation hints to reading prompt sentences.

Preserves reading sentence word translations through serialization so prompt words can show compact popovers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add word-level translation popovers to reading prompts so learners can tap a word to see its counterpart. Sentence token translations are serialized to power these hints, with lesson-word translations still taking priority; repeated prompt words now map correctly.

- **New Features**
  - Tappable prompt words show compact popovers with translations.
  - Hints are matched from `sentenceWordOptions` case/accent/punctuation-insensitively, using each target hint once for repeated words and falling back by order when unmatched; sentence-token translations are merged while lesson-word translations win. Tests added for matching and rendering.

<sup>Written for commit a02061b7c507705cfc3756fa3f825ffa15f0fab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

