### PR TITLE
fix(main): require completed lessons for user courses

### DIFF
--- a/apps/main/src/data/courses/get-continue-learning.test.ts
+++ b/apps/main/src/data/courses/get-continue-learning.test.ts
@@ -60,6 +60,27 @@ describe("authenticated users", () => {
     expect(result).toStrictEqual([]);
   });
 
+  it("ignores courses where the user started but did not complete a lesson", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    const { course, lesson1 } = await createCourseWithLessons(organization.id);
+
+    await Promise.all([
+      prisma.courseUser.create({ data: { courseId: course.id, userId: user.id } }),
+      lessonProgressFixture({
+        completedAt: null,
+        durationSeconds: null,
+        lessonId: lesson1.id,
+        userId: user.id,
+      }),
+    ]);
+
+    const result = await getContinueLearning(headers);
+
+    expect(result).toStrictEqual([]);
+  });
+
   it("returns courses with next lesson info based on completions", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);

--- a/apps/main/src/data/courses/list-user-courses.test.ts
+++ b/apps/main/src/data/courses/list-user-courses.test.ts
@@ -1,11 +1,40 @@
 import { ErrorCode } from "@/lib/app-error";
 import { prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture, courseUserFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeAll, describe, expect, it } from "vitest";
 import { listUserCourses } from "./list-user-courses";
+
+/**
+ * My Courses is backed by completed lesson progress, so tests create the
+ * smallest real course tree that can prove whether a course belongs in that
+ * list instead of relying on the CourseUser row alone.
+ */
+async function createCourseWithLesson({
+  organizationId,
+  userId,
+}: {
+  organizationId: string | null;
+  userId?: string;
+}) {
+  const course = await courseFixture({ isPublished: true, organizationId, userId });
+  const chapter = await chapterFixture({ courseId: course.id, isPublished: true, organizationId });
+  const lesson = await lessonFixture({ chapterId: chapter.id, isPublished: true, organizationId });
+
+  return { course, lesson };
+}
+
+/**
+ * A course only belongs in My Courses after a learner finishes a lesson, so
+ * tests call this helper whenever they need a course to satisfy that contract.
+ */
+async function completeLessonForUser({ lessonId, userId }: { lessonId: string; userId: string }) {
+  return lessonProgressFixture({ completedAt: new Date(), durationSeconds: 60, lessonId, userId });
+}
 
 describe("unauthenticated users", () => {
   it("returns Unauthorized", async () => {
@@ -37,10 +66,13 @@ describe("authenticated users", () => {
     expect(result.data).toStrictEqual([]);
   });
 
-  it("returns courses the user has started", async () => {
-    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+  it("returns courses where the user completed a lesson", async () => {
+    const { course, lesson } = await createCourseWithLesson({ organizationId: organization.id });
 
-    await courseUserFixture({ courseId: course.id, userId: user.id });
+    await Promise.all([
+      courseUserFixture({ courseId: course.id, userId: user.id }),
+      completeLessonForUser({ lessonId: lesson.id, userId: user.id }),
+    ]);
 
     const result = await listUserCourses(headers);
 
@@ -49,13 +81,37 @@ describe("authenticated users", () => {
     expect(result.data?.some((item) => item.id === course.id)).toBe(true);
   });
 
+  it("excludes courses where the user started but did not complete a lesson", async () => {
+    const testUser = await userFixture();
+    const testHeaders = await signInAs(testUser.email, testUser.password);
+    const { course, lesson } = await createCourseWithLesson({ organizationId: organization.id });
+
+    await Promise.all([
+      courseUserFixture({ courseId: course.id, userId: testUser.id }),
+      lessonProgressFixture({
+        completedAt: null,
+        durationSeconds: null,
+        lessonId: lesson.id,
+        userId: testUser.id,
+      }),
+    ]);
+
+    const result = await listUserCourses(testHeaders);
+
+    expect(result.error).toBeNull();
+    expect(result.data?.some((item) => item.id === course.id)).toBe(false);
+  });
+
   it("includes the organization in the response", async () => {
     const testUser = await userFixture();
     const testHeaders = await signInAs(testUser.email, testUser.password);
 
-    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+    const { course, lesson } = await createCourseWithLesson({ organizationId: organization.id });
 
-    await courseUserFixture({ courseId: course.id, userId: testUser.id });
+    await Promise.all([
+      courseUserFixture({ courseId: course.id, userId: testUser.id }),
+      completeLessonForUser({ lessonId: lesson.id, userId: testUser.id }),
+    ]);
 
     const result = await listUserCourses(testHeaders);
 
@@ -72,11 +128,13 @@ describe("authenticated users", () => {
     const testUser = await userFixture();
     const testHeaders = await signInAs(testUser.email, testUser.password);
 
-    const [course1, course2, course3] = await Promise.all([
-      courseFixture({ isPublished: true, organizationId: organization.id }),
-      courseFixture({ isPublished: true, organizationId: organization.id }),
-      courseFixture({ isPublished: true, organizationId: organization.id }),
+    const [data1, data2, data3] = await Promise.all([
+      createCourseWithLesson({ organizationId: organization.id }),
+      createCourseWithLesson({ organizationId: organization.id }),
+      createCourseWithLesson({ organizationId: organization.id }),
     ]);
+
+    const [course1, course2, course3] = [data1.course, data2.course, data3.course];
 
     // Create course users with specific timestamps
     const now = new Date();
@@ -90,6 +148,12 @@ describe("authenticated users", () => {
         { courseId: course3.id, startedAt: oneHourAgo, userId: testUser.id },
       ],
     });
+
+    await Promise.all(
+      [data1, data2, data3].map((data) =>
+        completeLessonForUser({ lessonId: data.lesson.id, userId: testUser.id }),
+      ),
+    );
 
     const result = await listUserCourses(testHeaders);
 
@@ -109,14 +173,18 @@ describe("authenticated users", () => {
       organizationFixture({ kind: "school" }),
     ]);
 
-    const [brandCourse, schoolCourse] = await Promise.all([
-      courseFixture({ isPublished: true, organizationId: brandOrg.id }),
-      courseFixture({ isPublished: true, organizationId: schoolOrg.id }),
+    const [brandData, schoolData] = await Promise.all([
+      createCourseWithLesson({ organizationId: brandOrg.id }),
+      createCourseWithLesson({ organizationId: schoolOrg.id }),
     ]);
+
+    const [brandCourse, schoolCourse] = [brandData.course, schoolData.course];
 
     await Promise.all([
       courseUserFixture({ courseId: brandCourse.id, userId: testUser.id }),
       courseUserFixture({ courseId: schoolCourse.id, userId: testUser.id }),
+      completeLessonForUser({ lessonId: brandData.lesson.id, userId: testUser.id }),
+      completeLessonForUser({ lessonId: schoolData.lesson.id, userId: testUser.id }),
     ]);
 
     const result = await listUserCourses(testHeaders);
@@ -130,13 +198,15 @@ describe("authenticated users", () => {
     const testUser = await userFixture();
     const testHeaders = await signInAs(testUser.email, testUser.password);
 
-    const personalCourse = await courseFixture({
-      isPublished: true,
+    const { course: personalCourse, lesson } = await createCourseWithLesson({
       organizationId: null,
       userId: testUser.id,
     });
 
-    await courseUserFixture({ courseId: personalCourse.id, userId: testUser.id });
+    await Promise.all([
+      courseUserFixture({ courseId: personalCourse.id, userId: testUser.id }),
+      completeLessonForUser({ lessonId: lesson.id, userId: testUser.id }),
+    ]);
 
     const result = await listUserCourses(testHeaders);
 
@@ -149,14 +219,18 @@ describe("authenticated users", () => {
 
     const testHeaders = await signInAs(testUser.email, testUser.password);
 
-    const [otherUserCourse, testUserCourse] = await Promise.all([
-      courseFixture({ isPublished: true, organizationId: organization.id }),
-      courseFixture({ isPublished: true, organizationId: organization.id }),
+    const [otherUserData, testUserData] = await Promise.all([
+      createCourseWithLesson({ organizationId: organization.id }),
+      createCourseWithLesson({ organizationId: organization.id }),
     ]);
+
+    const [otherUserCourse, testUserCourse] = [otherUserData.course, testUserData.course];
 
     await Promise.all([
       courseUserFixture({ courseId: otherUserCourse.id, userId: otherUser.id }),
       courseUserFixture({ courseId: testUserCourse.id, userId: testUser.id }),
+      completeLessonForUser({ lessonId: otherUserData.lesson.id, userId: otherUser.id }),
+      completeLessonForUser({ lessonId: testUserData.lesson.id, userId: testUser.id }),
     ]);
 
     const result = await listUserCourses(testHeaders);

--- a/apps/main/src/data/courses/list-user-courses.ts
+++ b/apps/main/src/data/courses/list-user-courses.ts
@@ -7,6 +7,27 @@ import { cache } from "react";
 
 type UserCourse = Course & { organization: Organization | null };
 
+/**
+ * My Courses is a resume surface, not raw start history. Opening a lesson
+ * creates a lesson_progress row with completedAt null, so the list must require
+ * at least one completed lesson in the same course before showing it.
+ */
+function getCompletedUserCourseWhere({ userId }: { userId: string }) {
+  return {
+    course: {
+      OR: [{ organization: { kind: "brand" } }, { organizationId: null }],
+      chapters: {
+        some: { lessons: { some: { progress: { some: { completedAt: { not: null }, userId } } } } },
+      },
+    },
+    userId,
+  };
+}
+
+/**
+ * The My Courses page only shows courses where the learner has real completion
+ * progress, while preserving the existing course metadata needed by the list UI.
+ */
 export const listUserCourses = cache(
   async (headers?: Headers): Promise<SafeReturn<UserCourse[]>> => {
     const session = await getSession(headers);
@@ -21,10 +42,7 @@ export const listUserCourses = cache(
       prisma.courseUser.findMany({
         include: { course: { include: { organization: true } } },
         orderBy: { startedAt: "desc" },
-        where: {
-          course: { OR: [{ organization: { kind: "brand" } }, { organizationId: null }] },
-          userId,
-        },
+        where: getCompletedUserCourseWhere({ userId }),
       }),
     );
 


### PR DESCRIPTION
## Summary

- require My Courses to have at least one completed lesson before showing a course
- add regression coverage for started-but-incomplete courses on My Courses and home continue learning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a completed lesson before a course appears in My Courses and Continue Learning, so courses the user only opened are hidden. This makes resume surfaces reflect real progress.

- **Bug Fixes**
  - Updated `listUserCourses` to include only courses with at least one completed lesson by the user via `getCompletedUserCourseWhere` (keeps existing brand/personal org filter and sort).
  - Added regression tests to exclude started-but-incomplete courses in My Courses and Continue Learning.

<sup>Written for commit c5095b1d84d4782b4ce4df7b1cf9e2f09c188e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

