### PR TITLE
feat(main): show brain power chart as bars

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -715,12 +715,12 @@ msgid "aAScNr"
 msgstr "About Brain Power"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "hRYALR"
-msgstr "Brain Power is your reputation. You earn Brain Power after each lesson you complete. It never goes down because knowledge is not something anyone can take from you."
+msgid "RLC4Ov"
+msgstr "Brain Power (BP) represents how much you have learned. You earn {brainPower} BP after each lesson you complete. It never goes down because knowledge is not something anyone can take from you."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "YhaJIG"
-msgstr "You do not lose Brain Power when your Energy drops or when you miss days."
+msgid "3vDry3"
+msgstr "The more Brain Power you have, the more knowledge you have built. You do not lose Brain Power when your Energy drops or when you miss days."
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "98M49A"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -715,12 +715,12 @@ msgid "aAScNr"
 msgstr "Sobre el Poder Mental"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "hRYALR"
-msgstr "El Poder Mental es tu reputación. Ganas Poder Mental después de cada lección que completas. Nunca baja porque el conocimiento es algo que nadie te puede quitar."
+msgid "RLC4Ov"
+msgstr "El Poder Mental (BP) representa cuánto has aprendido. Ganas {brainPower} BP después de cada lección que completas. Nunca baja porque el conocimiento es algo que nadie te puede quitar."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "YhaJIG"
-msgstr "No pierdes Poder Mental cuando baja la energía o cuando pasas un día sin estudiar."
+msgid "3vDry3"
+msgstr "Cuanto más Poder Mental tienes, más conocimiento has construido. No pierdes Poder Mental cuando baja tu Energía o cuando pasas días sin estudiar."
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "98M49A"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -715,12 +715,12 @@ msgid "aAScNr"
 msgstr "Sobre Poder Mental"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "hRYALR"
-msgstr "Poder Mental é a sua reputação. Você ganha Poder Mental após cada aula que completa. Ele nunca cai porque conhecimento é algo que ninguém tira de você."
+msgid "RLC4Ov"
+msgstr "Poder Mental (BP) representa o quanto você aprendeu. Você ganha {brainPower} BP depois de cada aula que completa. Ele nunca cai porque conhecimento é algo que ninguém tira de você."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "YhaJIG"
-msgstr "Você não perde Poder Mental quando a energia cai ou quando fica um dia sem estudar."
+msgid "3vDry3"
+msgstr "Quanto mais Poder Mental você tem, mais conhecimento construiu. Você não perde Poder Mental quando sua Energia cai ou quando fica dias sem estudar."
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "98M49A"

--- a/apps/main/src/app/(progress)/_components/progress-area-chart.tsx
+++ b/apps/main/src/app/(progress)/_components/progress-area-chart.tsx
@@ -1,10 +1,25 @@
 import { cn } from "@zoonk/ui/lib/utils";
 import { isValidChartPayload } from "@zoonk/utils/chart";
 import { type CSSProperties, type ComponentProps, type ReactNode } from "react";
-import { Area, AreaChart, CartesianGrid, ReferenceLine, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ReferenceLine,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 type ProgressAreaChartProps = Omit<
   ComponentProps<typeof AreaChart>,
+  "margin" | "responsive" | "style"
+>;
+
+type ProgressBarChartProps = Omit<
+  ComponentProps<typeof BarChart>,
   "margin" | "responsive" | "style"
 >;
 
@@ -16,9 +31,22 @@ type ProgressChartGradientProps = { color: string; id: string };
 
 type ProgressChartAreaProps = { color: string; dataKey: string; gradientId: string };
 
+type ProgressChartBarProps = { color: string; dataKey: string };
+
 type ProgressChartAverageLineProps = { children: string; y: number };
 
 type ProgressChartCompactYAxisProps = { locale: string };
+
+const PROGRESS_BAR_RADIUS = 4;
+
+const PROGRESS_BAR_CHART_MARGIN = { bottom: 0, left: 0, right: 0, top: 12 };
+
+const PROGRESS_BAR_RADIUS_VALUES: [number, number, number, number] = [
+  PROGRESS_BAR_RADIUS,
+  PROGRESS_BAR_RADIUS,
+  0,
+  0,
+];
 
 const PROGRESS_CHART_MARGIN = { bottom: 0, left: 0, right: 0, top: 10 };
 
@@ -48,6 +76,24 @@ export function ProgressChartFigure({ children, label }: ProgressChartFigureProp
 export function ProgressAreaChart(props: ProgressAreaChartProps) {
   return (
     <AreaChart {...props} margin={PROGRESS_CHART_MARGIN} responsive style={PROGRESS_CHART_STYLE} />
+  );
+}
+
+/**
+ * Keeps period-based progress bars on the same sizing path as the area charts.
+ * Brain Power is earned in discrete daily, weekly, monthly, or yearly buckets,
+ * so a bar chart can show each bucket directly while still avoiding the
+ * ResponsiveContainer measurement warning this chart family already fixed.
+ */
+export function ProgressBarChart(props: ProgressBarChartProps) {
+  return (
+    <BarChart
+      {...props}
+      barCategoryGap="28%"
+      margin={PROGRESS_BAR_CHART_MARGIN}
+      responsive
+      style={PROGRESS_CHART_STYLE}
+    />
   );
 }
 
@@ -146,6 +192,24 @@ export function ProgressChartArea({ color, dataKey, gradientId }: ProgressChartA
       stroke={color}
       strokeWidth={2}
       type="monotone"
+    />
+  );
+}
+
+/**
+ * Keeps bar-series styling focused on discrete progress totals. The radius and
+ * maximum width make a single short period readable without letting a sparse
+ * chart turn into oversized blocks.
+ */
+export function ProgressChartBar({ color, dataKey }: ProgressChartBarProps) {
+  return (
+    <Bar
+      activeBar={{ fill: color, opacity: 1 }}
+      dataKey={dataKey}
+      fill={color}
+      maxBarSize={40}
+      opacity={0.82}
+      radius={PROGRESS_BAR_RADIUS_VALUES}
     />
   );
 }

--- a/apps/main/src/app/(progress)/level/level-chart-client.tsx
+++ b/apps/main/src/app/(progress)/level/level-chart-client.tsx
@@ -2,11 +2,10 @@
 
 import { useExtracted, useLocale } from "next-intl";
 import {
-  ProgressAreaChart,
-  ProgressChartArea,
+  ProgressBarChart,
+  ProgressChartBar,
   ProgressChartCompactYAxis,
   ProgressChartFigure,
-  ProgressChartGradient,
   ProgressChartGrid,
   ProgressChartTooltip,
   ProgressChartTooltipContent,
@@ -29,15 +28,10 @@ export function LevelChartClient({
 
   const formattedTotal = new Intl.NumberFormat(locale).format(total);
   const color = "var(--primary)";
-  const gradientId = "bpGradient";
 
   return (
     <ProgressChartFigure label={t("Brain Power chart")}>
-      <ProgressAreaChart data={dataPoints}>
-        <defs>
-          <ProgressChartGradient color={color} id={gradientId} />
-        </defs>
-
+      <ProgressBarChart data={dataPoints}>
         <ProgressChartGrid />
         <ProgressChartXAxis />
         <ProgressChartCompactYAxis locale={locale} />
@@ -57,8 +51,8 @@ export function LevelChartClient({
           }}
         </ProgressChartTooltip>
 
-        <ProgressChartArea color={color} dataKey="bp" gradientId={gradientId} />
-      </ProgressAreaChart>
+        <ProgressChartBar color={color} dataKey="bp" />
+      </ProgressBarChart>
 
       <figcaption className="sr-only">
         {t("Total Brain Power earned: {total}", { total: formattedTotal })}

--- a/apps/main/src/app/(progress)/level/level-explanation.tsx
+++ b/apps/main/src/app/(progress)/level/level-explanation.tsx
@@ -1,4 +1,5 @@
 import { Explanation, ExplanationText, ExplanationTitle } from "@zoonk/ui/components/explanation";
+import { BRAIN_POWER_PER_LESSON } from "@zoonk/utils/brain-power";
 import { getExtracted } from "next-intl/server";
 
 export async function LevelExplanation() {
@@ -10,12 +11,15 @@ export async function LevelExplanation() {
 
       <ExplanationText>
         {t(
-          "Brain Power is your reputation. You earn Brain Power after each lesson you complete. It never goes down because knowledge is not something anyone can take from you.",
+          "Brain Power (BP) represents how much you have learned. You earn {brainPower} BP after each lesson you complete. It never goes down because knowledge is not something anyone can take from you.",
+          { brainPower: String(BRAIN_POWER_PER_LESSON) },
         )}
       </ExplanationText>
 
       <ExplanationText>
-        {t("You do not lose Brain Power when your Energy drops or when you miss days.")}
+        {t(
+          "The more Brain Power you have, the more knowledge you have built. You do not lose Brain Power when your Energy drops or when you miss days.",
+        )}
       </ExplanationText>
 
       <ExplanationText>


### PR DESCRIPTION
Updates the Brain Power chart on the level page to use bars while leaving the Energy and Score charts as area charts.

Improves the About Brain Power explanation and sources the per-lesson BP value from the shared constant.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Brain Power chart on the level page to bars to better show discrete per-period gains. Energy and Score charts remain area charts. Also improves the About Brain Power copy and shows the per-lesson BP using a shared constant.

- **New Features**
  - Brain Power now uses shared bar components: `ProgressBarChart` and `ProgressChartBar` for consistent styling and sizing.
  - Updated About Brain Power text to include the per-lesson amount via `BRAIN_POWER_PER_LESSON` from `@zoonk/utils/brain-power` (i18n updated for `en`, `es`, `pt`).

<sup>Written for commit 72ddd2b5e8fd437b42b36cd45dab7d51c3f38620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

