### PR TITLE
fix(main): respect lesson filters in continue learning

### DIFF
--- a/apps/main/e2e/continue-lesson-link.test.ts
+++ b/apps/main/e2e/continue-lesson-link.test.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { type Browser } from "@playwright/test";
+import { type LessonKind, prisma } from "@zoonk/db";
+import { getBaseURL } from "@zoonk/e2e/fixtures/base-url";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { createE2EUser } from "@zoonk/e2e/fixtures/users";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
@@ -126,6 +130,32 @@ async function createTestCourseWithPendingFirstLesson() {
   });
 
   return { chapter, course, lesson };
+}
+
+/**
+ * Lesson-type preferences are user-specific, so this helper creates a fresh
+ * browser user and stores the hidden kinds before the page renders. That keeps
+ * this regression isolated from the shared authenticated worker users.
+ */
+async function createPageWithHiddenLessonKinds({
+  browser,
+  hiddenLessonKinds,
+}: {
+  browser: Browser;
+  hiddenLessonKinds: LessonKind[];
+}) {
+  const user = await createE2EUser(getBaseURL(), { orgRole: "member" });
+
+  const [context] = await Promise.all([
+    browser.newContext({ storageState: user.storageState }),
+    prisma.userLearningProfile.create({
+      data: { preferences: { hiddenLessonKinds }, userId: user.id },
+    }),
+  ]);
+
+  const page = await context.newPage();
+
+  return { context, page, user };
 }
 
 test.describe("Continue Lesson Link", () => {
@@ -300,6 +330,123 @@ test.describe("Continue Lesson Link", () => {
       "href",
       `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${nextLesson.slug}`,
     );
+  });
+
+  test("hidden lesson types do not drive continue links or lesson progress", async ({
+    browser,
+  }) => {
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: org.id,
+      slug: `e2e-cal-filter-course-${uniqueId}`,
+      title: `E2E CAL Filter Course ${uniqueId}`,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-cal-filter-ch-${uniqueId}`,
+      title: `E2E CAL Filter Ch ${uniqueId}`,
+    });
+
+    const [completedLesson, hiddenLesson, nextVisibleLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        organizationId: org.id,
+        position: 0,
+        slug: `e2e-cal-filter-l1-${uniqueId}`,
+        title: `E2E CAL Filter L1 ${uniqueId}`,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "quiz",
+        organizationId: org.id,
+        position: 1,
+        slug: `e2e-cal-filter-l2-${uniqueId}`,
+        title: `E2E CAL Filter L2 ${uniqueId}`,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        organizationId: org.id,
+        position: 2,
+        slug: `e2e-cal-filter-l3-${uniqueId}`,
+        title: `E2E CAL Filter L3 ${uniqueId}`,
+      }),
+    ]);
+
+    const { context, page, user } = await createPageWithHiddenLessonKinds({
+      browser,
+      hiddenLessonKinds: ["quiz"],
+    });
+
+    await lessonProgressFixture({
+      completedAt: new Date("2024-01-01"),
+      durationSeconds: 60,
+      lessonId: completedLesson.id,
+      userId: user.id,
+    });
+
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
+
+    const continueLink = getContinueActionLink({ label: "Continue", page });
+
+    await expect(continueLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${nextVisibleLesson.slug}`,
+    );
+
+    await expect(continueLink).not.toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${hiddenLesson.slug}`,
+    );
+
+    const chapterLink = page.getByRole("link", { name: new RegExp(chapter.title, "u") });
+    await expect(chapterLink.getByText("1/2 done")).toBeVisible();
+
+    await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`);
+
+    await page.getByRole("button", { name: "Filter lesson types" }).click();
+    await expect(page.getByRole("menuitemcheckbox", { name: "Explanation" })).toBeDisabled();
+    await expect(page.getByRole("menuitemcheckbox", { name: "Quiz" })).toBeEnabled();
+    await page.keyboard.press("Escape");
+
+    const chapterContinueLink = page
+      .getByRole("main")
+      .getByRole("link", { name: "Continue 1 of 2 lessons completed" });
+
+    const nextVisibleLessonTitle = nextVisibleLesson.title ?? nextVisibleLesson.slug;
+
+    const nextVisibleLessonLink = page.getByRole("link", {
+      name: new RegExp(nextVisibleLessonTitle, "u"),
+    });
+
+    await expect(chapterContinueLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${nextVisibleLesson.slug}`,
+    );
+
+    await expect(chapterContinueLink).not.toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${hiddenLesson.slug}`,
+    );
+
+    await expect(nextVisibleLessonLink.getByText("2", { exact: true })).toBeVisible();
+    await expect(nextVisibleLessonLink.getByText("3", { exact: true })).toHaveCount(0);
+
+    await context.close();
   });
 
   test("course page shows Continue linking to ungenerated next chapter", async ({

--- a/apps/main/e2e/course-progress.test.ts
+++ b/apps/main/e2e/course-progress.test.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { prisma } from "@zoonk/db";
+import { getBaseURL } from "@zoonk/e2e/fixtures/base-url";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { createE2EUser } from "@zoonk/e2e/fixtures/users";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
@@ -154,6 +156,54 @@ async function createCourseWithIncompleteChapter() {
 }
 
 /**
+ * This scenario isolates the course-level progress suffix from the chapter
+ * card details. The only unfinished lesson is hidden by the user's preference,
+ * so the chapter should count as complete in both places.
+ */
+async function createCourseWithHiddenIncompleteLesson() {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-progress-hidden-course-${uniqueId}`,
+    title: `E2E Progress Hidden Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    description: `Hidden lesson chapter ${uniqueId}`,
+    isPublished: true,
+    organizationId: org.id,
+    position: 0,
+    slug: `e2e-progress-hidden-ch-${uniqueId}`,
+    title: `E2E Hidden Progress Chapter ${uniqueId}`,
+  });
+
+  const [visibleLesson] = await Promise.all([
+    lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      kind: "explanation",
+      organizationId: org.id,
+      position: 0,
+      title: `Visible Lesson ${uniqueId}`,
+    }),
+    lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      kind: "quiz",
+      organizationId: org.id,
+      position: 1,
+      title: `Hidden Quiz ${uniqueId}`,
+    }),
+  ]);
+
+  return { chapter, course, visibleLesson };
+}
+
+/**
  * Chapter cards still derive their status from direct lesson completion, so
  * this helper keeps that lower-level setup consistent across scenarios.
  */
@@ -171,8 +221,8 @@ async function completeLessons({ lessons, userId }: { lessons: { id: string }[];
 }
 
 /**
- * The course Continue button counts durable chapter completions because
- * generated lessons are not a stable course-level unit.
+ * Some scenarios still need durable chapter completions to cover the path
+ * where previously finished chapters stay complete after lesson changes.
  */
 async function completeChapters({
   chapters,
@@ -301,5 +351,37 @@ test.describe("Course Progress Indicators", () => {
     await expect(chapterLink).toBeVisible();
     await expect(chapterLink.getByText("1/2 done")).toBeVisible();
     await expect(chapterLink.getByText(/^completed$/iu)).toHaveCount(0);
+  });
+
+  test("ignores hidden lesson types in course progress", async ({ browser }) => {
+    const [{ chapter, course, visibleLesson }, user] = await Promise.all([
+      createCourseWithHiddenIncompleteLesson(),
+      createE2EUser(getBaseURL(), { orgRole: "member" }),
+    ]);
+
+    const [context] = await Promise.all([
+      browser.newContext({ storageState: user.storageState }),
+      completeLessons({ lessons: [visibleLesson], userId: user.id }),
+      prisma.userLearningProfile.create({
+        data: { preferences: { hiddenLessonKinds: ["quiz"] }, userId: user.id },
+      }),
+    ]);
+
+    const page = await context.newPage();
+
+    await page.goto(`/b/ai/c/${course.slug}`);
+
+    const main = page.getByRole("main");
+
+    await expect(
+      main.getByRole("link", { name: "Review 1 of 1 chapters completed" }),
+    ).toBeVisible();
+
+    const chapterLink = main.getByRole("link", { name: new RegExp(chapter.title, "u") });
+
+    await expect(chapterLink.getByText(/^completed$/iu)).toBeVisible();
+    await expect(chapterLink.getByText("1/2 done")).toHaveCount(0);
+
+    await context.close();
   });
 });

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-actions.ts
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-actions.ts
@@ -4,6 +4,7 @@ import { updateUserHiddenLessonKinds } from "@/data/users/lesson-filter-settings
 import { type LessonKind } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { logError } from "@zoonk/utils/logger";
+import { revalidatePath } from "next/cache";
 
 /**
  * Lesson type visibility is a user setting, so the data helper owns current
@@ -28,6 +29,8 @@ export async function updateHiddenLessonKindsAction({
   if (!result?.saved) {
     return { status: "error" as const };
   }
+
+  revalidatePath("/(catalog)", "layout");
 
   return { status: "success" as const };
 }

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
@@ -219,6 +219,42 @@ function getLessonFilterState({
 }
 
 /**
+ * The menu stores hidden kinds, but checkbox rendering reads better from the
+ * positive visible state. Naming this avoids repeating the negated Set lookup
+ * in every guard and checkbox prop.
+ */
+function isLessonKindVisible({
+  hiddenLessonKindSet,
+  kind,
+}: {
+  hiddenLessonKindSet: Set<LessonKind>;
+  kind: LessonKind;
+}) {
+  return !hiddenLessonKindSet.has(kind);
+}
+
+/**
+ * A learner should not be able to hide every lesson type currently available
+ * in the chapter. Hidden kinds must stay toggleable so the user can recover by
+ * showing them again, but the last visible kind needs to stay checked.
+ */
+function canChangeLessonKindVisibility({
+  hiddenLessonKindSet,
+  kind,
+  visibleLessonKindCount,
+}: {
+  hiddenLessonKindSet: Set<LessonKind>;
+  kind: LessonKind;
+  visibleLessonKindCount: number;
+}) {
+  if (!isLessonKindVisible({ hiddenLessonKindSet, kind })) {
+    return true;
+  }
+
+  return visibleLessonKindCount > 1;
+}
+
+/**
  * The dropdown keeps the control compact beside search while still showing the
  * full list of lesson kinds as regular menu checkbox items for keyboard users.
  */
@@ -242,6 +278,10 @@ function LessonTypeFilterMenu({
   if (lessonKindOptions.length === 0) {
     return null;
   }
+
+  const visibleLessonKindCount = lessonKindOptions.filter((option) =>
+    isLessonKindVisible({ hiddenLessonKindSet, kind: option.kind }),
+  ).length;
 
   return (
     <DropdownMenu>
@@ -276,18 +316,30 @@ function LessonTypeFilterMenu({
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuGroup>
           <DropdownMenuLabel>{t("Show lesson types")}</DropdownMenuLabel>
-          {lessonKindOptions.map((option) => (
-            <DropdownMenuCheckboxItem
-              checked={!hiddenLessonKindSet.has(option.kind)}
-              disabled={isPending}
-              key={option.kind}
-              onCheckedChange={(checked) =>
-                onVisibilityChange({ isVisible: checked, kind: option.kind })
-              }
-            >
-              {option.label}
-            </DropdownMenuCheckboxItem>
-          ))}
+          {lessonKindOptions.map((option) => {
+            const canChangeVisibility = canChangeLessonKindVisibility({
+              hiddenLessonKindSet,
+              kind: option.kind,
+              visibleLessonKindCount,
+            });
+
+            return (
+              <DropdownMenuCheckboxItem
+                checked={isLessonKindVisible({ hiddenLessonKindSet, kind: option.kind })}
+                disabled={isPending || !canChangeVisibility}
+                key={option.kind}
+                onCheckedChange={(checked) => {
+                  if (!canChangeVisibility) {
+                    return;
+                  }
+
+                  onVisibilityChange({ isVisible: checked, kind: option.kind });
+                }}
+              >
+                {option.label}
+              </DropdownMenuCheckboxItem>
+            );
+          })}
         </DropdownMenuGroup>
 
         {hiddenCount > 0 && (

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-position.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-position.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCatalogGridContext } from "@/components/catalog/catalog-grid-context";
+import { GridItemPosition, type GridItemTone } from "@zoonk/ui/components/grid";
+
+/**
+ * Lesson filters hide rows on the client, so the visible position badge needs
+ * to read the current catalog filter instead of using the database position.
+ * This keeps a filtered list numbered 1, 2, 3 even when hidden lessons sit
+ * between the visible lessons in the original chapter order.
+ */
+export function LessonListPosition({
+  lessonId,
+  position,
+  tone,
+}: {
+  lessonId: string;
+  position: number;
+  tone: GridItemTone;
+}) {
+  const context = useCatalogGridContext();
+
+  const lessonNumber = getVisibleLessonNumber({
+    filteredIds: context?.filteredIds ?? null,
+    lessonId,
+    position,
+  });
+
+  return <GridItemPosition tone={tone}>{lessonNumber}</GridItemPosition>;
+}
+
+/**
+ * The server-rendered map still includes every lesson, but the client filter
+ * exposes the visible ids in display order. The original position remains the
+ * fallback for the unfiltered state and for defensive cases where the tile is
+ * rendered before the filter context is ready.
+ */
+function getVisibleLessonNumber({
+  filteredIds,
+  lessonId,
+  position,
+}: {
+  filteredIds: Set<string> | null;
+  lessonId: string;
+  position: number;
+}) {
+  if (!filteredIds) {
+    return position;
+  }
+
+  const visibleIndex = [...filteredIds].indexOf(lessonId);
+
+  if (visibleIndex === -1) {
+    return position;
+  }
+
+  return visibleIndex + 1;
+}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -6,20 +6,18 @@ import {
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { getCatalogActiveItemKey } from "@/components/catalog/catalog-item-target";
 import { getCatalogLessonProgress } from "@/data/progress/catalog-progress";
-import { getUserHiddenLessonKinds } from "@/data/users/lesson-filter-settings";
 import { getDefaultLessonImage } from "@/lib/catalog/default-images";
 import { getLessonDisplayMeta, getLessonKindLabels } from "@/lib/lessons";
 import { getFilterableLessonKinds } from "@/lib/lessons/lesson-kind-filters";
 import { getActiveCatalogTarget } from "@zoonk/core/progress/active-catalog-target";
 import { getSession } from "@zoonk/core/users/session/get";
-import { type Lesson } from "@zoonk/db";
+import { type Lesson, type LessonKind } from "@zoonk/db";
 import {
   GridGroup,
   GridItemContent,
   GridItemDescription,
   GridItemFooter,
   GridItemMedia,
-  GridItemPosition,
   GridItemStatusCompleted,
   GridItemStatusIdle,
   GridItemTitle,
@@ -27,6 +25,7 @@ import {
 import { getExtracted } from "next-intl/server";
 import { getLessonKindTone } from "./_utils/lesson-kind-tones";
 import { LessonListFilters } from "./lesson-list-filters";
+import { LessonListPosition } from "./lesson-list-position";
 
 type LessonRow = { display: Awaited<ReturnType<typeof getLessonDisplayMeta>>; lesson: Lesson };
 
@@ -63,6 +62,7 @@ function LessonTile({
   isCompleted,
   lesson,
   notStartedLabel,
+  position,
 }: {
   brandSlug: string;
   chapterSlug: string;
@@ -72,9 +72,8 @@ function LessonTile({
   isCompleted: boolean;
   lesson: Lesson;
   notStartedLabel: string;
+  position: number;
 }) {
-  const lessonNumber = lesson.position + 1;
-
   return (
     <CatalogGridItem
       href={`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lesson.slug}`}
@@ -89,9 +88,11 @@ function LessonTile({
       </GridItemMedia>
 
       <GridItemContent>
-        <GridItemPosition tone={getLessonKindTone({ kind: lesson.kind })}>
-          {lessonNumber}
-        </GridItemPosition>
+        <LessonListPosition
+          lessonId={lesson.id}
+          position={position}
+          tone={getLessonKindTone({ kind: lesson.kind })}
+        />
         <GridItemTitle>{display.title}</GridItemTitle>
         <GridItemDescription>{display.description}</GridItemDescription>
       </GridItemContent>
@@ -124,6 +125,7 @@ export async function LessonList({
   chapterId,
   chapterSlug,
   courseSlug,
+  hiddenLessonKinds,
   isLanguageCourse,
   lessons,
 }: {
@@ -131,6 +133,7 @@ export async function LessonList({
   chapterId: string;
   chapterSlug: string;
   courseSlug: string;
+  hiddenLessonKinds: LessonKind[];
   isLanguageCourse: boolean;
   lessons: Lesson[];
 }) {
@@ -139,12 +142,11 @@ export async function LessonList({
   }
 
   const t = await getExtracted();
+  const session = await getSession();
 
-  const [completionData, activeTarget, session, hiddenLessonKinds] = await Promise.all([
-    getCatalogLessonProgress(chapterId),
-    getActiveCatalogTarget({ scope: { chapterId } }),
-    getSession(),
-    getUserHiddenLessonKinds(),
+  const [completionData, activeTarget] = await Promise.all([
+    getCatalogLessonProgress(chapterId, hiddenLessonKinds),
+    getActiveCatalogTarget({ excludedLessonKinds: hiddenLessonKinds, scope: { chapterId } }),
   ]);
 
   const lessonKindLabels = await getLessonKindLabels();
@@ -184,7 +186,7 @@ export async function LessonList({
       >
         <CatalogGridEmpty>{t("No lessons found")}</CatalogGridEmpty>
         <GridGroup variant="pane">
-          {lessonRows.map(({ display, lesson }) => {
+          {lessonRows.map(({ display, lesson }, index) => {
             const completion = completionMap.get(lesson.id);
             const isCompleted = completion?.isCompleted ?? false;
 
@@ -199,6 +201,7 @@ export async function LessonList({
                 key={lesson.id}
                 lesson={lesson}
                 notStartedLabel={t("Not started")}
+                position={index + 1}
               />
             );
           })}

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -8,8 +8,10 @@ import {
 } from "@/components/catalog/continue-lesson-link";
 import { getChapter } from "@/data/chapters/get-chapter";
 import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
+import { getUserHiddenLessonKinds } from "@/data/users/lesson-filter-settings";
 import { getNextChapterInCourse } from "@zoonk/core/lessons/next-chapter-in-course";
 import { getSession } from "@zoonk/core/users/session/get";
+import { type Lesson, type LessonKind } from "@zoonk/db";
 import { Grid, GridToolbar } from "@zoonk/ui/components/grid";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Metadata } from "next";
@@ -18,6 +20,23 @@ import { Suspense } from "react";
 import { ChapterHeader } from "./chapter-header";
 import { ChapterNotGenerated } from "./chapter-not-generated";
 import { LessonList } from "./lesson-list";
+
+/**
+ * Chapter fallbacks are only used when the shared continue target cannot find
+ * a destination. They still need to honor hidden lesson kinds so a filtered-out
+ * lesson never becomes the backup route.
+ */
+function getFirstVisibleLesson({
+  hiddenLessonKinds,
+  lessons,
+}: {
+  hiddenLessonKinds: LessonKind[];
+  lessons: Lesson[];
+}) {
+  const hiddenLessonKindSet = new Set(hiddenLessonKinds);
+
+  return lessons.find((lesson) => !hiddenLessonKindSet.has(lesson.kind));
+}
 
 export async function generateMetadata({
   params,
@@ -42,8 +61,9 @@ export default async function ChapterPage({
 }: PageProps<"/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]">) {
   const { brandSlug, chapterSlug, courseSlug } = await params;
 
-  const [chapter, session] = await Promise.all([
+  const [chapter, hiddenLessonKinds, session] = await Promise.all([
     getChapter({ brandSlug, chapterSlug, courseSlug }),
+    getUserHiddenLessonKinds(),
     getSession(),
   ]);
 
@@ -62,8 +82,10 @@ export default async function ChapterPage({
     ? (`/b/${nextChapter.brandSlug}/c/${nextChapter.courseSlug}/ch/${nextChapter.chapterSlug}` as const)
     : undefined;
 
-  const fallbackHref = lessons[0]
-    ? (`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessons[0].slug}` as const)
+  const firstVisibleLesson = getFirstVisibleLesson({ hiddenLessonKinds, lessons });
+
+  const fallbackHref = firstVisibleLesson
+    ? (`/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${firstVisibleLesson.slug}` as const)
     : undefined;
 
   return (
@@ -82,11 +104,13 @@ export default async function ChapterPage({
                 <ContinueLessonLink
                   chapterId={chapter.id}
                   completedHref={completedHref}
+                  excludedLessonKinds={hiddenLessonKinds}
                   fallbackHref={fallbackHref}
                 />
               </Suspense>
               <Suspense fallback={null}>
                 <CatalogActiveShortcutLink
+                  excludedLessonKinds={hiddenLessonKinds}
                   items={lessons}
                   kind="lesson"
                   scope={{ chapterId: chapter.id }}
@@ -113,6 +137,7 @@ export default async function ChapterPage({
               chapterId={chapter.id}
               chapterSlug={chapterSlug}
               courseSlug={courseSlug}
+              hiddenLessonKinds={hiddenLessonKinds}
               isLanguageCourse={Boolean(chapter.course.targetLanguage)}
               lessons={lessons}
             />

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -9,6 +9,7 @@ import { getCatalogActiveItemKey } from "@/components/catalog/catalog-item-targe
 import { type CourseChapter } from "@/data/chapters/list-course-chapters";
 import { getCatalogChapterProgress } from "@/data/progress/catalog-progress";
 import { getActiveCatalogTarget } from "@zoonk/core/progress/active-catalog-target";
+import { type LessonKind } from "@zoonk/db";
 import {
   GridGroup,
   GridItemContent,
@@ -167,12 +168,14 @@ export async function ChapterList({
   courseId,
   courseSlug,
   defaultChapterImage,
+  hiddenLessonKinds,
 }: {
   brandSlug: string;
   chapters: CourseChapter[];
   courseId: string;
   courseSlug: string;
   defaultChapterImage: string;
+  hiddenLessonKinds: LessonKind[];
 }) {
   if (chapters.length === 0) {
     return null;
@@ -181,8 +184,8 @@ export async function ChapterList({
   const t = await getExtracted();
 
   const [completionData, activeTarget] = await Promise.all([
-    getCatalogChapterProgress(courseId),
-    getActiveCatalogTarget({ scope: { courseId } }),
+    getCatalogChapterProgress(courseId, hiddenLessonKinds),
+    getActiveCatalogTarget({ excludedLessonKinds: hiddenLessonKinds, scope: { courseId } }),
   ]);
 
   const completionMap = new Map(completionData.map((row) => [row.chapterId, row]));
@@ -200,7 +203,7 @@ export async function ChapterList({
           {chapters.map((chapter) => {
             const completion = completionMap.get(chapter.id);
             const completedLessons = completion?.completedLessons ?? 0;
-            const totalLessons = chapter._count.lessons;
+            const totalLessons = completion?.totalLessons ?? chapter._count.lessons;
 
             return (
               <ChapterTile

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/catalog/continue-lesson-link";
 import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { getCourse } from "@/data/courses/get-course";
+import { getUserHiddenLessonKinds } from "@/data/users/lesson-filter-settings";
 import { getDefaultChapterImage } from "@/lib/catalog/default-images";
 import { getSession } from "@zoonk/core/users/session/get";
 import { Grid, GridToolbar } from "@zoonk/ui/components/grid";
@@ -43,7 +44,11 @@ export async function generateMetadata({
 export default async function CoursePage({ params }: PageProps<"/b/[brandSlug]/c/[courseSlug]">) {
   const { brandSlug, courseSlug } = await params;
 
-  const [course, session] = await Promise.all([getCourse({ brandSlug, courseSlug }), getSession()]);
+  const [course, hiddenLessonKinds, session] = await Promise.all([
+    getCourse({ brandSlug, courseSlug }),
+    getUserHiddenLessonKinds(),
+    getSession(),
+  ]);
 
   if (!course) {
     notFound();
@@ -68,10 +73,15 @@ export default async function CoursePage({ params }: PageProps<"/b/[brandSlug]/c
           <CourseHeader brandSlug={brandSlug} course={course} variant="sidebar" />
           <GridToolbar>
             <Suspense fallback={<ContinueLessonLinkSkeleton />}>
-              <ContinueLessonLink courseId={course.id} fallbackHref={fallbackHref} />
+              <ContinueLessonLink
+                courseId={course.id}
+                excludedLessonKinds={hiddenLessonKinds}
+                fallbackHref={fallbackHref}
+              />
             </Suspense>
             <Suspense fallback={null}>
               <CatalogActiveShortcutLink
+                excludedLessonKinds={hiddenLessonKinds}
                 items={chapters}
                 kind="chapter"
                 scope={{ courseId: course.id }}
@@ -95,6 +105,7 @@ export default async function CoursePage({ params }: PageProps<"/b/[brandSlug]/c
             courseId={course.id}
             courseSlug={courseSlug}
             defaultChapterImage={defaultChapterImage}
+            hiddenLessonKinds={hiddenLessonKinds}
           />
         </Suspense>
       </Grid>

--- a/apps/main/src/components/catalog/catalog-active-shortcut-link.tsx
+++ b/apps/main/src/components/catalog/catalog-active-shortcut-link.tsx
@@ -3,6 +3,7 @@ import {
   type ActiveCatalogTarget,
   getActiveCatalogTarget,
 } from "@zoonk/core/progress/active-catalog-target";
+import { type LessonKind } from "@zoonk/db";
 import { buttonVariants } from "@zoonk/ui/components/button";
 import { ArrowDownIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
@@ -15,6 +16,8 @@ import { CatalogSmoothScrollLink } from "./catalog-smooth-scroll-link";
 
 type CatalogActiveShortcutKind = "chapter" | "lesson";
 type CatalogActiveShortcutItem = { id: CatalogGridItemKey; slug: string };
+
+const EMPTY_EXCLUDED_LESSON_KINDS: LessonKind[] = [];
 
 /**
  * Course pages jump to chapters, while chapter pages jump to lessons. Keeping
@@ -45,15 +48,17 @@ function getActiveShortcutSlug({
  * the floating action.
  */
 export async function CatalogActiveShortcutLink({
+  excludedLessonKinds = EMPTY_EXCLUDED_LESSON_KINDS,
   items,
   kind,
   scope,
 }: {
+  excludedLessonKinds?: LessonKind[];
   items: readonly CatalogActiveShortcutItem[];
   kind: CatalogActiveShortcutKind;
   scope: LessonScope;
 }) {
-  const activeTarget = await getActiveCatalogTarget({ scope });
+  const activeTarget = await getActiveCatalogTarget({ excludedLessonKinds, scope });
   const activeSlug = getActiveShortcutSlug({ activeTarget, kind });
   const activeItemKey = getCatalogActiveItemKey({ activeSlug, items });
 

--- a/apps/main/src/components/catalog/continue-lesson-link.tsx
+++ b/apps/main/src/components/catalog/continue-lesson-link.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/data/progress/catalog-progress";
 import { type LessonScope } from "@zoonk/core/lessons/last-completed";
 import { getContinueLessonTarget } from "@zoonk/core/progress/continue-lesson-target";
+import { type LessonKind } from "@zoonk/db";
 import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronRightIcon } from "lucide-react";
@@ -13,6 +14,8 @@ import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 
 type ContinueLessonProgressContent = { ariaLabel: string; text: string };
+
+const EMPTY_EXCLUDED_LESSON_KINDS: LessonKind[] = [];
 
 function getScope(props: {
   chapterId?: string;
@@ -56,13 +59,19 @@ function getVisibleProgress({ progress }: { progress?: ContinueLessonProgress | 
  * from the scope keeps pages from threading promises through sibling
  * components just to feed this small visual hint.
  */
-function getContinueLessonProgress({ scope }: { scope: LessonScope }) {
+function getContinueLessonProgress({
+  excludedLessonKinds,
+  scope,
+}: {
+  excludedLessonKinds: LessonKind[];
+  scope: LessonScope;
+}) {
   if ("courseId" in scope) {
-    return getCourseContinueProgress(scope.courseId);
+    return getCourseContinueProgress(scope.courseId, excludedLessonKinds);
   }
 
   if ("chapterId" in scope) {
-    return getChapterContinueProgress(scope.chapterId);
+    return getChapterContinueProgress(scope.chapterId, excludedLessonKinds);
   }
 
   return Promise.resolve(null);
@@ -106,12 +115,14 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
   chapterId,
   completedHref,
   courseId,
+  excludedLessonKinds = EMPTY_EXCLUDED_LESSON_KINDS,
   fallbackHref,
   lessonId,
 }: {
   chapterId?: string;
   completedHref?: Route<CompletedHref>;
   courseId?: string;
+  excludedLessonKinds?: LessonKind[];
   fallbackHref?: Route<Href>;
   lessonId?: string;
 }) {
@@ -119,8 +130,8 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
   const scope = getScope({ chapterId, courseId, lessonId });
 
   const [data, resolvedProgress] = await Promise.all([
-    getContinueLessonTarget({ scope }),
-    getContinueLessonProgress({ scope }),
+    getContinueLessonTarget({ excludedLessonKinds, scope }),
+    getContinueLessonProgress({ excludedLessonKinds, scope }),
   ]);
 
   const className = cn(buttonVariants(), "min-w-0 flex-1 gap-2");

--- a/apps/main/src/data/courses/_utils/continue-learning-candidates.ts
+++ b/apps/main/src/data/courses/_utils/continue-learning-candidates.ts
@@ -1,5 +1,5 @@
 import { type NextLessonInCourse, getNextLessonInCourse } from "@zoonk/core/lessons/next-in-course";
-import { prisma } from "@zoonk/db";
+import { type LessonKind, prisma } from "@zoonk/db";
 import { type ContinueLearningState, listNextLessonStates } from "./continue-learning-next-state";
 import { type PendingTarget, listPendingTargets } from "./continue-learning-pending-targets";
 import { type ContinueLearningRow } from "./continue-learning-queries";
@@ -24,20 +24,22 @@ type SequentialTargetIds = { chapterIds: string[]; lessonIds: string[] };
  * function focused on choosing the final card for each course.
  */
 export async function listContinueLearningCandidates({
+  excludedLessonKinds,
   rows,
   userId,
 }: {
+  excludedLessonKinds?: LessonKind[];
   rows: ContinueLearningRow[];
   userId: string;
 }): Promise<ContinueLearningCandidate[]> {
   const [sequentialNextLessons, nextStates] = await Promise.all([
-    listSequentialNextLessons({ rows }),
-    listNextLessonStates({ rows, userId }),
+    listSequentialNextLessons({ excludedLessonKinds, rows }),
+    listNextLessonStates({ excludedLessonKinds, rows, userId }),
   ]);
 
   const [blockedSequentialTargetIds, pendingTargets] = await Promise.all([
     listBlockedSequentialTargetIds({ sequentialNextLessons, userId }),
-    listPendingTargets({ rows, states: nextStates }),
+    listPendingTargets({ excludedLessonKinds, rows, states: nextStates }),
   ]);
 
   return rows.map((row, idx) =>
@@ -56,13 +58,20 @@ export async function listContinueLearningCandidates({
  * first resolving the structural next lesson after the learner's most recent
  * completion in each course.
  */
-async function listSequentialNextLessons({ rows }: { rows: ContinueLearningRow[] }) {
+async function listSequentialNextLessons({
+  excludedLessonKinds,
+  rows,
+}: {
+  excludedLessonKinds?: LessonKind[];
+  rows: ContinueLearningRow[];
+}) {
   return Promise.all(
     rows.map((row) =>
       getNextLessonInCourse({
         chapterId: row.chapterId,
         chapterPosition: row.chapterPosition,
         courseId: row.courseId,
+        excludedLessonKinds,
         lessonPosition: row.lessonPosition,
       }),
     ),

--- a/apps/main/src/data/courses/_utils/continue-learning-next-state.ts
+++ b/apps/main/src/data/courses/_utils/continue-learning-next-state.ts
@@ -2,6 +2,7 @@ import {
   type NextLessonState,
   getNextLessonStateForUser,
 } from "@zoonk/core/progress/next-lesson-state";
+import { type LessonKind } from "@zoonk/db";
 import { type ContinueLearningRow } from "./continue-learning-queries";
 
 export type ContinueLearningState = NextLessonState | null;
@@ -12,9 +13,11 @@ export type ContinueLearningState = NextLessonState | null;
  * jumping back to earlier skipped lessons.
  */
 export async function listNextLessonStates({
+  excludedLessonKinds,
   rows,
   userId,
 }: {
+  excludedLessonKinds?: LessonKind[];
   rows: ContinueLearningRow[];
   userId: string;
 }) {
@@ -26,6 +29,7 @@ export async function listNextLessonStates({
           lessonId: row.lessonId,
           lessonPosition: row.lessonPosition,
         },
+        excludedLessonKinds,
         scope: { courseId: row.courseId },
         userId,
       }),

--- a/apps/main/src/data/courses/_utils/continue-learning-pending-targets.ts
+++ b/apps/main/src/data/courses/_utils/continue-learning-pending-targets.ts
@@ -1,6 +1,6 @@
 import { getNextChapterInCourse } from "@zoonk/core/lessons/next-chapter-in-course";
 import { getNextLessonInCourse } from "@zoonk/core/lessons/next-in-course";
-import { type Chapter, type Lesson } from "@zoonk/db";
+import { type Chapter, type Lesson, type LessonKind } from "@zoonk/db";
 import { type ContinueLearningState } from "./continue-learning-next-state";
 import { type ContinueLearningRow } from "./continue-learning-queries";
 
@@ -16,14 +16,18 @@ export type PendingTarget = {
  * rows that actually need them.
  */
 export async function listPendingTargets({
+  excludedLessonKinds,
   rows,
   states,
 }: {
+  excludedLessonKinds?: LessonKind[];
   rows: ContinueLearningRow[];
   states: ContinueLearningState[];
 }) {
   return Promise.all(
-    rows.map((row, idx) => listPendingTarget({ row, state: states[idx] ?? null })),
+    rows.map((row, idx) =>
+      listPendingTarget({ excludedLessonKinds, row, state: states[idx] ?? null }),
+    ),
   );
 }
 
@@ -41,9 +45,11 @@ function shouldLoadPendingTarget({ state }: { state: ContinueLearningState }) {
  * avoids embedding branching logic directly inside the array mapping step.
  */
 async function listPendingTarget({
+  excludedLessonKinds,
   row,
   state,
 }: {
+  excludedLessonKinds?: LessonKind[];
   row: ContinueLearningRow;
   state: ContinueLearningState;
 }) {
@@ -51,7 +57,7 @@ async function listPendingTarget({
     return null;
   }
 
-  return findPendingTarget({ row });
+  return findPendingTarget({ excludedLessonKinds, row });
 }
 
 /**
@@ -60,14 +66,17 @@ async function listPendingTarget({
  * chapter. That keeps the card useful even while generation is pending.
  */
 async function findPendingTarget({
+  excludedLessonKinds,
   row,
 }: {
+  excludedLessonKinds?: LessonKind[];
   row: ContinueLearningRow;
 }): Promise<PendingTarget | null> {
   const nextLesson = await getNextLessonInCourse({
     chapterId: row.chapterId,
     chapterPosition: row.chapterPosition,
     courseId: row.courseId,
+    excludedLessonKinds,
     lessonPosition: row.lessonPosition,
   });
 

--- a/apps/main/src/data/courses/_utils/continue-learning-queries.ts
+++ b/apps/main/src/data/courses/_utils/continue-learning-queries.ts
@@ -1,4 +1,5 @@
-import { prisma } from "@zoonk/db";
+import { getLessonKindExclusionSql } from "@zoonk/core/lessons/kind-exclusions";
+import { type LessonKind, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 
 /**
@@ -32,10 +33,14 @@ const SQL_LIMIT = 10;
  * published curriculum.
  */
 export async function listRecentContinueLearningRows({
+  excludedLessonKinds,
   userId,
 }: {
+  excludedLessonKinds?: LessonKind[];
   userId: string;
 }): Promise<ContinueLearningRow[]> {
+  const lessonKindFilter = getLessonKindExclusionSql({ excludedLessonKinds });
+
   const { data, error } = await safeAsync(
     () =>
       prisma.$queryRaw<ContinueLearningRow[]>`
@@ -57,7 +62,10 @@ export async function listRecentContinueLearningRows({
           JOIN chapters ch ON ch.id = l.chapter_id
           JOIN courses c ON c.id = ch.course_id AND c.is_published = true
           LEFT JOIN organizations o ON o.id = c.organization_id
-          WHERE ap.user_id = ${userId} AND ap.completed_at IS NOT NULL AND (o.kind = 'brand' OR o.id IS NULL)
+          WHERE ap.user_id = ${userId}
+            AND ap.completed_at IS NOT NULL
+            AND ${lessonKindFilter}
+            AND (o.kind = 'brand' OR o.id IS NULL)
           ORDER BY ch.course_id, ap.completed_at DESC
         )
         SELECT

--- a/apps/main/src/data/courses/get-continue-learning.test.ts
+++ b/apps/main/src/data/courses/get-continue-learning.test.ts
@@ -106,6 +106,75 @@ describe("authenticated users", () => {
     });
   });
 
+  it("uses visible lesson kinds when choosing the next home continue target", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const [headers, chapter] = await Promise.all([
+      signInAs(user.email, user.password),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+    ]);
+
+    const [completedLesson, hiddenLesson, nextVisibleLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "quiz",
+        organizationId: organization.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        organizationId: organization.id,
+        position: 2,
+      }),
+    ]);
+
+    await Promise.all([
+      prisma.userLearningProfile.create({
+        data: { preferences: { hiddenLessonKinds: ["quiz"] }, userId: user.id },
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: completedLesson.id,
+        userId: user.id,
+      }),
+    ]);
+
+    const result = await getContinueLearning(headers);
+
+    expect(result).toHaveLength(1);
+
+    expect(result[0]).toMatchObject({
+      chapter: { id: chapter.id, title: chapter.title },
+      course: { id: course.id },
+      lesson: { id: nextVisibleLesson.id },
+      status: "completed",
+    });
+
+    expect(result[0]).not.toMatchObject({ lesson: { id: hiddenLesson.id } });
+  });
+
   it("does not reopen a durably completed lesson after new lessons are added", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);

--- a/apps/main/src/data/courses/get-continue-learning.ts
+++ b/apps/main/src/data/courses/get-continue-learning.ts
@@ -3,6 +3,7 @@ import { type NextLessonInCourse } from "@zoonk/core/lessons/next-in-course";
 import { getSession } from "@zoonk/core/users/session/get";
 import { type Chapter, type Course, type LessonKind, type Organization } from "@zoonk/db";
 import { cache } from "react";
+import { getUserHiddenLessonKinds } from "../users/lesson-filter-settings";
 import {
   type ContinueLearningCandidate,
   listContinueLearningCandidates,
@@ -275,13 +276,22 @@ export const getContinueLearning = cache(
     }
 
     const userId = session.user.id;
-    const rows = await listRecentContinueLearningRows({ userId });
+    const hiddenLessonKinds = await getUserHiddenLessonKinds(headers);
+
+    const rows = await listRecentContinueLearningRows({
+      excludedLessonKinds: hiddenLessonKinds,
+      userId,
+    });
 
     if (rows.length === 0) {
       return [];
     }
 
-    const candidates = await listContinueLearningCandidates({ rows, userId });
+    const candidates = await listContinueLearningCandidates({
+      excludedLessonKinds: hiddenLessonKinds,
+      rows,
+      userId,
+    });
 
     return candidates
       .map((candidate) => toContinueLearningItem({ candidate }))

--- a/apps/main/src/data/progress/catalog-progress.ts
+++ b/apps/main/src/data/progress/catalog-progress.ts
@@ -1,8 +1,16 @@
 import "server-only";
+import {
+  getLessonKindExclusionCacheArgs,
+  getLessonKindExclusionWhere,
+} from "@zoonk/core/lessons/kind-exclusions";
 import { getChapterProgress } from "@zoonk/core/progress/chapters";
 import { getLessonProgress } from "@zoonk/core/progress/lessons";
-import { getSession } from "@zoonk/core/users/session/get";
-import { getPublishedChapterWhere, getPublishedLessonWhere, prisma } from "@zoonk/db";
+import {
+  type LessonKind,
+  getPublishedChapterWhere,
+  getPublishedLessonWhere,
+  prisma,
+} from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
@@ -17,45 +25,88 @@ export type ContinueLessonProgress = {
  * progress. React cache keeps repeated reads for the same course inside one
  * server render from issuing duplicate progress queries.
  */
-export const getCatalogChapterProgress = cache(async (courseId: string) =>
-  getChapterProgress({ courseId }),
+const cachedCatalogChapterProgress = cache(
+  async (courseId: string, ...excludedLessonKinds: LessonKind[]) =>
+    getChapterProgress({ courseId, excludedLessonKinds }),
 );
+
+export function getCatalogChapterProgress(
+  courseId: string,
+  excludedLessonKinds: LessonKind[] = [],
+) {
+  return cachedCatalogChapterProgress(
+    courseId,
+    ...getLessonKindExclusionCacheArgs({ excludedLessonKinds }),
+  );
+}
 
 /**
  * The Continue button and lesson grid both need the same lesson completion
  * rows on chapter pages. Caching by chapter id keeps those sibling Suspense
  * boundaries independent without paying for the query twice in one render.
  */
-export const getCatalogLessonProgress = cache(async (chapterId: string) =>
-  getLessonProgress({ chapterId }),
+const cachedCatalogLessonProgress = cache(
+  async (chapterId: string, ...excludedLessonKinds: LessonKind[]) =>
+    getLessonProgress({ chapterId, excludedLessonKinds }),
 );
 
+export function getCatalogLessonProgress(
+  chapterId: string,
+  excludedLessonKinds: LessonKind[] = [],
+) {
+  return cachedCatalogLessonProgress(
+    chapterId,
+    ...getLessonKindExclusionCacheArgs({ excludedLessonKinds }),
+  );
+}
+
 /**
- * Course-level progress counts completed chapters, not generated lesson rows.
- * Lessons are generated on demand, so chapter completions are the stable unit
- * learners expect when scanning overall course progress.
+ * A chapter counts as complete on the course CTA when every visible lesson is
+ * complete. Reusing the same filtered chapter rows as the cards prevents a
+ * hidden lesson type from keeping the course progress suffix stuck behind the
+ * lesson set the learner chose not to see.
  */
-export const getCourseContinueProgress = cache(
-  async (courseId: string): Promise<ContinueLessonProgress> => {
-    const [completedItems, totalItems] = await Promise.all([
-      countCompletedPublishedCourseChapters(courseId),
+const cachedCourseContinueProgress = cache(
+  async (
+    courseId: string,
+    ...excludedLessonKinds: LessonKind[]
+  ): Promise<ContinueLessonProgress> => {
+    const [chapterProgressRows, totalItems] = await Promise.all([
+      cachedCatalogChapterProgress(courseId, ...excludedLessonKinds),
       countPublishedCourseChapters(courseId),
     ]);
 
-    return { completedItems, totalItems, unit: "chapters" };
+    return {
+      completedItems: countCompletedChapterProgressRows({ rows: chapterProgressRows }),
+      totalItems,
+      unit: "chapters",
+    };
   },
 );
+
+export function getCourseContinueProgress(
+  courseId: string,
+  excludedLessonKinds: LessonKind[] = [],
+) {
+  return cachedCourseContinueProgress(
+    courseId,
+    ...getLessonKindExclusionCacheArgs({ excludedLessonKinds }),
+  );
+}
 
 /**
  * Chapter-level progress still counts lessons because chapter pages list the
  * concrete lesson rows. Reusing cached lesson progress keeps this aligned with
  * the status badges rendered by the lesson grid.
  */
-export const getChapterContinueProgress = cache(
-  async (chapterId: string): Promise<ContinueLessonProgress> => {
+const cachedChapterContinueProgress = cache(
+  async (
+    chapterId: string,
+    ...excludedLessonKinds: LessonKind[]
+  ): Promise<ContinueLessonProgress> => {
     const [progressRows, totalItems] = await Promise.all([
-      getCatalogLessonProgress(chapterId),
-      countPublishedChapterLessons(chapterId),
+      cachedCatalogLessonProgress(chapterId, ...excludedLessonKinds),
+      countPublishedChapterLessons({ chapterId, excludedLessonKinds }),
     ]);
 
     return {
@@ -66,25 +117,28 @@ export const getChapterContinueProgress = cache(
   },
 );
 
-/**
- * Anonymous users have no durable completions, but the course button still
- * needs a zero count against the visible chapter total.
- */
-async function countCompletedPublishedCourseChapters(courseId: string) {
-  const session = await getSession();
-  const userId = session?.user.id;
-
-  if (!userId) {
-    return 0;
-  }
-
-  const { data } = await safeAsync(() =>
-    prisma.chapterCompletion.count({
-      where: { chapter: getPublishedChapterWhere({ chapterWhere: { courseId } }), userId },
-    }),
+export function getChapterContinueProgress(
+  chapterId: string,
+  excludedLessonKinds: LessonKind[] = [],
+) {
+  return cachedChapterContinueProgress(
+    chapterId,
+    ...getLessonKindExclusionCacheArgs({ excludedLessonKinds }),
   );
+}
 
-  return data ?? 0;
+/**
+ * Empty chapters should not count as completed just because there are no
+ * visible lessons left after filtering. They stay at zero progress until the
+ * course has at least one visible completed lesson in that chapter.
+ */
+function countCompletedChapterProgressRows({
+  rows,
+}: {
+  rows: Awaited<ReturnType<typeof getCatalogChapterProgress>>;
+}) {
+  return rows.filter((row) => row.totalLessons > 0 && row.completedLessons >= row.totalLessons)
+    .length;
 }
 
 /**
@@ -103,9 +157,20 @@ async function countPublishedCourseChapters(courseId: string) {
  * Chapter progress uses the visible lesson total so the Continue button and
  * lesson grid agree about the same generated lesson set.
  */
-async function countPublishedChapterLessons(chapterId: string) {
+async function countPublishedChapterLessons({
+  chapterId,
+  excludedLessonKinds,
+}: {
+  chapterId: string;
+  excludedLessonKinds: LessonKind[];
+}) {
   const { data } = await safeAsync(() =>
-    prisma.lesson.count({ where: getPublishedLessonWhere({ chapterWhere: { id: chapterId } }) }),
+    prisma.lesson.count({
+      where: getPublishedLessonWhere({
+        chapterWhere: { id: chapterId },
+        lessonWhere: getLessonKindExclusionWhere({ excludedLessonKinds }),
+      }),
+    }),
   );
 
   return data ?? 0;

--- a/apps/main/src/data/users/lesson-filter-settings.ts
+++ b/apps/main/src/data/users/lesson-filter-settings.ts
@@ -12,8 +12,8 @@ import { logError } from "@zoonk/utils/logger";
  * The chapter lesson list reads hidden kinds from the learner profile so the
  * same filters follow the signed-in learner across devices and browser sessions.
  */
-export async function getUserHiddenLessonKinds(): Promise<LessonKind[]> {
-  const session = await getSession();
+export async function getUserHiddenLessonKinds(headers?: Headers): Promise<LessonKind[]> {
+  const session = await getSession(headers);
 
   if (!session) {
     return [];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
     "./lessons/access": "./src/lessons/access.ts",
     "./lessons/generated-companion-kinds": "./src/lessons/generated-companion-kinds.ts",
     "./lessons/generated-companions": "./src/lessons/generated-companions.ts",
+    "./lessons/kind-exclusions": "./src/lessons/lesson-kind-exclusions.ts",
     "./lessons/last-completed": "./src/lessons/find-last-completed.ts",
     "./lessons/next-chapter-in-course": "./src/lessons/get-next-chapter-in-course.ts",
     "./lessons/next-in-course": "./src/lessons/get-next-lesson-in-course.ts",

--- a/packages/core/src/lessons/find-last-completed.test.ts
+++ b/packages/core/src/lessons/find-last-completed.test.ts
@@ -138,6 +138,65 @@ describe(findLastCompleted, () => {
     expect(result).toHaveProperty("orgSlug");
   });
 
+  it("ignores completed excluded lesson kinds when choosing the latest completion", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: orgId }),
+    ]);
+
+    const uid = user.id;
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: orgId,
+      position: 0,
+    });
+
+    const [visibleLesson, hiddenCompletedLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        organizationId: orgId,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "quiz",
+        organizationId: orgId,
+        position: 1,
+      }),
+    ]);
+
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: visibleLesson.id,
+        userId: uid,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-02"),
+        durationSeconds: 60,
+        lessonId: hiddenCompletedLesson.id,
+        userId: uid,
+      }),
+    ]);
+
+    const result = await findLastCompleted(
+      uid,
+      { courseId: course.id },
+      { excludedLessonKinds: ["quiz"] },
+    );
+
+    expect(result).toMatchObject({ lessonId: visibleLesson.id, lessonPosition: 0 });
+    expect(result).not.toMatchObject({ lessonId: hiddenCompletedLesson.id });
+  });
+
   it("tiebreaker: returns furthest lesson when completedAt is identical", async () => {
     const user = await userFixture();
     const uid = user.id;

--- a/packages/core/src/lessons/find-last-completed.ts
+++ b/packages/core/src/lessons/find-last-completed.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { getPublishedLessonWhere, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { type LessonKindExclusion, getLessonKindExclusionWhere } from "./lesson-kind-exclusions";
 
 export type LessonScope = { courseId: string } | { chapterId: string } | { lessonId: string };
 
@@ -19,16 +20,21 @@ type LastCompletedLesson = {
 /**
  * Builds the published lesson filter for the requested curriculum scope.
  */
-function getScopeLessonWhere(scope: LessonScope) {
+function getScopeLessonWhere({
+  excludedLessonKinds,
+  scope,
+}: LessonKindExclusion & { scope: LessonScope }) {
+  const lessonWhere = getLessonKindExclusionWhere({ excludedLessonKinds });
+
   if ("courseId" in scope) {
-    return getPublishedLessonWhere({ courseWhere: { id: scope.courseId } });
+    return getPublishedLessonWhere({ courseWhere: { id: scope.courseId }, lessonWhere });
   }
 
   if ("chapterId" in scope) {
-    return getPublishedLessonWhere({ chapterWhere: { id: scope.chapterId } });
+    return getPublishedLessonWhere({ chapterWhere: { id: scope.chapterId }, lessonWhere });
   }
 
-  return getPublishedLessonWhere({ lessonWhere: { id: scope.lessonId } });
+  return getPublishedLessonWhere({ lessonWhere: { ...lessonWhere, id: scope.lessonId } });
 }
 
 /**
@@ -38,6 +44,7 @@ function getScopeLessonWhere(scope: LessonScope) {
 export async function findLastCompleted(
   userId: string,
   scope: LessonScope,
+  options: LessonKindExclusion = {},
 ): Promise<LastCompletedLesson | null> {
   const { data: progress, error } = await safeAsync(() =>
     prisma.lessonProgress.findFirst({
@@ -51,7 +58,11 @@ export async function findLastCompleted(
         { lesson: { chapter: { position: "desc" } } },
         { lesson: { position: "desc" } },
       ],
-      where: { completedAt: { not: null }, lesson: getScopeLessonWhere(scope), userId },
+      where: {
+        completedAt: { not: null },
+        lesson: getScopeLessonWhere({ excludedLessonKinds: options.excludedLessonKinds, scope }),
+        userId,
+      },
     }),
   );
 

--- a/packages/core/src/lessons/get-next-lesson-in-course.test.ts
+++ b/packages/core/src/lessons/get-next-lesson-in-course.test.ts
@@ -188,6 +188,63 @@ describe(getNextLessonInCourse, () => {
     });
   });
 
+  it("skips excluded lesson kinds", async () => {
+    const testOrg = await organizationFixture({ kind: "brand" });
+    const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });
+
+    const testChapter = await chapterFixture({
+      courseId: testCourse.id,
+      isPublished: true,
+      organizationId: testOrg.id,
+      position: 0,
+    });
+
+    const lessons = await Promise.all([
+      lessonFixture({
+        chapterId: testChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        organizationId: testOrg.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: testChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "quiz",
+        organizationId: testOrg.id,
+        position: 1,
+      }),
+      lessonFixture({
+        chapterId: testChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "practice",
+        organizationId: testOrg.id,
+        position: 2,
+      }),
+    ]);
+
+    const practiceLesson = lessons[2];
+
+    const result = await getNextLessonInCourse({
+      chapterId: testChapter.id,
+      chapterPosition: 0,
+      courseId: testCourse.id,
+      excludedLessonKinds: ["quiz"],
+      lessonPosition: 0,
+    });
+
+    expect(result).toMatchObject({
+      chapterSlug: testChapter.slug,
+      lessonId: practiceLesson.id,
+      lessonKind: "practice",
+      lessonPosition: 2,
+      lessonSlug: practiceLesson.slug,
+    });
+  });
+
   it("returns the next lesson shell even when it still needs generation", async () => {
     const testOrg = await organizationFixture({ kind: "brand" });
     const testCourse = await courseFixture({ isPublished: true, organizationId: testOrg.id });

--- a/packages/core/src/lessons/get-next-lesson-in-course.ts
+++ b/packages/core/src/lessons/get-next-lesson-in-course.ts
@@ -2,6 +2,11 @@ import "server-only";
 import { type GenerationStatus, type LessonKind, getPublishedLessonWhere, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
+import {
+  type LessonKindExclusion,
+  getLessonKindExclusionCacheArgs,
+  getLessonKindExclusionWhere,
+} from "./lesson-kind-exclusions";
 
 export type NextLessonInCourse = {
   lessonId: string;
@@ -23,6 +28,7 @@ const cachedGetNextLesson = cache(
     chapterPosition: number,
     courseId: string,
     lessonPosition: number,
+    ...excludedLessonKinds: LessonKind[]
   ): Promise<NextLessonInCourse | null> => {
     const { data: lesson, error } = await safeAsync(() =>
       prisma.lesson.findFirst({
@@ -31,6 +37,7 @@ const cachedGetNextLesson = cache(
         where: getPublishedLessonWhere({
           courseWhere: { id: courseId },
           lessonWhere: {
+            ...getLessonKindExclusionWhere({ excludedLessonKinds }),
             OR: [
               { chapter: { id: chapterId }, position: { gt: lessonPosition } },
               { chapter: { position: { gt: chapterPosition } } },
@@ -67,6 +74,7 @@ export function getNextLessonInCourse(params: {
   chapterId: string;
   chapterPosition: number;
   courseId: string;
+  excludedLessonKinds?: LessonKindExclusion["excludedLessonKinds"];
   lessonPosition: number;
 }): Promise<NextLessonInCourse | null> {
   return cachedGetNextLesson(
@@ -74,5 +82,6 @@ export function getNextLessonInCourse(params: {
     params.chapterPosition,
     params.courseId,
     params.lessonPosition,
+    ...getLessonKindExclusionCacheArgs({ excludedLessonKinds: params.excludedLessonKinds }),
   );
 }

--- a/packages/core/src/lessons/lesson-kind-exclusions.test.ts
+++ b/packages/core/src/lessons/lesson-kind-exclusions.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getLessonKindExclusionCacheArgs } from "./lesson-kind-exclusions";
+
+describe(getLessonKindExclusionCacheArgs, () => {
+  it("deduplicates and sorts hidden lesson kinds for primitive cache keys", () => {
+    const result = getLessonKindExclusionCacheArgs({
+      excludedLessonKinds: ["quiz", "explanation", "quiz"],
+    });
+
+    expect(result).toStrictEqual(["explanation", "quiz"]);
+  });
+
+  it("returns an empty key when no lesson kinds are hidden", () => {
+    expect(getLessonKindExclusionCacheArgs({})).toStrictEqual([]);
+  });
+});

--- a/packages/core/src/lessons/lesson-kind-exclusions.ts
+++ b/packages/core/src/lessons/lesson-kind-exclusions.ts
@@ -1,0 +1,55 @@
+import { type LessonKind, type Sql, sql } from "@zoonk/db";
+
+export type LessonKindExclusion = { excludedLessonKinds?: LessonKind[] };
+
+/**
+ * React cache keys compare array arguments by identity, so hidden-kind filters
+ * need to become sorted primitive arguments before they reach cached loaders.
+ * Dedupe keeps logically identical filters such as ["quiz", "quiz"] and
+ * ["quiz"] sharing the same cache entry.
+ */
+export function getLessonKindExclusionCacheArgs({
+  excludedLessonKinds,
+}: LessonKindExclusion): LessonKind[] {
+  return [...new Set(excludedLessonKinds)].toSorted();
+}
+
+/**
+ * Converts user-hidden lesson kinds into the Prisma fragment shared by lesson
+ * navigation queries. Returning an empty object when nothing is hidden keeps
+ * callers from adding separate branches around every published-lesson filter.
+ */
+export function getLessonKindExclusionWhere({ excludedLessonKinds }: LessonKindExclusion): {
+  kind?: { notIn: LessonKind[] };
+} {
+  if (!excludedLessonKinds?.length) {
+    return {};
+  }
+
+  return { kind: { notIn: excludedLessonKinds } };
+}
+
+/**
+ * Raw progress-style SQL uses the `lessons` table as alias `l`, so callers can
+ * reuse this predicate whenever they need the same hidden-kind exclusion
+ * outside Prisma's object query API.
+ */
+export function getLessonKindExclusionSql({ excludedLessonKinds }: LessonKindExclusion): Sql {
+  if (!excludedLessonKinds?.length) {
+    return sql`TRUE`;
+  }
+
+  return getLessonKindExclusionSqlParts(excludedLessonKinds);
+}
+
+/**
+ * Recursively composes one parameter per hidden lesson kind so raw SQL stays
+ * injection-safe without hand-building an `IN (...)` string.
+ */
+function getLessonKindExclusionSqlParts([kind, ...rest]: LessonKind[]): Sql {
+  if (!kind) {
+    return sql`TRUE`;
+  }
+
+  return sql`l.kind <> ${kind}::"LessonKind" AND ${getLessonKindExclusionSqlParts(rest)}`;
+}

--- a/packages/core/src/progress/_utils/published-lesson-progress-queries.ts
+++ b/packages/core/src/progress/_utils/published-lesson-progress-queries.ts
@@ -1,6 +1,7 @@
 import "server-only";
-import { type Sql, prisma, sql } from "@zoonk/db";
+import { type LessonKind, type Sql, prisma, sql } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
+import { getLessonKindExclusionSql } from "../../lessons/lesson-kind-exclusions";
 import {
   type PublishedLessonProgressRow,
   type PublishedLessonProgressScope,
@@ -12,13 +13,15 @@ import {
  * This helper dispatches to the narrowest query for the requested scope.
  */
 export async function listPublishedLessonProgressRows({
+  excludedLessonKinds,
   scope,
   userId,
 }: {
+  excludedLessonKinds?: LessonKind[];
   scope: PublishedLessonProgressScope;
   userId?: string;
 }): Promise<PublishedLessonProgressRow[]> {
-  return queryPublishedLessonProgressRows({ scope, userId });
+  return queryPublishedLessonProgressRows({ excludedLessonKinds, scope, userId });
 }
 
 /**
@@ -48,12 +51,15 @@ export async function listPublishedChaptersForCourse({
  * predicate for the requested scope.
  */
 async function queryPublishedLessonProgressRows({
+  excludedLessonKinds,
   scope,
   userId,
 }: {
+  excludedLessonKinds?: LessonKind[];
   scope: PublishedLessonProgressScope;
   userId?: string;
 }) {
+  const lessonKindFilter = getLessonKindExclusionSql({ excludedLessonKinds });
   const scopeFilter = getPublishedLessonProgressScopeFilter({ scope });
   const progressUserFilter = userId ? sql`lp.user_id = ${userId}` : sql`FALSE`;
 
@@ -92,6 +98,7 @@ async function queryPublishedLessonProgressRows({
           AND lp.completed_at IS NOT NULL
         WHERE l.is_published = true
           AND ${scopeFilter}
+          AND ${lessonKindFilter}
         GROUP BY o.slug, ch.id, c.id, l.id
         ORDER BY ch.position ASC, l.position ASC
       `,

--- a/packages/core/src/progress/get-active-catalog-target.ts
+++ b/packages/core/src/progress/get-active-catalog-target.ts
@@ -1,3 +1,4 @@
+import { type LessonKind } from "@zoonk/db";
 import { type LessonScope } from "../lessons/find-last-completed";
 import { getContinueLessonTarget } from "./get-continue-lesson-target";
 
@@ -9,13 +10,15 @@ export type ActiveCatalogTarget = { chapterSlug: string; lessonSlug?: string };
  * actually completed something in the requested scope.
  */
 export async function getActiveCatalogTarget({
+  excludedLessonKinds,
   headers,
   scope,
 }: {
+  excludedLessonKinds?: LessonKind[];
   headers?: Headers;
   scope: LessonScope;
 }): Promise<ActiveCatalogTarget | null> {
-  const target = await getContinueLessonTarget({ headers, scope });
+  const target = await getContinueLessonTarget({ excludedLessonKinds, headers, scope });
 
   if (!target?.hasStarted) {
     return null;

--- a/packages/core/src/progress/get-chapter-progress.test.ts
+++ b/packages/core/src/progress/get-chapter-progress.test.ts
@@ -225,6 +225,55 @@ describe(getChapterProgress, () => {
     expect(result).toStrictEqual([{ chapterId: chapter.id, completedLessons: 1, totalLessons: 1 }]);
   });
 
+  it("excludes hidden lesson kinds from chapter totals", async () => {
+    const [user, course] = await Promise.all([
+      userFixture(),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+    ]);
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const [visibleLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "explanation",
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "quiz",
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const [headers] = await Promise.all([
+      signInAs(user.email, user.password),
+      lessonProgressFixture({
+        completedAt: new Date(),
+        durationSeconds: 60,
+        lessonId: visibleLesson.id,
+        userId: user.id,
+      }),
+    ]);
+
+    const result = await getChapterProgress({
+      courseId: course.id,
+      excludedLessonKinds: ["quiz"],
+      headers,
+    });
+
+    expect(result).toStrictEqual([{ chapterId: chapter.id, completedLessons: 1, totalLessons: 1 }]);
+  });
+
   it("chapters with 0 published lessons return totalLessons 0", async () => {
     const [user, course] = await Promise.all([
       userFixture(),

--- a/packages/core/src/progress/get-chapter-progress.ts
+++ b/packages/core/src/progress/get-chapter-progress.ts
@@ -1,3 +1,4 @@
+import { type LessonKind } from "@zoonk/db";
 import { getSession } from "../users/get-user-session";
 import {
   listDurableChapterCompletionIds,
@@ -57,9 +58,11 @@ function getChapterProgressRows({
  */
 export async function getChapterProgress({
   courseId,
+  excludedLessonKinds,
   headers,
 }: {
   courseId: string;
+  excludedLessonKinds?: LessonKind[];
   headers?: Headers;
 }): Promise<{ chapterId: string; completedLessons: number; totalLessons: number }[]> {
   const session = await getSession(headers);
@@ -71,7 +74,7 @@ export async function getChapterProgress({
 
   const [chapterIds, rows] = await Promise.all([
     listPublishedChaptersForCourse({ courseId }),
-    listPublishedLessonProgressRows({ scope: { courseId }, userId }),
+    listPublishedLessonProgressRows({ excludedLessonKinds, scope: { courseId }, userId }),
   ]);
 
   const [durableLessonIds, durableChapterIds] = await Promise.all([

--- a/packages/core/src/progress/get-continue-lesson-target.test.ts
+++ b/packages/core/src/progress/get-continue-lesson-target.test.ts
@@ -1,3 +1,4 @@
+import { type LessonKind } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -26,8 +27,10 @@ describe(getContinueLessonTarget, () => {
    * being tested instead of repeating catalog setup.
    */
   async function createCourseTree({
+    lessonKinds = [],
     lessonStatuses = ["completed", "completed"],
   }: {
+    lessonKinds?: LessonKind[];
     lessonStatuses?: ("completed" | "failed" | "pending" | "running")[];
   } = {}): Promise<CourseTree> {
     const course = await courseFixture({ isPublished: true, organizationId: organization.id });
@@ -45,6 +48,7 @@ describe(getContinueLessonTarget, () => {
           chapterId: chapter.id,
           generationStatus,
           isPublished: true,
+          kind: lessonKinds[position] ?? "explanation",
           organizationId: organization.id,
           position,
         }),
@@ -121,6 +125,92 @@ describe(getContinueLessonTarget, () => {
       lessonPosition: 1,
       lessonSlug: nextLesson?.slug,
     });
+  });
+
+  it("continues from the latest visible completion when a newer hidden lesson is completed", async () => {
+    const [user, tree] = await Promise.all([
+      userFixture(),
+      createCourseTree({
+        lessonKinds: ["explanation", "explanation", "quiz"],
+        lessonStatuses: ["completed", "completed", "completed"],
+      }),
+    ]);
+
+    const [completedLesson, nextVisibleLesson, hiddenCompletedLesson] = tree.lessons;
+
+    const [headers] = await Promise.all([
+      signInAs(user.email, user.password),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: completedLesson?.id ?? "",
+        userId: user.id,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-02"),
+        durationSeconds: 60,
+        lessonId: hiddenCompletedLesson?.id ?? "",
+        userId: user.id,
+      }),
+    ]);
+
+    const result = await getContinueLessonTarget({
+      excludedLessonKinds: ["quiz"],
+      headers,
+      scope: { courseId: tree.course.id },
+    });
+
+    expect(result).toStrictEqual({
+      brandSlug: organization.slug,
+      canPrefetch: true,
+      chapterSlug: tree.chapter.slug,
+      completed: false,
+      courseSlug: tree.course.slug,
+      hasStarted: true,
+      lessonPosition: 1,
+      lessonSlug: nextVisibleLesson?.slug,
+    });
+  });
+
+  it("skips hidden incomplete lessons when choosing the next lesson", async () => {
+    const [user, tree] = await Promise.all([
+      userFixture(),
+      createCourseTree({
+        lessonKinds: ["explanation", "quiz", "explanation"],
+        lessonStatuses: ["completed", "completed", "completed"],
+      }),
+    ]);
+
+    const [completedLesson, hiddenLesson, nextVisibleLesson] = tree.lessons;
+
+    const [headers] = await Promise.all([
+      signInAs(user.email, user.password),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: completedLesson?.id ?? "",
+        userId: user.id,
+      }),
+    ]);
+
+    const result = await getContinueLessonTarget({
+      excludedLessonKinds: ["quiz"],
+      headers,
+      scope: { courseId: tree.course.id },
+    });
+
+    expect(result).toStrictEqual({
+      brandSlug: organization.slug,
+      canPrefetch: true,
+      chapterSlug: tree.chapter.slug,
+      completed: false,
+      courseSlug: tree.course.slug,
+      hasStarted: true,
+      lessonPosition: 2,
+      lessonSlug: nextVisibleLesson?.slug,
+    });
+
+    expect(result).not.toMatchObject({ lessonSlug: hiddenLesson?.slug });
   });
 
   it("returns the latest completed lesson as review state when the course is complete", async () => {

--- a/packages/core/src/progress/get-continue-lesson-target.ts
+++ b/packages/core/src/progress/get-continue-lesson-target.ts
@@ -1,6 +1,8 @@
 import { type LessonScope, findLastCompleted } from "@zoonk/core/lessons/last-completed";
+import { type LessonKind } from "@zoonk/db";
 import { cache } from "react";
 import { getNextChapterInCourse } from "../lessons/get-next-chapter-in-course";
+import { getLessonKindExclusionCacheArgs } from "../lessons/lesson-kind-exclusions";
 import { getSession } from "../users/get-user-session";
 import { type NextLessonState, getNextLessonStateForUser } from "./get-next-lesson-state";
 
@@ -65,12 +67,16 @@ const cachedGetContinueLessonTarget = cache(
     scopeKind: LessonScopeKind,
     scopeId: string,
     headers?: Headers,
+    ...excludedLessonKinds: LessonKind[]
   ): Promise<ContinueChapterTarget | ContinueLessonTarget | null> => {
     const scope = getLessonScopeFromParts({ id: scopeId, kind: scopeKind });
 
     const session = await getSession(headers);
     const userId = session?.user.id;
-    const lastCompleted = userId ? await findLastCompleted(userId, scope) : null;
+
+    const lastCompleted = userId
+      ? await findLastCompleted(userId, scope, { excludedLessonKinds })
+      : null;
 
     const state = await getNextLessonStateForUser({
       after: lastCompleted
@@ -80,6 +86,7 @@ const cachedGetContinueLessonTarget = cache(
             lessonPosition: lastCompleted.lessonPosition,
           }
         : undefined,
+      excludedLessonKinds,
       scope,
       userId,
     });
@@ -108,15 +115,22 @@ const cachedGetContinueLessonTarget = cache(
 );
 
 export function getContinueLessonTarget({
+  excludedLessonKinds,
   headers,
   scope,
 }: {
+  excludedLessonKinds?: LessonKind[];
   headers?: Headers;
   scope: LessonScope;
 }): Promise<ContinueChapterTarget | ContinueLessonTarget | null> {
   const { id, kind } = getLessonScopeParts(scope);
 
-  return cachedGetContinueLessonTarget(kind, id, headers);
+  return cachedGetContinueLessonTarget(
+    kind,
+    id,
+    headers,
+    ...getLessonKindExclusionCacheArgs({ excludedLessonKinds }),
+  );
 }
 
 /**

--- a/packages/core/src/progress/get-lesson-progress.test.ts
+++ b/packages/core/src/progress/get-lesson-progress.test.ts
@@ -129,6 +129,45 @@ describe(getLessonProgress, () => {
     expect(result).toStrictEqual([{ isCompleted: true, lessonId: publishedLesson.id }]);
   });
 
+  it("excludes hidden lesson kinds from progress rows", async () => {
+    const [user, chapter] = await Promise.all([userFixture(), createPublishedChapter()]);
+
+    const [visibleLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "explanation",
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "quiz",
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const [headers] = await Promise.all([
+      signInAs(user.email, user.password),
+      lessonProgressFixture({
+        completedAt: new Date(),
+        durationSeconds: 60,
+        lessonId: visibleLesson.id,
+        userId: user.id,
+      }),
+    ]);
+
+    const result = await getLessonProgress({
+      chapterId: chapter.id,
+      excludedLessonKinds: ["quiz"],
+      headers,
+    });
+
+    expect(result).toStrictEqual([{ isCompleted: true, lessonId: visibleLesson.id }]);
+  });
+
   it("keeps a completed lesson completed when a new lesson is added later", async () => {
     const [user, chapter] = await Promise.all([userFixture(), createPublishedChapter()]);
 

--- a/packages/core/src/progress/get-lesson-progress.ts
+++ b/packages/core/src/progress/get-lesson-progress.ts
@@ -1,3 +1,4 @@
+import { type LessonKind } from "@zoonk/db";
 import { getSession } from "../users/get-user-session";
 import { listDurableLessonCompletionIds } from "./_utils/durable-completion-queries";
 import { toEffectiveLessonProgressRows } from "./_utils/published-lesson-progress";
@@ -9,9 +10,11 @@ import { listPublishedLessonProgressRows } from "./_utils/published-lesson-progr
  */
 export async function getLessonProgress({
   chapterId,
+  excludedLessonKinds,
   headers,
 }: {
   chapterId: string;
+  excludedLessonKinds?: LessonKind[];
   headers?: Headers;
 }): Promise<{ isCompleted: boolean; lessonId: string }[]> {
   const session = await getSession(headers);
@@ -21,7 +24,11 @@ export async function getLessonProgress({
     return [];
   }
 
-  const rows = await listPublishedLessonProgressRows({ scope: { chapterId }, userId });
+  const rows = await listPublishedLessonProgressRows({
+    excludedLessonKinds,
+    scope: { chapterId },
+    userId,
+  });
 
   const durableLessonIds = await listDurableLessonCompletionIds({
     lessonIds: [...new Set(rows.map((row) => row.lessonId))],

--- a/packages/core/src/progress/get-next-lesson-state.ts
+++ b/packages/core/src/progress/get-next-lesson-state.ts
@@ -51,14 +51,16 @@ export type NextLessonState = {
  */
 export async function getNextLessonStateForUser({
   after,
+  excludedLessonKinds,
   scope,
   userId,
 }: {
   after?: NextLessonStateAnchor;
+  excludedLessonKinds?: LessonKind[];
   scope: PublishedLessonProgressScope;
   userId?: string;
 }): Promise<NextLessonState | null> {
-  const rows = await listPublishedLessonProgressRows({ scope, userId });
+  const rows = await listPublishedLessonProgressRows({ excludedLessonKinds, scope, userId });
 
   if (rows.length === 0) {
     return null;


### PR DESCRIPTION
## Summary
- Update continue-learning and lesson-progress logic to honor excluded lesson kinds and filter settings
- Keep next-lesson targeting, chapter progress, and continue links aligned across catalog surfaces
- Extend e2e and unit coverage for the continue-flow and progress helpers

## Testing
- Added and updated unit tests for lesson progression and progress targeting
- Added and updated e2e coverage for continue-lesson and course-progress behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Continue learning and progress now respect user-hidden lesson types across the catalog. Next-lesson links, chapter/course progress, and list numbering stay aligned with the learner’s filters.

- **Bug Fixes**
  - Continue targets and “Active” shortcut ignore hidden kinds when choosing the next lesson or latest completion.
  - Course and chapter CTAs use filtered totals, so hidden types don’t block “Continue” or “Completed” states.
  - Chapter fallback links start at the first visible lesson.
  - Lesson list numbering reflects the filtered list (1, 2, 3), not database position.
  - Expanded unit and e2e coverage for hidden-kind behavior across continue links and progress.

- **Refactors**
  - Added `@zoonk/core/lessons/kind-exclusions` helpers: `getLessonKindExclusionWhere`, `getLessonKindExclusionSql`, `getLessonKindExclusionCacheArgs`, and exported path in `packages/core`.
  - Threaded `excludedLessonKinds` through core and data APIs: `get-next-lesson-in-course`, `find-last-completed`, `get-continue-lesson-target`, `get-next-lesson-state`, `get-lesson-progress`, `get-chapter-progress`, and continue-learning queries; cache keys include exclusions.
  - UI: prevent hiding the last visible lesson type; revalidate catalog layout on filter updates.

<sup>Written for commit 776c41a3afb5d583fc3fe03c544da97bbdb7cb25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

