### PR TITLE
fix(core): cap player completion duration

### DIFF
--- a/apps/admin/src/data/users/get-user-learning-stats.ts
+++ b/apps/admin/src/data/users/get-user-learning-stats.ts
@@ -57,8 +57,8 @@ function findUserCompletedLessonRows({ userId }: { userId: string }) {
 }
 
 /**
- * DailyProgress stores the learner's client-local completion date, so it is the
- * best source for counting calendar learning days and total app learning time.
+ * DailyProgress stores the learner's client-local completion date, so it stays
+ * the best source for counting calendar learning days.
  */
 function findUserLearningDayRows({ userId }: { userId: string }) {
   return prisma.dailyProgress.findMany({
@@ -87,8 +87,9 @@ function buildUserLearningStats({
 }
 
 /**
- * DailyProgress may contain decay-only rows, so callers filter to learning days
- * first and this helper can stay a simple duration sum.
+ * DailyProgress is the durable aggregate for total learning time. Completion
+ * writes cap each increment before updating this row so admin metrics can keep
+ * using the cheap per-day summary without replaying raw lesson events.
  */
 function sumLearningTime({ rows }: { rows: LearningDayRow[] }) {
   return rows.reduce((total, row) => total + row.timeSpentSeconds, 0);

--- a/apps/main/src/lib/track-events.ts
+++ b/apps/main/src/lib/track-events.ts
@@ -1,4 +1,5 @@
 import { track } from "@vercel/analytics";
+import { getCappedLessonDurationSeconds } from "@zoonk/core/player/contracts/completion-duration";
 import { type LessonKind } from "@zoonk/core/steps/contract/content";
 
 type PlayerEventInput = {
@@ -184,9 +185,9 @@ function throwUnexpectedFeedbackTarget(input: never): never {
 }
 
 /**
- * Clamps client timing so clock edge cases cannot send negative durations to
- * analytics while still matching the server's whole-second completion metric.
+ * Uses the same capped duration as persistence so browser analytics cannot
+ * report idle tab time that the database correctly ignores.
  */
 function getCompletionDurationSeconds({ startedAt }: { startedAt: number }) {
-  return Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
+  return getCappedLessonDurationSeconds({ startedAt });
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "./player/commands/submit-player-completion": "./src/player/commands/submit-player-completion.ts",
     "./player/contracts/arrange-words-answers": "./src/player/contracts/arrange-words-answers.ts",
     "./player/contracts/check-answer": "./src/player/contracts/check-answer.ts",
+    "./player/contracts/completion-duration": "./src/player/contracts/completion-duration.ts",
     "./player/contracts/completion-input-schema": "./src/player/contracts/completion-input-schema.ts",
     "./player/contracts/compute-score": "./src/player/contracts/compute-score.ts",
     "./player/contracts/prepare-lesson-data": "./src/player/contracts/prepare-lesson-data.ts",

--- a/packages/core/src/player/commands/submit-player-completion.test.ts
+++ b/packages/core/src/player/commands/submit-player-completion.test.ts
@@ -10,6 +10,10 @@ import { describe, expect, it } from "vitest";
 import { type CompletionInput } from "../contracts/completion-input-schema";
 import { submitPlayerCompletion } from "./submit-player-completion";
 
+const TEST_SECONDS_PER_MINUTE = 60;
+const TEST_COMPLETION_CAP_MINUTES = 30;
+const TEST_COMPLETION_CAP_SECONDS = TEST_COMPLETION_CAP_MINUTES * TEST_SECONDS_PER_MINUTE;
+
 const REVIEW_TARGET_STEP_COUNT = 10;
 const REVIEW_SUBMITTED_STEP_COUNT = REVIEW_TARGET_STEP_COUNT + 1;
 
@@ -396,6 +400,69 @@ describe(submitPlayerCompletion, () => {
     expect(lessonProgress?.completedAt).toBeInstanceOf(Date);
     expect(stepAttempts).toHaveLength(1);
     expect(stepAttempts[0]?.isCorrect).toBe(true);
+  });
+
+  it("caps lesson duration so idle tabs do not inflate learning time", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson } = await createStaticLesson({
+      chapterId: chapter.id,
+      organizationId: organization.id,
+    });
+
+    await submitPlayerCompletion({
+      input: {
+        ...buildEmptyCompletionInput({ lessonId: lesson.id }),
+        startedAt: Date.now() - (TEST_COMPLETION_CAP_SECONDS + TEST_SECONDS_PER_MINUTE) * 1000,
+      },
+      userId: user.id,
+    });
+
+    const [dailyProgress, lessonProgress] = await Promise.all([
+      prisma.dailyProgress.findFirst({ where: { userId: user.id } }),
+      prisma.lessonProgress.findUnique({
+        where: { userLesson: { lessonId: lesson.id, userId: user.id } },
+      }),
+    ]);
+
+    expect(dailyProgress?.timeSpentSeconds).toBe(TEST_COMPLETION_CAP_SECONDS);
+    expect(lessonProgress?.durationSeconds).toBe(TEST_COMPLETION_CAP_SECONDS);
+  });
+
+  it("caps submitted step timings before creating attempt rows", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, step } = await createMultipleChoiceLesson({
+      chapterId: chapter.id,
+      organizationId: organization.id,
+    });
+
+    const input = buildCompletionInput({ lessonId: lesson.id, stepId: step.id });
+
+    await submitPlayerCompletion({
+      input: {
+        ...input,
+        stepTimings: {
+          [step.id]: {
+            ...input.stepTimings[step.id]!,
+            durationSeconds: TEST_COMPLETION_CAP_SECONDS + TEST_SECONDS_PER_MINUTE,
+          },
+        },
+      },
+      userId: user.id,
+    });
+
+    const attempt = await prisma.stepAttempt.findFirst({
+      where: { stepId: step.id, userId: user.id },
+    });
+
+    expect(attempt?.durationSeconds).toBe(TEST_COMPLETION_CAP_SECONDS);
   });
 
   it("rejects empty answers for an interactive lesson without writing progress", async () => {

--- a/packages/core/src/player/commands/submit-player-completion.ts
+++ b/packages/core/src/player/commands/submit-player-completion.ts
@@ -1,18 +1,15 @@
 import "server-only";
 import { type StepKind, prisma } from "@zoonk/db";
+import {
+  getCappedLessonDurationSeconds,
+  getCappedStepAttemptDurationSeconds,
+} from "../contracts/completion-duration";
 import { type CompletionInput } from "../contracts/completion-input-schema";
 import { computeLessonScore } from "../contracts/compute-score";
 import { countAnswerableSteps, validateAnswers } from "../contracts/validate-answers";
 import { getReviewValidationData } from "../queries/get-review-steps";
 import { getCompletableLessonWhere } from "./_utils/completable-lesson";
 import { submitLessonCompletion } from "./submit-lesson-completion";
-
-const MAX_DURATION_SECONDS = 7200;
-
-function clampDuration(startedAt: number): number {
-  const raw = Math.floor((Date.now() - startedAt) / 1000);
-  return Math.max(0, Math.min(raw, MAX_DURATION_SECONDS));
-}
 
 type StepWithSentence = {
   id: string;
@@ -112,7 +109,7 @@ export async function submitPlayerCompletion(params: {
 
   const score = computeLessonScore({ results: stepResults });
 
-  const durationSeconds = clampDuration(params.input.startedAt);
+  const durationSeconds = getCappedLessonDurationSeconds({ startedAt: params.input.startedAt });
 
   const mergedStepResults = stepResults.map((validated) => {
     const stepId = validated.stepId;
@@ -122,7 +119,9 @@ export async function submitPlayerCompletion(params: {
       answer: validated.answer,
       answeredAt: timing ? new Date(timing.answeredAt) : new Date(),
       dayOfWeek: timing?.dayOfWeek ?? new Date().getDay(),
-      durationSeconds: timing?.durationSeconds ?? 0,
+      durationSeconds: getCappedStepAttemptDurationSeconds({
+        durationSeconds: timing?.durationSeconds ?? 0,
+      }),
       hourOfDay: timing?.hourOfDay ?? new Date().getHours(),
       isCorrect: validated.isCorrect,
       stepId: validated.stepId,

--- a/packages/core/src/player/contracts/completion-duration.ts
+++ b/packages/core/src/player/contracts/completion-duration.ts
@@ -1,0 +1,56 @@
+const SECONDS_PER_MINUTE = 60;
+const MAX_COMPLETION_MINUTES = 30;
+
+const MAX_LESSON_COMPLETION_SECONDS = MAX_COMPLETION_MINUTES * SECONDS_PER_MINUTE;
+const MAX_STEP_ATTEMPT_SECONDS = MAX_COMPLETION_MINUTES * SECONDS_PER_MINUTE;
+
+/**
+ * Completion durations come from browser timestamps, so a learner can leave a
+ * tab open for hours before finishing a lesson. Capping the elapsed time keeps
+ * learning-time metrics focused on an active lesson session instead of idle tab
+ * time, while still preserving every real duration currently seen in production.
+ */
+export function getCappedLessonDurationSeconds({
+  now = Date.now(),
+  startedAt,
+}: {
+  now?: number;
+  startedAt: number;
+}) {
+  return clampDurationSeconds({
+    durationSeconds: Math.floor((now - startedAt) / 1000),
+    maxSeconds: MAX_LESSON_COMPLETION_SECONDS,
+  });
+}
+
+/**
+ * Step timing is also submitted by the client. Keeping the same guard around
+ * each persisted attempt prevents forged payloads or long-idle steps from
+ * creating outlier rows that later distort timing analysis.
+ */
+export function getCappedStepAttemptDurationSeconds({
+  durationSeconds,
+}: {
+  durationSeconds: number;
+}) {
+  return clampDurationSeconds({ durationSeconds, maxSeconds: MAX_STEP_ATTEMPT_SECONDS });
+}
+
+/**
+ * The cap helper accepts any number because persisted metrics should fail
+ * closed: negative, fractional, and non-finite client values become safe
+ * whole-second counts before they reach analytics tables.
+ */
+function clampDurationSeconds({
+  durationSeconds,
+  maxSeconds,
+}: {
+  durationSeconds: number;
+  maxSeconds: number;
+}) {
+  if (!Number.isFinite(durationSeconds)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(Math.floor(durationSeconds), maxSeconds));
+}


### PR DESCRIPTION
## Summary

- cap persisted lesson and step durations to prevent idle tabs from inflating learning time
- reuse the same capped lesson duration for Vercel Analytics events
- clarify that daily progress remains the aggregate source for admin learning time

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap lesson and step attempt durations at 30 minutes to prevent idle tabs from inflating learning-time metrics. The same cap is used for browser analytics; admin totals still rely on per-day `DailyProgress`.

- **Bug Fixes**
  - Persist capped lesson and step attempt durations (30m max).
  - Add `getCappedLessonDurationSeconds` and `getCappedStepAttemptDurationSeconds` in `@zoonk/core/player/contracts/completion-duration` and use them in `@vercel/analytics` events.
  - Confirm admin learning-time totals continue to use `DailyProgress` as the aggregate source.

<sup>Written for commit 92220278b17858964e261faf908d058a7689df12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

