### PR TITLE
feat(player): add lesson audio autoplay

### DIFF
--- a/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { page } from "vitest/browser";
+import { mockNextAudioPlayFailure } from "../_test-utils/browser-setup";
 import { runInMobilePlayerViewport } from "../_test-utils/browser-viewport";
 import {
   buildSerializedLesson,
@@ -84,6 +85,113 @@ describe("player browser integration: vocabulary", () => {
 
     await expect
       .element(page.getByRole("region", { name: /vocabulary: Adios/iu }))
+      .not.toBeInTheDocument();
+  });
+
+  it("automatically plays the next vocabulary prompt after audio is started", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "vocabulary",
+        steps: [
+          buildSerializedStep({
+            content: {},
+            id: "vocab-autoplay-1",
+            kind: "vocabulary",
+            word: buildSerializedWord({
+              audioUrl: "https://example.com/hola.mp3",
+              id: "word-autoplay-1",
+              translation: "Hello",
+              word: "Hola",
+            }),
+          }),
+          buildSerializedStep({
+            content: {},
+            id: "vocab-autoplay-2",
+            kind: "vocabulary",
+            position: 1,
+            word: buildSerializedWord({
+              audioUrl: "https://example.com/adios.mp3",
+              id: "word-autoplay-2",
+              translation: "Goodbye",
+              word: "Adios",
+            }),
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    const firstCard = page.getByRole("region", { name: /vocabulary: Hola/iu });
+
+    await firstCard.getByRole("button", { name: /play pronunciation/iu }).click();
+
+    await expect
+      .element(firstCard.getByRole("button", { name: /pause pronunciation/iu }))
+      .toBeInTheDocument();
+
+    fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
+
+    const secondCard = page.getByRole("region", { name: /vocabulary: Adios/iu });
+
+    await expect
+      .element(secondCard.getByRole("button", { name: /pause pronunciation/iu }))
+      .toBeInTheDocument();
+  });
+
+  it("keeps the play control ready when automatic vocabulary audio is blocked", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "vocabulary",
+        steps: [
+          buildSerializedStep({
+            content: {},
+            id: "vocab-blocked-autoplay-1",
+            kind: "vocabulary",
+            word: buildSerializedWord({
+              audioUrl: "https://example.com/hola.mp3",
+              id: "word-blocked-autoplay-1",
+              translation: "Hello",
+              word: "Hola",
+            }),
+          }),
+          buildSerializedStep({
+            content: {},
+            id: "vocab-blocked-autoplay-2",
+            kind: "vocabulary",
+            position: 1,
+            word: buildSerializedWord({
+              audioUrl: "https://example.com/adios.mp3",
+              id: "word-blocked-autoplay-2",
+              translation: "Goodbye",
+              word: "Adios",
+            }),
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    const firstCard = page.getByRole("region", { name: /vocabulary: Hola/iu });
+
+    await firstCard.getByRole("button", { name: /play pronunciation/iu }).click();
+
+    await expect
+      .element(firstCard.getByRole("button", { name: /pause pronunciation/iu }))
+      .toBeInTheDocument();
+
+    mockNextAudioPlayFailure();
+    fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
+
+    const secondCard = page.getByRole("region", { name: /vocabulary: Adios/iu });
+
+    await expect
+      .element(secondCard.getByRole("button", { name: /play pronunciation/iu }))
+      .toBeInTheDocument();
+
+    await expect
+      .element(secondCard.getByRole("button", { name: /pause pronunciation/iu }))
       .not.toBeInTheDocument();
   });
 

--- a/packages/player/src/_test-utils/browser-setup.ts
+++ b/packages/player/src/_test-utils/browser-setup.ts
@@ -16,6 +16,8 @@ type MockAudioInstance = {
   src: string;
 };
 
+const playAudio = vi.fn(() => Promise.resolve());
+
 /**
  * Audio playback is not part of these interaction tests, but several player
  * variants render audio controls. This stub makes those controls mount and
@@ -29,9 +31,18 @@ const MockAudio = vi.fn(function MockAudio(this: MockAudioInstance) {
   this.addEventListener = () => null;
   this.load = () => null;
   this.pause = () => null;
-  this.play = () => Promise.resolve();
+  this.play = playAudio;
   this.removeAttribute = () => null;
 });
+
+/**
+ * Browser autoplay rules are represented by play() rejecting. Tests use this
+ * helper for the next playback attempt so the player fallback stays covered
+ * without depending on a real browser policy decision.
+ */
+export function mockNextAudioPlayFailure() {
+  playAudio.mockRejectedValueOnce(new DOMException("Autoplay blocked", "NotAllowedError"));
+}
 
 beforeAll(() => {
   vi.stubGlobal("Audio", MockAudio);
@@ -40,4 +51,6 @@ beforeAll(() => {
 
 afterEach(() => {
   cleanup();
+  playAudio.mockReset();
+  playAudio.mockResolvedValue();
 });

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -177,7 +177,7 @@ export function ArrangeWordsInteraction({
         return;
       }
 
-      play(option.audioUrl);
+      void play(option.audioUrl);
       const placed: PlacedWord = { ...option, id: String(idCounter.current) };
       idCounter.current += 1;
       const next = [...placedWords, placed];

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -37,8 +37,11 @@ function usePlayAudioButtonState({ audioUrl, preload }: { audioUrl: string; prel
         return;
       }
 
-      play(audioUrl);
-      setIsPlaying(true);
+      void play(audioUrl).then((playbackStatus) => {
+        if (playbackStatus === "started") {
+          setIsPlaying(true);
+        }
+      });
     },
     isPlaying,
   };

--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useExtracted } from "next-intl";
+import { useCallback, useState } from "react";
 import { PlayerAudioProvider } from "../player-audio-context";
 import { usePlayerRuntime } from "../player-context";
 import {
@@ -84,6 +85,7 @@ function getAudioProviderKey({ audioUrl, stepId }: { audioUrl: string | null; st
 export function PlayerShell() {
   const t = useExtracted();
   const { screen, state } = usePlayerRuntime();
+  const [autoPlayAudio, setAutoPlayAudio] = useState(false);
 
   const currentResult = getCurrentResult(state);
   const currentStep = getCurrentStep(state);
@@ -102,13 +104,20 @@ export function PlayerShell() {
 
   const stageResetKey = getStageResetKey({ screenKind: screen.kind, stepId: currentStep?.id });
 
+  const enableAutoPlayAudio = useCallback(() => setAutoPlayAudio(true), []);
+
   usePlayerHaptics({ current: { phase: state.phase, result: currentResult, step: currentStep } });
 
   return (
     <main className="flex h-dvh flex-col overflow-hidden">
       {screen.showChrome && <InPlayStickyHeader progressValue={progressValue} />}
 
-      <PlayerAudioProvider audioUrl={bottomBarAudioUrl} key={audioProviderKey}>
+      <PlayerAudioProvider
+        audioUrl={bottomBarAudioUrl}
+        autoPlayAudio={autoPlayAudio}
+        key={audioProviderKey}
+        onAutoPlayAudioEnabled={enableAutoPlayAudio}
+      >
         <PlayerStage
           aria-label={t("Player screen")}
           isFullBleed={screen.stageIsFullBleed}

--- a/packages/player/src/components/translation-step.tsx
+++ b/packages/player/src/components/translation-step.tsx
@@ -68,7 +68,7 @@ export function TranslationStep({
       return;
     }
 
-    play(word.audioUrl);
+    void play(word.audioUrl);
     onSelectAnswer(step.id, { kind: "translation", selectedOptionId: word.id });
   };
 

--- a/packages/player/src/player-audio-context.tsx
+++ b/packages/player/src/player-audio-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useWordAudio } from "./use-word-audio";
 
 type PlayerAudioContextValue = {
@@ -21,11 +21,16 @@ const PlayerAudioContext = createContext<PlayerAudioContextValue | null>(null);
  */
 export function PlayerAudioProvider({
   audioUrl,
+  autoPlayAudio,
   children,
+  onAutoPlayAudioEnabled,
 }: {
   audioUrl: string | null;
+  autoPlayAudio: boolean;
   children: React.ReactNode;
+  onAutoPlayAudioEnabled: () => void;
 }) {
+  const [hasHandledAudioPrompt, setHasHandledAudioPrompt] = useState(false);
   const [playingAudioUrl, setPlayingAudioUrl] = useState<string | null>(null);
 
   const { pause, play } = useWordAudio({
@@ -35,19 +40,58 @@ export function PlayerAudioProvider({
 
   const isPlaying = Boolean(audioUrl && playingAudioUrl === audioUrl);
 
-  const toggleAudio = useCallback(
-    (targetAudioUrl: string) => {
-      if (playingAudioUrl === targetAudioUrl) {
-        pause();
+  /**
+   * Starts the active prompt and records that this step already had its automatic
+   * or manual playback attempt. That prevents an opt-in click or pause from
+   * immediately triggering another autoplay attempt for the same prompt.
+   */
+  const startAudio = useCallback(
+    async ({
+      shouldEnableAutoplay,
+      targetAudioUrl,
+    }: {
+      shouldEnableAutoplay: boolean;
+      targetAudioUrl: string;
+    }) => {
+      setHasHandledAudioPrompt(true);
+
+      const playbackStatus = await play(targetAudioUrl);
+
+      if (playbackStatus === "failed") {
         setPlayingAudioUrl(null);
         return;
       }
 
-      play(targetAudioUrl);
       setPlayingAudioUrl(targetAudioUrl);
+
+      if (shouldEnableAutoplay) {
+        onAutoPlayAudioEnabled();
+      }
     },
-    [pause, play, playingAudioUrl],
+    [onAutoPlayAudioEnabled, play],
   );
+
+  const toggleAudio = useCallback(
+    (targetAudioUrl: string) => {
+      if (playingAudioUrl === targetAudioUrl) {
+        pause();
+        setHasHandledAudioPrompt(true);
+        setPlayingAudioUrl(null);
+        return;
+      }
+
+      void startAudio({ shouldEnableAutoplay: true, targetAudioUrl });
+    },
+    [pause, playingAudioUrl, startAudio],
+  );
+
+  useEffect(() => {
+    if (!audioUrl || !autoPlayAudio || hasHandledAudioPrompt || isPlaying) {
+      return;
+    }
+
+    void startAudio({ shouldEnableAutoplay: false, targetAudioUrl: audioUrl });
+  }, [audioUrl, autoPlayAudio, hasHandledAudioPrompt, isPlaying, startAudio]);
 
   const value = useMemo(
     () => ({ audioUrl, isPlaying, toggleAudio }),

--- a/packages/player/src/use-word-audio.ts
+++ b/packages/player/src/use-word-audio.ts
@@ -9,6 +9,7 @@ import {
 } from "./_utils/audio-blob-cache";
 
 type UseWordAudioOptions = { onEnded?: () => void; preloadUrls?: (string | null)[] };
+type AudioPlaybackStatus = "failed" | "started";
 
 const AUDIO_PRELOAD_CONCURRENCY = 2;
 
@@ -148,6 +149,20 @@ function startAudioFromSource(audio: HTMLAudioElement, sourceUrl: string): void 
 }
 
 /**
+ * Browsers confirm media playback asynchronously and may reject audible audio
+ * when the call is not tied to an accepted user gesture. Returning an explicit
+ * status lets controls show the pause state only after playback really starts.
+ */
+async function getAudioPlaybackStatus(audio: HTMLAudioElement): Promise<AudioPlaybackStatus> {
+  try {
+    await audio.play();
+    return "started";
+  } catch {
+    return "failed";
+  }
+}
+
+/**
  * Short language clips need to start as close to instantly as possible. This
  * hook warms audio bytes in a bounded blob cache, then plays those bytes through
  * one reusable media element so mobile Safari does not retain a media element
@@ -155,7 +170,7 @@ function startAudioFromSource(audio: HTMLAudioElement, sourceUrl: string): void 
  */
 export function useWordAudio(options?: UseWordAudioOptions): {
   pause: () => void;
-  play: (url: string | null) => void;
+  play: (url: string | null) => Promise<AudioPlaybackStatus>;
 } {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const audioBlobCacheRef = useRef<AudioBlobCache>(new Map());
@@ -197,9 +212,9 @@ export function useWordAudio(options?: UseWordAudioOptions): {
   }, []);
 
   const play = useCallback(
-    (url: string | null) => {
+    async (url: string | null) => {
       if (!url) {
-        return;
+        return "failed";
       }
 
       const audio = getAudio();
@@ -210,9 +225,7 @@ export function useWordAudio(options?: UseWordAudioOptions): {
       });
 
       startAudioFromSource(audio, sourceUrl);
-      // Browser rejects play() when rapid clicks lose the user-gesture association.
-      // oxlint-disable-next-line no-empty-function -- intentional no-op for rejected play()
-      audio.play().catch(() => {});
+      return getAudioPlaybackStatus(audio);
     },
     [getAudio],
   );


### PR DESCRIPTION
Adds session-level audio autoplay after the learner starts pronunciation audio once.

Keeps manual playback available when the browser blocks automatic audio and covers the behavior in player browser tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds session-level lesson audio autoplay after the learner starts pronunciation once. When a browser blocks autoplay, manual play stays available and the UI reflects the real playback state.

- **New Features**
  - Added `autoPlayAudio` opt-in to `PlayerAudioProvider` with `onAutoPlayAudioEnabled`, enabling automatic playback on subsequent prompts after the first manual start.
  - Updated `use-word-audio` so `play(url)` returns `"started" | "failed"` and controls only show pause after playback actually starts.
  - Prevented repeat autoplay attempts per prompt using a handled-flag in the provider; toggling now routes through a `startAudio` helper.
  - Added browser tests for autoplay and blocked scenarios, plus `mockNextAudioPlayFailure()` to simulate `HTMLMediaElement.play()` rejection.

<sup>Written for commit 7552e1dad661b8a054adfb6790646d54b0f04567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

