### PR TITLE
feat(blog): add lessons structure post

### DIFF
--- a/apps/blog/src/app/(post)/2026/how-zoonk-lessons-work/page.mdx
+++ b/apps/blog/src/app/(post)/2026/how-zoonk-lessons-work/page.mdx
@@ -1,0 +1,71 @@
+import { PostMeta } from "@/components/post-meta";
+
+export const metadata = {
+  description:
+    "How core lessons work in Zoonk: explanations, practice, quizzes, and reviews create a simple loop for understanding, applying, testing, and revisiting mistakes.",
+  title: "How Zoonk lessons work",
+};
+
+# How Zoonk lessons work
+
+<PostMeta date="June 7, 2026" authorId="will" />
+
+Zoonk lessons are built around a simple loop:
+
+**explain -> practice -> test**
+
+The goal is not to turn learning into a long article or a list of facts to memorize. The goal is to help you understand an idea, use it in a real situation, and check whether it actually stuck.
+
+## Explanation
+
+An explanation lesson is where the concept becomes clear.
+
+It uses everyday language, practical examples, and concrete details. The point is not to make the subject feel academic or distant. The point is to make it understandable without removing the real substance.
+
+A good explanation should help you answer basic questions:
+
+- What is this?
+- How does it work?
+- Why does it matter?
+- Where does it show up in real life?
+
+If a lesson needs a formula, rule, term, diagram, or technical detail, it should include it. But it should explain the detail in plain language first, so the formal part has something to attach to.
+
+## Practice
+
+Every explanation is followed by practice.
+
+Practice lessons take the idea and put it inside a real problem or situation. Instead of asking you to repeat the explanation, they ask you to use it.
+
+That might mean reading a small chart, inspecting a receipt, comparing a few clues, choosing what to do next, or solving a practical problem with someone in the scene.
+
+This matters because understanding is not the same as recognizing words. A concept becomes useful when you can apply it outside the exact example where you learned it.
+
+## Quiz
+
+After every two practice lessons, there is a quiz.
+
+The quiz checks whether the concepts are holding together. It uses new situations, not just the same examples again, because the point is to test transferable understanding.
+
+Quizzes are short on purpose. They should help you notice what is clear, what is shaky, and what needs another pass.
+
+## Review
+
+At the end of a chapter, there is a review.
+
+Review lessons focus on your mistakes. If you missed something earlier, the review brings it back so you can practice it again while the chapter is still fresh.
+
+When there are not enough mistakes to review, Zoonk can include other useful questions from the chapter too. The point is still the same: spend your effort where it helps most.
+
+## Why this structure exists
+
+Learning works better when each step has a clear job.
+
+Explanations make the idea understandable.
+Practice makes the idea usable.
+Quizzes check whether the idea transferred.
+Reviews bring back what needs more attention.
+
+That structure keeps lessons from becoming passive. You are not just reading through content and hoping it sticks. You are connecting the idea to real situations, so you can understand why it matters and where you can use it.
+
+That is the goal: learn something because it makes sense, not just because you need to remember it for a test.

--- a/apps/blog/src/app/posts.json
+++ b/apps/blog/src/app/posts.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "2026/how-zoonk-lessons-work",
+    "date": "June 7, 2026",
+    "title": "How Zoonk lessons work",
+    "authorId": "will"
+  },
+  {
     "id": "2026/learning-anything",
     "date": "May 26, 2026",
     "title": "Learning anything with Zoonk",


### PR DESCRIPTION
## Summary
- Add a new blog post explaining how Zoonk lessons are structured around explanation, practice, quiz, and review
- Register the post in the blog index so it appears in the posts list
- Frame the ending around real-life relevance and understanding, not memorization

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new blog post explaining how Zoonk lessons work: explain → practice → quiz → review. Register the post in the blog index so it appears in the posts list.

<sup>Written for commit 2b41393bdbda527660ad1249bb0d8b09212be067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

