### PR TITLE
fix(admin): simplify activation rate query

### DIFF
--- a/apps/admin/src/data/stats/get-activation-rate.ts
+++ b/apps/admin/src/data/stats/get-activation-rate.ts
@@ -1,23 +1,25 @@
 import "server-only";
 import { cacheAdminData } from "@/data/_utils/admin-data-cache";
-import {
-  trackedAnalyticsUserSql,
-  trackedAnalyticsUserWhere,
-} from "@/data/stats/_utils/analytics-user-filter";
+import { trackedAnalyticsUserWhere } from "@/data/stats/_utils/analytics-user-filter";
 import { prisma } from "@zoonk/db";
+import { BRAIN_POWER_PER_LESSON } from "@zoonk/utils/brain-power";
 
+/**
+ * Activation should follow earned Brain Power instead of lesson progress rows
+ * because progress resets can remove lesson rows while preserving the durable
+ * learning credit that proves the user completed at least one lesson.
+ */
 export const getActivationRate = cacheAdminData(async () => {
-  const [activatedResult, total] = await Promise.all([
-    prisma.$queryRaw<[{ count: bigint }]>`
-      SELECT COUNT(DISTINCT user_id) as count
-      FROM lesson_progress
-      JOIN users ON users.id = lesson_progress.user_id
-      WHERE ${trackedAnalyticsUserSql} AND completed_at IS NOT NULL
-    `,
+  const [activated, total] = await Promise.all([
+    prisma.user.count({
+      where: {
+        ...trackedAnalyticsUserWhere,
+        progress: { is: { totalBrainPower: { gte: BigInt(BRAIN_POWER_PER_LESSON) } } },
+      },
+    }),
     prisma.user.count({ where: trackedAnalyticsUserWhere }),
   ]);
 
-  const activated = Number(activatedResult[0].count);
   const rate = total === 0 ? 0 : (activated / total) * 100;
 
   return { activated, rate, total };


### PR DESCRIPTION
## Summary
- Count activation from tracked users whose `totalBrainPower` meets `BRAIN_POWER_PER_LESSON`
- Keep the denominator and activation rate card behavior unchanged

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activation now counts tracked users whose `progress.totalBrainPower` meets `BRAIN_POWER_PER_LESSON` instead of relying on `lesson_progress` rows. This makes the metric resilient to progress resets while keeping the denominator and activation card behavior unchanged.

<sup>Written for commit 24c8ae7eca37cb7b083eebd9c2667cea0015d40c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

