### PR TITLE
fix(player): show tablet static step arrows

### DIFF
--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -1,10 +1,13 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { page } from "vitest/browser";
+import { cdp, page } from "vitest/browser";
+import { runInTabletLandscapePlayerViewport } from "../_test-utils/browser-viewport";
 import { buildInlineImageUrl } from "../_test-utils/build-inline-image-url";
 import { buildSerializedLesson, buildSerializedStep } from "../_test-utils/player-test-data";
 import { buildAuthenticatedViewer } from "../_test-utils/player-test-viewer";
 import { buildNavigation, renderPlayer } from "../_test-utils/render-player";
+
+type CdpClient = { send: (method: string, params?: unknown) => Promise<unknown> };
 
 function buildTouch({
   identifier,
@@ -18,6 +21,42 @@ function buildTouch({
   y: number;
 }) {
   return new Touch({ clientX: x, clientY: y, identifier, target });
+}
+
+/**
+ * CDP touch emulation lets this browser test recreate a real landscape tablet:
+ * the viewport has large-screen width, but CSS still evaluates
+ * `(pointer: coarse)` like it does on touch-first hardware.
+ */
+async function emulatePointer(pointer: "coarse" | null) {
+  const client = cdp() as CdpClient;
+
+  if (pointer === "coarse") {
+    await client.send("Emulation.setTouchEmulationEnabled", { enabled: true, maxTouchPoints: 5 });
+    return;
+  }
+
+  await client.send("Emulation.setTouchEmulationEnabled", { enabled: false });
+}
+
+/**
+ * Resets emulated pointer behavior after a targeted pointer test so later browser
+ * tests continue to run with the provider's default desktop environment.
+ */
+async function runWithPointerMedia({
+  pointer,
+  run,
+}: {
+  pointer: "coarse";
+  run: () => Promise<void>;
+}) {
+  await emulatePointer(pointer);
+
+  try {
+    await run();
+  } finally {
+    await emulatePointer(null);
+  }
 }
 
 function swipeLeft(target: HTMLElement) {
@@ -208,6 +247,52 @@ describe("player browser integration: static steps", () => {
     await page.getByRole("button", { name: /^Previous$/u }).click();
 
     await expect.element(page.getByRole("heading", { name: "First step" })).toBeInTheDocument();
+  });
+
+  it("shows arrow navigation on landscape tablets", async () => {
+    await runInTabletLandscapePlayerViewport(async () => {
+      await runWithPointerMedia({
+        pointer: "coarse",
+        run: async () => {
+          expect(globalThis.matchMedia("(pointer: coarse)").matches).toBe(true);
+
+          renderPlayer({
+            lesson: buildSerializedLesson({
+              kind: "explanation",
+              steps: [
+                buildSerializedStep({
+                  content: { text: "First body", title: "First step", variant: "text" as const },
+                  id: "static-tablet-landscape-1",
+                }),
+                buildSerializedStep({
+                  content: { text: "Second body", title: "Second step", variant: "text" as const },
+                  id: "static-tablet-landscape-2",
+                  position: 1,
+                }),
+              ],
+            }),
+            navigation: buildNavigation({ nextLessonHref: null }),
+            viewer: buildAuthenticatedViewer(),
+          });
+
+          await expect
+            .element(page.getByRole("heading", { name: "First step" }))
+            .toBeInTheDocument();
+
+          await page.getByRole("button", { name: /^Next step$/u }).click();
+
+          await expect
+            .element(page.getByRole("heading", { name: "Second step" }))
+            .toBeInTheDocument();
+
+          await page.getByRole("button", { name: /^Previous step$/u }).click();
+
+          await expect
+            .element(page.getByRole("heading", { name: "First step" }))
+            .toBeInTheDocument();
+        },
+      });
+    });
   });
 
   it("renders grammar example static variants through the shared shell", async () => {

--- a/packages/player/src/_test-utils/browser-viewport.ts
+++ b/packages/player/src/_test-utils/browser-viewport.ts
@@ -2,6 +2,7 @@ import { page } from "vitest/browser";
 
 const DEFAULT_DESKTOP_VIEWPORT = { height: 720, width: 1280 };
 const MOBILE_PLAYER_VIEWPORT = { height: 844, width: 390 };
+const TABLET_LANDSCAPE_PLAYER_VIEWPORT = { height: 768, width: 1024 };
 
 /**
  * Mobile player controls are intentionally hidden at desktop breakpoints. This
@@ -10,6 +11,24 @@ const MOBILE_PLAYER_VIEWPORT = { height: 844, width: 390 };
  */
 export async function runInMobilePlayerViewport(run: () => Promise<void>) {
   await page.viewport(MOBILE_PLAYER_VIEWPORT.width, MOBILE_PLAYER_VIEWPORT.height);
+
+  try {
+    await run();
+  } finally {
+    await page.viewport(DEFAULT_DESKTOP_VIEWPORT.width, DEFAULT_DESKTOP_VIEWPORT.height);
+  }
+}
+
+/**
+ * Recreates the first large-screen breakpoint on a common landscape tablet.
+ * Static-step arrows and the mobile bottom bar meet at this width, so this
+ * viewport catches gaps where neither navigation surface is visible.
+ */
+export async function runInTabletLandscapePlayerViewport(run: () => Promise<void>) {
+  await page.viewport(
+    TABLET_LANDSCAPE_PLAYER_VIEWPORT.width,
+    TABLET_LANDSCAPE_PLAYER_VIEWPORT.height,
+  );
 
   try {
     await run();

--- a/packages/player/src/components/swipe-navigable-step-layout.tsx
+++ b/packages/player/src/components/swipe-navigable-step-layout.tsx
@@ -31,9 +31,9 @@ function getNavigableFrameClass(frame: SwipeNavigableStepFrame) {
 
 /**
  * Desktop read screens still benefit from a visible navigation affordance, but
- * touch screens use the surface for swipe navigation. Keeping these controls
- * pointer-fine only avoids competing with the mobile gesture model while giving
- * keyboard users a discoverable mouse target.
+ * small touch screens use the surface for swipe navigation. The visibility
+ * should follow the same width breakpoint as the bottom bar so landscape
+ * tablets do not lose both explicit navigation surfaces.
  */
 function DesktopNavigationButton({
   "aria-label": ariaLabel,
@@ -51,7 +51,7 @@ function DesktopNavigationButton({
       aria-label={ariaLabel}
       aria-keyshortcuts={side === "previous" ? "ArrowLeft" : "ArrowRight"}
       className={cn(
-        "bg-background/95 text-foreground border-border/70 ring-border/30 hover:bg-background hover:border-border absolute top-1/2 z-20 hidden size-11 -translate-y-1/2 opacity-95 shadow-lg ring-1 shadow-black/5 backdrop-blur-md transition-[background-color,border-color,color,opacity,scale,box-shadow] hover:opacity-100 hover:shadow-xl focus-visible:opacity-100 lg:flex pointer-coarse:hidden [&_svg]:size-5",
+        "bg-background/95 text-foreground border-border/70 ring-border/30 hover:bg-background hover:border-border absolute top-1/2 z-20 hidden size-11 -translate-y-1/2 opacity-95 shadow-lg ring-1 shadow-black/5 backdrop-blur-md transition-[background-color,border-color,color,opacity,scale,box-shadow] hover:opacity-100 hover:shadow-xl focus-visible:opacity-100 lg:flex [&_svg]:size-5",
         side === "previous" ? "left-4 xl:left-6" : "right-4 xl:right-6",
       )}
       onClick={onClick}


### PR DESCRIPTION
## Summary

- show static-step side arrows on landscape tablets by matching the desktop width breakpoint
- add browser coverage for coarse-pointer tablet landscape navigation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore previous/next arrows on landscape tablets by matching the desktop width breakpoint, so navigation stays visible when the mobile bottom bar is hidden. Adds browser coverage for coarse-pointer tablet landscape navigation.

- **Bug Fixes**
  - Show static-step arrows at the `lg` breakpoint on all pointers by removing `pointer-coarse:hidden` in `swipe-navigable-step-layout`.
  - Add tablet landscape viewport helper and CDP touch emulation in `packages/player` browser tests to verify arrow behavior.

<sup>Written for commit 0781d6a2102c9a4f3cdf0f4abcfe551fed4720a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

