### PR TITLE
feat(admin): add user analytics exclusion toggle

### DIFF
--- a/apps/admin/src/app/(private)/users/[id]/_actions/update-user-analytics-disabled.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/update-user-analytics-disabled.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { assertAdmin } from "@/lib/admin-guard";
+import { prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { revalidatePath } from "next/cache";
+
+/**
+ * Admins need a reversible way to remove internal or test accounts from
+ * analytics without changing whether the user can sign in or keep learning.
+ */
+export async function updateUserAnalyticsDisabledAction(formData: FormData) {
+  await assertAdmin();
+
+  const userId = parseFormField(formData, "userId");
+  const analyticsDisabled = parseAnalyticsDisabled(parseFormField(formData, "analyticsDisabled"));
+
+  if (!userId) {
+    throw new Error("Invalid user ID");
+  }
+
+  const { error } = await safeAsync(() =>
+    prisma.user.update({ data: { analyticsDisabled }, where: { id: userId } }),
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  revalidateUserAnalyticsPaths({ userId });
+}
+
+/**
+ * The form sends an explicit string value so the action can reject malformed
+ * submissions instead of treating any unexpected value as enabled or disabled.
+ */
+function parseAnalyticsDisabled(value: string | null) {
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  throw new Error("Invalid analytics setting");
+}
+
+/**
+ * Updating the flag changes both the user detail page and aggregate admin
+ * analytics, so the common dashboard and stats routes should refresh together.
+ */
+function revalidateUserAnalyticsPaths({ userId }: { userId: string }) {
+  revalidatePath(`/users/${userId}`);
+  revalidatePath("/");
+  revalidatePath("/stats");
+  revalidatePath("/stats/growth");
+  revalidatePath("/stats/engagement");
+}

--- a/apps/admin/src/app/(private)/users/[id]/user-account.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-account.tsx
@@ -1,5 +1,7 @@
 import { getUser } from "@/data/users/get-user";
+import { Button } from "@zoonk/ui/components/button";
 import { Separator } from "@zoonk/ui/components/separator";
+import { updateUserAnalyticsDisabledAction } from "./_actions/update-user-analytics-disabled";
 import { DetailField } from "./detail-field";
 
 export async function UserAccount({ userId }: { userId: string }) {
@@ -14,12 +16,19 @@ export async function UserAccount({ userId }: { userId: string }) {
 
   return (
     <section>
-      <h3 className="mb-2 text-sm font-semibold">Account</h3>
+      <div className="mb-2 flex items-center justify-between gap-4">
+        <h3 className="text-sm font-semibold">Account</h3>
+        <AnalyticsTrackingForm analyticsDisabled={user.analyticsDisabled} userId={user.id} />
+      </div>
+
       <Separator />
 
       <dl className="mt-2">
         <DetailField label="Email">{user.email}</DetailField>
         <DetailField label="Email verified">{user.emailVerified ? "Yes" : "No"}</DetailField>
+        <DetailField label="Analytics">
+          {user.analyticsDisabled ? "Excluded" : "Included"}
+        </DetailField>
 
         <DetailField label="Auth providers">
           {providers.length > 0 ? <span className="capitalize">{providers.join(", ")}</span> : "—"}
@@ -35,5 +44,29 @@ export async function UserAccount({ userId }: { userId: string }) {
         </DetailField>
       </dl>
     </section>
+  );
+}
+
+/**
+ * A plain form keeps this admin-only toggle usable without adding client state,
+ * while still sending the exact target state the server action should persist.
+ */
+function AnalyticsTrackingForm({
+  analyticsDisabled,
+  userId,
+}: {
+  analyticsDisabled: boolean;
+  userId: string;
+}) {
+  const nextValue = !analyticsDisabled;
+
+  return (
+    <form action={updateUserAnalyticsDisabledAction}>
+      <input name="userId" type="hidden" value={userId} />
+      <input name="analyticsDisabled" type="hidden" value={String(nextValue)} />
+      <Button size="sm" type="submit" variant="outline">
+        {analyticsDisabled ? "Include in analytics" : "Exclude from analytics"}
+      </Button>
+    </form>
   );
 }

--- a/apps/admin/src/app/(private)/users/[id]/user-header.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-header.tsx
@@ -42,6 +42,7 @@ export async function UserHeader({ userId }: { userId: string }) {
               </Badge>
 
               {user.emailVerified && <Badge variant="secondary">Verified</Badge>}
+              {user.analyticsDisabled && <Badge variant="secondary">Analytics excluded</Badge>}
               {user.banned && <Badge variant="destructive">Banned</Badge>}
             </div>
           </div>

--- a/apps/admin/src/data/stats/_utils/analytics-user-filter.ts
+++ b/apps/admin/src/data/stats/_utils/analytics-user-filter.ts
@@ -1,0 +1,5 @@
+import { sql } from "@zoonk/db";
+
+export const trackedAnalyticsUserWhere = { analyticsDisabled: false } as const;
+export const trackedAnalyticsUserRelationWhere = { user: trackedAnalyticsUserWhere } as const;
+export const trackedAnalyticsUserSql = sql`users.analytics_disabled = FALSE`;

--- a/apps/admin/src/data/stats/count-active-learners.ts
+++ b/apps/admin/src/data/stats/count-active-learners.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserSql } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const countActiveLearners = cacheAdminData(
@@ -8,12 +9,14 @@ export const countActiveLearners = cacheAdminData(
       prisma.$queryRaw<[{ count: bigint }]>`
       SELECT COUNT(DISTINCT user_id) as count
       FROM daily_progress
-      WHERE date >= ${sevenDaysAgo}
+      JOIN users ON users.id = daily_progress.user_id
+      WHERE ${trackedAnalyticsUserSql} AND date >= ${sevenDaysAgo}
     `,
       prisma.$queryRaw<[{ count: bigint }]>`
       SELECT COUNT(DISTINCT user_id) as count
       FROM daily_progress
-      WHERE date >= ${thirtyDaysAgo}
+      JOIN users ON users.id = daily_progress.user_id
+      WHERE ${trackedAnalyticsUserSql} AND date >= ${thirtyDaysAgo}
     `,
     ]);
 

--- a/apps/admin/src/data/stats/count-subscribers-by-plan.ts
+++ b/apps/admin/src/data/stats/count-subscribers-by-plan.ts
@@ -5,12 +5,24 @@ import { prisma } from "@zoonk/db";
 
 export const countSubscribersByPlan = cacheAdminData(async () => {
   const results = await prisma.$queryRaw<{ count: bigint; plan: string }[]>`
-    SELECT subscriptions.plan, COUNT(*) AS count
-    FROM subscriptions
-    JOIN users ON users.id = subscriptions.reference_id
-    WHERE ${trackedAnalyticsUserSql} AND subscriptions.status = 'active'
-    GROUP BY subscriptions.plan
-    ORDER BY subscriptions.plan ASC
+    WITH current_subscriptions AS (
+      SELECT
+        subscriptions.plan,
+        ROW_NUMBER() OVER (
+          PARTITION BY subscriptions.reference_id
+          ORDER BY
+            COALESCE(subscriptions.period_start, subscriptions.period_end) DESC NULLS LAST,
+            subscriptions.id DESC
+        ) AS subscription_rank
+      FROM subscriptions
+      JOIN users ON users.id = subscriptions.reference_id
+      WHERE ${trackedAnalyticsUserSql} AND subscriptions.status = 'active'
+    )
+    SELECT plan, COUNT(*) AS count
+    FROM current_subscriptions
+    WHERE subscription_rank = 1
+    GROUP BY plan
+    ORDER BY plan ASC
   `;
 
   return results.map((row) => ({ count: Number(row.count), plan: row.plan }));

--- a/apps/admin/src/data/stats/count-subscribers-by-plan.ts
+++ b/apps/admin/src/data/stats/count-subscribers-by-plan.ts
@@ -1,13 +1,17 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserSql } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const countSubscribersByPlan = cacheAdminData(async () => {
-  const results = await prisma.subscription.groupBy({
-    _count: { plan: true },
-    by: ["plan"],
-    where: { status: "active" },
-  });
+  const results = await prisma.$queryRaw<{ count: bigint; plan: string }[]>`
+    SELECT subscriptions.plan, COUNT(*) AS count
+    FROM subscriptions
+    JOIN users ON users.id = subscriptions.reference_id
+    WHERE ${trackedAnalyticsUserSql} AND subscriptions.status = 'active'
+    GROUP BY subscriptions.plan
+    ORDER BY subscriptions.plan ASC
+  `;
 
-  return results.map((row) => ({ count: row._count.plan, plan: row.plan }));
+  return results.map((row) => ({ count: Number(row.count), plan: row.plan }));
 });

--- a/apps/admin/src/data/stats/count-users.ts
+++ b/apps/admin/src/data/stats/count-users.ts
@@ -1,5 +1,8 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
-export const countUsers = cacheAdminData(() => prisma.user.count());
+export const countUsers = cacheAdminData(() =>
+  prisma.user.count({ where: trackedAnalyticsUserWhere }),
+);

--- a/apps/admin/src/data/stats/get-accuracy-rate.ts
+++ b/apps/admin/src/data/stats/get-accuracy-rate.ts
@@ -1,11 +1,12 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserRelationWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getAccuracyRate = cacheAdminData(async () => {
   const [total, correct] = await Promise.all([
-    prisma.stepAttempt.count(),
-    prisma.stepAttempt.count({ where: { isCorrect: true } }),
+    prisma.stepAttempt.count({ where: trackedAnalyticsUserRelationWhere }),
+    prisma.stepAttempt.count({ where: { ...trackedAnalyticsUserRelationWhere, isCorrect: true } }),
   ]);
 
   return total === 0 ? 0 : (correct / total) * 100;

--- a/apps/admin/src/data/stats/get-activation-rate.ts
+++ b/apps/admin/src/data/stats/get-activation-rate.ts
@@ -1,5 +1,9 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import {
+  trackedAnalyticsUserSql,
+  trackedAnalyticsUserWhere,
+} from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getActivationRate = cacheAdminData(async () => {
@@ -7,9 +11,10 @@ export const getActivationRate = cacheAdminData(async () => {
     prisma.$queryRaw<[{ count: bigint }]>`
       SELECT COUNT(DISTINCT user_id) as count
       FROM lesson_progress
-      WHERE completed_at IS NOT NULL
+      JOIN users ON users.id = lesson_progress.user_id
+      WHERE ${trackedAnalyticsUserSql} AND completed_at IS NOT NULL
     `,
-    prisma.user.count(),
+    prisma.user.count({ where: trackedAnalyticsUserWhere }),
   ]);
 
   const activated = Number(activatedResult[0].count);

--- a/apps/admin/src/data/stats/get-avg-lesson-time.ts
+++ b/apps/admin/src/data/stats/get-avg-lesson-time.ts
@@ -1,11 +1,12 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserRelationWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getAvgLessonTime = cacheAdminData(async () => {
   const result = await prisma.lessonProgress.aggregate({
     _avg: { durationSeconds: true },
-    where: { durationSeconds: { not: null } },
+    where: { ...trackedAnalyticsUserRelationWhere, durationSeconds: { not: null } },
   });
 
   return result._avg.durationSeconds ?? 0;

--- a/apps/admin/src/data/stats/get-avg-lessons-per-learner.ts
+++ b/apps/admin/src/data/stats/get-avg-lessons-per-learner.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserSql } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getAvgLessonsPerLearner = cacheAdminData(async () => {
@@ -8,7 +9,8 @@ export const getAvgLessonsPerLearner = cacheAdminData(async () => {
       COUNT(*) as total,
       COUNT(DISTINCT user_id) as learners
     FROM lesson_progress
-    WHERE completed_at IS NOT NULL
+    JOIN users ON users.id = lesson_progress.user_id
+    WHERE ${trackedAnalyticsUserSql} AND completed_at IS NOT NULL
   `;
 
   const total = Number(result[0].total);

--- a/apps/admin/src/data/stats/get-avg-time-by-lesson-kind.ts
+++ b/apps/admin/src/data/stats/get-avg-time-by-lesson-kind.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserSql } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getAvgTimeByLessonKind = cacheAdminData(async (start: Date, end: Date) => {
@@ -13,7 +14,8 @@ export const getAvgTimeByLessonKind = cacheAdminData(async (start: Date, end: Da
       COUNT(*) as started
     FROM lesson_progress lp
     JOIN lessons l ON l.id = lp.lesson_id
-    WHERE lp.started_at >= ${start} AND lp.started_at <= ${end}
+    JOIN users ON users.id = lp.user_id
+    WHERE ${trackedAnalyticsUserSql} AND lp.started_at >= ${start} AND lp.started_at <= ${end}
     GROUP BY l.kind
     ORDER BY avg_duration DESC
   `;

--- a/apps/admin/src/data/stats/get-completion-rate.ts
+++ b/apps/admin/src/data/stats/get-completion-rate.ts
@@ -1,11 +1,14 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserRelationWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getCompletionRate = cacheAdminData(async () => {
   const [started, completed] = await Promise.all([
-    prisma.lessonProgress.count(),
-    prisma.lessonProgress.count({ where: { completedAt: { not: null } } }),
+    prisma.lessonProgress.count({ where: trackedAnalyticsUserRelationWhere }),
+    prisma.lessonProgress.count({
+      where: { ...trackedAnalyticsUserRelationWhere, completedAt: { not: null } },
+    }),
   ]);
 
   return started === 0 ? 0 : (completed / started) * 100;

--- a/apps/admin/src/data/stats/get-conversion-rate.ts
+++ b/apps/admin/src/data/stats/get-conversion-rate.ts
@@ -8,7 +8,7 @@ import { prisma } from "@zoonk/db";
 
 export const getConversionRate = cacheAdminData(async () => {
   const [paid, total] = await Promise.all([
-    countPaidTrackedSubscriptions(),
+    countPaidTrackedUsers(),
     prisma.user.count({ where: trackedAnalyticsUserWhere }),
   ]);
 
@@ -18,13 +18,12 @@ export const getConversionRate = cacheAdminData(async () => {
 });
 
 /**
- * Subscription rows store the owning user id as Better Auth's `reference_id`,
- * so raw SQL is the simplest way to apply the user analytics exclusion without
- * introducing a duplicate Prisma relation just for admin reporting.
+ * Conversion rate compares paid users against total users, so duplicate active
+ * subscription rows for one user must still count as one paid account.
  */
-async function countPaidTrackedSubscriptions() {
+async function countPaidTrackedUsers() {
   const result = await prisma.$queryRaw<[{ count: bigint }]>`
-    SELECT COUNT(*) AS count
+    SELECT COUNT(DISTINCT subscriptions.reference_id) AS count
     FROM subscriptions
     JOIN users ON users.id = subscriptions.reference_id
     WHERE

--- a/apps/admin/src/data/stats/get-conversion-rate.ts
+++ b/apps/admin/src/data/stats/get-conversion-rate.ts
@@ -1,14 +1,37 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import {
+  trackedAnalyticsUserSql,
+  trackedAnalyticsUserWhere,
+} from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getConversionRate = cacheAdminData(async () => {
   const [paid, total] = await Promise.all([
-    prisma.subscription.count({ where: { plan: { not: "free" }, status: "active" } }),
-    prisma.user.count(),
+    countPaidTrackedSubscriptions(),
+    prisma.user.count({ where: trackedAnalyticsUserWhere }),
   ]);
 
   const rate = total === 0 ? 0 : (paid / total) * 100;
 
   return { paid, rate, total };
 });
+
+/**
+ * Subscription rows store the owning user id as Better Auth's `reference_id`,
+ * so raw SQL is the simplest way to apply the user analytics exclusion without
+ * introducing a duplicate Prisma relation just for admin reporting.
+ */
+async function countPaidTrackedSubscriptions() {
+  const result = await prisma.$queryRaw<[{ count: bigint }]>`
+    SELECT COUNT(*) AS count
+    FROM subscriptions
+    JOIN users ON users.id = subscriptions.reference_id
+    WHERE
+      ${trackedAnalyticsUserSql}
+      AND subscriptions.plan != 'free'
+      AND subscriptions.status = 'active'
+  `;
+
+  return Number(result[0].count);
+}

--- a/apps/admin/src/data/stats/get-daily-active-learners.ts
+++ b/apps/admin/src/data/stats/get-daily-active-learners.ts
@@ -1,12 +1,14 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserSql } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getDailyActiveLearners = cacheAdminData(async (start: Date, end: Date) => {
   const results = await prisma.$queryRaw<{ date: Date; count: bigint }[]>`
     SELECT date, COUNT(DISTINCT user_id) as count
     FROM daily_progress
-    WHERE date >= ${start} AND date <= ${end}
+    JOIN users ON users.id = daily_progress.user_id
+    WHERE ${trackedAnalyticsUserSql} AND date >= ${start} AND date <= ${end}
     GROUP BY date
     ORDER BY date ASC
   `;

--- a/apps/admin/src/data/stats/get-daily-signups.ts
+++ b/apps/admin/src/data/stats/get-daily-signups.ts
@@ -1,12 +1,13 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserSql } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getDailySignups = cacheAdminData(async (start: Date, end: Date) => {
   const results = await prisma.$queryRaw<{ date: Date; count: bigint }[]>`
     SELECT DATE(created_at) as date, COUNT(*) as count
     FROM users
-    WHERE created_at >= ${start} AND created_at <= ${end}
+    WHERE ${trackedAnalyticsUserSql} AND created_at >= ${start} AND created_at <= ${end}
     GROUP BY DATE(created_at)
     ORDER BY date ASC
   `;

--- a/apps/admin/src/data/stats/get-learner-milestones.ts
+++ b/apps/admin/src/data/stats/get-learner-milestones.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserSql } from "@/data/stats/_utils/analytics-user-filter";
 import { type LearnerMilestoneKind } from "@/lib/learner-milestone-filters";
 import { type Sql, prisma, sql } from "@zoonk/db";
 
@@ -113,7 +114,8 @@ async function countUsersByLearnerMilestone({
     FROM (
       SELECT user_id
       FROM lesson_progress
-      WHERE completed_at IS NOT NULL
+      JOIN users ON users.id = lesson_progress.user_id
+      WHERE ${trackedAnalyticsUserSql} AND completed_at IS NOT NULL
       GROUP BY user_id
       HAVING ${queryParts.havingFilter}
     ) qualifying_users
@@ -154,7 +156,8 @@ async function listUsersByLearnerMilestone({
         COUNT(DISTINCT completed_at::date) AS learning_days,
         MAX(completed_at) AS last_completed_at
       FROM lesson_progress
-      WHERE completed_at IS NOT NULL
+      JOIN users ON users.id = lesson_progress.user_id
+      WHERE ${trackedAnalyticsUserSql} AND completed_at IS NOT NULL
       GROUP BY user_id
       HAVING ${queryParts.havingFilter}
     ) learner_progress

--- a/apps/admin/src/data/stats/get-new-signups.ts
+++ b/apps/admin/src/data/stats/get-new-signups.ts
@@ -1,7 +1,10 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getNewSignups = cacheAdminData(async (start: Date, end: Date) =>
-  prisma.user.count({ where: { createdAt: { gte: start, lte: end } } }),
+  prisma.user.count({
+    where: { ...trackedAnalyticsUserWhere, createdAt: { gte: start, lte: end } },
+  }),
 );

--- a/apps/admin/src/data/stats/get-period-accuracy-rate.ts
+++ b/apps/admin/src/data/stats/get-period-accuracy-rate.ts
@@ -1,11 +1,14 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserRelationWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getPeriodAccuracyRate = cacheAdminData(async (start: Date, end: Date) => {
+  const where = { ...trackedAnalyticsUserRelationWhere, answeredAt: { gte: start, lte: end } };
+
   const [total, correct] = await Promise.all([
-    prisma.stepAttempt.count({ where: { answeredAt: { gte: start, lte: end } } }),
-    prisma.stepAttempt.count({ where: { answeredAt: { gte: start, lte: end }, isCorrect: true } }),
+    prisma.stepAttempt.count({ where }),
+    prisma.stepAttempt.count({ where: { ...where, isCorrect: true } }),
   ]);
 
   return total === 0 ? 0 : (correct / total) * 100;

--- a/apps/admin/src/data/stats/get-period-active-learners.ts
+++ b/apps/admin/src/data/stats/get-period-active-learners.ts
@@ -1,12 +1,14 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserSql } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getPeriodActiveLearners = cacheAdminData(async (start: Date, end: Date) => {
   const result = await prisma.$queryRaw<[{ count: bigint }]>`
     SELECT COUNT(DISTINCT user_id) as count
     FROM daily_progress
-    WHERE date >= ${start} AND date <= ${end}
+    JOIN users ON users.id = daily_progress.user_id
+    WHERE ${trackedAnalyticsUserSql} AND date >= ${start} AND date <= ${end}
   `;
 
   return Number(result[0].count);

--- a/apps/admin/src/data/stats/get-period-avg-lesson-time.ts
+++ b/apps/admin/src/data/stats/get-period-avg-lesson-time.ts
@@ -1,11 +1,16 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserRelationWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getPeriodAvgLessonTime = cacheAdminData(async (start: Date, end: Date) => {
   const result = await prisma.lessonProgress.aggregate({
     _avg: { durationSeconds: true },
-    where: { completedAt: { gte: start, lte: end }, durationSeconds: { not: null } },
+    where: {
+      ...trackedAnalyticsUserRelationWhere,
+      completedAt: { gte: start, lte: end },
+      durationSeconds: { not: null },
+    },
   });
 
   return result._avg.durationSeconds ?? 0;

--- a/apps/admin/src/data/stats/get-period-completion-rate.ts
+++ b/apps/admin/src/data/stats/get-period-completion-rate.ts
@@ -1,9 +1,10 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserRelationWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getPeriodCompletionRate = cacheAdminData(async (start: Date, end: Date) => {
-  const where = { startedAt: { gte: start, lte: end } };
+  const where = { ...trackedAnalyticsUserRelationWhere, startedAt: { gte: start, lte: end } };
 
   const [started, completed] = await Promise.all([
     prisma.lessonProgress.count({ where }),

--- a/apps/admin/src/data/stats/get-period-learning-time.ts
+++ b/apps/admin/src/data/stats/get-period-learning-time.ts
@@ -1,11 +1,12 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserRelationWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getPeriodLearningTime = cacheAdminData(async (start: Date, end: Date) => {
   const result = await prisma.dailyProgress.aggregate({
     _sum: { timeSpentSeconds: true },
-    where: { date: { gte: start, lte: end } },
+    where: { ...trackedAnalyticsUserRelationWhere, date: { gte: start, lte: end } },
   });
 
   return result._sum.timeSpentSeconds ?? 0;

--- a/apps/admin/src/data/stats/get-total-learning-time.ts
+++ b/apps/admin/src/data/stats/get-total-learning-time.ts
@@ -1,9 +1,13 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { trackedAnalyticsUserRelationWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
 
 export const getTotalLearningTime = cacheAdminData(async () => {
-  const result = await prisma.dailyProgress.aggregate({ _sum: { timeSpentSeconds: true } });
+  const result = await prisma.dailyProgress.aggregate({
+    _sum: { timeSpentSeconds: true },
+    where: trackedAnalyticsUserRelationWhere,
+  });
 
   return result._sum.timeSpentSeconds ?? 0;
 });

--- a/apps/main/src/app/(settings)/subscription/subscription-conversion-tracker.tsx
+++ b/apps/main/src/app/(settings)/subscription/subscription-conversion-tracker.tsx
@@ -11,14 +11,17 @@ const MAX_CONFIRMATION_REFRESH_COUNT = 5;
 
 /**
  * Reports the Google Ads conversion only when Stripe returned to the
- * subscription page and the server-rendered billing state already shows an
- * active Stripe subscription.
+ * subscription page, analytics are enabled, and the server-rendered billing
+ * state already shows an active Stripe subscription. Disabled users still need
+ * the refresh and URL cleanup path, so only the conversion call is skipped.
  */
 export function SubscriptionConversionTracker({
   activeSubscriptionId,
+  analyticsDisabled,
   stripeCheckoutCompleted,
 }: {
   activeSubscriptionId: string | null;
+  analyticsDisabled: boolean;
   stripeCheckoutCompleted: boolean;
 }) {
   const router = useRouter();
@@ -39,10 +42,13 @@ export function SubscriptionConversionTracker({
       return;
     }
 
-    trackGoogleAdsSubscriptionConversion();
+    if (!analyticsDisabled) {
+      trackGoogleAdsSubscriptionConversion();
+    }
+
     markSubscriptionConversionHandled(activeSubscriptionId);
     removeStripeCheckoutParamFromCurrentUrl();
-  }, [activeSubscriptionId, refresh, stripeCheckoutCompleted]);
+  }, [activeSubscriptionId, analyticsDisabled, refresh, stripeCheckoutCompleted]);
 
   return null;
 }

--- a/apps/main/src/app/(settings)/subscription/subscription-plans.tsx
+++ b/apps/main/src/app/(settings)/subscription/subscription-plans.tsx
@@ -1,3 +1,4 @@
+import { getCurrentUserAnalyticsDisabled } from "@/data/users/get-current-user-analytics-disabled";
 import { getStripePrices } from "@zoonk/core/auth/stripe-prices";
 import { getActiveSubscription } from "@zoonk/core/auth/subscription";
 import { prisma } from "@zoonk/db";
@@ -32,9 +33,10 @@ export async function SubscriptionPlans({
     [plan.lookupKey, plan.annualLookupKey].filter((key) => key !== null),
   );
 
-  const [subscription, priceMap] = await Promise.all([
+  const [subscription, priceMap, analyticsDisabled] = await Promise.all([
     getCurrentSubscription(requestHeaders),
     getStripePrices(lookupKeys, currency),
+    getCurrentUserAnalyticsDisabled(),
   ]);
 
   const titles: Record<string, string> = {
@@ -68,6 +70,7 @@ export async function SubscriptionPlans({
       <>
         <SubscriptionConversionTracker
           activeSubscriptionId={activeStripeSubscriptionId}
+          analyticsDisabled={analyticsDisabled}
           stripeCheckoutCompleted={stripeCheckoutCompleted}
         />
         <ManagedSubscription
@@ -105,6 +108,7 @@ export async function SubscriptionPlans({
     <>
       <SubscriptionConversionTracker
         activeSubscriptionId={activeStripeSubscriptionId}
+        analyticsDisabled={analyticsDisabled}
         stripeCheckoutCompleted={stripeCheckoutCompleted}
       />
       <PlanList

--- a/apps/main/src/app/app-analytics.tsx
+++ b/apps/main/src/app/app-analytics.tsx
@@ -1,0 +1,24 @@
+import { getCurrentUserAnalyticsDisabled } from "@/data/users/get-current-user-analytics-disabled";
+import { GoogleAnalytics } from "@next/third-parties/google";
+import { Analytics } from "@vercel/analytics/next";
+
+const googleAdsTagId = process.env.NEXT_PUBLIC_GOOGLE_ADS_TAG_ID;
+
+/**
+ * Keeps the user-specific analytics lookup inside a Suspense boundary so the
+ * root layout can stream the rest of the route without waiting on this flag.
+ */
+export async function AppAnalytics() {
+  const analyticsDisabled = await getCurrentUserAnalyticsDisabled();
+
+  if (analyticsDisabled) {
+    return null;
+  }
+
+  return (
+    <>
+      <Analytics debug={false} />
+      {googleAdsTagId ? <GoogleAnalytics gaId={googleAdsTagId} /> : null}
+    </>
+  );
+}

--- a/apps/main/src/app/layout.tsx
+++ b/apps/main/src/app/layout.tsx
@@ -1,5 +1,3 @@
-import { GoogleAnalytics } from "@next/third-parties/google";
-import { Analytics } from "@vercel/analytics/next";
 import { Toaster } from "@zoonk/ui/components/sonner";
 import { SITE_URL } from "@zoonk/utils/url";
 import { type Metadata } from "next";
@@ -7,14 +5,13 @@ import { NextIntlClientProvider } from "next-intl";
 import { getLocale } from "next-intl/server";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { Suspense } from "react";
+import { AppAnalytics } from "./app-analytics";
 import "@zoonk/ui/globals.css";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: { default: "Zoonk", template: "%s | Zoonk" },
 };
-
-const googleAdsTagId = process.env.NEXT_PUBLIC_GOOGLE_ADS_TAG_ID;
 
 async function HtmlDocument({ children }: React.PropsWithChildren) {
   const locale = await getLocale();
@@ -29,10 +26,11 @@ export default async function RootLayout({ children }: LayoutProps<"/">) {
           <NuqsAdapter>
             <NextIntlClientProvider>{children}</NextIntlClientProvider>
           </NuqsAdapter>
-          <Analytics debug={false} />
+          <Suspense fallback={null}>
+            <AppAnalytics />
+          </Suspense>
           <Toaster />
         </body>
-        {googleAdsTagId && <GoogleAnalytics gaId={googleAdsTagId} />}
       </HtmlDocument>
     </Suspense>
   );

--- a/apps/main/src/data/users/get-current-user-analytics-disabled.ts
+++ b/apps/main/src/data/users/get-current-user-analytics-disabled.ts
@@ -1,0 +1,21 @@
+import "server-only";
+import { getSession } from "@zoonk/core/users/session/get";
+import { prisma } from "@zoonk/db";
+import { cache } from "react";
+
+/**
+ * The root layout needs a server-side tracking decision before any analytics
+ * component mounts, but Better Auth sessions do not expose custom Prisma user
+ * columns, so the flag is read from the user row directly.
+ */
+export const getCurrentUserAnalyticsDisabled = cache(async () => {
+  const session = await getSession();
+
+  if (!session) {
+    return false;
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+
+  return user?.analyticsDisabled ?? false;
+});

--- a/packages/db/src/prisma/migrations/20260609174841_add_user_analytics_disabled/migration.sql
+++ b/packages/db/src/prisma/migrations/20260609174841_add_user_analytics_disabled/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "analytics_disabled" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -12,6 +12,7 @@ model User {
   banned             Boolean?             @default(false)
   banReason          String?              @map("ban_reason")
   banExpires         DateTime?            @map("ban_expires")
+  analyticsDisabled  Boolean              @default(false) @map("analytics_disabled")
   stripeCustomerId   String?              @map("stripe_customer_id")
   username           String?
   displayUsername    String?              @map("display_username")


### PR DESCRIPTION
## Summary
- add an admin toggle to exclude a user from analytics without affecting access
- filter admin metrics and main app analytics for excluded users
- store the flag on the user model and surface it in admin user views

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin toggle to exclude specific users from analytics without changing their access. Applies this across admin dashboards, app analytics, and ads tracking, and fixes conversion rate to count each paid user once.

- New Features
  - Admin: Add “Exclude from analytics” toggle on the user page, show a badge, and persist via a server action that revalidates affected dashboards.
  - Metrics: Exclude flagged users using a shared filter; join `users` in raw SQL; fix conversion rate to count each paid user once; count subscribers by plan using only the current active plan per user.
  - App analytics: Add `AppAnalytics` to conditionally load `@vercel/analytics/next` and `@next/third-parties/google`; skipped for excluded users.
  - Subscriptions: Skip Google Ads conversion tracking when the user is excluded, while keeping the refresh and URL cleanup flow.

- Migration
  - DB: Add `users.analytics_disabled BOOLEAN NOT NULL DEFAULT false`.
  - Run the new migration before deploy; no changes required to auth or sessions.

<sup>Written for commit 40af8d44e261d1495b757dc7b36cf7f602e679ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

