### PR TITLE
fix(api): handle better auth email login errors

### DIFF
--- a/apps/api/e2e/login.test.ts
+++ b/apps/api/e2e/login.test.ts
@@ -19,4 +19,17 @@ test.describe("Login Page", () => {
 
     await expect(page.getByRole("button", { name: /continue with apple/iu })).toBeVisible();
   });
+
+  test("shows a validation error when Better Auth rejects the email", async ({ page }) => {
+    await page.goto("/auth/login");
+
+    const emailInput = page.getByLabel(/email/iu);
+
+    await emailInput.fill("not-an-email");
+    await emailInput.evaluate((input) => input.closest("form")?.setAttribute("novalidate", ""));
+    await page.getByRole("button", { name: /^continue$/iu }).click();
+
+    await expect(page).toHaveURL(/\/auth\/login/u);
+    await expect(page.getByText(/enter a valid email address/iu)).toBeVisible();
+  });
 });

--- a/apps/api/messages/en.po
+++ b/apps/api/messages/en.po
@@ -10,6 +10,29 @@ msgstr ""
 msgid "dVItHD"
 msgstr "Sign in to Zoonk"
 
+#: src/app/auth/login/email-login-form.tsx
+msgid "sy+pv5"
+msgstr "Email"
+
+#: src/app/auth/login/email-login-form.tsx
+msgid "apQW0E"
+msgstr "me@gmail.com"
+
+#: src/app/auth/login/email-login-form.tsx
+msgid "YRe93Y"
+msgstr "Enter a valid email address"
+
+#: src/app/auth/login/email-login-form.tsx
+#: src/app/auth/login/social-login.tsx
+msgid "pN2p0t"
+msgstr "There was an error signing you in. Please try again or contact hello@zoonk.com"
+
+#: src/app/auth/login/email-login-form.tsx
+#: src/app/auth/otp/otp-form.tsx
+#: src/app/auth/setup/setup-form.tsx
+msgid "acrOoz"
+msgstr "Continue"
+
 #: src/app/auth/login/page.tsx
 msgid "eN8MTJ"
 msgstr "Sign in or create an account"
@@ -23,20 +46,6 @@ msgid "4wpUNc"
 msgstr "Or"
 
 #: src/app/auth/login/page.tsx
-msgid "sy+pv5"
-msgstr "Email"
-
-#: src/app/auth/login/page.tsx
-msgid "4nOs3z"
-msgstr "me@myorg.com"
-
-#: src/app/auth/login/page.tsx
-#: src/app/auth/otp/otp-form.tsx
-#: src/app/auth/setup/setup-form.tsx
-msgid "acrOoz"
-msgstr "Continue"
-
-#: src/app/auth/login/page.tsx
 msgid "Ju9oB+"
 msgstr "By clicking on Continue, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>."
 
@@ -47,10 +56,6 @@ msgstr "Continue with Google"
 #: src/app/auth/login/social-login.tsx
 msgid "BmecBA"
 msgstr "Continue with Apple"
-
-#: src/app/auth/login/social-login.tsx
-msgid "pN2p0t"
-msgstr "There was an error signing you in. Please try again or contact hello@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
 msgid "HkHvQv"

--- a/apps/api/messages/es.po
+++ b/apps/api/messages/es.po
@@ -10,6 +10,29 @@ msgstr ""
 msgid "dVItHD"
 msgstr "Inicia sesión en Zoonk"
 
+#: src/app/auth/login/email-login-form.tsx
+msgid "sy+pv5"
+msgstr "Correo electrónico"
+
+#: src/app/auth/login/email-login-form.tsx
+msgid "apQW0E"
+msgstr "yo@gmail.com"
+
+#: src/app/auth/login/email-login-form.tsx
+msgid "YRe93Y"
+msgstr "Ingresa un correo electrónico válido"
+
+#: src/app/auth/login/email-login-form.tsx
+#: src/app/auth/login/social-login.tsx
+msgid "pN2p0t"
+msgstr "Hubo un error al iniciar sesión. Intenta de nuevo o contacta a contacto@zoonk.com"
+
+#: src/app/auth/login/email-login-form.tsx
+#: src/app/auth/otp/otp-form.tsx
+#: src/app/auth/setup/setup-form.tsx
+msgid "acrOoz"
+msgstr "Continuar"
+
 #: src/app/auth/login/page.tsx
 msgid "eN8MTJ"
 msgstr "Inicia sesión o crea una cuenta"
@@ -23,20 +46,6 @@ msgid "4wpUNc"
 msgstr "O"
 
 #: src/app/auth/login/page.tsx
-msgid "sy+pv5"
-msgstr "Correo electrónico"
-
-#: src/app/auth/login/page.tsx
-msgid "4nOs3z"
-msgstr "yo@miempresa.com"
-
-#: src/app/auth/login/page.tsx
-#: src/app/auth/otp/otp-form.tsx
-#: src/app/auth/setup/setup-form.tsx
-msgid "acrOoz"
-msgstr "Continuar"
-
-#: src/app/auth/login/page.tsx
 msgid "Ju9oB+"
 msgstr "Al hacer clic en Continuar, aceptas nuestros <terms>Términos de servicio</terms> y <privacy>Política de privacidad</privacy>."
 
@@ -47,10 +56,6 @@ msgstr "Continuar con Google"
 #: src/app/auth/login/social-login.tsx
 msgid "BmecBA"
 msgstr "Continuar con Apple"
-
-#: src/app/auth/login/social-login.tsx
-msgid "pN2p0t"
-msgstr "Hubo un error al iniciar sesión. Intenta de nuevo o contacta a contacto@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
 msgid "HkHvQv"

--- a/apps/api/messages/pt.po
+++ b/apps/api/messages/pt.po
@@ -10,6 +10,29 @@ msgstr ""
 msgid "dVItHD"
 msgstr "Entrar no Zoonk"
 
+#: src/app/auth/login/email-login-form.tsx
+msgid "sy+pv5"
+msgstr "Email"
+
+#: src/app/auth/login/email-login-form.tsx
+msgid "apQW0E"
+msgstr "eu@gmail.com"
+
+#: src/app/auth/login/email-login-form.tsx
+msgid "YRe93Y"
+msgstr "Digite um email válido"
+
+#: src/app/auth/login/email-login-form.tsx
+#: src/app/auth/login/social-login.tsx
+msgid "pN2p0t"
+msgstr "Houve um erro ao conectar você. Por favor, tente novamente ou entre em contato com contato@zoonk.com"
+
+#: src/app/auth/login/email-login-form.tsx
+#: src/app/auth/otp/otp-form.tsx
+#: src/app/auth/setup/setup-form.tsx
+msgid "acrOoz"
+msgstr "Continuar"
+
 #: src/app/auth/login/page.tsx
 msgid "eN8MTJ"
 msgstr "Entre ou crie uma conta"
@@ -23,20 +46,6 @@ msgid "4wpUNc"
 msgstr "Ou"
 
 #: src/app/auth/login/page.tsx
-msgid "sy+pv5"
-msgstr "Email"
-
-#: src/app/auth/login/page.tsx
-msgid "4nOs3z"
-msgstr "eu@minhaempresa.com"
-
-#: src/app/auth/login/page.tsx
-#: src/app/auth/otp/otp-form.tsx
-#: src/app/auth/setup/setup-form.tsx
-msgid "acrOoz"
-msgstr "Continuar"
-
-#: src/app/auth/login/page.tsx
 msgid "Ju9oB+"
 msgstr "Ao clicar em Continuar, você concorda com nossos <terms>Termos de Serviço</terms> e <privacy>Política de Privacidade</privacy>."
 
@@ -47,10 +56,6 @@ msgstr "Continuar com Google"
 #: src/app/auth/login/social-login.tsx
 msgid "BmecBA"
 msgstr "Continuar com Apple"
-
-#: src/app/auth/login/social-login.tsx
-msgid "pN2p0t"
-msgstr "Houve um erro ao conectar você. Por favor, tente novamente ou entre em contato com contato@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
 msgid "HkHvQv"

--- a/apps/api/src/app/auth/login/actions.ts
+++ b/apps/api/src/app/auth/login/actions.ts
@@ -1,19 +1,64 @@
 "use server";
 
+import { getBetterAuthError } from "@/lib/better-auth-errors";
 import { sendVerificationOTP } from "@zoonk/core/users/otp/send";
+import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
-export async function sendVerificationOTPAction(formData: FormData) {
+type VerificationOTPState = { status: "idle" | "invalidEmail" | "error" };
+
+/**
+ * Keeps Better Auth's stricter server-side email validation from becoming a
+ * Server Components crash. Browser validation catches common invalid emails,
+ * but direct POSTs and embedded browsers can still submit values Better Auth
+ * rejects, so the login form needs a normal recoverable state for that case.
+ */
+function getExpectedVerificationOTPErrorState(error: unknown): VerificationOTPState | null {
+  const authError = getBetterAuthError(error);
+
+  if (authError?.code === "INVALID_EMAIL" || authError?.message === "Invalid email") {
+    return { status: "invalidEmail" };
+  }
+
+  return null;
+}
+
+/**
+ * Starts the email OTP login flow while returning form state for validation
+ * errors users can fix immediately. Successful submissions still redirect to
+ * the OTP page, while unexpected auth failures keep throwing so production
+ * monitoring catches real service problems.
+ */
+export async function sendVerificationOTPAction(
+  _previousState: VerificationOTPState,
+  formData: FormData,
+): Promise<VerificationOTPState> {
   const email = parseFormField(formData, "email");
   const redirectTo = parseFormField(formData, "redirectTo");
 
   if (!email) {
-    return;
+    return { status: "invalidEmail" };
   }
 
-  await sendVerificationOTP({ email, headers: await headers() });
+  const { data, error } = await safeAsync(async () =>
+    sendVerificationOTP({ email, headers: await headers() }),
+  );
+
+  if (error) {
+    const expectedState = getExpectedVerificationOTPErrorState(error);
+
+    if (expectedState) {
+      return expectedState;
+    }
+
+    throw error;
+  }
+
+  if (!data.success) {
+    return { status: "error" };
+  }
 
   const params = new URLSearchParams({ email });
 

--- a/apps/api/src/app/auth/login/email-login-form.tsx
+++ b/apps/api/src/app/auth/login/email-login-form.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import {
+  LoginEmailInput,
+  LoginEmailLabel,
+  LoginError,
+  LoginField,
+  LoginForm,
+  LoginSubmit,
+} from "@/components/login";
+import { useExtracted } from "next-intl";
+import { useActionState } from "react";
+import { sendVerificationOTPAction } from "./actions";
+
+const emailErrorId = "login-email-error";
+const initialEmailLoginState = { status: "idle" as const };
+
+/**
+ * Owns the interactive email form because invalid-email feedback comes from
+ * the Server Action result after Better Auth validates the submitted value.
+ * Keeping this as a focused client component lets the login page itself stay a
+ * Server Component while still showing recoverable form errors.
+ */
+export function EmailLoginForm({ redirectTo }: { redirectTo?: string }) {
+  const t = useExtracted();
+  const [state, formAction] = useActionState(sendVerificationOTPAction, initialEmailLoginState);
+  const hasEmailError = state.status === "invalidEmail";
+  const hasGenericError = state.status === "error";
+  const hasError = hasEmailError || hasGenericError;
+
+  return (
+    <LoginForm action={formAction}>
+      <input name="redirectTo" type="hidden" value={redirectTo ?? ""} />
+
+      <LoginField>
+        <LoginEmailLabel>{t("Email")}</LoginEmailLabel>
+        <LoginEmailInput
+          aria-describedby={hasError ? emailErrorId : undefined}
+          aria-invalid={hasError}
+          placeholder={t("me@gmail.com")}
+        />
+      </LoginField>
+
+      <LoginError aria-live="polite" hasError={hasError} id={emailErrorId}>
+        {hasEmailError
+          ? t("Enter a valid email address")
+          : t("There was an error signing you in. Please try again or contact hello@zoonk.com")}
+      </LoginError>
+
+      <LoginSubmit>{t("Continue")}</LoginSubmit>
+    </LoginForm>
+  );
+}

--- a/apps/api/src/app/auth/login/page.tsx
+++ b/apps/api/src/app/auth/login/page.tsx
@@ -2,13 +2,8 @@ import {
   Login,
   LoginDescription,
   LoginDivider,
-  LoginEmailInput,
-  LoginEmailLabel,
-  LoginField,
   LoginFooter,
-  LoginForm,
   LoginHeader,
-  LoginSubmit,
   LoginTitle,
 } from "@/components/login";
 import { getSession } from "@zoonk/core/users/session/get";
@@ -16,7 +11,7 @@ import { FullPageLoading } from "@zoonk/ui/components/loading";
 import { getExtracted } from "next-intl/server";
 import { redirect } from "next/navigation";
 import { type ReactNode, Suspense } from "react";
-import { sendVerificationOTPAction } from "./actions";
+import { EmailLoginForm } from "./email-login-form";
 import { SocialLogin } from "./social-login";
 
 /**
@@ -61,16 +56,7 @@ async function LoginView({ searchParams }: PageProps<"/auth/login">) {
 
       <LoginDivider>{t("Or")}</LoginDivider>
 
-      <LoginForm action={sendVerificationOTPAction}>
-        <input name="redirectTo" type="hidden" value={redirectTo ? String(redirectTo) : ""} />
-
-        <LoginField>
-          <LoginEmailLabel>{t("Email")}</LoginEmailLabel>
-          <LoginEmailInput placeholder={t("me@myorg.com")} />
-        </LoginField>
-
-        <LoginSubmit>{t("Continue")}</LoginSubmit>
-      </LoginForm>
+      <EmailLoginForm redirectTo={redirectTo ? String(redirectTo) : undefined} />
 
       <LoginFooter>
         {t.rich(

--- a/packages/core/src/users/send-otp.ts
+++ b/packages/core/src/users/send-otp.ts
@@ -2,11 +2,13 @@ import "server-only";
 import { auth } from "@zoonk/auth";
 
 /**
- * Send the sign-in OTP through Better Auth.
+ * Send the sign-in OTP through Better Auth and return its delivery result.
  *
  * Better Auth now needs request headers when resolving a dynamic base URL.
  * Accepting the current request headers here keeps login actions aligned with
- * the real incoming host instead of relying on the auth fallback.
+ * the real incoming host instead of relying on the auth fallback. Callers keep
+ * the `success` response so they do not advance to the OTP screen if Better
+ * Auth accepts the request shape but reports that it did not send the code.
  */
 export async function sendVerificationOTP({
   email,
@@ -15,7 +17,5 @@ export async function sendVerificationOTP({
   email: string;
   headers?: Headers;
 }) {
-  const data = await auth.api.sendVerificationOTP({ body: { email, type: "sign-in" }, headers });
-
-  return { data };
+  return auth.api.sendVerificationOTP({ body: { email, type: "sign-in" }, headers });
 }

--- a/packages/player/src/use-player-actions.test.tsx
+++ b/packages/player/src/use-player-actions.test.tsx
@@ -53,10 +53,13 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
 describe(usePlayerActions, () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     globalThis.sessionStorage.clear();
   });
 
   it("stores shown completion milestone keys before persistence returns", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 5, 12));
     globalThis.sessionStorage.clear();
 
     const dispatch = vi.fn();


### PR DESCRIPTION
## Summary
- Keep `/auth/login` from turning Better Auth email validation into an RSC 500
- Show a recoverable email error on the login form instead of redirecting on failure
- Check Better Auth's `success` result before advancing to the OTP screen
- Update the login placeholder to a more familiar Gmail example across API locales

## Testing
- E2E login flow updated with a regression for invalid email handling
- `pnpm --filter api typecheck`
- `pnpm --filter api build:e2e`
- `pnpm --filter api e2e e2e/login.test.ts`
- `pnpm i18n`
- `pnpm format`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Better Auth email validation from crashing `/auth/login` and shows a clear, inline error instead. The form now advances to OTP only when Better Auth reports success.

- **Bug Fixes**
  - Handle Better Auth `INVALID_EMAIL` as a recoverable form state instead of an RSC 500.
  - Check `success` from `sendVerificationOTP` before redirecting to the OTP screen.
  - Add E2E invalid email test and stabilize a player milestone test by freezing the clock.

- **Refactors**
  - Extract `EmailLoginForm` client component using `useActionState` to surface server-side validation errors.
  - Return Better Auth’s response directly from `@zoonk/core` `sendVerificationOTP`; use `safeAsync` from `@zoonk/utils/error` and `getBetterAuthError` in the action.
  - Update i18n strings and placeholders to a familiar Gmail example across locales.

<sup>Written for commit 1080ac09daf11599e000d5b86b0a7de6712ceee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

