### PR TITLE
fix(main): use bearer auth for workflow requests

### DIFF
--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -31,6 +31,7 @@ import { expect, test } from "./fixtures";
 const TEST_RUN_ID = "test-run-id-12345";
 
 type MockApiOptions = {
+  assertBearerAuth?: boolean;
   triggerResponse?: { runId?: string; error?: string; status?: number };
   streamMessages?: { entityId?: string; reason?: string; step: string; status: string }[];
   streamError?: boolean;
@@ -48,11 +49,21 @@ function createSSEStream(
 }
 
 /**
+ * Confirms authenticated workflow calls use the API's bearer-token contract
+ * instead of depending on cross-origin cookies that do not work in previews
+ * and custom-domain environments.
+ */
+function expectBearerAuthorization(route: Route): void {
+  expect(route.request().headers().authorization).toMatch(/^Bearer .+/u);
+}
+
+/**
  * Creates the route handler function for mocking APIs.
  * Extracted to reduce complexity in test functions.
  */
 function createRouteHandler(options: MockApiOptions) {
   const {
+    assertBearerAuth = false,
     statusDelayMs = 0,
     triggerResponse = { runId: TEST_RUN_ID },
     streamMessages = [],
@@ -65,6 +76,10 @@ function createRouteHandler(options: MockApiOptions) {
 
     // Mock trigger API
     if (url.includes("/v1/workflows/course-generation/trigger") && method === "POST") {
+      if (assertBearerAuth) {
+        expectBearerAuthorization(route);
+      }
+
       if (triggerResponse.error) {
         await route.fulfill({
           body: JSON.stringify({ error: triggerResponse.error }),
@@ -86,6 +101,10 @@ function createRouteHandler(options: MockApiOptions) {
 
     // Mock status stream API
     if (url.includes("/v1/workflows/course-generation/status")) {
+      if (assertBearerAuth) {
+        expectBearerAuthorization(route);
+      }
+
       if (streamError) {
         await route.abort("failed");
         return;
@@ -272,6 +291,7 @@ test.describe("Generate Course Page", () => {
       await lessonFixture({ chapterId: chapter.id, isPublished: true, organizationId: org.id });
 
       await setupMockApis(authenticatedPage, {
+        assertBearerAuth: true,
         streamMessages: [
           { status: "started", step: "getCourseSuggestion" },
           { status: "completed", step: "getCourseSuggestion" },

--- a/apps/main/src/lib/workflow/auth-headers.ts
+++ b/apps/main/src/lib/workflow/auth-headers.ts
@@ -1,0 +1,17 @@
+import { authClient } from "@zoonk/core/auth/client";
+
+type WorkflowAuthHeaders = { Authorization?: string };
+
+/**
+ * Reads the current same-origin Better Auth session so browser workflow calls
+ * can authenticate to the centralized API with Better Auth's bearer-token
+ * contract. Cross-origin cookies are unreliable for previews, custom domains,
+ * and remote-device testing, while the API already accepts this session token
+ * through the Authorization header.
+ */
+export async function getWorkflowAuthHeaders(): Promise<WorkflowAuthHeaders> {
+  const { data } = await authClient.getSession();
+  const token = data?.session.token;
+
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/apps/main/src/lib/workflow/use-sse.ts
+++ b/apps/main/src/lib/workflow/use-sse.ts
@@ -2,6 +2,7 @@
 
 import { type EventSourceMessage, createParser } from "eventsource-parser";
 import { useEffect, useEffectEvent, useRef } from "react";
+import { getWorkflowAuthHeaders } from "./auth-headers";
 
 export function useSSE<T>(
   url: string | null,
@@ -29,9 +30,10 @@ export function useSSE<T>(
     void (async () => {
       try {
         const fullUrl = `${url}&startIndex=${indexRef.current}`;
+        const headers = await getWorkflowAuthHeaders();
 
         const response = await fetch(fullUrl, {
-          credentials: "include",
+          headers,
           signal: controller.signal,
         });
 

--- a/apps/main/src/lib/workflow/use-sse.ts
+++ b/apps/main/src/lib/workflow/use-sse.ts
@@ -32,10 +32,7 @@ export function useSSE<T>(
         const fullUrl = `${url}&startIndex=${indexRef.current}`;
         const headers = await getWorkflowAuthHeaders();
 
-        const response = await fetch(fullUrl, {
-          headers,
-          signal: controller.signal,
-        });
+        const response = await fetch(fullUrl, { headers, signal: controller.signal });
 
         if (!response.ok) {
           onErrorEvent(new Error(`HTTP ${response.status}`));

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -3,6 +3,7 @@
 import { type StepStreamMessage } from "@zoonk/core/workflows/steps";
 import { getString } from "@zoonk/utils/json";
 import { useCallback, useEffect, useEffectEvent, useReducer, useRef } from "react";
+import { getWorkflowAuthHeaders } from "./auth-headers";
 import {
   type GenerationAction,
   type GenerationState,
@@ -11,7 +12,6 @@ import {
   handleStepStreamMessage,
   initialGenerationState,
 } from "./generation-store";
-import { getWorkflowAuthHeaders } from "./auth-headers";
 import { useSSE } from "./use-sse";
 
 const MAX_STREAM_RECONNECTS = 5;

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -11,6 +11,7 @@ import {
   handleStepStreamMessage,
   initialGenerationState,
 } from "./generation-store";
+import { getWorkflowAuthHeaders } from "./auth-headers";
 import { useSSE } from "./use-sse";
 
 const MAX_STREAM_RECONNECTS = 5;
@@ -117,10 +118,11 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
     dispatch({ type: "triggerStart" });
 
     try {
+      const authHeaders = await getWorkflowAuthHeaders();
+
       const response = await fetch(triggerUrl, {
         body: JSON.stringify(triggerBody),
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
+        headers: { ...authHeaders, "Content-Type": "application/json" },
         method: "POST",
       });
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch workflow requests to bearer-token auth using the current Better Auth session, replacing cross-origin cookies. Fixes auth in previews, custom domains, and remote-device testing for workflow trigger and SSE status stream.

- **Bug Fixes**
  - Added getWorkflowAuthHeaders to read the session token from `@zoonk/core/auth/client` and set Authorization: Bearer.
  - Updated workflow trigger and SSE fetches to use Authorization header; removed credentials: "include".
  - E2E tests now assert Bearer auth on trigger and status endpoints.

<sup>Written for commit a24bd86ceb08dfe0621f867bb66c9e81ebfbbdf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

