### PR TITLE
fix(player): improve grammar highlight contrast

### DIFF
--- a/packages/player/src/components/fill-blank-step.test.tsx
+++ b/packages/player/src/components/fill-blank-step.test.tsx
@@ -106,8 +106,12 @@ describe("fill in the blank step", () => {
     const alphaButton = buttons.find((button) => button.textContent === "alpha");
     const betaButton = buttons.find((button) => button.textContent === "beta");
 
-    fireEvent.click(alphaButton!);
-    fireEvent.click(betaButton!);
+    if (!alphaButton || !betaButton) {
+      throw new Error("Expected alpha and beta buttons to render.");
+    }
+
+    fireEvent.click(alphaButton);
+    fireEvent.click(betaButton);
 
     const renderWarnings = consoleErrorSpy.mock.calls.filter((args: unknown[]) =>
       String(args[0]).includes("Cannot update a component"),

--- a/packages/player/src/components/highlight-text.tsx
+++ b/packages/player/src/components/highlight-text.tsx
@@ -29,9 +29,9 @@ export function HighlightText({ text, highlight }: { text: string; highlight: st
   return (
     <>
       {before}
-      <span className="bg-primary/10 text-primary rounded-sm px-1 py-0.5 font-semibold">
+      <mark className="bg-foreground text-background rounded-sm px-1 py-0.5 font-semibold">
         {match}
-      </span>
+      </mark>
       {after}
     </>
   );


### PR DESCRIPTION
## Summary

- Increase grammar example highlight contrast in the player
- Use semantic mark markup for highlighted grammar text
- Keep fill-blank test clicks type-safe with an explicit render guard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the grammar highlight in the player by using high-contrast styles and semantic `mark` for better readability and accessibility. Also makes the fill‑in‑the‑blank test clicks type-safe with an explicit render guard.

- **Bug Fixes**
  - Switch to semantic `mark` with high-contrast classes in `packages/player/src/components/highlight-text.tsx` to improve highlight visibility.
  - Add a render guard in `packages/player/src/components/fill-blank-step.test.tsx` before clicking "alpha"/"beta" to ensure buttons exist and reduce noisy warnings.

<sup>Written for commit 795df04fa83ceaa3ad7a6625cb5e2665c8bb3cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

