### PR TITLE
fix(main): prevent stale lesson filter rollbacks

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -554,7 +554,9 @@ test.describe("Chapter Lesson Type Filters", () => {
     await page.goto(chapterUrl);
 
     const filterButton = await openLessonTypeFilterMenu({ page });
-    await page.getByRole("menuitemcheckbox", { name: /^quiz$/iu }).click();
+    const quizFilterItem = page.getByRole("menuitemcheckbox", { name: /^quiz$/iu });
+
+    await quizFilterItem.click();
 
     await expect(
       page.getByRole("link", { name: new RegExp(lessonNames.first, "u") }),
@@ -564,10 +566,13 @@ test.describe("Chapter Lesson Type Filters", () => {
       page.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),
     ).not.toBeVisible();
 
-    await expect(page.getByRole("menuitem", { name: /clear filter/iu })).toBeVisible();
+    const clearFilterItem = page.getByRole("menuitem", { name: /clear filter/iu });
+
+    await expect(quizFilterItem).toBeEnabled();
+    await expect(clearFilterItem).toBeEnabled();
     await expect(filterButton).toBeEnabled();
 
-    await page.getByRole("menuitem", { name: /clear filter/iu }).click();
+    await clearFilterItem.click();
 
     await expect(
       page.getByRole("link", { name: new RegExp(lessonNames.second, "u") }),
@@ -598,9 +603,11 @@ test.describe("Chapter Lesson Type Filters", () => {
 
     await openLessonTypeFilterMenu({ page: secondPage });
 
-    await expect(secondPage.getByRole("menuitem", { name: /clear filter/iu })).toBeVisible();
+    const clearFilterItem = secondPage.getByRole("menuitem", { name: /clear filter/iu });
 
-    await secondPage.getByRole("menuitem", { name: /clear filter/iu }).click();
+    await expect(clearFilterItem).toBeEnabled();
+
+    await clearFilterItem.click();
     await expectSavedHiddenLessonKinds({ hiddenLessonKinds: [], userId: user.id });
 
     await expect(

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
@@ -29,7 +29,7 @@ import { normalizeString } from "@zoonk/utils/string";
 import { ListFilterIcon, XIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { useQueryState } from "nuqs";
-import { type ReactNode, useState, useTransition } from "react";
+import { type ReactNode, useRef, useState, useTransition } from "react";
 import { updateHiddenLessonKindsAction } from "./lesson-list-actions";
 
 type LessonKindOption = { kind: LessonKind; label: string };
@@ -57,7 +57,8 @@ export function LessonListFilters({
   placeholder: string;
 }) {
   const t = useExtracted();
-  const [isPending, startTransition] = useTransition();
+  const [, startTransition] = useTransition();
+  const saveRequestId = useRef(0);
 
   const [search, setSearch] = useQueryState("q", {
     defaultValue: "",
@@ -85,8 +86,8 @@ export function LessonListFilters({
 
   /**
    * The UI updates optimistically because hiding one kind is a lightweight
-   * preference change; failed saves roll back so the visible list still matches
-   * the server-owned setting.
+   * preference change. Only the latest failed save can roll back the visible
+   * list, otherwise an older request could undo a newer learner choice.
    */
   function persistHiddenLessonKinds(nextHiddenLessonKinds: LessonKind[]) {
     const previousHiddenLessonKinds = hiddenLessonKinds;
@@ -97,12 +98,15 @@ export function LessonListFilters({
       return;
     }
 
+    const currentSaveRequestId = saveRequestId.current + 1;
+    saveRequestId.current = currentSaveRequestId;
+
     startTransition(async () => {
       const result = await updateHiddenLessonKindsAction({
         hiddenLessonKinds: nextHiddenLessonKinds,
       });
 
-      if (result.status === "error") {
+      if (result.status === "error" && saveRequestId.current === currentSaveRequestId) {
         setHiddenLessonKinds(previousHiddenLessonKinds);
         toast.error(t("Could not update lesson filters. Please try again."));
       }
@@ -141,7 +145,6 @@ export function LessonListFilters({
         <LessonTypeFilterMenu
           hiddenLessonKindSet={hiddenLessonKindSet}
           hiddenCount={hiddenCount}
-          isPending={isPending}
           lessonKindOptions={lessonKindOptions}
           onClear={() =>
             persistHiddenLessonKinds(
@@ -261,14 +264,12 @@ function canChangeLessonKindVisibility({
 function LessonTypeFilterMenu({
   hiddenLessonKindSet,
   hiddenCount,
-  isPending,
   lessonKindOptions,
   onClear,
   onVisibilityChange,
 }: {
   hiddenLessonKindSet: Set<LessonKind>;
   hiddenCount: number;
-  isPending: boolean;
   lessonKindOptions: LessonKindOption[];
   onClear: () => void;
   onVisibilityChange: (params: { isVisible: boolean; kind: LessonKind }) => void;
@@ -289,7 +290,6 @@ function LessonTypeFilterMenu({
         render={
           <Button
             aria-label={t("Filter lesson types")}
-            disabled={isPending}
             size="adaptive"
             variant={hiddenCount > 0 ? "secondary" : "outline"}
           />
@@ -326,7 +326,7 @@ function LessonTypeFilterMenu({
             return (
               <DropdownMenuCheckboxItem
                 checked={isLessonKindVisible({ hiddenLessonKindSet, kind: option.kind })}
-                disabled={isPending || !canChangeVisibility}
+                disabled={!canChangeVisibility}
                 key={option.kind}
                 onCheckedChange={(checked) => {
                   if (!canChangeVisibility) {
@@ -345,7 +345,7 @@ function LessonTypeFilterMenu({
         {hiddenCount > 0 && (
           <>
             <DropdownMenuSeparator />
-            <DropdownMenuItem disabled={isPending} onClick={onClear} variant="destructive">
+            <DropdownMenuItem onClick={onClear} variant="destructive">
               <XIcon aria-hidden="true" />
               {t("Clear filter")}
             </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- prevent older failed lesson-filter saves from rolling back newer choices
- keep the lesson filter menu usable while a save is in flight
- tighten the chapter detail e2e coverage around enabled filter actions

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent stale lesson filter saves from rolling back newer selections. Keep the lesson type filter menu interactive during saves, and strengthen e2e coverage for enabled filter actions.

- Bug Fixes
  - Use a request id via `useRef` to ensure only the latest failed save can roll back the optimistic state.
  - Remove pending-based disabling from the filter button, items, and “Clear filter”; rely solely on `canChangeLessonKindVisibility` for gating.
  - E2E: assert quiz item and “Clear filter” stay enabled and use stable locators to reduce flakiness.

<sup>Written for commit 292b3ebf2edd599610657c28a169c4175c0f1b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

