### PR TITLE
fix(main): rename hobby plan to max

### DIFF
--- a/apps/api/e2e/helpers/auth.ts
+++ b/apps/api/e2e/helpers/auth.ts
@@ -90,7 +90,7 @@ export async function createSubscribedApiContext({
   await prisma.subscription.create({
     data: {
       id: randomUUID(),
-      plan: "hobby",
+      plan: "plus",
       referenceId: authContext.user.id,
       status: "active",
       stripeCustomerId: `cus_test_${authContext.uniqueId}`,

--- a/apps/api/e2e/me.test.ts
+++ b/apps/api/e2e/me.test.ts
@@ -58,7 +58,7 @@ async function createBearerApiContext({
     await prisma.subscription.create({
       data: {
         id: randomUUID(),
-        plan: "hobby",
+        plan: "plus",
         provider: "zoonk",
         referenceId: user.id,
         status: "active",
@@ -141,7 +141,7 @@ test.describe("Current User API", () => {
     expect(body.account.hasActiveSubscription).toBe(true);
 
     expect(body.account.subscription).toMatchObject({
-      plan: "hobby",
+      plan: "plus",
       provider: "zoonk",
       status: "active",
     });

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -151,7 +151,7 @@ async function createTestSubscription(userId: string) {
   const subscription = await prisma.subscription.create({
     data: {
       id: randomUUID(),
-      plan: "hobby",
+      plan: "plus",
       referenceId: userId,
       status: "active",
       stripeCustomerId: `cus_test_e2e_${uniqueId}`,

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -283,7 +283,7 @@ async function createTestSubscription(userId: string) {
   const subscription = await prisma.subscription.create({
     data: {
       id: randomUUID(),
-      plan: "hobby",
+      plan: "plus",
       referenceId: userId,
       status: "active",
       stripeCustomerId: `cus_test_e2e_lesson_${uniqueId}`,

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -117,11 +117,11 @@ async function captureStripeActionRequest({
  * Drive checkout through the visible plan controls because the locale is added
  * by the client-side Better Auth call, not by the server-rendered plan page.
  */
-async function requestHobbyCheckout({ page }: { page: Page }) {
+async function requestPlusCheckout({ page }: { page: Page }) {
   const requestBody = captureStripeActionRequest({ page, path: "/api/auth/subscription/upgrade" });
 
-  await page.getByRole("radio", { name: /hobby/iu }).click();
-  await page.getByRole("button", { name: /hobby/iu }).click();
+  await page.getByRole("radio", { name: /plus/iu }).click();
+  await page.getByRole("button", { name: /plus/iu }).click();
 
   return requestBody;
 }
@@ -146,9 +146,9 @@ test.describe("Subscription Page - No Subscription", () => {
     ).toBeVisible();
 
     await expect(authenticatedPage.getByRole("radio", { name: /free/iu })).toBeVisible();
-    await expect(authenticatedPage.getByRole("radio", { name: /hobby/iu })).toBeVisible();
     await expect(authenticatedPage.getByRole("radio", { name: /plus/iu })).toBeVisible();
     await expect(authenticatedPage.getByRole("radio", { name: /pro/iu })).toBeVisible();
+    await expect(authenticatedPage.getByRole("radio", { name: /max/iu })).toBeVisible();
   });
 
   test("has Free plan selected by default when no subscription", async ({ authenticatedPage }) => {
@@ -177,23 +177,23 @@ test.describe("Subscription Page - No Subscription", () => {
   test("shows Upgrade button when selecting a paid plan", async ({ authenticatedPage }) => {
     await authenticatedPage.goto("/subscription");
 
-    await authenticatedPage.getByRole("radio", { name: /hobby/iu }).click();
+    await authenticatedPage.getByRole("radio", { name: /plus/iu }).click();
 
     await expect(
-      authenticatedPage.getByRole("button", { name: /upgrade to hobby/iu }),
+      authenticatedPage.getByRole("button", { name: /upgrade to plus/iu }),
     ).toBeVisible();
   });
 
   test("changes CTA label when selecting different plans", async ({ authenticatedPage }) => {
     await authenticatedPage.goto("/subscription");
 
-    await authenticatedPage.getByRole("radio", { name: /pro/iu }).click();
-    await expect(authenticatedPage.getByRole("button", { name: /upgrade to pro/iu })).toBeVisible();
+    await authenticatedPage.getByRole("radio", { name: /max/iu }).click();
+    await expect(authenticatedPage.getByRole("button", { name: /upgrade to max/iu })).toBeVisible();
 
     await authenticatedPage.getByRole("radio", { name: /free/iu }).click();
 
     await expect(
-      authenticatedPage.getByRole("button", { name: /upgrade to pro/iu }),
+      authenticatedPage.getByRole("button", { name: /upgrade to max/iu }),
     ).not.toBeVisible();
   });
 });
@@ -203,7 +203,7 @@ test.describe("Subscription Page - Stripe Locale", () => {
     await setLocale(authenticatedPage, "es");
     await authenticatedPage.goto("/subscription");
 
-    await expect(requestHobbyCheckout({ page: authenticatedPage })).resolves.toMatchObject({
+    await expect(requestPlusCheckout({ page: authenticatedPage })).resolves.toMatchObject({
       locale: "es",
     });
   });
@@ -214,7 +214,7 @@ test.describe("Subscription Page - Stripe Locale", () => {
     await setLocale(authenticatedPage, "pt");
     await authenticatedPage.goto("/subscription");
 
-    await expect(requestHobbyCheckout({ page: authenticatedPage })).resolves.toMatchObject({
+    await expect(requestPlusCheckout({ page: authenticatedPage })).resolves.toMatchObject({
       locale: "pt-BR",
     });
   });
@@ -223,23 +223,23 @@ test.describe("Subscription Page - Stripe Locale", () => {
     await setLocale(authenticatedPage, "en");
     await authenticatedPage.goto("/subscription");
 
-    const requestBody = await requestHobbyCheckout({ page: authenticatedPage });
+    const requestBody = await requestPlusCheckout({ page: authenticatedPage });
 
     expect(requestBody).not.toHaveProperty("locale");
   });
 });
 
-test.describe("Subscription Page - With Hobby Subscription", () => {
+test.describe("Subscription Page - With Plus Subscription", () => {
   test("has current plan selected by default and shows Current badge", async ({
     browser,
     baseURL,
   }) => {
-    const email = await createUserWithSubscription(baseURL!, "hobby");
+    const email = await createUserWithSubscription(baseURL!, "plus");
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
     await page.goto("/subscription");
 
-    await expect(page.getByRole("radio", { name: /hobby/iu })).toBeChecked();
+    await expect(page.getByRole("radio", { name: /plus/iu })).toBeChecked();
     await expect(page.getByLabel(/current plan/iu)).toBeVisible();
     await expect(page.getByRole("button", { name: /manage/iu })).toBeVisible();
 
@@ -247,19 +247,19 @@ test.describe("Subscription Page - With Hobby Subscription", () => {
   });
 
   test("shows Upgrade when selecting a higher plan", async ({ browser, baseURL }) => {
-    const email = await createUserWithSubscription(baseURL!, "hobby");
+    const email = await createUserWithSubscription(baseURL!, "plus");
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
     await page.goto("/subscription");
 
-    await page.getByRole("radio", { name: /plus/iu }).click();
-    await expect(page.getByRole("button", { name: /upgrade to plus/iu })).toBeVisible();
+    await page.getByRole("radio", { name: /pro/iu }).click();
+    await expect(page.getByRole("button", { name: /upgrade to pro/iu })).toBeVisible();
 
     await browserContext.close();
   });
 
   test("shows Cancel when selecting Free plan", async ({ browser, baseURL }) => {
-    const email = await createUserWithSubscription(baseURL!, "hobby");
+    const email = await createUserWithSubscription(baseURL!, "plus");
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
     await page.goto("/subscription");
@@ -271,7 +271,7 @@ test.describe("Subscription Page - With Hobby Subscription", () => {
   });
 
   test("CTA button shows loading state when clicked", async ({ browser, baseURL }) => {
-    const email = await createUserWithSubscription(baseURL!, "hobby");
+    const email = await createUserWithSubscription(baseURL!, "plus");
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
     await page.goto("/subscription");
@@ -284,18 +284,18 @@ test.describe("Subscription Page - With Hobby Subscription", () => {
   });
 });
 
-test.describe("Subscription Page - With Pro Subscription", () => {
+test.describe("Subscription Page - With Max Subscription", () => {
   test("shows Switch to for lower paid plans and Cancel for Free", async ({ browser, baseURL }) => {
-    const email = await createUserWithSubscription(baseURL!, "pro");
+    const email = await createUserWithSubscription(baseURL!, "max");
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
     await page.goto("/subscription");
 
-    await expect(page.getByRole("radio", { name: /pro/iu })).toBeChecked();
+    await expect(page.getByRole("radio", { name: /max/iu })).toBeChecked();
     await expect(page.getByLabel(/current plan/iu)).toBeVisible();
 
-    await page.getByRole("radio", { name: /hobby/iu }).click();
-    await expect(page.getByRole("button", { name: /switch to hobby/iu })).toBeVisible();
+    await page.getByRole("radio", { name: /plus/iu }).click();
+    await expect(page.getByRole("button", { name: /switch to plus/iu })).toBeVisible();
 
     await page.getByRole("radio", { name: /free/iu }).click();
     await expect(page.getByRole("button", { name: /cancel/iu })).toBeVisible();
@@ -309,7 +309,7 @@ test.describe("Subscription Page - Provider Managed", () => {
     browser,
     baseURL,
   }) => {
-    const email = await createUserWithSubscription(baseURL!, "hobby", { provider: "apple" });
+    const email = await createUserWithSubscription(baseURL!, "plus", { provider: "apple" });
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
     await page.goto("/subscription");
@@ -337,7 +337,7 @@ test.describe("Subscription Page - Provider Managed", () => {
     browser,
     baseURL,
   }) => {
-    const email = await createUserWithSubscription(baseURL!, "hobby", { provider: "zoonk" });
+    const email = await createUserWithSubscription(baseURL!, "plus", { provider: "zoonk" });
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
     await page.goto("/subscription");
@@ -359,7 +359,7 @@ test.describe("Subscription Page - Provider Managed", () => {
 test.describe("Subscription Page - With Cancelled Subscription", () => {
   test("shows cancellation notice when cancel_at is set", async ({ browser, baseURL }) => {
     const cancelAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
-    const email = await createUserWithSubscription(baseURL!, "hobby", { cancelAt });
+    const email = await createUserWithSubscription(baseURL!, "plus", { cancelAt });
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
     await page.goto("/subscription");
@@ -369,7 +369,7 @@ test.describe("Subscription Page - With Cancelled Subscription", () => {
   });
 
   test("does not show cancellation notice when cancel_at is null", async ({ browser, baseURL }) => {
-    const email = await createUserWithSubscription(baseURL!, "hobby");
+    const email = await createUserWithSubscription(baseURL!, "plus");
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
 
     await page.goto("/subscription");

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1003,8 +1003,8 @@ msgid "fF376U"
 msgstr "Current"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "HYX1JL"
-msgstr "Hobby"
+msgid "kkjl2v"
+msgstr "Max"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "lOdoIb"
@@ -1027,16 +1027,16 @@ msgid "uNQcTY"
 msgstr "Limited lessons with ads"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
+msgid "mqHNd6"
+msgstr "Personalized lessons, smartest AI"
+
+#: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "LnosqI"
 msgstr "Unlimited lessons, no ads"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "eaOADK"
 msgstr "Personalized lessons, fast AI"
-
-#: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "mqHNd6"
-msgstr "Personalized lessons, smartest AI"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1003,8 +1003,8 @@ msgid "fF376U"
 msgstr "Actual"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "HYX1JL"
-msgstr "Hobby"
+msgid "kkjl2v"
+msgstr "Max"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "lOdoIb"
@@ -1027,16 +1027,16 @@ msgid "uNQcTY"
 msgstr "Lecciones limitadas con anuncios"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
+msgid "mqHNd6"
+msgstr "Lecciones personalizadas, IA más inteligente"
+
+#: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "LnosqI"
 msgstr "Lecciones ilimitadas, sin anuncios"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "eaOADK"
 msgstr "Lecciones personalizadas, IA rápida"
-
-#: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "mqHNd6"
-msgstr "Lecciones personalizadas, IA más inteligente"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1003,8 +1003,8 @@ msgid "fF376U"
 msgstr "Atual"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "HYX1JL"
-msgstr "Hobby"
+msgid "kkjl2v"
+msgstr "Max"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "lOdoIb"
@@ -1027,16 +1027,16 @@ msgid "uNQcTY"
 msgstr "Aulas limitadas com anúncios"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
+msgid "mqHNd6"
+msgstr "Aulas personalizadas, IA mais inteligente"
+
+#: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "LnosqI"
 msgstr "Aulas ilimitadas, sem anúncios"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "eaOADK"
 msgstr "Aulas personalizadas, IA rápida"
-
-#: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "mqHNd6"
-msgstr "Aulas personalizadas, IA mais inteligente"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx

--- a/apps/main/src/app/(settings)/subscription/subscription-plans.tsx
+++ b/apps/main/src/app/(settings)/subscription/subscription-plans.tsx
@@ -41,7 +41,7 @@ export async function SubscriptionPlans({
 
   const titles: Record<string, string> = {
     free: t("Free"),
-    hobby: t("Hobby"),
+    max: t("Max"),
     plus: t("Plus"),
     pro: t("Pro"),
   };
@@ -99,9 +99,9 @@ export async function SubscriptionPlans({
 
   const descriptions: Record<string, string> = {
     free: t("Limited lessons with ads"),
-    hobby: t("Unlimited lessons, no ads"),
-    plus: t("Personalized lessons, fast AI"),
-    pro: t("Personalized lessons, smartest AI"),
+    max: t("Personalized lessons, smartest AI"),
+    plus: t("Unlimited lessons, no ads"),
+    pro: t("Personalized lessons, fast AI"),
   };
 
   return (

--- a/packages/auth/src/_blocked-usernames/zoonk-specific.ts
+++ b/packages/auth/src/_blocked-usernames/zoonk-specific.ts
@@ -14,6 +14,7 @@ export const zoonkSpecific = [
   "hobby",
   "language",
   "level",
+  "max",
   "official",
   "personalized",
   "plus",

--- a/packages/auth/src/stripe/prices.test.ts
+++ b/packages/auth/src/stripe/prices.test.ts
@@ -25,42 +25,42 @@ describe(getStripePrices, () => {
         {
           currency: "usd",
           currency_options: { brl: { unit_amount: 2990 } },
-          lookup_key: "hobby_monthly",
+          lookup_key: "plus_monthly",
           unit_amount: 999,
         },
       ],
     });
 
-    const result = await getStripePrices(["hobby_monthly"], "brl");
+    const result = await getStripePrices(["plus_monthly"], "brl");
 
-    expect(result.get("hobby_monthly")).toStrictEqual({ amount: 2990, currency: "brl" });
+    expect(result.get("plus_monthly")).toStrictEqual({ amount: 2990, currency: "brl" });
   });
 
   it("falls back to default price when currency option is unavailable", async () => {
     mockList.mockResolvedValue({
       data: [
-        { currency: "usd", currency_options: {}, lookup_key: "hobby_monthly", unit_amount: 999 },
+        { currency: "usd", currency_options: {}, lookup_key: "plus_monthly", unit_amount: 999 },
       ],
     });
 
-    const result = await getStripePrices(["hobby_monthly"], "xyz");
+    const result = await getStripePrices(["plus_monthly"], "xyz");
 
-    expect(result.get("hobby_monthly")).toStrictEqual({ amount: 999, currency: "usd" });
+    expect(result.get("plus_monthly")).toStrictEqual({ amount: 999, currency: "usd" });
   });
 
   it("handles multiple lookup keys", async () => {
     mockList.mockResolvedValue({
       data: [
-        { currency: "usd", currency_options: {}, lookup_key: "hobby_monthly", unit_amount: 999 },
-        { currency: "usd", currency_options: {}, lookup_key: "plus_monthly", unit_amount: 1999 },
+        { currency: "usd", currency_options: {}, lookup_key: "plus_monthly", unit_amount: 999 },
+        { currency: "usd", currency_options: {}, lookup_key: "pro_monthly", unit_amount: 1999 },
       ],
     });
 
-    const result = await getStripePrices(["hobby_monthly", "plus_monthly"], "usd");
+    const result = await getStripePrices(["plus_monthly", "pro_monthly"], "usd");
 
     expect(result.size).toBe(2);
-    expect(result.get("hobby_monthly")?.amount).toBe(999);
-    expect(result.get("plus_monthly")?.amount).toBe(1999);
+    expect(result.get("plus_monthly")?.amount).toBe(999);
+    expect(result.get("pro_monthly")?.amount).toBe(1999);
   });
 
   it("skips prices without lookup_key", async () => {
@@ -68,7 +68,7 @@ describe(getStripePrices, () => {
       data: [{ currency: "usd", currency_options: {}, lookup_key: null, unit_amount: 999 }],
     });
 
-    const result = await getStripePrices(["hobby_monthly"], "usd");
+    const result = await getStripePrices(["plus_monthly"], "usd");
     expect(result.size).toBe(0);
   });
 });

--- a/packages/db/src/prisma/seed/subscriptions.ts
+++ b/packages/db/src/prisma/seed/subscriptions.ts
@@ -14,7 +14,7 @@ export async function seedSubscriptions(prisma: PrismaClient, users: SeedUsers):
   const subscriptionData = allUsers.map((user) => ({
     periodEnd: oneYearFromNow,
     periodStart: now,
-    plan: "hobby",
+    plan: "plus",
     provider: "zoonk" as const,
     referenceId: user.id,
     status: "active",

--- a/packages/e2e/src/fixtures/users.ts
+++ b/packages/e2e/src/fixtures/users.ts
@@ -67,7 +67,7 @@ export async function createE2EUser(
     await prisma.subscription.create({
       data: {
         id: randomUUID(),
-        plan: "hobby",
+        plan: "plus",
         referenceId: user.id,
         status: "active",
         stripeCustomerId: `cus_e2e_${uniqueId}`,

--- a/packages/utils/src/subscription.ts
+++ b/packages/utils/src/subscription.ts
@@ -1,11 +1,11 @@
-const PLAN_NAMES = ["free", "hobby", "plus", "pro"] as const;
+const PLAN_NAMES = ["free", "plus", "pro", "max"] as const;
 type PlanName = (typeof PLAN_NAMES)[number];
 
 const SUBSCRIPTION_PROVIDERS = ["stripe", "google", "apple", "zoonk"] as const;
 export type SubscriptionProvider = (typeof SUBSCRIPTION_PROVIDERS)[number];
 
 const PLAN_LOOKUP_KEYS: Record<Exclude<PlanName, "free">, { monthly: string; yearly: string }> = {
-  hobby: { monthly: "hobby_monthly", yearly: "hobby_yearly" },
+  max: { monthly: "max_monthly", yearly: "max_yearly" },
   plus: { monthly: "plus_monthly", yearly: "plus_yearly" },
   pro: { monthly: "pro_monthly", yearly: "pro_yearly" },
 };
@@ -32,21 +32,21 @@ const HIDDEN_PLANS = new Set(
 
 const ALL_PAID_PLANS: readonly PaidPlan[] = [
   {
-    annualLookupKey: PLAN_LOOKUP_KEYS.hobby.yearly,
-    lookupKey: PLAN_LOOKUP_KEYS.hobby.monthly,
-    name: "hobby",
-    tier: 1,
-  },
-  {
     annualLookupKey: PLAN_LOOKUP_KEYS.plus.yearly,
     lookupKey: PLAN_LOOKUP_KEYS.plus.monthly,
     name: "plus",
-    tier: 2,
+    tier: 1,
   },
   {
     annualLookupKey: PLAN_LOOKUP_KEYS.pro.yearly,
     lookupKey: PLAN_LOOKUP_KEYS.pro.monthly,
     name: "pro",
+    tier: 2,
+  },
+  {
+    annualLookupKey: PLAN_LOOKUP_KEYS.max.yearly,
+    lookupKey: PLAN_LOOKUP_KEYS.max.monthly,
+    name: "max",
     tier: 3,
   },
 ];


### PR DESCRIPTION
## Summary
- Rename the hobby subscription tier to max across plan data, labels, and lookup keys
- Update seeded and E2E subscription fixtures to use the new tier name
- Refresh subscription page coverage and localized copy for the renamed plan

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the “Hobby” plan to “Max” and re-ordered tiers and copy. Updated plan keys, Stripe lookup keys, seeds, E2E tests, and i18n to match the new lineup.

- **Refactors**
  - Removed “hobby” plan; added “max” to plan list and lookup keys (`max_monthly`, `max_yearly`).
  - Rebased fixtures/seeds to use “plus” where “hobby” was used.
  - Updated subscription UI: titles, descriptions, radio labels, and CTAs (added “Max”; adjusted “Plus”/“Pro” copy).
  - Updated Stripe price tests to new keys and flows; kept locale checks; added “max” to blocked usernames.

- **Migration**
  - Ensure Stripe has prices for `max_monthly` and `max_yearly`.
  - Map any persisted “hobby” subscriptions to “plus” going forward.

<sup>Written for commit 61d2558fd8cc17df1dc097a48bfad34e42c05c74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

