### PR TITLE
fix(main): show current energy on progress page

### DIFF
--- a/apps/main/e2e/energy.test.ts
+++ b/apps/main/e2e/energy.test.ts
@@ -38,6 +38,13 @@ test.describe("Energy Page", () => {
       await expect(authenticatedPage.getByText(/vs last month/iu)).toBeVisible();
     });
 
+    test("displays current energy and selected-period average", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/energy");
+
+      await expect(authenticatedPage.getByText(/current energy/iu)).toBeVisible();
+      await expect(authenticatedPage.getByText(/% average/iu)).toBeVisible();
+    });
+
     test("switching to 6 months shows different comparison text", async ({ authenticatedPage }) => {
       await authenticatedPage.goto("/energy");
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -690,6 +690,14 @@ msgstr "It goes up when you answer correctly and goes down when you answer incor
 msgid "okV1HG"
 msgstr "It is not a streak. Missing a day does not reset Energy to zero. It drops a little, and you can recover it when you return."
 
+#: src/app/(progress)/energy/energy-stats.tsx
+msgid "zLCmVM"
+msgstr "Current Energy"
+
+#: src/app/(progress)/energy/energy-stats.tsx
+msgid "yGxJvo"
+msgstr "{value}% average"
+
 #: src/app/(progress)/energy/page.tsx
 msgid "AZMpf3"
 msgstr "Energy is a 0% to 100% score based on recent activity and accuracy."

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -690,6 +690,14 @@ msgstr "Sube cuando respondes correctamente y baja cuando respondes mal o pasas 
 msgid "okV1HG"
 msgstr "No es una racha. Pasar un día sin estudiar no pone la energía en cero. Baja un poco, pero puedes recuperarla cuando vuelves."
 
+#: src/app/(progress)/energy/energy-stats.tsx
+msgid "zLCmVM"
+msgstr "Energía actual"
+
+#: src/app/(progress)/energy/energy-stats.tsx
+msgid "yGxJvo"
+msgstr "{value}% promedio"
+
 #: src/app/(progress)/energy/page.tsx
 msgid "AZMpf3"
 msgstr "La energía es una puntuación de 0% a 100% basada en tu actividad y precisión recientes."

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -690,6 +690,14 @@ msgstr "Ela sobe quando você responde corretamente e cai quando você responde 
 msgid "okV1HG"
 msgstr "Não é uma sequência. Ficar um dia sem estudar não zera a energia. Ela cai um pouquinho, mas você consegue recuperar quando voltar."
 
+#: src/app/(progress)/energy/energy-stats.tsx
+msgid "zLCmVM"
+msgstr "Energia atual"
+
+#: src/app/(progress)/energy/energy-stats.tsx
+msgid "yGxJvo"
+msgstr "{value}% em média"
+
 #: src/app/(progress)/energy/page.tsx
 msgid "AZMpf3"
 msgstr "Energia é uma pontuação de 0% a 100% baseada em atividade e precisão recentes."

--- a/apps/main/src/app/(progress)/energy/energy-content.tsx
+++ b/apps/main/src/app/(progress)/energy/energy-content.tsx
@@ -37,6 +37,7 @@ export async function EnergyContent({
     <div className="flex flex-col gap-8">
       <EnergyStats
         average={data.average}
+        currentEnergy={data.currentEnergy}
         period={validPeriod}
         periodEnd={data.periodEnd}
         periodStart={data.periodStart}

--- a/apps/main/src/app/(progress)/energy/energy-stats.tsx
+++ b/apps/main/src/app/(progress)/energy/energy-stats.tsx
@@ -5,12 +5,14 @@ import { MetricComparison } from "../_components/metric-comparison";
 
 export async function EnergyStats({
   average,
+  currentEnergy,
   period,
   periodEnd,
   periodStart,
   previousAverage,
 }: {
   average: number;
+  currentEnergy: number;
   period: HistoryPeriod;
   periodEnd: Date;
   periodStart: Date;
@@ -24,20 +26,35 @@ export async function EnergyStats({
     trailingZeroDisplay: "stripIfInteger",
   }).format(average);
 
+  const formattedCurrentEnergy = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 1,
+    trailingZeroDisplay: "stripIfInteger",
+  }).format(currentEnergy);
+
   const periodLabel = formatPeriodLabel(periodStart, periodEnd, period, locale);
 
   return (
-    <div className="flex flex-col gap-1">
-      <span className="text-muted-foreground text-sm">{periodLabel}</span>
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <span className="text-muted-foreground text-sm">{t("Current Energy")}</span>
 
-      <div className="flex items-baseline gap-3">
         <span className="text-energy text-5xl font-bold tracking-tight tabular-nums">
-          {t("{value}%", { value: formattedAverage })}
+          {t("{value}%", { value: formattedCurrentEnergy })}
         </span>
+      </div>
 
-        {previousAverage !== null && (
-          <MetricComparison current={average} period={period} previous={previousAverage} />
-        )}
+      <div className="flex flex-col gap-1">
+        <span className="text-muted-foreground text-sm">{periodLabel}</span>
+
+        <div className="flex items-baseline gap-3">
+          <span className="text-2xl font-semibold tracking-tight tabular-nums">
+            {t("{value}% average", { value: formattedAverage })}
+          </span>
+
+          {previousAverage !== null && (
+            <MetricComparison current={average} period={period} previous={previousAverage} />
+          )}
+        </div>
       </div>
     </div>
   );
@@ -45,11 +62,18 @@ export async function EnergyStats({
 
 export function EnergyStatsSkeleton() {
   return (
-    <div className="flex flex-col gap-1">
-      <Skeleton className="h-4 w-28" />
-      <div className="flex items-baseline gap-3">
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-4 w-28" />
         <Skeleton className="h-12 w-28" />
-        <Skeleton className="h-5 w-32" />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-4 w-24" />
+        <div className="flex items-baseline gap-3">
+          <Skeleton className="h-7 w-28" />
+          <Skeleton className="h-5 w-32" />
+        </div>
       </div>
     </div>
   );

--- a/apps/main/src/data/progress/get-energy-history.test.ts
+++ b/apps/main/src/data/progress/get-energy-history.test.ts
@@ -65,6 +65,35 @@ describe("authenticated users", () => {
       expect(result?.average).toBe(75);
     });
 
+    it("includes current energy from the user progress row", async () => {
+      const user = await userFixture();
+      const headers = await signInAs(user.email, user.password);
+
+      const today = new Date();
+
+      const todayMidnight = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()),
+      );
+
+      const fiveDaysAgo = new Date(todayMidnight.getTime() - 5 * 86_400_000);
+
+      await prisma.userProgress.create({
+        data: { currentEnergy: 50, lastActiveAt: fiveDaysAgo, userId: user.id },
+      });
+
+      const date = createSafeDate(0);
+
+      await prisma.dailyProgress.create({
+        data: { date, dayOfWeek: date.getDay(), energyAtEnd: 75, userId: user.id },
+      });
+
+      const result = await getEnergyHistory({ headers, period: "month" });
+
+      expect(result).not.toBeNull();
+      expect(result?.average).toBe(75);
+      expect(result?.currentEnergy).toBe(46);
+    });
+
     it("calculates comparison with previous month", async () => {
       const user = await userFixture();
       const headers = await signInAs(user.email, user.password);

--- a/apps/main/src/data/progress/get-energy-history.ts
+++ b/apps/main/src/data/progress/get-energy-history.ts
@@ -4,6 +4,7 @@ import { prisma } from "@zoonk/db";
 import { type TimePeriod, aggregateByPeriod } from "@zoonk/utils/aggregation";
 import { formatLabel } from "@zoonk/utils/chart";
 import { type HistoryPeriod, calculateDateRanges } from "@zoonk/utils/date-ranges";
+import { computeDecayedEnergy } from "@zoonk/utils/energy";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 import { fillGapsWithDecay } from "./_fill-gaps";
@@ -15,6 +16,7 @@ export type EnergyDataPoint = { date: Date; energy: number; label: string };
 type EnergyHistoryData = {
   dataPoints: EnergyDataPoint[];
   average: number;
+  currentEnergy: number;
   previousAverage: number | null;
   periodStart: Date;
   periodEnd: Date;
@@ -76,9 +78,10 @@ const cachedGetEnergyHistory = cache(
     const userId = session.user.id;
     const { current, previous } = calculateDateRanges(period, offset);
 
-    const [currentResult, previousResult] = await Promise.all([
+    const [currentResult, previousResult, progressResult] = await Promise.all([
       fetchDailyData(userId, current.start, current.end),
       fetchDailyData(userId, previous.start, previous.end),
+      safeAsync(() => prisma.userProgress.findUnique({ where: { userId } })),
     ]);
 
     if (currentResult.error || !currentResult.data || currentResult.data.length === 0) {
@@ -95,6 +98,13 @@ const cachedGetEnergyHistory = cache(
 
     return {
       average: calculateAverage(currentData),
+      currentEnergy: progressResult.data
+        ? computeDecayedEnergy(
+            progressResult.data.currentEnergy,
+            progressResult.data.lastActiveAt,
+            new Date(),
+          )
+        : 0,
       dataPoints,
       hasNextPeriod: offset > 0,
       hasPreviousPeriod: await hasEarlierData(userId, current.start),


### PR DESCRIPTION
## Summary

- Show current energy separately from selected-period average on the Energy progress page
- Return decayed current energy from the energy history data path
- Add data and e2e coverage for the new current-energy display

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Energy page now shows your current Energy as a separate metric from the selected period’s average. Current Energy is computed with decay since your last activity and returned by the history API.

- **New Features**
  - Display “Current Energy” as the primary stat; period section shows “{value}% average” with comparison.
  - `get-energy-history` now returns `currentEnergy`, computed via decay from `userProgress` (`currentEnergy`, `lastActiveAt`).
  - Updated UI skeletons, i18n strings (en/es/pt), and added unit + e2e tests for the new display.

<sup>Written for commit d955e55b8c65a77a3dbe4562fca442de5130caef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

