### PR TITLE
fix(player): keep tablet arrows clear of static copy

### DIFF
--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -155,6 +155,33 @@ function buildLongStaticText() {
 }
 
 /**
+ * Rich text renders plain text inside inline spans, while the visual collision
+ * risk belongs to the block-level paragraph. Measuring the nearest paragraph
+ * keeps the regression focused on the readable copy box the learner sees.
+ */
+function getMeasuredTextBlock(element: HTMLElement) {
+  return element.closest("p") ?? element;
+}
+
+/**
+ * Desktop side arrows are allowed to float above empty stage space, but they
+ * should never cover readable lesson copy. A small gap gives the focus ring and
+ * touch target room without forcing tablet users back to the bottom bar.
+ */
+function expectHorizontalGap({
+  firstElement,
+  secondElement,
+}: {
+  firstElement: HTMLElement;
+  secondElement: HTMLElement;
+}) {
+  const firstRect = firstElement.getBoundingClientRect();
+  const secondRect = secondElement.getBoundingClientRect();
+
+  expect(secondRect.left).toBeGreaterThanOrEqual(firstRect.right + 8);
+}
+
+/**
  * Long static copy should not rely on the page body to scroll because the
  * player shell owns the viewport. This finds the nearest element that can
  * actually scroll the semantic content the learner is trying to read.
@@ -291,6 +318,45 @@ describe("player browser integration: static steps", () => {
             .element(page.getByRole("heading", { name: "First step" }))
             .toBeInTheDocument();
         },
+      });
+    });
+  });
+
+  it("keeps landscape tablet arrows outside image-backed static copy", async () => {
+    await runInTabletLandscapePlayerViewport(async () => {
+      renderPlayer({
+        lesson: buildSerializedLesson({
+          kind: "explanation",
+          steps: [
+            buildSerializedStep({
+              content: {
+                image: {
+                  prompt: "A tablet-safe static explanation image",
+                  url: buildInlineImageUrl({ label: "A tablet-safe static explanation image" }),
+                },
+                text: "This copy intentionally sits in the media column on a landscape tablet, where the next arrow used to cover the readable paragraph.",
+                title: "Tablet explanation",
+                variant: "text" as const,
+              },
+              id: "static-tablet-copy-safe",
+            }),
+          ],
+        }),
+        navigation: buildNavigation({ nextLessonHref: null }),
+        viewer: buildAuthenticatedViewer(),
+      });
+
+      await expect
+        .element(page.getByRole("heading", { name: "Tablet explanation" }))
+        .toBeInTheDocument();
+
+      const copy = getMeasuredTextBlock(
+        screen.getByText(/next arrow used to cover the readable paragraph/u),
+      );
+
+      expectHorizontalGap({
+        firstElement: copy,
+        secondElement: screen.getByRole("button", { name: /^Next step$/u }),
       });
     });
   });

--- a/packages/player/src/components/step-media-layout.tsx
+++ b/packages/player/src/components/step-media-layout.tsx
@@ -6,8 +6,9 @@ import { StepImageView } from "./step-image";
 /**
  * Static image-led reading steps share one immersive media shell: the image
  * fills the available visual area, while the copy stays anchored below it on
- * mobile and centered beside it on desktop. Keeping that split here prevents
- * static variants from drifting into separate image policies.
+ * mobile and centered beside it on desktop. The desktop copy column reserves a
+ * small right gutter because the navigable side arrow appears at the same
+ * breakpoint and should float over empty stage space, not the text.
  */
 export function StepMediaLayout({
   children,
@@ -26,7 +27,7 @@ export function StepMediaLayout({
       </div>
 
       <div
-        className="bg-background max-h-[45dvh] min-h-0 overflow-y-auto overscroll-contain px-4 py-4 sm:px-6 sm:py-6 lg:flex lg:max-h-none lg:items-center lg:justify-center lg:px-12 lg:py-10"
+        className="bg-background max-h-[45dvh] min-h-0 overflow-y-auto overscroll-contain px-4 py-4 sm:px-6 sm:py-6 lg:flex lg:max-h-none lg:items-center lg:justify-center lg:py-10 lg:pr-20 lg:pl-12"
         data-slot="step-media-copy"
       >
         <div className="mx-auto w-full max-w-2xl lg:mx-0 lg:max-w-md">{children}</div>

--- a/packages/player/src/use-player-actions.test.tsx
+++ b/packages/player/src/use-player-actions.test.tsx
@@ -6,6 +6,7 @@ import {
   getEffectiveCompletionProgressSnapshot,
   getStoredCompletionMilestoneKeys,
 } from "./completion-milestone-storage";
+import { getLocalDate } from "./player-date";
 import { type PlayerState } from "./player-reducer";
 import { usePlayerActions } from "./use-player-actions";
 
@@ -53,6 +54,7 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
 describe(usePlayerActions, () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     globalThis.sessionStorage.clear();
   });
 
@@ -61,8 +63,14 @@ describe(usePlayerActions, () => {
 
     const dispatch = vi.fn();
     const onComplete = vi.fn();
+    const completionDate = new Date(2026, 5, 5, 12);
+    const localDate = getLocalDate(completionDate);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(completionDate);
 
     const state = buildState({
+      localDate,
       phase: "feedback",
       progressSnapshot: {
         currentEnergy: 9.9,
@@ -89,7 +97,7 @@ describe(usePlayerActions, () => {
 
     expect(
       getEffectiveCompletionProgressSnapshot({
-        localDate: "2026-06-05",
+        localDate,
         progressSnapshot: {
           currentEnergy: 9.9,
           fullEnergyDays: 0,


### PR DESCRIPTION
## Summary
- reserve a right-side gutter in the image-led static step layout at desktop breakpoints so the side arrow does not sit over readable copy on landscape tablets
- add a browser regression for the iPad landscape static-step overlap case
- stabilize an unrelated player unit test by freezing the completion date it depends on

## Testing
- `@zoonk/player` browser regression passes
- `@zoonk/player` unit test suite passes
- `@zoonk/player` typecheck passes
- repo lint passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the desktop side arrow from covering static-step text on landscape tablets by reserving a small right gutter in the copy column. Adds a browser regression to lock this behavior and stabilizes a flaky completion test in `@zoonk/player`.

- **Bug Fixes**
  - Layout: adds a right gutter (`lg:pr-20`) to the desktop copy column so the side arrow sits over empty space, not text.
  - Browser test: verifies an 8px+ gap between readable paragraph and the “Next step” button on tablet landscape.
  - Test stability: freezes time and uses `getLocalDate` to make the completion flow test deterministic.

<sup>Written for commit 84d2ed5196354c3319e3a4958bb08c1129747104. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

