### PR TITLE
feat(main): add richer analytics event tracking

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -30,6 +30,7 @@
     "next": "catalog:",
     "next-intl": "catalog:",
     "posthog-js": "catalog:",
+    "posthog-node": "5.37.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "server-only": "catalog:",

--- a/apps/api/src/app/auth/callback/page.tsx
+++ b/apps/api/src/app/auth/callback/page.tsx
@@ -1,3 +1,4 @@
+import { trackAuthCompleted } from "@/lib/server-track-events";
 import { getSession } from "@zoonk/core/users/session/get";
 import { externalRedirect } from "@zoonk/next/navigation/external-redirect";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
@@ -23,6 +24,7 @@ async function CallbackHandler({
   const needsSetup = !session?.user.username || !session?.user.name;
 
   if (session && needsSetup) {
+    await trackAuthCompleted({ action: "sign-up", userId: session.user.id });
     redirect(`/auth/setup?redirectTo=${encodeURIComponent(redirectToStr)}`);
   }
 
@@ -30,6 +32,10 @@ async function CallbackHandler({
 
   if (!result.success) {
     return redirect("/auth/untrusted-origin");
+  }
+
+  if (session) {
+    await trackAuthCompleted({ action: "sign-in", userId: session.user.id });
   }
 
   return externalRedirect(result.url);

--- a/apps/api/src/app/auth/login/email-login-form.tsx
+++ b/apps/api/src/app/auth/login/email-login-form.tsx
@@ -8,6 +8,7 @@ import {
   LoginForm,
   LoginSubmit,
 } from "@/components/login";
+import { trackSignInMethodChosen } from "@/lib/track-events";
 import { useExtracted } from "next-intl";
 import { useActionState } from "react";
 import { sendVerificationOTPAction } from "./actions";
@@ -29,7 +30,7 @@ export function EmailLoginForm({ redirectTo }: { redirectTo?: string }) {
   const hasError = hasEmailError || hasGenericError;
 
   return (
-    <LoginForm action={formAction}>
+    <LoginForm action={formAction} onSubmit={() => trackSignInMethodChosen({ method: "otp" })}>
       <input name="redirectTo" type="hidden" value={redirectTo ?? ""} />
 
       <LoginField>

--- a/apps/api/src/app/auth/login/social-login.tsx
+++ b/apps/api/src/app/auth/login/social-login.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { LoginError, LoginSocial, LoginWithApple, LoginWithGoogle } from "@/components/login";
+import { trackSignInMethodChosen } from "@/lib/track-events";
 import { authClient } from "@zoonk/core/auth/client";
 import { logError } from "@zoonk/utils/logger";
 import { useExtracted } from "next-intl";
@@ -18,6 +19,7 @@ export function SocialLogin({ redirectTo }: { redirectTo?: string }) {
 
   const signIn = async (provider: "google" | "apple") => {
     setState(getLoadingState(provider));
+    trackSignInMethodChosen({ method: provider });
 
     const callbackURL = redirectTo
       ? `/auth/callback?redirectTo=${encodeURIComponent(redirectTo)}`

--- a/apps/api/src/instrumentation-client.ts
+++ b/apps/api/src/instrumentation-client.ts
@@ -1,8 +1,8 @@
 import { captureRouterTransitionStart, init } from "@sentry/nextjs";
+import { getPostHogConfig } from "@zoonk/utils/posthog";
 import posthog from "posthog-js";
 
-const postHogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
-const postHogProjectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+const postHogConfig = getPostHogConfig();
 
 if (process.env.NODE_ENV === "production") {
   init({
@@ -13,8 +13,11 @@ if (process.env.NODE_ENV === "production") {
   });
 }
 
-if (postHogHost && postHogProjectToken) {
-  posthog.init(postHogProjectToken, { api_host: postHogHost, defaults: "2026-01-30" });
+if (postHogConfig) {
+  posthog.init(postHogConfig.projectToken, {
+    api_host: postHogConfig.host,
+    defaults: postHogConfig.defaults,
+  });
 }
 
 export const onRouterTransitionStart = captureRouterTransitionStart;

--- a/apps/api/src/lib/server-posthog.ts
+++ b/apps/api/src/lib/server-posthog.ts
@@ -1,0 +1,37 @@
+import "server-only";
+import { getPostHogConfig } from "@zoonk/utils/posthog";
+import { type EventMessage, PostHog } from "posthog-node";
+
+type ServerPostHogClient = {
+  capture: (props: EventMessage) => void;
+  [Symbol.asyncDispose]: () => Promise<void>;
+};
+
+/**
+ * Creates a short-lived PostHog Node client for API server analytics so each
+ * event helper can share one initialization path while still flushing before
+ * the request finishes.
+ */
+export function createServerPostHogClient(): ServerPostHogClient | null {
+  const postHogConfig = getPostHogConfig();
+
+  if (!postHogConfig) {
+    return null;
+  }
+
+  const posthog = new PostHog(postHogConfig.projectToken, {
+    flushAt: 1,
+    flushInterval: 0,
+    host: postHogConfig.host,
+  });
+
+  return {
+    async [Symbol.asyncDispose]() {
+      await posthog.shutdown();
+    },
+
+    capture(props: EventMessage) {
+      posthog.capture(props);
+    },
+  };
+}

--- a/apps/api/src/lib/server-track-events.ts
+++ b/apps/api/src/lib/server-track-events.ts
@@ -1,0 +1,47 @@
+import "server-only";
+import { createServerPostHogClient } from "@/lib/server-posthog";
+
+type AuthCompletionAction = "sign-in" | "sign-up";
+type ServerEventProperties = Record<string, boolean | number | string>;
+
+/**
+ * Captures one API server event with a short-lived PostHog client so event
+ * helpers only need to choose names and properties instead of repeating SDK
+ * lifecycle code.
+ */
+async function trackServerEvent({
+  distinctId,
+  event,
+  properties,
+}: {
+  distinctId: string;
+  event: string;
+  properties?: ServerEventProperties;
+}) {
+  const posthog = createServerPostHogClient();
+
+  if (!posthog) {
+    return;
+  }
+
+  await using client = posthog;
+
+  client.capture({ distinctId, event, properties });
+}
+
+/**
+ * Captures completed auth outcomes from the server callback because that route
+ * already knows whether the returning session still needs first-time setup.
+ */
+export async function trackAuthCompleted({
+  action,
+  userId,
+}: {
+  action: AuthCompletionAction;
+  userId: string;
+}) {
+  await trackServerEvent({
+    distinctId: userId,
+    event: action === "sign-up" ? "Sign Up Completed" : "Sign In Completed",
+  });
+}

--- a/apps/api/src/lib/server-track-events.ts
+++ b/apps/api/src/lib/server-track-events.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { createServerPostHogClient } from "@/lib/server-posthog";
+import { safeAsync } from "@zoonk/utils/error";
 
 type AuthCompletionAction = "sign-in" | "sign-up";
 type ServerEventProperties = Record<string, boolean | number | string>;
@@ -18,15 +19,17 @@ async function trackServerEvent({
   event: string;
   properties?: ServerEventProperties;
 }) {
-  const posthog = createServerPostHogClient();
+  await safeAsync(async () => {
+    const posthog = createServerPostHogClient();
 
-  if (!posthog) {
-    return;
-  }
+    if (!posthog) {
+      return;
+    }
 
-  await using client = posthog;
+    await using client = posthog;
 
-  client.capture({ distinctId, event, properties });
+    client.capture({ distinctId, event, properties });
+  });
 }
 
 /**

--- a/apps/api/src/lib/track-events.ts
+++ b/apps/api/src/lib/track-events.ts
@@ -1,0 +1,25 @@
+import { getPostHogConfig } from "@zoonk/utils/posthog";
+import posthog from "posthog-js";
+
+type AuthMethod = "apple" | "google" | "otp";
+type AnalyticsEventProperties = Record<string, boolean | number | string>;
+
+/**
+ * Records the provider the user chose on the login page before the browser may
+ * leave for an OAuth provider or the OTP page.
+ */
+export function trackSignInMethodChosen({ method }: { method: AuthMethod }) {
+  trackEvent({ name: "Sign In Method Chosen", properties: { method } });
+}
+
+/**
+ * Sends API auth events to PostHog only when the browser SDK has a configured
+ * project, matching the app's instrumentation-client initialization gate.
+ */
+function trackEvent({ name, properties }: { name: string; properties: AnalyticsEventProperties }) {
+  if (!getPostHogConfig()) {
+    return;
+  }
+
+  posthog.capture(name, properties);
+}

--- a/apps/main/src/app/(catalog)/(home)/hero-tracker.tsx
+++ b/apps/main/src/app/(catalog)/(home)/hero-tracker.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { trackHeroShown } from "@/lib/track-events";
+import { useEffect } from "react";
+
+/**
+ * Sends a custom event only when the zero-progress hero actually renders,
+ * which is narrower than using the home pageview as a proxy.
+ */
+export function HeroTracker() {
+  useEffect(() => {
+    trackHeroShown();
+  }, []);
+
+  return null;
+}

--- a/apps/main/src/app/(catalog)/(home)/hero.tsx
+++ b/apps/main/src/app/(catalog)/(home)/hero.tsx
@@ -2,6 +2,7 @@ import { buttonVariants } from "@zoonk/ui/components/button";
 import { ArrowRightIcon, SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import Link from "next/link";
+import { HeroTracker } from "./hero-tracker";
 
 /**
  * Shows the zero-progress home state with one action for creating a new course
@@ -12,6 +13,8 @@ export async function Hero() {
 
   return (
     <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center gap-8 px-4 py-16 md:py-24">
+      <HeroTracker />
+
       <div className="flex flex-col items-center gap-4 text-center">
         <h1 className="text-foreground/90 text-3xl font-semibold tracking-tight text-balance md:text-5xl md:tracking-tighter">
           {t("Learn anything with AI")}

--- a/apps/main/src/app/(catalog)/_components/command-palette.tsx
+++ b/apps/main/src/app/(catalog)/_components/command-palette.tsx
@@ -2,7 +2,6 @@
 
 import { logout } from "@/lib/logout";
 import { getMenu } from "@/lib/menu";
-import { trackCommandPaletteSearch } from "@/lib/track-events";
 import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import {
   CommandDialog,
@@ -46,11 +45,7 @@ export function CommandPalette({
   const locale = useLocale();
 
   const handleSearch = useCallback(
-    (searchQuery: string) => {
-      trackCommandPaletteSearch({ searchTerm: searchQuery });
-
-      return searchCatalogAction({ language: locale, query: searchQuery });
-    },
+    (searchQuery: string) => searchCatalogAction({ language: locale, query: searchQuery }),
     [locale],
   );
 

--- a/apps/main/src/app/(settings)/subscription/plan-list.tsx
+++ b/apps/main/src/app/(settings)/subscription/plan-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { trackSubscriptionCheckoutStarted } from "@/lib/track-events";
 import { authClient } from "@zoonk/core/auth/client";
 import { Badge } from "@zoonk/ui/components/badge";
 import { Button } from "@zoonk/ui/components/button";
@@ -13,6 +14,7 @@ import {
 import { RadioGroup, RadioGroupItem } from "@zoonk/ui/components/radio-group";
 import { Tabs, TabsList, TabsTrigger } from "@zoonk/ui/components/tabs";
 import { type PriceInfo, formatPrice } from "@zoonk/utils/currency";
+import { logError } from "@zoonk/utils/logger";
 import { FREE_PLAN, getPlanTier } from "@zoonk/utils/subscription";
 import { Loader2Icon } from "lucide-react";
 import { useExtracted, useLocale } from "next-intl";
@@ -89,10 +91,13 @@ export function PlanList({
 
       if (error) {
         setState("error");
+        logError("Subscription action failed", { error });
       }
 
       return;
     }
+
+    trackSubscriptionCheckoutStarted({ billingPeriod: period, plan: selectedPlan });
 
     const { error } = await authClient.subscription.upgrade({
       annual: period === "yearly",
@@ -104,6 +109,7 @@ export function PlanList({
 
     if (error) {
       setState("error");
+      logError("Subscription upgrade failed", { error });
     }
   };
 

--- a/apps/main/src/app/(settings)/subscription/subscription-conversion-tracker.tsx
+++ b/apps/main/src/app/(settings)/subscription/subscription-conversion-tracker.tsx
@@ -18,10 +18,12 @@ const MAX_CONFIRMATION_REFRESH_COUNT = 5;
 export function SubscriptionConversionTracker({
   activeSubscriptionId,
   analyticsDisabled,
+  plan,
   stripeCheckoutCompleted,
 }: {
   activeSubscriptionId: string | null;
   analyticsDisabled: boolean;
+  plan: string;
   stripeCheckoutCompleted: boolean;
 }) {
   const router = useRouter();
@@ -43,12 +45,12 @@ export function SubscriptionConversionTracker({
     }
 
     if (!analyticsDisabled) {
-      trackGoogleAdsSubscriptionConversion();
+      trackGoogleAdsSubscriptionConversion({ plan });
     }
 
     markSubscriptionConversionHandled(activeSubscriptionId);
     removeStripeCheckoutParamFromCurrentUrl();
-  }, [activeSubscriptionId, analyticsDisabled, refresh, stripeCheckoutCompleted]);
+  }, [activeSubscriptionId, analyticsDisabled, plan, refresh, stripeCheckoutCompleted]);
 
   return null;
 }

--- a/apps/main/src/app/(settings)/subscription/subscription-plans.tsx
+++ b/apps/main/src/app/(settings)/subscription/subscription-plans.tsx
@@ -71,6 +71,7 @@ export async function SubscriptionPlans({
         <SubscriptionConversionTracker
           activeSubscriptionId={activeStripeSubscriptionId}
           analyticsDisabled={analyticsDisabled}
+          plan={currentPlan ?? "free"}
           stripeCheckoutCompleted={stripeCheckoutCompleted}
         />
         <ManagedSubscription
@@ -109,6 +110,7 @@ export async function SubscriptionPlans({
       <SubscriptionConversionTracker
         activeSubscriptionId={activeStripeSubscriptionId}
         analyticsDisabled={analyticsDisabled}
+        plan={currentPlan ?? "free"}
         stripeCheckoutCompleted={stripeCheckoutCompleted}
       />
       <PlanList

--- a/apps/main/src/app/app-analytics.tsx
+++ b/apps/main/src/app/app-analytics.tsx
@@ -10,11 +10,11 @@ const googleAdsTagId = process.env.NEXT_PUBLIC_GOOGLE_ADS_TAG_ID;
  * root layout can stream the rest of the route without waiting on this flag.
  */
 export async function AppAnalytics() {
-  const { analyticsDisabled, userId } = await getCurrentUserAnalyticsState();
+  const { analyticsDisabled, plan, userId } = await getCurrentUserAnalyticsState();
 
   return (
     <>
-      <PostHogIdentify analyticsDisabled={analyticsDisabled} userId={userId} />
+      <PostHogIdentify analyticsDisabled={analyticsDisabled} plan={plan} userId={userId} />
       {analyticsDisabled ? null : (
         <>
           <Analytics debug={false} />

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { ContentFeedback } from "@/components/feedback/content-feedback";
-import { trackLessonCompleted, trackPlayerLoaded, trackPlayerSecondStep } from "@/lib/track-events";
+import {
+  trackLessonCompleted,
+  trackLessonSecondStep,
+  trackLessonStarted,
+} from "@/lib/track-events";
 import { type CompletionInput } from "@zoonk/core/player/contracts/completion-input-schema";
 import { type SerializedLesson } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import {
@@ -16,6 +20,27 @@ import { type LessonProgressMeta, buildLessonPlayerModel } from "./lesson-player
 import { preloadNextLesson } from "./preload-next-lesson-action";
 import { submitCompletion } from "./submit-completion-action";
 
+type LessonPlayerClientProps = {
+  lesson: SerializedLesson;
+  brandSlug: string;
+  chapterPosition: number;
+  chapterTitle: string;
+  courseSlug: string;
+  chapterSlug: string;
+  isAuthenticated: boolean;
+  lessonDescription: string;
+  lessonProgress: LessonProgressMeta;
+  lessonPosition: number;
+  lessonSlug: string;
+  lessonTitle: string;
+  nextChapter: { brandSlug: string; chapterSlug: string; courseSlug: string } | null;
+  nextLesson: { chapterSlug: string; lessonSlug: string; lessonTitle: string | null } | null;
+  progressSnapshot: PlayerProgressSnapshot | null;
+  totalBrainPower: number;
+  userEmail?: string;
+  userName: string | null;
+};
+
 /**
  * Identifies the exact funnel moment where a learner has advanced from the
  * first player step to the second, regardless of whether the first step was
@@ -28,12 +53,14 @@ function isSecondStepForwardEvent(event: PlayerStepChangeEvent) {
 export function LessonPlayerClient({
   lesson,
   brandSlug,
+  chapterPosition,
   chapterTitle,
   courseSlug,
   chapterSlug,
   isAuthenticated,
   lessonDescription,
   lessonProgress,
+  lessonPosition,
   lessonSlug,
   lessonTitle,
   nextChapter,
@@ -42,24 +69,7 @@ export function LessonPlayerClient({
   totalBrainPower,
   userEmail,
   userName,
-}: {
-  lesson: SerializedLesson;
-  brandSlug: string;
-  chapterTitle: string;
-  courseSlug: string;
-  chapterSlug: string;
-  isAuthenticated: boolean;
-  lessonDescription: string;
-  lessonProgress: LessonProgressMeta;
-  lessonSlug: string;
-  lessonTitle: string;
-  nextChapter: { brandSlug: string; chapterSlug: string; courseSlug: string } | null;
-  nextLesson: { chapterSlug: string; lessonSlug: string; lessonTitle: string | null } | null;
-  progressSnapshot: PlayerProgressSnapshot | null;
-  totalBrainPower: number;
-  userEmail?: string;
-  userName: string | null;
-}) {
+}: LessonPlayerClientProps) {
   const router = useRouter();
   const hasRequestedNextLessonPreload = useRef(false);
   const hasTrackedSecondStep = useRef(false);
@@ -86,23 +96,33 @@ export function LessonPlayerClient({
       return;
     }
 
-    trackPlayerLoaded({
+    trackLessonStarted({
+      chapterPosition,
       courseSlug,
       lessonKind: lesson.kind,
+      lessonPosition,
       lessonSlug,
       stepCount: lesson.steps.length,
     });
-  }, [courseSlug, lesson.id, lesson.kind, lessonSlug, lesson.steps.length]);
+  }, [
+    chapterPosition,
+    courseSlug,
+    lesson.id,
+    lesson.kind,
+    lessonPosition,
+    lessonSlug,
+    lesson.steps.length,
+  ]);
 
   /** Fire-and-forget: analytics runs for all learners; persistence requires auth. */
   const handleComplete = useCallback(
     (input: CompletionInput) => {
       trackLessonCompleted({
+        chapterPosition,
         courseSlug,
         lessonKind: lesson.kind,
+        lessonPosition,
         lessonSlug,
-        startedAt: input.startedAt,
-        stepCount: lesson.steps.length,
       });
 
       if (!isAuthenticated) {
@@ -111,7 +131,7 @@ export function LessonPlayerClient({
 
       void submitCompletion(input);
     },
-    [courseSlug, isAuthenticated, lesson.kind, lessonSlug, lesson.steps.length],
+    [chapterPosition, courseSlug, isAuthenticated, lesson.kind, lessonPosition, lessonSlug],
   );
 
   /** Fire once after the first forward step change; completion handles short lessons. */
@@ -120,9 +140,11 @@ export function LessonPlayerClient({
       if (isSecondStepForwardEvent(event) && !hasTrackedSecondStep.current) {
         hasTrackedSecondStep.current = true;
 
-        trackPlayerSecondStep({
+        trackLessonSecondStep({
+          chapterPosition,
           courseSlug,
           lessonKind: lesson.kind,
+          lessonPosition,
           lessonSlug,
           stepCount: lesson.steps.length,
         });
@@ -140,7 +162,15 @@ export function LessonPlayerClient({
       hasRequestedNextLessonPreload.current = true;
       void preloadNextLesson(event.lessonId);
     },
-    [courseSlug, isAuthenticated, lesson.kind, lessonSlug, lesson.steps.length],
+    [
+      chapterPosition,
+      courseSlug,
+      isAuthenticated,
+      lesson.kind,
+      lessonPosition,
+      lessonSlug,
+      lesson.steps.length,
+    ],
   );
 
   return (

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -285,12 +285,14 @@ export default async function LessonPage({ params }: Props) {
     <LessonPlayerClient
       lesson={serialized}
       brandSlug={brandSlug}
+      chapterPosition={lessonShell.chapter.position}
       chapterTitle={lessonShell.chapter.title}
       courseSlug={courseSlug}
       chapterSlug={chapterSlug}
       isAuthenticated={Boolean(session)}
       lessonDescription={lessonMeta.description}
       lessonProgress={lessonProgress}
+      lessonPosition={lessonShell.position}
       lessonSlug={lessonSlug}
       lessonTitle={lessonMeta.title}
       nextChapter={nextChapter}

--- a/apps/main/src/app/posthog-identify.tsx
+++ b/apps/main/src/app/posthog-identify.tsx
@@ -9,14 +9,16 @@ import { useEffect } from "react";
  */
 export function PostHogIdentify({
   analyticsDisabled,
+  plan,
   userId,
 }: {
   analyticsDisabled: boolean;
+  plan: string;
   userId: string | null;
 }) {
   useEffect(() => {
-    identifyPostHogUser({ analyticsDisabled, userId });
-  }, [analyticsDisabled, userId]);
+    identifyPostHogUser({ analyticsDisabled, plan, userId });
+  }, [analyticsDisabled, plan, userId]);
 
   return null;
 }

--- a/apps/main/src/app/privacy/en.mdx
+++ b/apps/main/src/app/privacy/en.mdx
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-- **Effective date:** May 31, 2026
+- **Effective date:** June 13, 2026
 - **Company:** Zoonk Tecnologia e Educação Ltda
 - **CNPJ:** 42.262.784/0001-76
 - **Address:** Setor SGAN 601, Módulo H, Sala 55, SS1, Parte 14, Edif Ion, Asa Norte, Brasília (DF), 70830-018, Brazil
@@ -18,6 +18,7 @@ When you use Zoonk, we may collect:
 - Learning data, such as courses viewed or created, lessons completed, answers, progress, time spent, feedback, and preferences.
 - User-generated content, such as prompts, uploaded content, pages, comments, answers, and support messages.
 - Technical data, such as IP address, device information, browser, operating system, cookies, app-access logs, security events, and approximate location inferred from technical data.
+- Product analytics and session data, such as pages or screens visited, referring pages, actions taken, feature usage, clicks or taps, scrolling, navigation paths, session replays, and identifiers or context for the course, lesson, prompt, plan, or feedback event involved.
 
 ---
 
@@ -29,7 +30,7 @@ We use personal data for the following purposes and legal bases:
 - To personalize your learning experience, recommend content, and remember preferences, based on the contract with you and our legitimate interests.
 - To generate educational content with AI, evaluate quality and safety, improve Zoonk's AI features, and train or fine-tune systems that Zoonk operates or configures, based on the contract with you, our legitimate interests, and consent where required.
 - To process payments, prevent fraud, handle support, and manage refunds or cancellations, based on the contract with you, legal obligations, and our legitimate interests.
-- To measure usage, improve the product, debug errors, and keep the platform secure, based on our legitimate interests and consent where required.
+- To measure usage, improve the product, debug errors and user flows, and keep the platform secure, based on our legitimate interests and consent where required.
 - To comply with tax, accounting, consumer, data-protection, internet, court, regulatory, and other legal obligations.
 
 ---
@@ -44,12 +45,23 @@ We use personal data for the following purposes and legal bases:
 
 ---
 
-## 4. Sharing data
+## 4. Product analytics and session replay
+
+- We use analytics tools, including PostHog and Vercel Analytics, to understand how people use Zoonk, improve onboarding and learning flows, debug interface problems, measure feature quality, and keep the platform reliable.
+- These tools may collect product events, page URLs, referrers, device and browser data, approximate location, clicks or taps, scrolling, navigation paths, form-interaction metadata, and session replays showing how Zoonk was displayed and used.
+- Analytics events may include account or user identifiers, plan information, course and lesson identifiers, feedback values, and prompt or content context when that context is needed to understand the event.
+- Session replay is not intended to capture passwords, payment details, or sensitive personal data. Inputs may be masked by default or by configuration, but prompts, uploaded content, URLs, and visible page content may contain personal data if you include it in Zoonk.
+- We limit access to analytics and replay tools to authorized people who need that access to operate, protect, or improve Zoonk.
+
+---
+
+## 5. Sharing data
 
 We share data only as needed to operate, protect, and improve Zoonk:
 
-- Hosting, database, authentication, email, analytics, security, and error-monitoring providers.
+- Hosting, database, authentication, email, analytics, session replay, security, and error-monitoring providers.
 - Vercel Analytics for product analytics.
+- PostHog for product analytics, event tracking, and session replay.
 - Google Ads conversion tracking to measure whether ads lead to subscriptions. Google may use cookies or similar technologies for this measurement.
 - AI infrastructure and model providers such as Vercel, OpenAI, Microsoft, Google, and Anthropic when needed to provide or improve AI features.
 - Payment providers such as Stripe, Apple, and Google for billing, subscription management, refunds, fraud prevention, and tax or accounting records.
@@ -59,7 +71,7 @@ We never sell or rent your personal data.
 
 ---
 
-## 5. Your LGPD rights
+## 6. Your LGPD rights
 
 Subject to the limits and procedures in the LGPD, you may request:
 
@@ -77,7 +89,7 @@ To exercise these rights, contact [hello@zoonk.com](mailto:hello@zoonk.com). We 
 
 ---
 
-## 6. Account deletion and retention
+## 7. Account deletion and retention
 
 - You can request account deletion by emailing [hello@zoonk.com](mailto:hello@zoonk.com).
 - When your account is deleted, you will lose access to it.
@@ -89,7 +101,7 @@ To exercise these rights, contact [hello@zoonk.com](mailto:hello@zoonk.com). We 
 
 ---
 
-## 7. Minors
+## 8. Minors
 
 - Zoonk is for users 13 and older.
 - Users under the age of majority may use Zoonk only with authorization and supervision from a parent or legal guardian.
@@ -100,18 +112,18 @@ To exercise these rights, contact [hello@zoonk.com](mailto:hello@zoonk.com). We 
 
 ---
 
-## 8. International transfers
+## 9. International transfers
 
 Some of our providers may process data outside Brazil. When this happens, we use appropriate contractual, technical, and organizational measures to protect the data according to applicable law.
 
 ---
 
-## 9. Security
+## 10. Security
 
 We use reasonable measures to protect your data, but no system is 100% secure.
 
 ---
 
-## 10. Changes
+## 11. Changes
 
 We may update this Policy. If we make important changes, we'll notify you in-app, by email, or on our website.

--- a/apps/main/src/app/privacy/es.mdx
+++ b/apps/main/src/app/privacy/es.mdx
@@ -1,6 +1,6 @@
 # Política de Privacidad
 
-- **Fecha de vigencia:** 31 de mayo de 2026
+- **Fecha de vigencia:** 13 de junio de 2026
 - **Empresa:** Zoonk Tecnologia e Educação Ltda
 - **CNPJ:** 42.262.784/0001-76
 - **Dirección:** Setor SGAN 601, Módulo H, Sala 55, SS1, Parte 14, Edif Ion, Asa Norte, Brasília (DF), 70830-018, Brasil
@@ -18,6 +18,7 @@ Cuando usas Zoonk, podemos recopilar:
 - Datos de aprendizaje, como cursos vistos o creados, lecciones completadas, respuestas, progreso, tiempo de uso, comentarios y preferencias.
 - Contenido generado por usuarios, como prompts, cargas, páginas, comentarios, respuestas y mensajes de soporte.
 - Datos técnicos, como dirección IP, información del dispositivo, navegador, sistema operativo, cookies, registros de acceso a la aplicación, eventos de seguridad y ubicación aproximada inferida a partir de datos técnicos.
+- Datos de analítica de producto y de sesión, como páginas o pantallas visitadas, páginas de origen, acciones realizadas, uso de funciones, clics o toques, desplazamiento, rutas de navegación, repeticiones de sesión e identificadores o contexto del curso, lección, prompt, plan o evento de comentarios involucrado.
 
 ---
 
@@ -29,7 +30,7 @@ Usamos datos personales para las siguientes finalidades y bases legales:
 - Para personalizar tu experiencia de aprendizaje, recomendar contenido y recordar preferencias, con base en el contrato contigo y en nuestros intereses legítimos.
 - Para generar contenido educativo con IA, evaluar calidad y seguridad, mejorar los recursos de IA de Zoonk y entrenar o ajustar sistemas que Zoonk opera o configura, con base en el contrato contigo, nuestros intereses legítimos y consentimiento cuando sea requerido.
 - Para procesar pagos, prevenir fraude, brindar soporte y gestionar reembolsos o cancelaciones, con base en el contrato contigo, obligaciones legales y nuestros intereses legítimos.
-- Para medir el uso, mejorar el producto, depurar errores y mantener la plataforma segura, con base en nuestros intereses legítimos y consentimiento cuando sea requerido.
+- Para medir el uso, mejorar el producto, depurar errores y flujos de uso, y mantener la plataforma segura, con base en nuestros intereses legítimos y consentimiento cuando sea requerido.
 - Para cumplir obligaciones legales, fiscales, contables, de consumo, de protección de datos, de internet, judiciales, regulatorias y otras.
 
 ---
@@ -44,12 +45,23 @@ Usamos datos personales para las siguientes finalidades y bases legales:
 
 ---
 
-## 4. Compartir datos
+## 4. Analítica de producto y repeticiones de sesión
+
+- Usamos herramientas de analítica, incluidas PostHog y Vercel Analytics, para entender cómo las personas usan Zoonk, mejorar el onboarding y los flujos de aprendizaje, depurar problemas de interfaz, medir la calidad de las funciones y mantener la plataforma confiable.
+- Estas herramientas pueden recopilar eventos de producto, URLs de páginas, páginas de origen, datos de dispositivo y navegador, ubicación aproximada, clics o toques, desplazamiento, rutas de navegación, metadatos de interacción con formularios y repeticiones de sesión que muestran cómo se mostró y usó Zoonk.
+- Los eventos de analítica pueden incluir identificadores de cuenta o usuario, información del plan, identificadores de cursos y lecciones, valores de comentarios y contexto de prompts o contenido cuando ese contexto sea necesario para entender el evento.
+- Las repeticiones de sesión no tienen como finalidad capturar contraseñas, datos de pago ni datos personales sensibles. Los campos pueden estar enmascarados por defecto o por configuración, pero prompts, cargas, URLs y contenido visible de la página pueden contener datos personales si los incluyes en Zoonk.
+- Limitamos el acceso a las herramientas de analítica y repetición a personas autorizadas que necesiten ese acceso para operar, proteger o mejorar Zoonk.
+
+---
+
+## 5. Compartir datos
 
 Compartimos datos solo cuando es necesario para operar, proteger y mejorar Zoonk:
 
-- Proveedores de alojamiento, base de datos, autenticación, correo electrónico, análisis, seguridad y monitoreo de errores.
+- Proveedores de alojamiento, base de datos, autenticación, correo electrónico, analítica, repetición de sesión, seguridad y monitoreo de errores.
 - Vercel Analytics para análisis de producto.
+- PostHog para analítica de producto, seguimiento de eventos y repetición de sesión.
 - Seguimiento de conversiones de Google Ads para medir si los anuncios generan suscripciones. Google puede usar cookies o tecnologías similares para esta medición.
 - Infraestructura de IA y proveedores de modelos como Vercel, OpenAI, Microsoft, Google y Anthropic cuando sea necesario para proporcionar o mejorar recursos de IA.
 - Proveedores de pago como Stripe, Apple y Google para facturación, gestión de suscripciones, reembolsos, prevención de fraude y registros fiscales o contables.
@@ -59,7 +71,7 @@ Nunca vendemos ni alquilamos tus datos personales.
 
 ---
 
-## 5. Tus derechos bajo la LGPD
+## 6. Tus derechos bajo la LGPD
 
 Sujeto a los límites y procedimientos de la LGPD, puedes solicitar:
 
@@ -77,7 +89,7 @@ Para ejercer estos derechos, contáctanos en [contacto@zoonk.com](mailto:contact
 
 ---
 
-## 6. Eliminación de cuenta y retención
+## 7. Eliminación de cuenta y retención
 
 - Puedes solicitar la eliminación de cuenta enviando un correo electrónico a [contacto@zoonk.com](mailto:contacto@zoonk.com).
 - Cuando tu cuenta se elimina, perderás el acceso a ella.
@@ -89,7 +101,7 @@ Para ejercer estos derechos, contáctanos en [contacto@zoonk.com](mailto:contact
 
 ---
 
-## 7. Menores
+## 8. Menores
 
 - Zoonk es para usuarios de 13 años o más.
 - Los usuarios menores de edad solo pueden usar Zoonk con autorización y supervisión de su padre, madre o representante legal.
@@ -100,18 +112,18 @@ Para ejercer estos derechos, contáctanos en [contacto@zoonk.com](mailto:contact
 
 ---
 
-## 8. Transferencias internacionales
+## 9. Transferencias internacionales
 
 Algunos de nuestros proveedores pueden procesar datos fuera de Brasil. Cuando esto ocurre, usamos medidas contractuales, técnicas y organizativas adecuadas para proteger los datos conforme a la ley aplicable.
 
 ---
 
-## 9. Seguridad
+## 10. Seguridad
 
 Utilizamos medidas razonables para proteger tus datos, pero ningún sistema es 100% seguro.
 
 ---
 
-## 10. Cambios
+## 11. Cambios
 
 Podemos actualizar esta Política. Si hacemos cambios importantes, te notificaremos en la aplicación, por correo electrónico o en nuestro sitio web.

--- a/apps/main/src/app/privacy/pt.mdx
+++ b/apps/main/src/app/privacy/pt.mdx
@@ -1,6 +1,6 @@
 # Política de Privacidade
 
-- **Data de vigência:** 31 de maio de 2026
+- **Data de vigência:** 13 de junho de 2026
 - **Empresa:** Zoonk Tecnologia e Educação Ltda
 - **CNPJ:** 42.262.784/0001-76
 - **Endereço:** Setor SGAN 601, Módulo H, Sala 55, SS1, Parte 14, Edif Ion, Asa Norte, Brasília (DF), 70830-018, Brasil
@@ -18,6 +18,7 @@ Ao usar o Zoonk, podemos coletar:
 - Dados de aprendizagem, como cursos vistos ou criados, aulas concluídas, respostas, progresso, tempo de uso, feedback e preferências.
 - Conteúdo gerado por usuários, como prompts, uploads, páginas, comentários, respostas e mensagens de suporte.
 - Dados técnicos, como endereço IP, informações do dispositivo, navegador, sistema operacional, cookies, registros de acesso à aplicação, eventos de segurança e localização aproximada inferida a partir de dados técnicos.
+- Dados de análise de produto e de sessão, como páginas ou telas visitadas, páginas de origem, ações realizadas, uso de recursos, cliques ou toques, rolagem, caminhos de navegação, reproduções de sessão e identificadores ou contexto do curso, aula, prompt, plano ou evento de feedback envolvido.
 
 ---
 
@@ -29,7 +30,7 @@ Usamos dados pessoais para as seguintes finalidades e bases legais:
 - Para personalizar sua experiência de aprendizagem, recomendar conteúdo e lembrar preferências, com base no contrato com você e em nossos legítimos interesses.
 - Para gerar conteúdo educacional com IA, avaliar qualidade e segurança, melhorar os recursos de IA do Zoonk e treinar ou ajustar sistemas que o Zoonk opera ou configura, com base no contrato com você, em nossos legítimos interesses e em consentimento quando exigido.
 - Para processar pagamentos, prevenir fraudes, prestar suporte e gerenciar reembolsos ou cancelamentos, com base no contrato com você, em obrigações legais e em nossos legítimos interesses.
-- Para medir uso, melhorar o produto, depurar erros e manter a plataforma segura, com base em nossos legítimos interesses e em consentimento quando exigido.
+- Para medir uso, melhorar o produto, depurar erros e fluxos de uso e manter a plataforma segura, com base em nossos legítimos interesses e em consentimento quando exigido.
 - Para cumprir obrigações legais, fiscais, contábeis, consumeristas, de proteção de dados, de internet, judiciais, regulatórias e outras.
 
 ---
@@ -44,12 +45,23 @@ Usamos dados pessoais para as seguintes finalidades e bases legais:
 
 ---
 
-## 4. Compartilhamento de dados
+## 4. Análise de produto e reproduções de sessão
+
+- Usamos ferramentas de análise, incluindo PostHog e Vercel Analytics, para entender como as pessoas usam o Zoonk, melhorar onboarding e fluxos de aprendizagem, depurar problemas de interface, medir a qualidade de recursos e manter a plataforma confiável.
+- Essas ferramentas podem coletar eventos de produto, URLs de páginas, páginas de origem, dados de dispositivo e navegador, localização aproximada, cliques ou toques, rolagem, caminhos de navegação, metadados de interação com formulários e reproduções de sessão mostrando como o Zoonk foi exibido e usado.
+- Eventos de análise podem incluir identificadores de conta ou usuário, informações de plano, identificadores de cursos e aulas, valores de feedback e contexto de prompts ou conteúdo quando esse contexto for necessário para entender o evento.
+- Reproduções de sessão não têm a finalidade de capturar senhas, dados de pagamento ou dados pessoais sensíveis. Campos podem ser mascarados por padrão ou por configuração, mas prompts, uploads, URLs e conteúdo visível na página podem conter dados pessoais se você os incluir no Zoonk.
+- Limitamos o acesso às ferramentas de análise e reprodução a pessoas autorizadas que precisem desse acesso para operar, proteger ou melhorar o Zoonk.
+
+---
+
+## 5. Compartilhamento de dados
 
 Compartilhamos dados apenas conforme necessário para operar, proteger e melhorar o Zoonk:
 
-- Provedores de hospedagem, banco de dados, autenticação, e-mail, análise, segurança e monitoramento de erros.
+- Provedores de hospedagem, banco de dados, autenticação, e-mail, análise, reprodução de sessão, segurança e monitoramento de erros.
 - Vercel Analytics para análise de produto.
+- PostHog para análise de produto, rastreamento de eventos e reprodução de sessão.
 - Acompanhamento de conversões do Google Ads para medir se anúncios geram assinaturas. O Google pode usar cookies ou tecnologias semelhantes para essa medição.
 - Infraestrutura de IA e provedores de modelos como Vercel, OpenAI, Microsoft, Google e Anthropic quando necessário para fornecer ou melhorar recursos de IA.
 - Provedores de pagamento como Stripe, Apple e Google para cobrança, gestão de assinaturas, reembolsos, prevenção a fraudes e registros fiscais ou contábeis.
@@ -59,7 +71,7 @@ Nunca vendemos ou alugamos seus dados pessoais.
 
 ---
 
-## 5. Seus direitos pela LGPD
+## 6. Seus direitos pela LGPD
 
 Observados os limites e procedimentos da LGPD, você pode solicitar:
 
@@ -77,7 +89,7 @@ Para exercer esses direitos, entre em contato pelo e-mail [contato@zoonk.com](ma
 
 ---
 
-## 6. Exclusão de conta e retenção
+## 7. Exclusão de conta e retenção
 
 - Você pode solicitar a exclusão da conta enviando um e-mail para [contato@zoonk.com](mailto:contato@zoonk.com).
 - Quando sua conta for excluída, você perderá o acesso a ela.
@@ -89,7 +101,7 @@ Para exercer esses direitos, entre em contato pelo e-mail [contato@zoonk.com](ma
 
 ---
 
-## 7. Menores de idade
+## 8. Menores de idade
 
 - O Zoonk é para usuários com 13 anos ou mais.
 - Usuários menores de idade só podem usar o Zoonk com autorização e supervisão de um dos pais ou responsável legal.
@@ -100,18 +112,18 @@ Para exercer esses direitos, entre em contato pelo e-mail [contato@zoonk.com](ma
 
 ---
 
-## 8. Transferências internacionais
+## 9. Transferências internacionais
 
 Alguns de nossos provedores podem tratar dados fora do Brasil. Quando isso acontece, usamos medidas contratuais, técnicas e organizacionais adequadas para proteger os dados conforme a legislação aplicável.
 
 ---
 
-## 9. Segurança
+## 10. Segurança
 
 Utilizamos medidas razoáveis para proteger seus dados, mas nenhum sistema é 100% seguro.
 
 ---
 
-## 10. Alterações
+## 11. Alterações
 
 Podemos atualizar esta Política. Se fizermos alterações importantes, notificaremos você pelo app, por e-mail ou pelo nosso site.

--- a/apps/main/src/data/users/get-current-user-analytics-disabled.ts
+++ b/apps/main/src/data/users/get-current-user-analytics-disabled.ts
@@ -1,6 +1,8 @@
 import "server-only";
+import { getActiveSubscription } from "@zoonk/core/auth/subscription";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { headers } from "next/headers";
 import { cache } from "react";
 
 /**
@@ -9,19 +11,27 @@ import { cache } from "react";
  * row stays the source of truth.
  */
 export const getCurrentUserAnalyticsState = cache(async () => {
-  const session = await getSession();
+  const requestHeaders = await headers();
+  const session = await getSession(requestHeaders);
 
   if (!session) {
-    return { analyticsDisabled: false, userId: null };
+    return { analyticsDisabled: false, plan: "free", userId: null };
   }
 
-  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+  const [subscription, user] = await Promise.all([
+    getActiveSubscription(requestHeaders),
+    prisma.user.findUnique({ where: { id: session.user.id } }),
+  ]);
 
   if (!user) {
-    return { analyticsDisabled: false, userId: null };
+    return { analyticsDisabled: false, plan: "free", userId: null };
   }
 
-  return { analyticsDisabled: user.analyticsDisabled, userId: user.id };
+  return {
+    analyticsDisabled: user.analyticsDisabled,
+    plan: subscription?.plan ?? "free",
+    userId: user.id,
+  };
 });
 
 /**

--- a/apps/main/src/instrumentation-client.ts
+++ b/apps/main/src/instrumentation-client.ts
@@ -1,5 +1,5 @@
-import { getPostHogConfig } from "@/lib/posthog";
 import { captureRouterTransitionStart, init } from "@sentry/nextjs";
+import { getPostHogConfig } from "@zoonk/utils/posthog";
 import { initBotId } from "botid/client/core";
 import posthog from "posthog-js";
 
@@ -17,7 +17,7 @@ if (process.env.NODE_ENV === "production") {
 if (postHogConfig) {
   posthog.init(postHogConfig.projectToken, {
     api_host: postHogConfig.host,
-    defaults: "2026-05-30",
+    defaults: postHogConfig.defaults,
   });
 }
 

--- a/apps/main/src/lib/posthog.ts
+++ b/apps/main/src/lib/posthog.ts
@@ -1,21 +1,5 @@
+import { getPostHogConfig } from "@zoonk/utils/posthog";
 import posthog from "posthog-js";
-
-type PostHogConfig = { host: string; projectToken: string };
-
-/**
- * Reads PostHog config from public environment variables so the SDK can be
- * disabled in environments that do not define both required client values.
- */
-export function getPostHogConfig(): PostHogConfig | null {
-  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST;
-  const projectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
-
-  if (!host || !projectToken) {
-    return null;
-  }
-
-  return { host, projectToken };
-}
 
 /**
  * Links browser events to the authenticated Zoonk user and stores the user flag
@@ -23,9 +7,11 @@ export function getPostHogConfig(): PostHogConfig | null {
  */
 export function identifyPostHogUser({
   analyticsDisabled,
+  plan,
   userId,
 }: {
   analyticsDisabled: boolean;
+  plan: string;
   userId: string | null;
 }) {
   if (!getPostHogConfig()) {
@@ -36,7 +22,7 @@ export function identifyPostHogUser({
     return;
   }
 
-  posthog.identify(userId, { analyticsDisabled });
+  posthog.identify(userId, { analyticsDisabled, plan });
 }
 
 /**

--- a/apps/main/src/lib/track-events.ts
+++ b/apps/main/src/lib/track-events.ts
@@ -1,15 +1,20 @@
-import { getPostHogConfig } from "@/lib/posthog";
 import { track as trackVercelEvent } from "@vercel/analytics";
-import { getCappedLessonDurationSeconds } from "@zoonk/core/player/contracts/completion-duration";
 import { type LessonKind } from "@zoonk/core/steps/contract/content";
+import { getPostHogConfig } from "@zoonk/utils/posthog";
 import posthog from "posthog-js";
 
-type PlayerEventInput = {
+type LessonProgressEventInput = {
+  chapterPosition: number;
   courseSlug: string;
   lessonKind: LessonKind;
+  lessonPosition: number;
   lessonSlug: string;
   stepCount: number;
 };
+
+type LessonCompletionEventInput = Omit<LessonProgressEventInput, "stepCount">;
+
+type SubscriptionBillingPeriod = "monthly" | "yearly";
 
 export type FeedbackValue = "upvote" | "downvote";
 
@@ -50,64 +55,63 @@ export function trackFeedback(input: FeedbackInput) {
 }
 
 /**
- * Records only submitted command-palette searches because the shared search
- * hook debounces before calling the `onSearch` callback.
- */
-export function trackCommandPaletteSearch({ searchTerm }: { searchTerm: string }) {
-  const trimmedSearchTerm = searchTerm.trim();
-
-  if (!trimmedSearchTerm) {
-    return;
-  }
-
-  trackEvent({ name: "Command Palette Search", properties: { searchTerm: trimmedSearchTerm } });
-}
-
-/**
  * Counts learners who reached the first playable step after the player shell
  * mounted, which is the funnel denominator for later player events.
  */
-export function trackPlayerLoaded(input: PlayerEventInput) {
-  trackEvent({ name: "Player Loaded", properties: getPlayerEventData(input) });
+export function trackLessonStarted(input: LessonProgressEventInput) {
+  trackEvent({ name: "Lesson Started", properties: getLessonProgressEventData(input) });
 }
 
 /**
  * Counts learners who moved beyond the first step without depending on a
  * specific step renderer or interaction type.
  */
-export function trackPlayerSecondStep(input: PlayerEventInput) {
-  trackEvent({ name: "Player Second Step", properties: getPlayerEventData(input) });
+export function trackLessonSecondStep(input: LessonProgressEventInput) {
+  trackEvent({ name: "Lesson Second Step", properties: getLessonProgressEventData(input) });
 }
 
 /**
- * Reports lesson completions with the client-side duration because the player
- * already owns the local lesson start timestamp before persistence runs.
+ * Counts learners who reached the lesson completion event without sending
+ * volatile step counts or client-side timing values.
  */
-export function trackLessonCompleted({
-  startedAt,
-  ...input
-}: PlayerEventInput & { startedAt: number }) {
-  trackEvent({
-    name: "Lesson Completed",
-    properties: {
-      ...getPlayerEventData(input),
-      durationSeconds: getCompletionDurationSeconds({ startedAt }),
-    },
-  });
+export function trackLessonCompleted(input: LessonCompletionEventInput) {
+  trackEvent({ name: "Lesson Completed", properties: getLessonEventData(input) });
 }
 
 /**
  * Reports completed subscription checkouts after Stripe confirms the purchase
  * so analytics count real conversions instead of checkout button clicks.
  */
-export function trackGoogleAdsSubscriptionConversion() {
-  trackEvent({ name: "Subscription Conversion" });
+export function trackGoogleAdsSubscriptionConversion({ plan }: { plan: string }) {
+  trackEvent({ name: "Subscription Conversion", properties: { plan } });
 
   if (!googleAdsSubscriptionConversionId) {
     return;
   }
 
   getGoogleTag()("event", "conversion", { send_to: googleAdsSubscriptionConversionId });
+}
+
+/**
+ * Captures the plan a learner selected before they leave the app for Stripe
+ * checkout, which is the subscription funnel denominator.
+ */
+export function trackSubscriptionCheckoutStarted({
+  billingPeriod,
+  plan,
+}: {
+  billingPeriod: SubscriptionBillingPeriod;
+  plan: string;
+}) {
+  trackEvent({ name: "Subscription Checkout Started", properties: { billingPeriod, plan } });
+}
+
+/**
+ * Counts zero-progress home visits where the learner actually saw the main
+ * creation hero instead of the authenticated progress dashboard.
+ */
+export function trackHeroShown() {
+  trackEvent({ name: "Hero Shown" });
 }
 
 /**
@@ -146,9 +150,11 @@ function queueGoogleTagArguments(...args: unknown[]) {
  */
 function trackEvent({
   name,
+  postHogOptions,
   properties = {},
 }: {
   name: string;
+  postHogOptions?: { send_instantly?: boolean; transport?: "sendBeacon" };
   properties?: AnalyticsEventProperties;
 }) {
   trackVercelEvent(name, properties);
@@ -157,20 +163,29 @@ function trackEvent({
     return;
   }
 
-  posthog.capture(name, properties);
+  posthog.capture(name, properties, postHogOptions);
 }
 
 /**
- * Reuses the same primitive payload shape across player events because Vercel
+ * Reuses the same primitive payload shape across lesson events because Vercel
  * Analytics custom event properties do not support nested objects.
  */
-function getPlayerEventData({
+function getLessonProgressEventData(input: LessonProgressEventInput): AnalyticsEventProperties {
+  return { ...getLessonEventData(input), stepCount: input.stepCount };
+}
+
+/**
+ * Keeps every lesson funnel event filterable by course position while omitting
+ * properties that are not stable enough for activation cohorts.
+ */
+function getLessonEventData({
+  chapterPosition,
   courseSlug,
   lessonKind,
+  lessonPosition,
   lessonSlug,
-  stepCount,
-}: PlayerEventInput): AnalyticsEventProperties {
-  return { courseSlug, lessonKind, lessonSlug, stepCount };
+}: LessonCompletionEventInput): AnalyticsEventProperties {
+  return { chapterPosition, courseSlug, lessonKind, lessonPosition, lessonSlug };
 }
 
 /**
@@ -214,12 +229,4 @@ function getFeedbackEventData(input: FeedbackInput): AnalyticsEventProperties {
  */
 function throwUnexpectedFeedbackTarget(input: never): never {
   throw new Error(`Unexpected feedback target: ${String(input)}`);
-}
-
-/**
- * Uses the same capped duration as persistence so browser analytics cannot
- * report idle tab time that the database correctly ignores.
- */
-function getCompletionDurationSeconds({ startedAt }: { startedAt: number }) {
-  return getCappedLessonDurationSeconds({ startedAt });
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,6 +25,7 @@
     "./number": "./src/number.ts",
     "./org": "./src/org.ts",
     "./origin": "./src/origin.ts",
+    "./posthog": "./src/posthog.ts",
     "./search": "./src/search.ts",
     "./settled": "./src/settled.ts",
     "./shuffle": "./src/shuffle.ts",

--- a/packages/utils/src/posthog.ts
+++ b/packages/utils/src/posthog.ts
@@ -1,0 +1,18 @@
+const POSTHOG_DEFAULTS = "2026-05-30" as const;
+
+type PostHogConfig = { defaults: typeof POSTHOG_DEFAULTS; host: string; projectToken: string };
+
+/**
+ * Reads shared browser PostHog settings from public environment variables so
+ * every app initializes the SDK with the same project contract and defaults.
+ */
+export function getPostHogConfig(): PostHogConfig | null {
+  const host = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  const projectToken = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
+
+  if (!host || !projectToken) {
+    return null;
+  }
+
+  return { defaults: POSTHOG_DEFAULTS, host, projectToken };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,6 +244,9 @@ importers:
       posthog-js:
         specifier: 'catalog:'
         version: 1.386.6
+      posthog-node:
+        specifier: 5.37.0
+        version: 5.37.0(rxjs@7.8.2)
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -6848,6 +6851,15 @@ packages:
 
   posthog-js@1.386.6:
     resolution: {integrity: sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==}
+
+  posthog-node@5.37.0:
+    resolution: {integrity: sha512-wFwWGcqAqZ1WJRlNNYc92veV83d1lOQcP4Lq0q7Kar9GdZLPpiFYHeudyybYJnjZjkI9v06vLvY/Og5CZIfByg==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
@@ -13770,6 +13782,12 @@ snapshots:
       preact: 10.29.2
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.3.0
+
+  posthog-node@5.37.0(rxjs@7.8.2):
+    dependencies:
+      '@posthog/core': 1.32.3
+    optionalDependencies:
+      rxjs: 7.8.2
 
   preact@10.29.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,6 +60,7 @@ minimumReleaseAgeExclude:
   - "@hono/node-server@1.19.13"
   - postcss@8.5.10
   - devalue@5.8.1
+  - posthog-node@5.37.0
 
 overrides:
   "@hono/node-server@<1.19.13": ^1.19.13


### PR DESCRIPTION
## Summary
- Add shared PostHog config helpers and move browser tracking to the new utility layer
- Expand auth, lesson, hero, and subscription events with plan and position context
- Wire analytics state through the main app so identify and conversion events carry the right metadata

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds richer analytics with server- and client-side PostHog tracking. Improves funnel accuracy by wiring plan and position context into auth, lesson, and subscription events, and standardizing SDK init across apps.

- **New Features**
  - Server auth tracking via `posthog-node`: capture “Sign In Completed” and “Sign Up Completed”.
  - Track selected sign-in method (Google, Apple, OTP) before redirect.
  - Lesson funnel: “Lesson Started”, “Lesson Second Step”, “Lesson Completed” with chapter/lesson position and kind.
  - Home hero: “Hero Shown” only when the zero-progress hero renders.
  - Subscriptions: “Subscription Checkout Started” with plan and billing period; Google Ads conversion now includes plan.
  - Identify now sends `plan` and `analyticsDisabled`; plan resolved from active subscription.

- **Refactors**
  - Unified PostHog config in `@zoonk/utils/posthog` with shared `defaults`; updated instrumentation in both apps.
  - Removed command palette search tracking.
  - Updated privacy policy to document product analytics and session replay (PostHog) and set the new effective date.

<sup>Written for commit a6ff00e699d09c3f7e20a2caff279412262ac33b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

