### PR TITLE
fix(main): remove completed belt labels

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -805,10 +805,6 @@ msgid "ZKbTsS"
 msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "JXdbo8"
-msgstr "Done"
-
-#: src/app/(progress)/level/level-progression.tsx
 msgid "FM+wHG"
 msgstr "Level {current} of 10 in {color} belt"
 

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -805,10 +805,6 @@ msgid "ZKbTsS"
 msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "JXdbo8"
-msgstr "Listo"
-
-#: src/app/(progress)/level/level-progression.tsx
 msgid "FM+wHG"
 msgstr "Nivel {current} de 10 en cinturón {color}"
 

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -805,10 +805,6 @@ msgid "ZKbTsS"
 msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "JXdbo8"
-msgstr "Pronto"
-
-#: src/app/(progress)/level/level-progression.tsx
 msgid "FM+wHG"
 msgstr "Nível {current} de 10 na faixa {color}"
 

--- a/apps/main/src/app/(progress)/level/level-progression.tsx
+++ b/apps/main/src/app/(progress)/level/level-progression.tsx
@@ -61,18 +61,11 @@ export async function LevelProgression({ currentBelt }: { currentBelt: BeltLevel
                   />
                 </div>
 
-                <span
-                  className={cn(
-                    "text-xs tabular-nums",
-                    isCurrent && "text-foreground font-medium",
-                    isPast && "text-muted-foreground/50",
-                    isFuture && "invisible",
-                  )}
-                >
-                  {isCurrent
-                    ? t("{current}/10", { current: String(currentBelt.level) })
-                    : t("Done")}
-                </span>
+                {isCurrent && (
+                  <span className="text-foreground text-xs font-medium tabular-nums">
+                    {t("{current}/10", { current: String(currentBelt.level) })}
+                  </span>
+                )}
               </div>
             );
           })}


### PR DESCRIPTION
## Summary

- remove visible Done labels from completed belts in the level progression
- keep the progression state available through the existing accessible progress label

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Done" label from completed belts in level progression. Only the current belt shows its count.

- **Bug Fixes**
  - Kept progress state available via the existing accessible label.
  - Removed unused "Done" translations in `en`, `es`, and `pt`.

<sup>Written for commit 32f597f44682ae3db84e25c32f98959a66c29dce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

