### PR TITLE
fix(player): show completion score as percentage

### DIFF
--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -292,7 +292,7 @@ test.describe("Lesson Completion UX", () => {
     await completeQuiz(page, uniqueId);
 
     const completionScreen = page.getByRole("status");
-    await expect(completionScreen.getByText("1/1")).toBeVisible();
+    await expect(completionScreen.getByText("100%")).toBeVisible();
     await expect(completionScreen.getByText(/correct/iu)).toBeVisible();
     await expect(completionScreen.getByText(`First Lesson ${uniqueId}`)).toBeVisible();
     await expect(completionScreen.getByText("Lesson 1 of 2")).toBeVisible();
@@ -496,7 +496,7 @@ test.describe("Lesson Completion UX", () => {
     await completeQuiz(page, uniqueId);
 
     const completionScreen = page.getByRole("status");
-    await expect(completionScreen.getByText("1/1")).toBeVisible();
+    await expect(completionScreen.getByText("100%")).toBeVisible();
     await expect(completionScreen.getByRole("link", { name: "Next" })).toBeVisible();
 
     await browserContext.close();

--- a/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
@@ -241,7 +241,7 @@ describe("player browser integration: arrangement steps", () => {
     await page.getByRole("button", { name: /check/iu }).click();
 
     await expect.element(page.getByRole("status")).toBeInTheDocument();
-    await expect.element(page.getByText("0/1")).toBeInTheDocument();
+    await expect.element(page.getByText("0%")).toBeInTheDocument();
   });
 
   it("shows the correct order when the shared sort-order answer is wrong", async () => {

--- a/packages/player/src/_browser-tests/player-choice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-choice.browser.test.tsx
@@ -43,7 +43,7 @@ describe("player browser integration: choice steps", () => {
 
     await page.getByRole("button", { name: /continue/iu }).click();
 
-    await expect.element(page.getByText("1/1")).toBeInTheDocument();
+    await expect.element(page.getByText("100%")).toBeInTheDocument();
     expect(onComplete).toHaveBeenCalledOnce();
   });
 
@@ -103,7 +103,7 @@ describe("player browser integration: choice steps", () => {
     await expect.element(page.getByText(/your answer:/iu)).toBeInTheDocument();
 
     await page.getByRole("button", { name: /continue/iu }).click();
-    await expect.element(page.getByText("1/1")).toBeInTheDocument();
+    await expect.element(page.getByText("100%")).toBeInTheDocument();
   });
 
   it("selects an image option and shows inline feedback", async () => {

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -72,7 +72,7 @@ describe("player browser integration: completion", () => {
 
     const completionScreen = page.getByRole("status");
 
-    await expect.element(completionScreen.getByText("1/1")).toBeInTheDocument();
+    await expect.element(completionScreen.getByText("100%")).toBeInTheDocument();
     await expect.element(completionScreen.getByText("Lesson 2 of 5")).toBeInTheDocument();
 
     const chapterProgress = completionScreen.getByRole("progressbar", {
@@ -140,13 +140,13 @@ describe("player browser integration: completion", () => {
       .element(milestoneScreen.getByRole("link", { name: /learn about levels/iu }))
       .toHaveAttribute("href", "/level");
 
-    await expect.element(milestoneScreen.getByText("1/1")).not.toBeInTheDocument();
+    await expect.element(milestoneScreen.getByText("100%")).not.toBeInTheDocument();
 
     await milestoneScreen.getByRole("button", { name: /continue/iu }).click();
 
     const completionScreen = page.getByRole("status");
 
-    await expect.element(completionScreen.getByText("1/1")).toBeInTheDocument();
+    await expect.element(completionScreen.getByText("100%")).toBeInTheDocument();
     await expect.element(completionScreen.getByText(/\+10\s*BP/iu)).not.toBeInTheDocument();
 
     await expect.element(completionScreen.getByRole("link", { name: "Next" })).toBeInTheDocument();
@@ -308,7 +308,7 @@ describe("player browser integration: completion", () => {
 
     const nextLink = completionScreen.getByRole("link", { name: "Next" });
 
-    await expect.element(completionScreen.getByText("1/1")).toBeInTheDocument();
+    await expect.element(completionScreen.getByText("100%")).toBeInTheDocument();
 
     await expect
       .element(completionScreen.getByText(/sign up to track your progress/iu))

--- a/packages/player/src/_browser-tests/player-practice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-practice.browser.test.tsx
@@ -118,7 +118,7 @@ describe("player browser integration: practice lessons", () => {
     await page.getByRole("button", { name: /check/iu }).click();
     await page.getByRole("button", { name: /continue/iu }).click();
 
-    await expect.element(page.getByText("1/1")).toBeInTheDocument();
+    await expect.element(page.getByText("100%")).toBeInTheDocument();
     await expect.element(page.getByText(/\+10\s*BP/iu)).not.toBeInTheDocument();
 
     await expect

--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -44,7 +44,7 @@ describe("player browser integration: word bank steps", () => {
     await expect.element(page.getByText(/correct!/iu)).toBeInTheDocument();
 
     await page.getByRole("button", { name: /continue/iu }).click();
-    await expect.element(page.getByText("1/1")).toBeInTheDocument();
+    await expect.element(page.getByText("100%")).toBeInTheDocument();
   });
 
   it("builds a reading answer from the word bank and shows inline feedback", async () => {
@@ -81,7 +81,7 @@ describe("player browser integration: word bank steps", () => {
 
     await expect.element(page.getByRole("button", { name: /continue/iu })).toBeInTheDocument();
     await page.getByRole("button", { name: /continue/iu }).click();
-    await expect.element(page.getByText("1/1")).toBeInTheDocument();
+    await expect.element(page.getByText("100%")).toBeInTheDocument();
   });
 
   it("shows reading word translations from the prompt sentence", async () => {
@@ -166,7 +166,7 @@ describe("player browser integration: word bank steps", () => {
       await controls.getByRole("button", { name: /check/iu }).click();
       await controls.getByRole("button", { name: /continue/iu }).click();
 
-      await expect.element(page.getByText("1/1")).toBeInTheDocument();
+      await expect.element(page.getByText("100%")).toBeInTheDocument();
     });
   });
 

--- a/packages/player/src/components/completion-screen.tsx
+++ b/packages/player/src/components/completion-screen.tsx
@@ -43,6 +43,25 @@ function CompletionScore({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
+/**
+ * Converts the raw correct/incorrect counts into the score users expect to see
+ * on completion. The persisted score still keeps counts, but the summary reads
+ * as accuracy, so a whole percentage is easier to scan than a fraction.
+ */
+function getCompletionScorePercent({
+  correctCount,
+  totalCount,
+}: {
+  correctCount: number;
+  totalCount: number;
+}) {
+  if (totalCount === 0) {
+    return 0;
+  }
+
+  return Math.round((correctCount / totalCount) * 100);
+}
+
 function CompletionSignal() {
   const t = useExtracted();
 
@@ -188,13 +207,15 @@ export function CompletionScreenContent({
     ? completionResult.correctCount + completionResult.incorrectCount
     : 0;
 
+  const scorePercent = completionResult
+    ? getCompletionScorePercent({ correctCount: completionResult.correctCount, totalCount })
+    : 0;
+
   return (
     <CompletionScreen>
       {totalCount > 0 && completionResult ? (
         <CompletionScore>
-          <p className="text-5xl font-bold tracking-tight tabular-nums">
-            {completionResult.correctCount}/{totalCount}
-          </p>
+          <p className="text-5xl font-bold tracking-tight tabular-nums">{scorePercent}%</p>
           <PlayerSupportingText>{t("correct")}</PlayerSupportingText>
         </CompletionScore>
       ) : (


### PR DESCRIPTION
## Summary
- Render the player completion score as a percentage instead of a fraction
- Update browser coverage to expect percentage output across completion flows

## Testing
- `pnpm --filter @zoonk/player test`
- `pnpm --filter @zoonk/player typecheck`
- `pnpm exec oxfmt --check ...`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the completion score as a percentage on the player completion screen (e.g., 1/1 → 100%), rounded to a whole number and guarded for zero totals. Updated tests to expect percentages across `@zoonk/player` browser flows and `apps/main` lesson completion E2E.

<sup>Written for commit 9d53dc3e3f15f18e0b36614447ce21d13364b634. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

