### PR TITLE
feat(main): add progress insight cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,8 @@ page.getByLabel(/email/i);
 - Use `getExtracted` (server) or `useExtracted` (client) for translations, don't use `getTranslations` or `useTranslations`
 - Pass string literals, never variables or keys (e.g., `getExtracted("Hello world")`, not `getExtracted(greeting)` nor `getExtracted("greeting")`)
 - **NEVER pass `t` / `getExtracted` / `useExtracted` as a function argument, prop, or store it in a variable to call later.** Always call `t("literal")` directly in the component. If you need translated text in a helper, use conditionals in the component: `verdict === "correct" ? t("Correct!") : t("Not quite")`
+- Always use ICU standards for translation, see the [next-intl docs](https://next-intl.dev/docs/usage/translations)
+- For plural text, always use ICU plural syntax in one message (e.g., `{count, plural, one {# item} other {# items}}`) instead of branching in code or creating separate singular/plural strings
 - Translation strings are extracted to PO files automatically when running `pnpm --filter {app} build`
 - After extracting messages, translate empty strings in PO files maintaining consistency with terms used in the app
 - When using `render` prop with base-ui components (e.g., `useRender`), use `ClientLink` instead of `Link` since the render prop requires a client component

--- a/apps/main/e2e/_utils/progress-insight-date.ts
+++ b/apps/main/e2e/_utils/progress-insight-date.ts
@@ -1,0 +1,16 @@
+/**
+ * Progress insight fixtures seed their winning rows on the current UTC day.
+ * Formatting that day here the same way as the page keeps value assertions
+ * stable when the test suite runs on a different calendar date.
+ */
+export function getCurrentUtcProgressInsightDateLabel(): string {
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+
+  return new Intl.DateTimeFormat("en", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(today);
+}

--- a/apps/main/e2e/energy.test.ts
+++ b/apps/main/e2e/energy.test.ts
@@ -1,3 +1,4 @@
+import { getCurrentUtcProgressInsightDateLabel } from "./_utils/progress-insight-date";
 import { expect, test } from "./fixtures";
 
 test.describe("Energy Page", () => {
@@ -43,6 +44,22 @@ test.describe("Energy Page", () => {
 
       await expect(authenticatedPage.getByText(/current energy/iu)).toBeVisible();
       await expect(authenticatedPage.getByText(/% average/iu)).toBeVisible();
+    });
+
+    test("displays current-month energy insight values", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/energy");
+
+      const highestEnergyCard = authenticatedPage.getByRole("article", {
+        name: /highest energy day/iu,
+      });
+
+      const fullEnergyCard = authenticatedPage.getByRole("article", { name: /full energy/iu });
+      const todayLabel = getCurrentUtcProgressInsightDateLabel();
+
+      await expect(highestEnergyCard).toContainText(`${todayLabel} with 100%`);
+      await expect(highestEnergyCard).toContainText("This month");
+      await expect(fullEnergyCard).toContainText("1 day");
+      await expect(fullEnergyCard).toContainText("This month");
     });
 
     test("switching to 6 months shows different comparison text", async ({ authenticatedPage }) => {

--- a/apps/main/e2e/level.test.ts
+++ b/apps/main/e2e/level.test.ts
@@ -1,3 +1,4 @@
+import { getCurrentUtcProgressInsightDateLabel } from "./_utils/progress-insight-date";
 import { expect, test } from "./fixtures";
 
 test.describe("Level Page", () => {
@@ -53,6 +54,19 @@ test.describe("Level Page", () => {
       await expect(authenticatedPage.getByText(/belt progression/iu)).toBeVisible();
 
       await expect(authenticatedPage.getByRole("progressbar")).toBeVisible();
+    });
+
+    test("displays current-month level insight values", async ({ authenticatedPage }) => {
+      await authenticatedPage.goto("/level");
+
+      const highestBpCard = authenticatedPage.getByRole("article", { name: /highest bp/iu });
+      const learningDaysCard = authenticatedPage.getByRole("article", { name: /learning days/iu });
+      const todayLabel = getCurrentUtcProgressInsightDateLabel();
+
+      await expect(highestBpCard).toContainText(`${todayLabel} with 250 BP`);
+      await expect(highestBpCard).toContainText("This month");
+      await expect(learningDaysCard).toContainText("1 day");
+      await expect(learningDaysCard).toContainText("This month");
     });
 
     test("switching to 6 months shows different comparison text", async ({ authenticatedPage }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -137,6 +137,7 @@ msgid "HHFpcy"
 msgstr "Best day"
 
 #: src/app/(catalog)/(home)/best-day.tsx
+#: src/app/(progress)/energy/energy-insights.tsx
 #: src/app/(progress)/score/score-insights.tsx
 msgid "bcsugq"
 msgstr "{day} with {value}%"
@@ -614,8 +615,9 @@ msgid "R9qHBU"
 msgstr "vs last 6 months"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "HOfw3D"
-msgstr "all time"
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "s+lPP3"
+msgstr "All time"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "YFV6dH"
@@ -657,6 +659,10 @@ msgstr "Year"
 msgid "OlW5Z8"
 msgstr "No data available for this period"
 
+#: src/app/(progress)/_components/progress-day-count-label.ts
+msgid "xcWsw2"
+msgstr "{count, plural, one {# day} other {# days}}"
+
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "FVh2Tr"
 msgstr "Start learning to track your progress"
@@ -664,6 +670,18 @@ msgstr "Start learning to track your progress"
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "Y1zzQt"
 msgstr "Log in to track your progress"
+
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "J3fNDZ"
+msgstr "This month"
+
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "eWUXBX"
+msgstr "Past 6 months"
+
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "lPShsT"
+msgstr "This year"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
 msgid "M+JIpD"
@@ -697,6 +715,14 @@ msgstr "Why is Energy important?"
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "TRcArs"
 msgstr "Energy is like heart rate in a health app: it shows your current learning rhythm. It is not a streak; missing a day does not reset it, and you can recover when you come back."
+
+#: src/app/(progress)/energy/energy-insights.tsx
+msgid "XxS+he"
+msgstr "Highest energy day"
+
+#: src/app/(progress)/energy/energy-insights.tsx
+msgid "aaiQkv"
+msgstr "Full energy"
 
 #: src/app/(progress)/energy/energy-stats.tsx
 msgid "zLCmVM"
@@ -749,6 +775,18 @@ msgstr "Why is Brain Power important?"
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "6g8QfE"
 msgstr "It is like steps in a health app: a record of how much you have learned. It also works like martial arts for your mind: build Brain Power to move from white belt toward black belt in knowledge."
+
+#: src/app/(progress)/level/level-insights.tsx
+msgid "elq+tg"
+msgstr "Highest BP"
+
+#: src/app/(progress)/level/level-insights.tsx
+msgid "BW4bMl"
+msgstr "{date} with {value} BP"
+
+#: src/app/(progress)/level/level-insights.tsx
+msgid "8F6teD"
+msgstr "Learning days"
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "VHH0kD"
@@ -829,18 +867,6 @@ msgstr "Why is Score important?"
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "E0saoA"
 msgstr "Score shows accuracy, not activity. Best day and best time help you find when you learn most effectively."
-
-#: src/app/(progress)/score/score-insights.tsx
-msgid "J3fNDZ"
-msgstr "This month"
-
-#: src/app/(progress)/score/score-insights.tsx
-msgid "eWUXBX"
-msgstr "Past 6 months"
-
-#: src/app/(progress)/score/score-insights.tsx
-msgid "lPShsT"
-msgstr "This year"
 
 #: src/app/(settings)/_components/protected-section.tsx
 #: src/components/auth/login-required.tsx

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -660,8 +660,8 @@ msgid "OlW5Z8"
 msgstr "No data available for this period"
 
 #: src/app/(progress)/_components/progress-day-count-label.ts
-msgid "xcWsw2"
-msgstr "{count, plural, one {# day} other {# days}}"
+msgid "r9koty"
+msgstr "{count, plural, =0 {# days} one {# day} other {# days}}"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "FVh2Tr"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -137,6 +137,7 @@ msgid "HHFpcy"
 msgstr "Mejor día"
 
 #: src/app/(catalog)/(home)/best-day.tsx
+#: src/app/(progress)/energy/energy-insights.tsx
 #: src/app/(progress)/score/score-insights.tsx
 msgid "bcsugq"
 msgstr "{day} con {value}%"
@@ -614,8 +615,9 @@ msgid "R9qHBU"
 msgstr "vs últimos 6 meses"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "HOfw3D"
-msgstr "todo el tiempo"
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "s+lPP3"
+msgstr "Todo el tiempo"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "YFV6dH"
@@ -657,6 +659,10 @@ msgstr "Año"
 msgid "OlW5Z8"
 msgstr "No hay datos disponibles para este período"
 
+#: src/app/(progress)/_components/progress-day-count-label.ts
+msgid "xcWsw2"
+msgstr "{count, plural, one {# día} other {# días}}"
+
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "FVh2Tr"
 msgstr "Empieza a aprender para seguir tu progreso"
@@ -664,6 +670,18 @@ msgstr "Empieza a aprender para seguir tu progreso"
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "Y1zzQt"
 msgstr "Inicia sesión para seguir tu progreso"
+
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "J3fNDZ"
+msgstr "Este mes"
+
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "eWUXBX"
+msgstr "Últimos 6 meses"
+
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "lPShsT"
+msgstr "Este año"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
 msgid "M+JIpD"
@@ -697,6 +715,14 @@ msgstr "¿Por qué es importante la energía?"
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "TRcArs"
 msgstr "La energía es como la frecuencia cardíaca en una app de salud: muestra el ritmo actual de tu aprendizaje. No es una racha; pasar un día sin estudiar no la pone en cero, y puedes recuperarla cuando vuelves."
+
+#: src/app/(progress)/energy/energy-insights.tsx
+msgid "XxS+he"
+msgstr "Día con más energía"
+
+#: src/app/(progress)/energy/energy-insights.tsx
+msgid "aaiQkv"
+msgstr "Energía completa"
 
 #: src/app/(progress)/energy/energy-stats.tsx
 msgid "zLCmVM"
@@ -749,6 +775,18 @@ msgstr "¿Por qué es importante el Poder Mental?"
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "6g8QfE"
 msgstr "Es como los pasos en una app de salud: un registro de cuánto has aprendido. También funciona como artes marciales para la mente: aumenta tu Poder Mental para pasar del cinturón blanco al cinturón negro del conocimiento."
+
+#: src/app/(progress)/level/level-insights.tsx
+msgid "elq+tg"
+msgstr "Mayor PM"
+
+#: src/app/(progress)/level/level-insights.tsx
+msgid "BW4bMl"
+msgstr "{date} con {value} PM"
+
+#: src/app/(progress)/level/level-insights.tsx
+msgid "8F6teD"
+msgstr "Días de aprendizaje"
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "VHH0kD"
@@ -829,18 +867,6 @@ msgstr "¿Por qué son importantes los aciertos?"
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "E0saoA"
 msgstr "Los aciertos muestran precisión, no actividad. El mejor día y la mejor hora te ayudan a encontrar cuándo aprendes mejor."
-
-#: src/app/(progress)/score/score-insights.tsx
-msgid "J3fNDZ"
-msgstr "Este mes"
-
-#: src/app/(progress)/score/score-insights.tsx
-msgid "eWUXBX"
-msgstr "Últimos 6 meses"
-
-#: src/app/(progress)/score/score-insights.tsx
-msgid "lPShsT"
-msgstr "Este año"
 
 #: src/app/(settings)/_components/protected-section.tsx
 #: src/components/auth/login-required.tsx

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -660,8 +660,8 @@ msgid "OlW5Z8"
 msgstr "No hay datos disponibles para este período"
 
 #: src/app/(progress)/_components/progress-day-count-label.ts
-msgid "xcWsw2"
-msgstr "{count, plural, one {# día} other {# días}}"
+msgid "r9koty"
+msgstr "{count, plural, =0 {# días} one {# día} other {# días}}"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "FVh2Tr"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -137,6 +137,7 @@ msgid "HHFpcy"
 msgstr "Melhor dia"
 
 #: src/app/(catalog)/(home)/best-day.tsx
+#: src/app/(progress)/energy/energy-insights.tsx
 #: src/app/(progress)/score/score-insights.tsx
 msgid "bcsugq"
 msgstr "{day} com {value}%"
@@ -614,8 +615,9 @@ msgid "R9qHBU"
 msgstr "vs últimos 6 meses"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "HOfw3D"
-msgstr "todo o período"
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "s+lPP3"
+msgstr "Todo o período"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "YFV6dH"
@@ -657,6 +659,10 @@ msgstr "Ano"
 msgid "OlW5Z8"
 msgstr "Nenhum dado disponível para este período"
 
+#: src/app/(progress)/_components/progress-day-count-label.ts
+msgid "xcWsw2"
+msgstr "{count, plural, one {# dia} other {# dias}}"
+
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "FVh2Tr"
 msgstr "Comece a aprender para acompanhar seu progresso"
@@ -664,6 +670,18 @@ msgstr "Comece a aprender para acompanhar seu progresso"
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "Y1zzQt"
 msgstr "Entre para acompanhar seu progresso"
+
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "J3fNDZ"
+msgstr "Este mês"
+
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "eWUXBX"
+msgstr "Últimos 6 meses"
+
+#: src/app/(progress)/_components/progress-insight-period-label.ts
+msgid "lPShsT"
+msgstr "Este ano"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
 msgid "M+JIpD"
@@ -697,6 +715,14 @@ msgstr "Por que a Energia importa?"
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "TRcArs"
 msgstr "A Energia é como a frequência cardíaca em um app de saúde: mostra o ritmo atual do seu aprendizado. Ela não é uma sequência; ficar um dia sem estudar não zera a Energia, e você pode recuperar quando voltar."
+
+#: src/app/(progress)/energy/energy-insights.tsx
+msgid "XxS+he"
+msgstr "Dia de maior energia"
+
+#: src/app/(progress)/energy/energy-insights.tsx
+msgid "aaiQkv"
+msgstr "Energia completa"
 
 #: src/app/(progress)/energy/energy-stats.tsx
 msgid "zLCmVM"
@@ -749,6 +775,18 @@ msgstr "Por que o Poder Mental importa?"
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "6g8QfE"
 msgstr "Ele é como os passos em um app de saúde: um registro do quanto você aprendeu. Também funciona como artes marciais para a mente: aumente seu Poder Mental para sair da faixa branca e chegar à faixa preta do conhecimento."
+
+#: src/app/(progress)/level/level-insights.tsx
+msgid "elq+tg"
+msgstr "Maior PM"
+
+#: src/app/(progress)/level/level-insights.tsx
+msgid "BW4bMl"
+msgstr "{date} com {value} PM"
+
+#: src/app/(progress)/level/level-insights.tsx
+msgid "8F6teD"
+msgstr "Dias de aprendizado"
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "VHH0kD"
@@ -829,18 +867,6 @@ msgstr "Por que os acertos importam?"
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "E0saoA"
 msgstr "Os acertos mostram precisão, não atividade. Melhor dia e melhor horário ajudam você a encontrar quando aprende melhor."
-
-#: src/app/(progress)/score/score-insights.tsx
-msgid "J3fNDZ"
-msgstr "Este mês"
-
-#: src/app/(progress)/score/score-insights.tsx
-msgid "eWUXBX"
-msgstr "Últimos 6 meses"
-
-#: src/app/(progress)/score/score-insights.tsx
-msgid "lPShsT"
-msgstr "Este ano"
 
 #: src/app/(settings)/_components/protected-section.tsx
 #: src/components/auth/login-required.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -661,7 +661,7 @@ msgstr "Nenhum dado disponível para este período"
 
 #: src/app/(progress)/_components/progress-day-count-label.ts
 msgid "xcWsw2"
-msgstr "{count, plural, one {# dia} other {# dias}}"
+msgstr "{count, plural, =0 {# dias} one {# dia} other {# dias}}"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "FVh2Tr"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -660,7 +660,7 @@ msgid "OlW5Z8"
 msgstr "Nenhum dado disponível para este período"
 
 #: src/app/(progress)/_components/progress-day-count-label.ts
-msgid "xcWsw2"
+msgid "r9koty"
 msgstr "{count, plural, =0 {# dias} one {# dia} other {# dias}}"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx

--- a/apps/main/src/app/(progress)/_components/metric-comparison.tsx
+++ b/apps/main/src/app/(progress)/_components/metric-comparison.tsx
@@ -40,7 +40,7 @@ export async function MetricComparison({
     }
 
     if (period === "all") {
-      return t("all time");
+      return t("All time");
     }
 
     return t("vs last year");
@@ -56,7 +56,7 @@ export async function MetricComparison({
       <Icon aria-hidden className="size-4 shrink-0" />
       <span className="whitespace-nowrap">
         <span>{t("{value}%", { value: formattedChange })}</span>
-        <span className="hidden sm:inline"> {getComparisonLabel()}</span>
+        <span className="hidden lowercase sm:inline"> {getComparisonLabel()}</span>
       </span>
     </div>
   );

--- a/apps/main/src/app/(progress)/_components/progress-day-count-label.ts
+++ b/apps/main/src/app/(progress)/_components/progress-day-count-label.ts
@@ -1,0 +1,12 @@
+import { getExtracted } from "next-intl/server";
+
+/**
+ * Insight cards use day counts in multiple metrics. Keeping this as one ICU
+ * plural message lets each locale choose its own grammar instead of branching
+ * between English singular and plural strings in application code.
+ */
+export async function getProgressDayCountLabel({ count }: { count: number }): Promise<string> {
+  const t = await getExtracted();
+
+  return t("{count, plural, one {# day} other {# days}}", { count });
+}

--- a/apps/main/src/app/(progress)/_components/progress-day-count-label.ts
+++ b/apps/main/src/app/(progress)/_components/progress-day-count-label.ts
@@ -8,5 +8,5 @@ import { getExtracted } from "next-intl/server";
 export async function getProgressDayCountLabel({ count }: { count: number }): Promise<string> {
   const t = await getExtracted();
 
-  return t("{count, plural, one {# day} other {# days}}", { count });
+  return t("{count, plural, =0 {# days} one {# day} other {# days}}", { count });
 }

--- a/apps/main/src/app/(progress)/_components/progress-insight-period-label.ts
+++ b/apps/main/src/app/(progress)/_components/progress-insight-period-label.ts
@@ -1,0 +1,28 @@
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
+import { getExtracted } from "next-intl/server";
+
+/**
+ * Insight card subtitles should describe the selected history window in short,
+ * plain language instead of repeating the chart axis label.
+ */
+export async function getProgressInsightPeriodLabel({
+  period,
+}: {
+  period: HistoryPeriod;
+}): Promise<string> {
+  const t = await getExtracted();
+
+  if (period === "month") {
+    return t("This month");
+  }
+
+  if (period === "6months") {
+    return t("Past 6 months");
+  }
+
+  if (period === "all") {
+    return t("All time");
+  }
+
+  return t("This year");
+}

--- a/apps/main/src/app/(progress)/energy/energy-content.tsx
+++ b/apps/main/src/app/(progress)/energy/energy-content.tsx
@@ -7,6 +7,7 @@ import { ProgressEmptyState } from "../_components/progress-empty-state";
 import { ProgressExplanationSkeleton } from "../_components/progress-explanation-skeleton";
 import { EnergyChart } from "./energy-chart";
 import { EnergyExplanation } from "./energy-explanation";
+import { EnergyInsights, EnergyInsightsSkeleton } from "./energy-insights";
 import { EnergyStats, EnergyStatsSkeleton } from "./energy-stats";
 
 export async function EnergyContent({
@@ -54,6 +55,12 @@ export async function EnergyContent({
         periodStart={data.periodStart}
       />
 
+      <EnergyInsights
+        period={validPeriod}
+        periodEnd={data.periodEnd}
+        periodStart={data.periodStart}
+      />
+
       <EnergyExplanation />
     </div>
   );
@@ -64,6 +71,7 @@ export function EnergyContentSkeleton() {
     <div className="flex flex-col gap-8">
       <EnergyStatsSkeleton />
       <ProgressChartSkeleton />
+      <EnergyInsightsSkeleton />
       <ProgressExplanationSkeleton />
     </div>
   );

--- a/apps/main/src/app/(progress)/energy/energy-insights.tsx
+++ b/apps/main/src/app/(progress)/energy/energy-insights.tsx
@@ -1,0 +1,158 @@
+import { getEnergyInsights } from "@/data/progress/get-energy-insights";
+import {
+  FeatureCard,
+  FeatureCardBody,
+  FeatureCardHeader,
+  FeatureCardHeaderContent,
+  FeatureCardIcon,
+  FeatureCardLabel,
+  FeatureCardSubtitle,
+  FeatureCardTitle,
+} from "@zoonk/ui/components/feature";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
+import { CalendarDays, ZapIcon } from "lucide-react";
+import { getExtracted, getLocale } from "next-intl/server";
+import { getProgressDayCountLabel } from "../_components/progress-day-count-label";
+import { getProgressInsightPeriodLabel } from "../_components/progress-insight-period-label";
+
+/**
+ * Energy insights mirror the score-page card pattern while answering energy
+ * questions that are more useful than another chart value.
+ */
+export async function EnergyInsights({
+  period,
+  periodEnd,
+  periodStart,
+}: {
+  period: HistoryPeriod;
+  periodEnd: Date;
+  periodStart: Date;
+}) {
+  const locale = await getLocale();
+  const insights = await getEnergyInsights({ endDate: periodEnd, startDate: periodStart });
+
+  if (!insights) {
+    return null;
+  }
+
+  const periodLabel = await getProgressInsightPeriodLabel({ period });
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <HighestEnergyDayCard
+        date={insights.highestEnergyDay.date}
+        energy={insights.highestEnergyDay.energy}
+        locale={locale}
+        periodLabel={periodLabel}
+      />
+
+      <FullEnergyCard count={insights.fullEnergyDays} periodLabel={periodLabel} />
+    </div>
+  );
+}
+
+/**
+ * The highest-energy card highlights the exact calendar day, with ties resolved
+ * by the data helper so the UI only formats the winning row.
+ */
+async function HighestEnergyDayCard({
+  date,
+  energy,
+  locale,
+  periodLabel,
+}: {
+  date: Date;
+  energy: number;
+  locale: string;
+  periodLabel: string;
+}) {
+  const t = await getExtracted();
+
+  const formattedDate = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(date);
+
+  const formattedEnergy = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 1,
+    trailingZeroDisplay: "stripIfInteger",
+  }).format(energy);
+
+  return (
+    <FeatureCard aria-labelledby="energy-highest-day-label">
+      <FeatureCardHeader className="text-energy">
+        <FeatureCardHeaderContent>
+          <FeatureCardIcon>
+            <CalendarDays />
+          </FeatureCardIcon>
+          <FeatureCardLabel id="energy-highest-day-label">
+            {t("Highest energy day")}
+          </FeatureCardLabel>
+        </FeatureCardHeaderContent>
+      </FeatureCardHeader>
+
+      <FeatureCardBody>
+        <FeatureCardTitle>
+          {t("{day} with {value}%", { day: formattedDate, value: formattedEnergy })}
+        </FeatureCardTitle>
+        <FeatureCardSubtitle>{periodLabel}</FeatureCardSubtitle>
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}
+
+/**
+ * Full-energy days are useful even at zero because they tell the learner how
+ * often they kept Energy capped during the selected window.
+ */
+async function FullEnergyCard({ count, periodLabel }: { count: number; periodLabel: string }) {
+  const t = await getExtracted();
+  const countLabel = await getProgressDayCountLabel({ count });
+
+  return (
+    <FeatureCard aria-labelledby="energy-full-energy-label">
+      <FeatureCardHeader className="text-energy">
+        <FeatureCardHeaderContent>
+          <FeatureCardIcon>
+            <ZapIcon />
+          </FeatureCardIcon>
+          <FeatureCardLabel id="energy-full-energy-label">{t("Full energy")}</FeatureCardLabel>
+        </FeatureCardHeaderContent>
+      </FeatureCardHeader>
+
+      <FeatureCardBody>
+        <FeatureCardTitle>{countLabel}</FeatureCardTitle>
+        <FeatureCardSubtitle>{periodLabel}</FeatureCardSubtitle>
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}
+
+/**
+ * Keep the loading layout the same size as the loaded insight cards so the
+ * progress page does not jump when server data resolves.
+ */
+export function EnergyInsightsSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <FeatureCard className="w-full">
+        <Skeleton className="h-5 w-36" />
+        <FeatureCardBody className="gap-1">
+          <Skeleton className="h-4 w-full max-w-44" />
+          <Skeleton className="h-3 w-full max-w-28" />
+        </FeatureCardBody>
+      </FeatureCard>
+
+      <FeatureCard className="w-full">
+        <Skeleton className="h-5 w-24" />
+        <FeatureCardBody className="gap-1">
+          <Skeleton className="h-4 w-full max-w-28" />
+          <Skeleton className="h-3 w-full max-w-28" />
+        </FeatureCardBody>
+      </FeatureCard>
+    </div>
+  );
+}

--- a/apps/main/src/app/(progress)/level/level-content.tsx
+++ b/apps/main/src/app/(progress)/level/level-content.tsx
@@ -7,6 +7,7 @@ import { ProgressEmptyState } from "../_components/progress-empty-state";
 import { ProgressExplanationSkeleton } from "../_components/progress-explanation-skeleton";
 import { LevelChart } from "./level-chart";
 import { LevelExplanation } from "./level-explanation";
+import { LevelInsights, LevelInsightsSkeleton } from "./level-insights";
 import { LevelProgression, LevelProgressionSkeleton } from "./level-progression";
 import { LevelStats, LevelStatsSkeleton } from "./level-stats";
 
@@ -56,6 +57,12 @@ export async function LevelContent({
         periodTotal={data.periodTotal}
       />
 
+      <LevelInsights
+        period={validPeriod}
+        periodEnd={data.periodEnd}
+        periodStart={data.periodStart}
+      />
+
       <LevelProgression currentBelt={data.currentBelt} />
 
       <LevelExplanation />
@@ -68,6 +75,7 @@ export function LevelContentSkeleton() {
     <div className="flex flex-col gap-8">
       <LevelStatsSkeleton />
       <ProgressChartSkeleton />
+      <LevelInsightsSkeleton />
       <LevelProgressionSkeleton />
       <ProgressExplanationSkeleton />
     </div>

--- a/apps/main/src/app/(progress)/level/level-insights.tsx
+++ b/apps/main/src/app/(progress)/level/level-insights.tsx
@@ -1,0 +1,154 @@
+import { getLevelInsights } from "@/data/progress/get-level-insights";
+import {
+  FeatureCard,
+  FeatureCardBody,
+  FeatureCardHeader,
+  FeatureCardHeaderContent,
+  FeatureCardIcon,
+  FeatureCardLabel,
+  FeatureCardSubtitle,
+  FeatureCardTitle,
+} from "@zoonk/ui/components/feature";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
+import { BrainIcon, CalendarDays } from "lucide-react";
+import { getExtracted, getLocale } from "next-intl/server";
+import { getProgressDayCountLabel } from "../_components/progress-day-count-label";
+import { getProgressInsightPeriodLabel } from "../_components/progress-insight-period-label";
+
+/**
+ * Level insights add calendar context to Brain Power: the best learning day and
+ * how often the learner completed at least one lesson in the selected window.
+ */
+export async function LevelInsights({
+  period,
+  periodEnd,
+  periodStart,
+}: {
+  period: HistoryPeriod;
+  periodEnd: Date;
+  periodStart: Date;
+}) {
+  const locale = await getLocale();
+  const insights = await getLevelInsights({ endDate: periodEnd, startDate: periodStart });
+
+  if (!insights) {
+    return null;
+  }
+
+  const periodLabel = await getProgressInsightPeriodLabel({ period });
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      {insights.highestBpDay && (
+        <HighestBpCard
+          brainPower={insights.highestBpDay.brainPower}
+          date={insights.highestBpDay.date}
+          locale={locale}
+          periodLabel={periodLabel}
+        />
+      )}
+
+      <LearningDaysCard count={insights.learningDays} periodLabel={periodLabel} />
+    </div>
+  );
+}
+
+/**
+ * Highest BP points to the single strongest learning day, so the learner can
+ * connect Brain Power with a concrete date rather than only an aggregate.
+ */
+async function HighestBpCard({
+  brainPower,
+  date,
+  locale,
+  periodLabel,
+}: {
+  brainPower: number;
+  date: Date;
+  locale: string;
+  periodLabel: string;
+}) {
+  const t = await getExtracted();
+
+  const formattedDate = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(date);
+
+  const formattedBrainPower = new Intl.NumberFormat(locale).format(brainPower);
+
+  return (
+    <FeatureCard aria-labelledby="level-highest-bp-label">
+      <FeatureCardHeader>
+        <FeatureCardHeaderContent>
+          <FeatureCardIcon>
+            <BrainIcon />
+          </FeatureCardIcon>
+          <FeatureCardLabel id="level-highest-bp-label">{t("Highest BP")}</FeatureCardLabel>
+        </FeatureCardHeaderContent>
+      </FeatureCardHeader>
+
+      <FeatureCardBody>
+        <FeatureCardTitle>
+          {t("{date} with {value} BP", { date: formattedDate, value: formattedBrainPower })}
+        </FeatureCardTitle>
+        <FeatureCardSubtitle>{periodLabel}</FeatureCardSubtitle>
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}
+
+/**
+ * Learning days counts completed-lesson calendar days, not raw attempts, so it
+ * stays focused on meaningful learning sessions.
+ */
+async function LearningDaysCard({ count, periodLabel }: { count: number; periodLabel: string }) {
+  const t = await getExtracted();
+  const countLabel = await getProgressDayCountLabel({ count });
+
+  return (
+    <FeatureCard aria-labelledby="level-learning-days-label">
+      <FeatureCardHeader>
+        <FeatureCardHeaderContent>
+          <FeatureCardIcon>
+            <CalendarDays />
+          </FeatureCardIcon>
+          <FeatureCardLabel id="level-learning-days-label">{t("Learning days")}</FeatureCardLabel>
+        </FeatureCardHeaderContent>
+      </FeatureCardHeader>
+
+      <FeatureCardBody>
+        <FeatureCardTitle>{countLabel}</FeatureCardTitle>
+        <FeatureCardSubtitle>{periodLabel}</FeatureCardSubtitle>
+      </FeatureCardBody>
+    </FeatureCard>
+  );
+}
+
+/**
+ * Keep the Level page skeleton aligned with the two loaded insight cards.
+ */
+export function LevelInsightsSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <FeatureCard className="w-full">
+        <Skeleton className="h-5 w-24" />
+        <FeatureCardBody className="gap-1">
+          <Skeleton className="h-4 w-full max-w-44" />
+          <Skeleton className="h-3 w-full max-w-28" />
+        </FeatureCardBody>
+      </FeatureCard>
+
+      <FeatureCard className="w-full">
+        <Skeleton className="h-5 w-28" />
+        <FeatureCardBody className="gap-1">
+          <Skeleton className="h-4 w-full max-w-28" />
+          <Skeleton className="h-3 w-full max-w-28" />
+        </FeatureCardBody>
+      </FeatureCard>
+    </div>
+  );
+}

--- a/apps/main/src/app/(progress)/score/score-insights.tsx
+++ b/apps/main/src/app/(progress)/score/score-insights.tsx
@@ -15,20 +15,7 @@ import { EPOCH_YEAR, FIRST_SUNDAY_OFFSET } from "@zoonk/utils/date";
 import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 import { CalendarDays, Clock } from "lucide-react";
 import { getExtracted, getLocale } from "next-intl/server";
-
-async function getPeriodLabel(period: HistoryPeriod): Promise<string> {
-  const t = await getExtracted();
-
-  if (period === "month") {
-    return t("This month");
-  }
-
-  if (period === "6months") {
-    return t("Past 6 months");
-  }
-
-  return t("This year");
-}
+import { getProgressInsightPeriodLabel } from "../_components/progress-insight-period-label";
 
 export async function ScoreInsights({
   period,
@@ -41,15 +28,16 @@ export async function ScoreInsights({
 }) {
   const locale = await getLocale();
 
-  const [bestDayData, bestTimeData, periodLabel] = await Promise.all([
+  const [bestDayData, bestTimeData] = await Promise.all([
     getBestDay({ endDate: periodEnd, startDate: periodStart }),
     getBestTime({ endDate: periodEnd, startDate: periodStart }),
-    getPeriodLabel(period),
   ]);
 
   if (!(bestDayData || bestTimeData)) {
     return null;
   }
+
+  const periodLabel = await getProgressInsightPeriodLabel({ period });
 
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/apps/main/src/data/progress/_utils/progress-date-filter.ts
+++ b/apps/main/src/data/progress/_utils/progress-date-filter.ts
@@ -1,0 +1,24 @@
+import { getDefaultStartDate } from "@zoonk/utils/date-ranges";
+
+/**
+ * Progress insight queries share the same optional closed date window. Keeping
+ * the default lookback and optional end boundary here prevents Energy and Level
+ * cards from drifting apart when their selected-period contract changes.
+ */
+export function getProgressDateFilter({
+  endDateIso,
+  startDateIso,
+}: {
+  endDateIso?: string;
+  startDateIso?: string;
+}) {
+  const startDate = getDefaultStartDate(startDateIso);
+
+  if (endDateIso) {
+    return { gte: startDate, lte: new Date(endDateIso) };
+  }
+
+  return { gte: startDate };
+}
+
+export type ProgressDateFilter = ReturnType<typeof getProgressDateFilter>;

--- a/apps/main/src/data/progress/get-energy-insights.test.ts
+++ b/apps/main/src/data/progress/get-energy-insights.test.ts
@@ -1,0 +1,50 @@
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, it } from "vitest";
+import { getEnergyInsights } from "./get-energy-insights";
+
+describe("unauthenticated users", () => {
+  it("returns null", async () => {
+    const result = await getEnergyInsights({ headers: new Headers() });
+    expect(result).toBeNull();
+  });
+});
+
+describe("authenticated users", () => {
+  it("returns null when user has no DailyProgress records", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getEnergyInsights({ headers });
+    expect(result).toBeNull();
+  });
+
+  it("returns the most recent highest energy day and full energy days for the period", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    await prisma.dailyProgress.createMany({
+      data: [
+        { date: new Date("2025-01-05T00:00:00Z"), dayOfWeek: 0, energyAtEnd: 100, userId: user.id },
+        { date: new Date("2025-01-10T00:00:00Z"), dayOfWeek: 5, energyAtEnd: 88, userId: user.id },
+        { date: new Date("2025-01-15T00:00:00Z"), dayOfWeek: 3, energyAtEnd: 100, userId: user.id },
+        { date: new Date("2025-02-01T00:00:00Z"), dayOfWeek: 6, energyAtEnd: 100, userId: user.id },
+      ],
+    });
+
+    const result = await getEnergyInsights({
+      endDate: new Date("2025-01-31T23:59:59.999Z"),
+      headers,
+      startDate: new Date("2025-01-01T00:00:00Z"),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.fullEnergyDays).toBe(2);
+
+    expect(result?.highestEnergyDay).toStrictEqual({
+      date: new Date("2025-01-15T00:00:00Z"),
+      energy: 100,
+    });
+  });
+});

--- a/apps/main/src/data/progress/get-energy-insights.ts
+++ b/apps/main/src/data/progress/get-energy-insights.ts
@@ -1,0 +1,76 @@
+import "server-only";
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+import { getProgressDateFilter } from "./_utils/progress-date-filter";
+
+type HighestEnergyDayData = { date: Date; energy: number };
+type EnergyInsightsData = { fullEnergyDays: number; highestEnergyDay: HighestEnergyDayData };
+
+/**
+ * The page needs compact card data, not raw DailyProgress rows. Returning null
+ * only when no period row exists keeps a zero full-energy count visible for
+ * learners who had progress but did not reach 100%.
+ */
+function buildEnergyInsights({
+  fullEnergyDays,
+  highestEnergyDay,
+}: {
+  fullEnergyDays: number;
+  highestEnergyDay: { date: Date; energyAtEnd: number } | null;
+}): EnergyInsightsData | null {
+  if (!highestEnergyDay) {
+    return null;
+  }
+
+  return {
+    fullEnergyDays,
+    highestEnergyDay: { date: highestEnergyDay.date, energy: highestEnergyDay.energyAtEnd },
+  };
+}
+
+const cachedGetEnergyInsights = cache(
+  async (
+    startDateIso?: string,
+    endDateIso?: string,
+    headers?: Headers,
+  ): Promise<EnergyInsightsData | null> => {
+    const session = await getSession(headers);
+
+    if (!session) {
+      return null;
+    }
+
+    const userId = session.user.id;
+    const dateFilter = getProgressDateFilter({ endDateIso, startDateIso });
+
+    const [highestEnergyDay, fullEnergyDays] = await Promise.all([
+      prisma.dailyProgress.findFirst({
+        orderBy: [{ energyAtEnd: "desc" }, { date: "desc" }],
+        where: { date: dateFilter, userId },
+      }),
+      prisma.dailyProgress.count({
+        where: { date: dateFilter, energyAtEnd: { gte: 100 }, userId },
+      }),
+    ]);
+
+    return buildEnergyInsights({ fullEnergyDays, highestEnergyDay });
+  },
+);
+
+/**
+ * Energy insight cards share the score-page date contract: callers may provide
+ * an explicit history window, otherwise the query uses the default recent
+ * lookback used by progress summaries.
+ */
+export function getEnergyInsights(params?: {
+  endDate?: Date;
+  headers?: Headers;
+  startDate?: Date;
+}): Promise<EnergyInsightsData | null> {
+  return cachedGetEnergyInsights(
+    params?.startDate?.toISOString(),
+    params?.endDate?.toISOString(),
+    params?.headers,
+  );
+}

--- a/apps/main/src/data/progress/get-level-insights.test.ts
+++ b/apps/main/src/data/progress/get-level-insights.test.ts
@@ -1,0 +1,75 @@
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, it } from "vitest";
+import { getLevelInsights } from "./get-level-insights";
+
+describe("unauthenticated users", () => {
+  it("returns null", async () => {
+    const result = await getLevelInsights({ headers: new Headers() });
+    expect(result).toBeNull();
+  });
+});
+
+describe("authenticated users", () => {
+  it("returns null when user has no DailyProgress records", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getLevelInsights({ headers });
+    expect(result).toBeNull();
+  });
+
+  it("returns the most recent highest BP day and learning days for the period", async () => {
+    const user = await userFixture();
+    const headers = await signInAs(user.email, user.password);
+
+    await prisma.dailyProgress.createMany({
+      data: [
+        {
+          brainPowerEarned: 40,
+          date: new Date("2025-01-05T00:00:00Z"),
+          dayOfWeek: 0,
+          staticCompleted: 1,
+          userId: user.id,
+        },
+        {
+          brainPowerEarned: 75,
+          date: new Date("2025-01-06T00:00:00Z"),
+          dayOfWeek: 1,
+          interactiveCompleted: 1,
+          userId: user.id,
+        },
+        {
+          brainPowerEarned: 75,
+          date: new Date("2025-01-10T00:00:00Z"),
+          dayOfWeek: 5,
+          staticCompleted: 1,
+          userId: user.id,
+        },
+        {
+          brainPowerEarned: 100,
+          date: new Date("2025-02-01T00:00:00Z"),
+          dayOfWeek: 6,
+          interactiveCompleted: 1,
+          userId: user.id,
+        },
+      ],
+    });
+
+    const result = await getLevelInsights({
+      endDate: new Date("2025-01-31T23:59:59.999Z"),
+      headers,
+      startDate: new Date("2025-01-01T00:00:00Z"),
+    });
+
+    expect(result).not.toBeNull();
+
+    expect(result?.highestBpDay).toStrictEqual({
+      brainPower: 75,
+      date: new Date("2025-01-10T00:00:00Z"),
+    });
+
+    expect(result?.learningDays).toBe(3);
+  });
+});

--- a/apps/main/src/data/progress/get-level-insights.ts
+++ b/apps/main/src/data/progress/get-level-insights.ts
@@ -1,0 +1,97 @@
+import "server-only";
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+import { type ProgressDateFilter, getProgressDateFilter } from "./_utils/progress-date-filter";
+
+type HighestBpDayData = { brainPower: number; date: Date };
+type LevelInsightsData = { highestBpDay: HighestBpDayData | null; learningDays: number };
+
+/**
+ * DailyProgress stores the learner's local calendar day and completion counts.
+ * Counting those rows matches the admin learning-days stat and avoids drifting
+ * when server-side LessonProgress timestamps cross a local day boundary.
+ */
+function getCompletedLessonDayWhere({
+  dateFilter,
+  userId,
+}: {
+  dateFilter: ProgressDateFilter;
+  userId: string;
+}) {
+  return {
+    OR: [{ interactiveCompleted: { gt: 0 } }, { staticCompleted: { gt: 0 } }],
+    date: dateFilter,
+    userId,
+  };
+}
+
+/**
+ * A period can have progress rows without any BP earned, for example when only
+ * energy decay rows exist. In that case the learning-day card can still report
+ * zero while the highest-BP card stays hidden.
+ */
+function buildLevelInsights({
+  highestBpDay,
+  learningDays,
+  periodProgress,
+}: {
+  highestBpDay: { brainPowerEarned: number; date: Date } | null;
+  learningDays: number;
+  periodProgress: { date: Date } | null;
+}): LevelInsightsData | null {
+  if (!periodProgress) {
+    return null;
+  }
+
+  return {
+    highestBpDay: highestBpDay
+      ? { brainPower: highestBpDay.brainPowerEarned, date: highestBpDay.date }
+      : null,
+    learningDays,
+  };
+}
+
+const cachedGetLevelInsights = cache(
+  async (
+    startDateIso?: string,
+    endDateIso?: string,
+    headers?: Headers,
+  ): Promise<LevelInsightsData | null> => {
+    const session = await getSession(headers);
+
+    if (!session) {
+      return null;
+    }
+
+    const userId = session.user.id;
+    const dateFilter = getProgressDateFilter({ endDateIso, startDateIso });
+
+    const [periodProgress, highestBpDay, learningDays] = await Promise.all([
+      prisma.dailyProgress.findFirst({ where: { date: dateFilter, userId } }),
+      prisma.dailyProgress.findFirst({
+        orderBy: [{ brainPowerEarned: "desc" }, { date: "desc" }],
+        where: { brainPowerEarned: { gt: 0 }, date: dateFilter, userId },
+      }),
+      prisma.dailyProgress.count({ where: getCompletedLessonDayWhere({ dateFilter, userId }) }),
+    ]);
+
+    return buildLevelInsights({ highestBpDay, learningDays, periodProgress });
+  },
+);
+
+/**
+ * Level insight cards share the selected period window with the Brain Power
+ * chart. The optional params keep the helper usable for rolling summaries too.
+ */
+export function getLevelInsights(params?: {
+  endDate?: Date;
+  headers?: Headers;
+  startDate?: Date;
+}): Promise<LevelInsightsData | null> {
+  return cachedGetLevelInsights(
+    params?.startDate?.toISOString(),
+    params?.endDate?.toISOString(),
+    params?.headers,
+  );
+}

--- a/packages/e2e/src/fixtures/progress.ts
+++ b/packages/e2e/src/fixtures/progress.ts
@@ -13,6 +13,7 @@ const DAYS_PER_GROUP = 5;
 const CURRENT_MONTH_CORRECT = 17;
 const PREVIOUS_MONTH_CORRECT = 13;
 const CURRENT_MONTH_ENERGY = 75;
+const CURRENT_MONTH_FULL_ENERGY = 100;
 const PREVIOUS_MONTH_ENERGY = 65;
 const CURRENT_MONTH_INCORRECT = 3;
 const PREVIOUS_MONTH_INCORRECT = 7;
@@ -20,6 +21,30 @@ const COMPLETED_LESSON_DURATION_SECONDS = 120;
 const COMPLETED_LESSON_START_OFFSET_SECONDS = 180;
 
 const ALL_PERIODS = ["month", "6months", "year"] as const;
+
+/**
+ * The authenticated e2e user needs one visible full-energy day so the Energy
+ * insight card proves a non-zero count without changing the broader chart data.
+ */
+function getEnergyAtEnd({ dayIndex, isCurrent }: { dayIndex: number; isCurrent: boolean }) {
+  if (isCurrent && dayIndex === 0) {
+    return CURRENT_MONTH_FULL_ENERGY;
+  }
+
+  return isCurrent ? CURRENT_MONTH_ENERGY : PREVIOUS_MONTH_ENERGY;
+}
+
+/**
+ * The Level learning-days card counts DailyProgress completion rows, so the
+ * fixture marks the same current-day row that represents the completed lesson.
+ */
+function getStaticCompleted({ dayIndex, isCurrent }: { dayIndex: number; isCurrent: boolean }) {
+  if (isCurrent && dayIndex === 0) {
+    return 1;
+  }
+
+  return 0;
+}
 
 /**
  * Build a small but stable group of dates for a reporting window.
@@ -32,9 +57,9 @@ function buildGroupDates(today: Date, range: { start: Date; end: Date }, isCurre
   const midpoint = new Date(midpointMs);
   const baseDate = isCurrent ? today : midpoint;
 
-  return Array.from({ length: DAYS_PER_GROUP }, (_, i) => {
+  return Array.from({ length: DAYS_PER_GROUP }, (_, dayIndex) => {
     const date = new Date(
-      Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth(), baseDate.getUTCDate() - i),
+      Date.UTC(baseDate.getUTCFullYear(), baseDate.getUTCMonth(), baseDate.getUTCDate() - dayIndex),
     );
 
     if (date < range.start || date > range.end) {
@@ -45,8 +70,9 @@ function buildGroupDates(today: Date, range: { start: Date; end: Date }, isCurre
       brainPowerEarned: 250,
       correctAnswers: isCurrent ? CURRENT_MONTH_CORRECT : PREVIOUS_MONTH_CORRECT,
       date,
-      energyAtEnd: isCurrent ? CURRENT_MONTH_ENERGY : PREVIOUS_MONTH_ENERGY,
+      energyAtEnd: getEnergyAtEnd({ dayIndex, isCurrent }),
       incorrectAnswers: isCurrent ? CURRENT_MONTH_INCORRECT : PREVIOUS_MONTH_INCORRECT,
+      staticCompleted: getStaticCompleted({ dayIndex, isCurrent }),
     };
   }).filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 }

--- a/packages/testing/src/fixtures/progress.ts
+++ b/packages/testing/src/fixtures/progress.ts
@@ -11,7 +11,9 @@ export async function dailyProgressFixtureMany(
     correctAnswers?: number;
     date: Date;
     energyAtEnd?: number;
+    interactiveCompleted?: number;
     incorrectAnswers?: number;
+    staticCompleted?: number;
     userId: string;
   }[],
 ) {
@@ -23,6 +25,8 @@ export async function dailyProgressFixtureMany(
       dayOfWeek: input.date.getDay(),
       energyAtEnd: input.energyAtEnd ?? 0,
       incorrectAnswers: input.incorrectAnswers ?? 0,
+      interactiveCompleted: input.interactiveCompleted ?? 0,
+      staticCompleted: input.staticCompleted ?? 0,
       userId: input.userId,
     })),
   });


### PR DESCRIPTION
Adds Energy and Level insight cards for highest activity days and completion-day counts.

Also shares period/day-count labels, updates progress e2e coverage, and keeps progress comparison translations consistent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds progress insight cards on Energy and Level pages to highlight best day and day counts. Centralizes period/day labels, updates tests, and defines zero‑day plural labels.

- **New Features**
  - Energy: Highest energy day and Full energy days cards powered by `get-energy-insights` (UTC date formatting, cached queries).
  - Level: Highest BP day and Learning days cards powered by `get-level-insights`.
  - Shared helpers: `progress-insight-period-label` and `progress-day-count-label` (ICU plural via `next-intl`).
  - Insight skeletons to avoid layout shift; stable e2e coverage with a date-label util and fixtures updated to seed a full-energy and a completed-lesson day.
  - Shared date filter for insight queries.

- **Refactors**
  - Score insights now use the shared period label helper.
  - Standardized comparison labels: lowercase trailing text and “All time” in metric comparison.
  - Updated `en/es/pt` PO files to ICU plural syntax with zero-day labels and new strings; added translation guidelines in AGENTS.md.

<sup>Written for commit 427a1160c8ddf099c929f71b580db41a86c0534a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

