### PR TITLE
fix(main): clarify progress metric explanations

### DIFF
--- a/apps/main/e2e/energy.test.ts
+++ b/apps/main/e2e/energy.test.ts
@@ -119,6 +119,24 @@ test.describe("Energy Page", () => {
         authenticatedPage.getByText(/start learning to track your progress/iu),
       ).not.toBeVisible();
     });
+
+    test("displays energy explanation sections", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/energy");
+
+      await expect(
+        authenticatedPage.getByRole("heading", { name: /what is energy/iu }),
+      ).toBeVisible();
+
+      await expect(
+        authenticatedPage.getByRole("heading", { name: /how do i improve energy/iu }),
+      ).toBeVisible();
+
+      await expect(
+        authenticatedPage.getByRole("heading", { name: /why is energy important/iu }),
+      ).toBeVisible();
+
+      await expect(authenticatedPage.getByText(/not a streak/iu)).toBeVisible();
+    });
   });
 
   test.describe("Users Without Progress", () => {

--- a/apps/main/e2e/level.test.ts
+++ b/apps/main/e2e/level.test.ts
@@ -115,6 +115,24 @@ test.describe("Level Page", () => {
 
       await expect(authenticatedPage.getByText(/vs last 6 months/iu)).toBeVisible();
     });
+
+    test("displays brain power explanation sections", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/level");
+
+      await expect(
+        authenticatedPage.getByRole("heading", { name: /what is brain power/iu }),
+      ).toBeVisible();
+
+      await expect(
+        authenticatedPage.getByRole("heading", { name: /how do i increase brain power/iu }),
+      ).toBeVisible();
+
+      await expect(
+        authenticatedPage.getByRole("heading", { name: /why is brain power important/iu }),
+      ).toBeVisible();
+
+      await expect(authenticatedPage.getByText(/never goes down/iu)).toBeVisible();
+    });
   });
 
   test.describe("Users Without Progress", () => {

--- a/apps/main/e2e/score.test.ts
+++ b/apps/main/e2e/score.test.ts
@@ -110,10 +110,18 @@ test.describe("Score Page", () => {
     test("displays score explanation section", async ({ authenticatedPage }) => {
       await authenticatedPage.goto("/score");
 
-      // User sees the explanation about score
-      await expect(authenticatedPage.getByText(/about score/iu)).toBeVisible();
+      await expect(
+        authenticatedPage.getByRole("heading", { name: /what is score/iu }),
+      ).toBeVisible();
 
-      // User sees the explanation text
+      await expect(
+        authenticatedPage.getByRole("heading", { name: /how do i improve score/iu }),
+      ).toBeVisible();
+
+      await expect(
+        authenticatedPage.getByRole("heading", { name: /why is score important/iu }),
+      ).toBeVisible();
+
       await expect(
         authenticatedPage.getByText(/percentage of questions you answered correctly/iu),
       ).toBeVisible();

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -675,20 +675,28 @@ msgid "rGSqvt"
 msgstr "Avg"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "tqJIUh"
-msgstr "About Energy"
+msgid "TLPAMC"
+msgstr "What is Energy?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "OWC2V9"
-msgstr "Energy is a score from 0% to 100%. The goal is to keep it near 100%."
+msgid "OvOWOR"
+msgstr "Energy is a 0% to 100% score for your recent learning consistency and accuracy."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "5oXyw+"
-msgstr "It goes up when you answer correctly and goes down when you answer incorrectly or go a day without studying."
+msgid "K3jN6p"
+msgstr "How do I improve Energy?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "okV1HG"
-msgstr "It is not a streak. Missing a day does not reset Energy to zero. It drops a little, and you can recover it when you return."
+msgid "pssms6"
+msgstr "Answer questions correctly and keep learning regularly. Correct answers raise Energy; wrong answers and days away from studying lower it."
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "+8Qx8X"
+msgstr "Why is Energy important?"
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "TRcArs"
+msgstr "Energy is like heart rate in a health app: it shows your current learning rhythm. It is not a streak; missing a day does not reset it, and you can recover when you come back."
 
 #: src/app/(progress)/energy/energy-stats.tsx
 msgid "zLCmVM"
@@ -719,20 +727,28 @@ msgid "tDbspx"
 msgstr "Total Brain Power earned: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "aAScNr"
-msgstr "About Brain Power"
+msgid "EMy5Vs"
+msgstr "What is Brain Power?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "RLC4Ov"
-msgstr "Brain Power (BP) represents how much you have learned. You earn {brainPower} BP after each lesson you complete. It never goes down because knowledge is not something anyone can take from you."
+msgid "MIjvOA"
+msgstr "Brain Power (BP) is the total learning credit you have earned. Each completed lesson adds {brainPower} BP."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "3vDry3"
-msgstr "The more Brain Power you have, the more knowledge you have built. You do not lose Brain Power when your Energy drops or when you miss days."
+msgid "jzKXJS"
+msgstr "How do I increase Brain Power?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "98M49A"
-msgstr "Brain Power is like martial arts for your mind: the more you study, the stronger it gets. You start as a white belt and can work your way up to black belt."
+msgid "Gzq1tT"
+msgstr "Complete lessons. Brain Power never goes down, even when your Energy drops or you take a break."
+
+#: src/app/(progress)/level/level-explanation.tsx
+msgid "JGLOtn"
+msgstr "Why is Brain Power important?"
+
+#: src/app/(progress)/level/level-explanation.tsx
+msgid "6g8QfE"
+msgstr "It is like steps in a health app: a record of how much you have learned. It also works like martial arts for your mind: build Brain Power to move from white belt toward black belt in knowledge."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "VHH0kD"
@@ -791,12 +807,28 @@ msgid "J+05ol"
 msgstr "Score chart"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "dN8FhY"
-msgstr "About Score"
+msgid "bIZaXJ"
+msgstr "What is Score?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "vWQIxU"
-msgstr "Your score shows the percentage of questions you answered correctly. It helps you track your accuracy over time and identify your best days and times for learning."
+msgid "JA+N5Z"
+msgstr "Score is the percentage of questions you answered correctly during this period."
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "z9kvhA"
+msgstr "How do I improve Score?"
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "7/C9do"
+msgstr "Review mistakes and retry lessons. As you answer more questions correctly, your Score goes up."
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "WqH8eP"
+msgstr "Why is Score important?"
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "E0saoA"
+msgstr "Score shows accuracy, not activity. Best day and best time help you find when you learn most effectively."
 
 #: src/app/(progress)/score/score-insights.tsx
 msgid "J3fNDZ"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -675,20 +675,28 @@ msgid "rGSqvt"
 msgstr "Prom"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "tqJIUh"
-msgstr "Acerca de la energía"
+msgid "TLPAMC"
+msgstr "¿Qué es la energía?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "OWC2V9"
-msgstr "La energía es una puntuación de 0% a 100%. El objetivo es mantenerla cerca del 100%."
+msgid "OvOWOR"
+msgstr "La energía es una puntuación de 0% a 100% que muestra tu constancia reciente y tus aciertos."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "5oXyw+"
-msgstr "Sube cuando respondes correctamente y baja cuando respondes mal o pasas un día sin estudiar."
+msgid "K3jN6p"
+msgstr "¿Cómo mejoro mi energía?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "okV1HG"
-msgstr "No es una racha. Pasar un día sin estudiar no pone la energía en cero. Baja un poco, pero puedes recuperarla cuando vuelves."
+msgid "pssms6"
+msgstr "Responde correctamente y mantén una rutina de estudio. Las respuestas correctas hacen que la energía suba; las incorrectas y los días sin estudiar hacen que baje."
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "+8Qx8X"
+msgstr "¿Por qué es importante la energía?"
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "TRcArs"
+msgstr "La energía es como la frecuencia cardíaca en una app de salud: muestra el ritmo actual de tu aprendizaje. No es una racha; pasar un día sin estudiar no la pone en cero, y puedes recuperarla cuando vuelves."
 
 #: src/app/(progress)/energy/energy-stats.tsx
 msgid "zLCmVM"
@@ -719,20 +727,28 @@ msgid "tDbspx"
 msgstr "Poder Mental total ganado: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "aAScNr"
-msgstr "Sobre el Poder Mental"
+msgid "EMy5Vs"
+msgstr "¿Qué es el Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "RLC4Ov"
-msgstr "El Poder Mental (BP) representa cuánto has aprendido. Ganas {brainPower} BP después de cada lección que completas. Nunca baja porque el conocimiento es algo que nadie te puede quitar."
+msgid "MIjvOA"
+msgstr "El Poder Mental (PM) es el total de aprendizaje que has acumulado. Cada lección completada añade {brainPower} PM."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "3vDry3"
-msgstr "Cuanto más Poder Mental tienes, más conocimiento has construido. No pierdes Poder Mental cuando baja tu Energía o cuando pasas días sin estudiar."
+msgid "jzKXJS"
+msgstr "¿Cómo aumento mi Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "98M49A"
-msgstr "El Poder Mental es como artes marciales para tu mente: cuanto más estudias, más fuerte se vuelve. Empiezas como cinturón blanco y puedes avanzar hasta cinturón negro."
+msgid "Gzq1tT"
+msgstr "Completa lecciones. El Poder Mental nunca baja, incluso cuando baja tu energía o tomas una pausa."
+
+#: src/app/(progress)/level/level-explanation.tsx
+msgid "JGLOtn"
+msgstr "¿Por qué es importante el Poder Mental?"
+
+#: src/app/(progress)/level/level-explanation.tsx
+msgid "6g8QfE"
+msgstr "Es como los pasos en una app de salud: un registro de cuánto has aprendido. También funciona como artes marciales para la mente: aumenta tu Poder Mental para pasar del cinturón blanco al cinturón negro del conocimiento."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "VHH0kD"
@@ -791,12 +807,28 @@ msgid "J+05ol"
 msgstr "Gráfico de aciertos"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "dN8FhY"
-msgstr "Sobre aciertos"
+msgid "bIZaXJ"
+msgstr "¿Qué son los aciertos?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "vWQIxU"
-msgstr "Tus aciertos muestran el porcentaje de preguntas que has respondido correctamente. Te ayudan a rastrear tu precisión a lo largo del tiempo y a identificar tus mejores días y horarios para aprender."
+msgid "JA+N5Z"
+msgstr "Los aciertos son el porcentaje de preguntas que respondiste correctamente en este período."
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "z9kvhA"
+msgstr "¿Cómo mejoro mis aciertos?"
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "7/C9do"
+msgstr "Revisa tus errores y repite lecciones. A medida que respondes más preguntas correctamente, tus aciertos mejoran."
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "WqH8eP"
+msgstr "¿Por qué son importantes los aciertos?"
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "E0saoA"
+msgstr "Los aciertos muestran precisión, no actividad. El mejor día y la mejor hora te ayudan a encontrar cuándo aprendes mejor."
 
 #: src/app/(progress)/score/score-insights.tsx
 msgid "J3fNDZ"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -675,20 +675,28 @@ msgid "rGSqvt"
 msgstr "Média"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "tqJIUh"
-msgstr "Sobre energia"
+msgid "TLPAMC"
+msgstr "O que é Energia?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "OWC2V9"
-msgstr "Energia é uma pontuação de 0% a 100%. O objetivo é mantê-la perto de 100%."
+msgid "OvOWOR"
+msgstr "Energia é uma pontuação de 0% a 100% que mostra sua constância recente e seus acertos."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "5oXyw+"
-msgstr "Ela sobe quando você responde corretamente e cai quando você responde errado ou fica um dia sem estudar."
+msgid "K3jN6p"
+msgstr "Como melhoro minha Energia?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "okV1HG"
-msgstr "Não é uma sequência. Ficar um dia sem estudar não zera a energia. Ela cai um pouquinho, mas você consegue recuperar quando voltar."
+msgid "pssms6"
+msgstr "Responda corretamente e mantenha uma rotina de estudo. Respostas corretas fazem a Energia subir; respostas erradas e dias sem estudar fazem a Energia cair."
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "+8Qx8X"
+msgstr "Por que a Energia importa?"
+
+#: src/app/(progress)/energy/energy-explanation.tsx
+msgid "TRcArs"
+msgstr "A Energia é como a frequência cardíaca em um app de saúde: mostra o ritmo atual do seu aprendizado. Ela não é uma sequência; ficar um dia sem estudar não zera a Energia, e você pode recuperar quando voltar."
 
 #: src/app/(progress)/energy/energy-stats.tsx
 msgid "zLCmVM"
@@ -719,20 +727,28 @@ msgid "tDbspx"
 msgstr "Total de Poder Mental ganho: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "aAScNr"
-msgstr "Sobre Poder Mental"
+msgid "EMy5Vs"
+msgstr "O que é Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "RLC4Ov"
-msgstr "Poder Mental (BP) representa o quanto você aprendeu. Você ganha {brainPower} BP depois de cada aula que completa. Ele nunca cai porque conhecimento é algo que ninguém tira de você."
+msgid "MIjvOA"
+msgstr "Poder Mental (PM) é o total de aprendizado que você acumulou. Cada aula concluída adiciona {brainPower} PM."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "3vDry3"
-msgstr "Quanto mais Poder Mental você tem, mais conhecimento construiu. Você não perde Poder Mental quando sua Energia cai ou quando fica dias sem estudar."
+msgid "jzKXJS"
+msgstr "Como aumento meu Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "98M49A"
-msgstr "O Poder Mental é como artes marciais para a sua mente: quanto mais você estuda, mais forte fica. Você começa como faixa branca e pode evoluir até faixa preta."
+msgid "Gzq1tT"
+msgstr "Conclua aulas. O Poder Mental nunca cai, mesmo quando sua Energia cai ou você faz uma pausa."
+
+#: src/app/(progress)/level/level-explanation.tsx
+msgid "JGLOtn"
+msgstr "Por que o Poder Mental importa?"
+
+#: src/app/(progress)/level/level-explanation.tsx
+msgid "6g8QfE"
+msgstr "Ele é como os passos em um app de saúde: um registro do quanto você aprendeu. Também funciona como artes marciais para a mente: aumente seu Poder Mental para sair da faixa branca e chegar à faixa preta do conhecimento."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "VHH0kD"
@@ -791,12 +807,28 @@ msgid "J+05ol"
 msgstr "Gráfico de acertos"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "dN8FhY"
-msgstr "Sobre acertos"
+msgid "bIZaXJ"
+msgstr "O que são acertos?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "vWQIxU"
-msgstr "Seu acerto mostra o percentual de questões que você respondeu corretamente. Ele ajuda você a acompanhar sua precisão ao longo do tempo e identificar seus melhores dias e horários para aprender."
+msgid "JA+N5Z"
+msgstr "Acertos são o percentual de questões que você respondeu corretamente neste período."
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "z9kvhA"
+msgstr "Como melhoro meus acertos?"
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "7/C9do"
+msgstr "Revise seus erros e refaça aulas. À medida que você responde mais questões corretamente, seus acertos melhoram."
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "WqH8eP"
+msgstr "Por que os acertos importam?"
+
+#: src/app/(progress)/score/score-explanation.tsx
+msgid "E0saoA"
+msgstr "Os acertos mostram precisão, não atividade. Melhor dia e melhor horário ajudam você a encontrar quando aprende melhor."
 
 #: src/app/(progress)/score/score-insights.tsx
 msgid "J3fNDZ"

--- a/apps/main/src/app/(progress)/_components/progress-explanation-skeleton.tsx
+++ b/apps/main/src/app/(progress)/_components/progress-explanation-skeleton.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+
+const EXPLANATION_SKELETON_SECTIONS = ["definition", "change", "importance"];
+
+/**
+ * Mirrors the three-part metric explanation layout so loading states reserve
+ * roughly the same vertical space as the final content.
+ */
+export function ProgressExplanationSkeleton() {
+  return (
+    <div className="flex flex-col gap-5 border-t pt-6">
+      {EXPLANATION_SKELETON_SECTIONS.map((section) => (
+        <div className="flex flex-col gap-2" key={section}>
+          <Skeleton className="h-4 w-44 max-w-full" />
+          <Skeleton className="h-4 w-80 max-w-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/main/src/app/(progress)/energy/energy-content.tsx
+++ b/apps/main/src/app/(progress)/energy/energy-content.tsx
@@ -1,10 +1,10 @@
 import { getEnergyHistory } from "@/data/progress/get-energy-history";
 import { getSession } from "@zoonk/core/users/session/get";
-import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { validatePeriod } from "@zoonk/utils/date-ranges";
 import { getLocale } from "next-intl/server";
 import { ProgressChartSkeleton } from "../_components/progress-chart-skeleton";
 import { ProgressEmptyState } from "../_components/progress-empty-state";
+import { ProgressExplanationSkeleton } from "../_components/progress-explanation-skeleton";
 import { EnergyChart } from "./energy-chart";
 import { EnergyExplanation } from "./energy-explanation";
 import { EnergyStats, EnergyStatsSkeleton } from "./energy-stats";
@@ -64,13 +64,7 @@ export function EnergyContentSkeleton() {
     <div className="flex flex-col gap-8">
       <EnergyStatsSkeleton />
       <ProgressChartSkeleton />
-
-      <div className="flex flex-col gap-2">
-        <Skeleton className="h-4 w-36" />
-        <Skeleton className="h-4 w-72 max-w-full" />
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-4/5" />
-      </div>
+      <ProgressExplanationSkeleton />
     </div>
   );
 }

--- a/apps/main/src/app/(progress)/energy/energy-explanation.tsx
+++ b/apps/main/src/app/(progress)/energy/energy-explanation.tsx
@@ -11,27 +11,37 @@ export async function EnergyExplanation() {
   const t = await getExtracted();
 
   return (
-    <Explanation className="gap-1 border-t pt-6">
-      <ExplanationHeader className="text-energy">
-        <ZapIcon aria-hidden />
-        <ExplanationTitle>{t("About Energy")}</ExplanationTitle>
-      </ExplanationHeader>
+    <div className="flex flex-col gap-5 border-t pt-6">
+      <Explanation className="gap-1">
+        <ExplanationHeader className="text-energy">
+          <ZapIcon aria-hidden />
+          <ExplanationTitle>{t("What is Energy?")}</ExplanationTitle>
+        </ExplanationHeader>
 
-      <ExplanationText>
-        {t("Energy is a score from 0% to 100%. The goal is to keep it near 100%.")}
-      </ExplanationText>
+        <ExplanationText>
+          {t("Energy is a 0% to 100% score for your recent learning consistency and accuracy.")}
+        </ExplanationText>
+      </Explanation>
 
-      <ExplanationText>
-        {t(
-          "It goes up when you answer correctly and goes down when you answer incorrectly or go a day without studying.",
-        )}
-      </ExplanationText>
+      <Explanation className="gap-1">
+        <ExplanationTitle>{t("How do I improve Energy?")}</ExplanationTitle>
 
-      <ExplanationText>
-        {t(
-          "It is not a streak. Missing a day does not reset Energy to zero. It drops a little, and you can recover it when you return.",
-        )}
-      </ExplanationText>
-    </Explanation>
+        <ExplanationText>
+          {t(
+            "Answer questions correctly and keep learning regularly. Correct answers raise Energy; wrong answers and days away from studying lower it.",
+          )}
+        </ExplanationText>
+      </Explanation>
+
+      <Explanation className="gap-1">
+        <ExplanationTitle>{t("Why is Energy important?")}</ExplanationTitle>
+
+        <ExplanationText>
+          {t(
+            "Energy is like heart rate in a health app: it shows your current learning rhythm. It is not a streak; missing a day does not reset it, and you can recover when you come back.",
+          )}
+        </ExplanationText>
+      </Explanation>
+    </div>
   );
 }

--- a/apps/main/src/app/(progress)/level/level-content.tsx
+++ b/apps/main/src/app/(progress)/level/level-content.tsx
@@ -1,10 +1,10 @@
 import { getBpHistory } from "@/data/progress/get-bp-history";
 import { getSession } from "@zoonk/core/users/session/get";
-import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { validatePeriod } from "@zoonk/utils/date-ranges";
 import { getLocale } from "next-intl/server";
 import { ProgressChartSkeleton } from "../_components/progress-chart-skeleton";
 import { ProgressEmptyState } from "../_components/progress-empty-state";
+import { ProgressExplanationSkeleton } from "../_components/progress-explanation-skeleton";
 import { LevelChart } from "./level-chart";
 import { LevelExplanation } from "./level-explanation";
 import { LevelProgression, LevelProgressionSkeleton } from "./level-progression";
@@ -69,13 +69,7 @@ export function LevelContentSkeleton() {
       <LevelStatsSkeleton />
       <ProgressChartSkeleton />
       <LevelProgressionSkeleton />
-
-      <div className="flex flex-col gap-2">
-        <Skeleton className="h-4 w-36" />
-        <Skeleton className="h-4 w-72 max-w-full" />
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-4/5" />
-      </div>
+      <ProgressExplanationSkeleton />
     </div>
   );
 }

--- a/apps/main/src/app/(progress)/level/level-explanation.tsx
+++ b/apps/main/src/app/(progress)/level/level-explanation.tsx
@@ -1,32 +1,51 @@
-import { Explanation, ExplanationText, ExplanationTitle } from "@zoonk/ui/components/explanation";
+import {
+  Explanation,
+  ExplanationHeader,
+  ExplanationText,
+  ExplanationTitle,
+} from "@zoonk/ui/components/explanation";
 import { BRAIN_POWER_PER_LESSON } from "@zoonk/utils/brain-power";
+import { BrainIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 
 export async function LevelExplanation() {
   const t = await getExtracted();
 
   return (
-    <Explanation className="gap-1 border-t pt-6">
-      <ExplanationTitle>{t("About Brain Power")}</ExplanationTitle>
+    <div className="flex flex-col gap-5 border-t pt-6">
+      <Explanation className="gap-1">
+        <ExplanationHeader className="text-score">
+          <BrainIcon aria-hidden />
+          <ExplanationTitle>{t("What is Brain Power?")}</ExplanationTitle>
+        </ExplanationHeader>
 
-      <ExplanationText>
-        {t(
-          "Brain Power (BP) represents how much you have learned. You earn {brainPower} BP after each lesson you complete. It never goes down because knowledge is not something anyone can take from you.",
-          { brainPower: String(BRAIN_POWER_PER_LESSON) },
-        )}
-      </ExplanationText>
+        <ExplanationText>
+          {t(
+            "Brain Power (BP) is the total learning credit you have earned. Each completed lesson adds {brainPower} BP.",
+            { brainPower: String(BRAIN_POWER_PER_LESSON) },
+          )}
+        </ExplanationText>
+      </Explanation>
 
-      <ExplanationText>
-        {t(
-          "The more Brain Power you have, the more knowledge you have built. You do not lose Brain Power when your Energy drops or when you miss days.",
-        )}
-      </ExplanationText>
+      <Explanation className="gap-1">
+        <ExplanationTitle>{t("How do I increase Brain Power?")}</ExplanationTitle>
 
-      <ExplanationText>
-        {t(
-          "Brain Power is like martial arts for your mind: the more you study, the stronger it gets. You start as a white belt and can work your way up to black belt.",
-        )}
-      </ExplanationText>
-    </Explanation>
+        <ExplanationText>
+          {t(
+            "Complete lessons. Brain Power never goes down, even when your Energy drops or you take a break.",
+          )}
+        </ExplanationText>
+      </Explanation>
+
+      <Explanation className="gap-1">
+        <ExplanationTitle>{t("Why is Brain Power important?")}</ExplanationTitle>
+
+        <ExplanationText>
+          {t(
+            "It is like steps in a health app: a record of how much you have learned. It also works like martial arts for your mind: build Brain Power to move from white belt toward black belt in knowledge.",
+          )}
+        </ExplanationText>
+      </Explanation>
+    </div>
   );
 }

--- a/apps/main/src/app/(progress)/score/score-content.tsx
+++ b/apps/main/src/app/(progress)/score/score-content.tsx
@@ -1,10 +1,10 @@
 import { getScoreHistory } from "@/data/progress/get-score-history";
 import { getSession } from "@zoonk/core/users/session/get";
-import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { validatePeriod } from "@zoonk/utils/date-ranges";
 import { getLocale } from "next-intl/server";
 import { ProgressChartSkeleton } from "../_components/progress-chart-skeleton";
 import { ProgressEmptyState } from "../_components/progress-empty-state";
+import { ProgressExplanationSkeleton } from "../_components/progress-explanation-skeleton";
 import { ScoreChart } from "./score-chart";
 import { ScoreExplanation } from "./score-explanation";
 import { ScoreInsights, ScoreInsightsSkeleton } from "./score-insights";
@@ -71,12 +71,7 @@ export function ScoreContentSkeleton() {
       <ScoreStatsSkeleton />
       <ProgressChartSkeleton />
       <ScoreInsightsSkeleton />
-
-      <div className="flex flex-col gap-2">
-        <Skeleton className="h-4 w-36" />
-        <Skeleton className="h-5 w-64" />
-        <Skeleton className="h-4 w-full" />
-      </div>
+      <ProgressExplanationSkeleton />
     </div>
   );
 }

--- a/apps/main/src/app/(progress)/score/score-explanation.tsx
+++ b/apps/main/src/app/(progress)/score/score-explanation.tsx
@@ -11,17 +11,37 @@ export async function ScoreExplanation() {
   const t = await getExtracted();
 
   return (
-    <Explanation className="gap-1 border-t pt-6">
-      <ExplanationHeader className="text-score">
-        <Target aria-hidden />
-        <ExplanationTitle>{t("About Score")}</ExplanationTitle>
-      </ExplanationHeader>
+    <div className="flex flex-col gap-5 border-t pt-6">
+      <Explanation className="gap-1">
+        <ExplanationHeader className="text-score">
+          <Target aria-hidden />
+          <ExplanationTitle>{t("What is Score?")}</ExplanationTitle>
+        </ExplanationHeader>
 
-      <ExplanationText className="leading-relaxed">
-        {t(
-          "Your score shows the percentage of questions you answered correctly. It helps you track your accuracy over time and identify your best days and times for learning.",
-        )}
-      </ExplanationText>
-    </Explanation>
+        <ExplanationText>
+          {t("Score is the percentage of questions you answered correctly during this period.")}
+        </ExplanationText>
+      </Explanation>
+
+      <Explanation className="gap-1">
+        <ExplanationTitle>{t("How do I improve Score?")}</ExplanationTitle>
+
+        <ExplanationText>
+          {t(
+            "Review mistakes and retry lessons. As you answer more questions correctly, your Score goes up.",
+          )}
+        </ExplanationText>
+      </Explanation>
+
+      <Explanation className="gap-1">
+        <ExplanationTitle>{t("Why is Score important?")}</ExplanationTitle>
+
+        <ExplanationText>
+          {t(
+            "Score shows accuracy, not activity. Best day and best time help you find when you learn most effectively.",
+          )}
+        </ExplanationText>
+      </Explanation>
+    </div>
   );
 }


### PR DESCRIPTION
Clarifies Energy, Brain Power, and Score explanations by splitting each into focused sections. Updates localized copy and adds e2e coverage for the new explanation structure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split Energy, Brain Power, and Score explanations into three clear sections to make metrics easier to understand. Added a shared loading skeleton and refreshed EN/ES/PT copy with new e2e coverage.

- **New Features**
  - Three-part explanations on `/energy`, `/level`, and `/score`: “What is…”, “How do I improve…”, and “Why is … important?” with clearer guidance (e.g., Energy is not a streak; Brain Power never goes down; Score shows accuracy).
  - Added `ProgressExplanationSkeleton` and used it in Energy/Level/Score skeletons for consistent loading states.
  - Updated translations in `apps/main/messages/en.po`, `es.po`, and `pt.po`.
  - Expanded e2e tests to assert new section headings and key phrases on each page.

<sup>Written for commit 6f887a3dc7272a7fc327d4b95d2aa367bb41b846. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

