### PR TITLE
fix(player): show milestone curriculum title

### DIFF
--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -338,7 +338,9 @@ test.describe("Lesson Completion UX", () => {
   }) => {
     const email = await createUniqueUser(baseURL!);
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
-    const { lessonUrl, chapter2, uniqueId } = await createChapterCompleteScenario("chnext");
+
+    const { lessonUrl, chapter1, chapter2, uniqueId } =
+      await createChapterCompleteScenario("chnext");
 
     await page.goto(lessonUrl);
     await page.waitForLoadState("networkidle");
@@ -346,8 +348,9 @@ test.describe("Lesson Completion UX", () => {
 
     const completionScreen = page.getByRole("status");
     await expect(completionScreen.getByText(/chapter complete/iu)).toBeVisible();
-    await expect(completionScreen.getByText(`Chapter Lesson ${uniqueId}`)).toBeVisible();
-    await expect(completionScreen.getByText("1 chapter left in this course")).toBeVisible();
+    await expect(completionScreen.getByText(chapter1.title)).toBeVisible();
+    await expect(completionScreen.getByText(`Chapter Lesson ${uniqueId}`)).not.toBeVisible();
+    await expect(completionScreen.getByText("1 chapter left in this course")).not.toBeVisible();
 
     await completionScreen.getByRole("link", { name: /next chapter/iu }).click();
     await expect(page.getByRole("heading", { level: 1, name: chapter2.title })).toBeVisible();
@@ -418,8 +421,9 @@ test.describe("Lesson Completion UX", () => {
 
     const completionScreen = page.getByRole("status");
     await expect(completionScreen.getByText(/course complete/iu)).toBeVisible();
-    await expect(completionScreen.getByText(`Final Lesson ${uniqueId}`)).toBeVisible();
-    await expect(completionScreen.getByText("No chapters left in this course")).toBeVisible();
+    await expect(completionScreen.getByText(course.title)).toBeVisible();
+    await expect(completionScreen.getByText(`Final Lesson ${uniqueId}`)).not.toBeVisible();
+    await expect(completionScreen.getByText("No chapters left in this course")).not.toBeVisible();
 
     await completionScreen.getByRole("link", { name: /review course/iu }).click();
     await expect(page.getByRole("heading", { level: 1, name: course.title })).toBeVisible();

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -25,6 +25,7 @@ type LessonPlayerClientProps = {
   brandSlug: string;
   chapterPosition: number;
   chapterTitle: string;
+  courseTitle: string;
   courseSlug: string;
   chapterSlug: string;
   isAuthenticated: boolean;
@@ -55,6 +56,7 @@ export function LessonPlayerClient({
   brandSlug,
   chapterPosition,
   chapterTitle,
+  courseTitle,
   courseSlug,
   chapterSlug,
   isAuthenticated,
@@ -177,6 +179,7 @@ export function LessonPlayerClient({
     <PlayerProvider
       lesson={lesson}
       chapterTitle={chapterTitle}
+      courseTitle={courseTitle}
       lessonDescription={lessonDescription}
       lessonProgress={model.lessonProgress}
       lessonTitle={lessonTitle}

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -287,6 +287,7 @@ export default async function LessonPage({ params }: Props) {
       brandSlug={brandSlug}
       chapterPosition={lessonShell.chapter.position}
       chapterTitle={lessonShell.chapter.title}
+      courseTitle={lessonShell.chapter.course.title}
       courseSlug={courseSlug}
       chapterSlug={chapterSlug}
       isAuthenticated={Boolean(session)}

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -163,10 +163,6 @@ msgid "t2VOpl"
 msgstr "Chapter Complete"
 
 #: src/components/completion-screen.tsx
-msgid "2kQf_C"
-msgstr "{count, plural, =0 {No chapters left in this course} one {# chapter left in this course} other {# chapters left in this course}}"
-
-#: src/components/completion-screen.tsx
 #: src/components/in-play-sticky-header.tsx
 msgid "qXzoF7"
 msgstr "Lesson {current} of {total}"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -163,10 +163,6 @@ msgid "t2VOpl"
 msgstr "Capítulo completado"
 
 #: src/components/completion-screen.tsx
-msgid "2kQf_C"
-msgstr "{count, plural, =0 {No quedan capítulos en este curso} one {Queda # capítulo en este curso} other {Quedan # capítulos en este curso}}"
-
-#: src/components/completion-screen.tsx
 #: src/components/in-play-sticky-header.tsx
 msgid "qXzoF7"
 msgstr "Lección {current} de {total}"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -163,10 +163,6 @@ msgid "t2VOpl"
 msgstr "Capítulo Concluído"
 
 #: src/components/completion-screen.tsx
-msgid "2kQf_C"
-msgstr "{count, plural, =0 {Não há mais capítulos neste curso} one {Falta # capítulo neste curso} other {Faltam # capítulos neste curso}}"
-
-#: src/components/completion-screen.tsx
 #: src/components/in-play-sticky-header.tsx
 msgid "qXzoF7"
 msgstr "Aula {current} de {total}"

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -336,7 +336,15 @@ describe("player browser integration: completion", () => {
 
   it("falls back to review-only chapter completion when there is no next chapter", async () => {
     renderPlayer({
+      chapterTitle: "Completed Chapter",
       lesson: buildCompletionQuizLesson(),
+      lessonProgress: {
+        currentLessonNumber: 4,
+        remainingChaptersInCourse: 1,
+        remainingLessonsInChapter: 0,
+        totalLessonsInChapter: 4,
+      },
+      lessonTitle: "Completed Lesson",
       milestone: { kind: "chapter", nextHref: null, reviewHref: "/review-chapter" },
       viewer: buildAuthenticatedViewer(),
     });
@@ -346,6 +354,17 @@ describe("player browser integration: completion", () => {
     const completionScreen = page.getByRole("status");
 
     await expect.element(completionScreen.getByText(/chapter complete/iu)).toBeInTheDocument();
+    await expect.element(completionScreen.getByText("Completed Chapter")).toBeInTheDocument();
+    await expect.element(completionScreen.getByText("Completed Lesson")).not.toBeInTheDocument();
+    await expect.element(completionScreen.getByText("Lesson 4 of 4")).not.toBeInTheDocument();
+
+    await expect
+      .element(completionScreen.getByRole("progressbar", { name: /chapter progress/iu }))
+      .not.toBeInTheDocument();
+
+    await expect
+      .element(completionScreen.getByText(/chapter left in this course/iu))
+      .not.toBeInTheDocument();
 
     await expect
       .element(completionScreen.getByRole("link", { name: /review chapter/iu }))
@@ -358,7 +377,9 @@ describe("player browser integration: completion", () => {
 
   it("renders course completion review actions", async () => {
     renderPlayer({
+      courseTitle: "Completed Course",
       lesson: buildCompletionQuizLesson(),
+      lessonTitle: "Final Lesson",
       milestone: {
         kind: "course",
         reviewHref: "/review-course",
@@ -372,6 +393,17 @@ describe("player browser integration: completion", () => {
     const completionScreen = page.getByRole("status");
 
     await expect.element(completionScreen.getByText(/course complete/iu)).toBeInTheDocument();
+    await expect.element(completionScreen.getByText("Completed Course")).toBeInTheDocument();
+    await expect.element(completionScreen.getByText("Final Lesson")).not.toBeInTheDocument();
+    await expect.element(completionScreen.getByText("Lesson 1 of 1")).not.toBeInTheDocument();
+
+    await expect
+      .element(completionScreen.getByRole("progressbar", { name: /chapter progress/iu }))
+      .not.toBeInTheDocument();
+
+    await expect
+      .element(completionScreen.getByText(/chapters left in this course/iu))
+      .not.toBeInTheDocument();
 
     await expect
       .element(completionScreen.getByRole("link", { name: /review course/iu }))

--- a/packages/player/src/_test-utils/render-player.tsx
+++ b/packages/player/src/_test-utils/render-player.tsx
@@ -51,6 +51,7 @@ function getDefaultLessonTitle(lesson: SerializedLesson) {
 export function renderPlayer({
   lesson,
   chapterTitle = "Test Chapter",
+  courseTitle = "Test Course",
   lessonDescription = "Test lesson description",
   lessonProgress = buildLessonProgress(),
   lessonTitle = getDefaultLessonTitle(lesson),
@@ -65,6 +66,7 @@ export function renderPlayer({
 }: {
   lesson: SerializedLesson;
   chapterTitle?: string;
+  courseTitle?: string;
   lessonDescription?: string;
   lessonProgress?: PlayerLessonProgress;
   lessonTitle?: string;
@@ -81,6 +83,7 @@ export function renderPlayer({
     <PlayerProvider
       lesson={lesson}
       chapterTitle={chapterTitle}
+      courseTitle={courseTitle}
       lessonDescription={lessonDescription}
       lessonProgress={lessonProgress}
       lessonTitle={lessonTitle}

--- a/packages/player/src/components/completion-screen.tsx
+++ b/packages/player/src/components/completion-screen.tsx
@@ -88,16 +88,33 @@ function MilestoneHeading({ milestone }: { milestone: PlayerMilestone }) {
 }
 
 /**
- * Keeps chapter-count grammar in one ICU message. Course completion naturally
- * becomes the zero case, while chapter milestones use the locale's singular
- * and plural rules for the remaining chapter count.
+ * Groups the focused context below a completion or milestone headline. Both
+ * regular lesson completion and structural milestones need the same centered
+ * width, spacing, and text alignment, so keeping this chrome in one component
+ * prevents the two branches from drifting as the screen evolves.
  */
-function RemainingChaptersText({ count }: { count: number }) {
-  const t = useExtracted();
+function CompletionContext({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex w-full max-w-md flex-col items-center gap-3 text-center", className)}
+      data-slot="completion-context"
+      {...props}
+    />
+  );
+}
 
-  return t(
-    "{count, plural, =0 {No chapters left in this course} one {# chapter left in this course} other {# chapters left in this course}}",
-    { count },
+/**
+ * Renders the main context label with the shared completion typography. Callers
+ * can choose the exact text size for the screen hierarchy while the color,
+ * weight, and line-height stay consistent.
+ */
+function CompletionContextTitle({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn("text-foreground leading-snug font-medium", className)}
+      data-slot="completion-context-title"
+      {...props}
+    />
   );
 }
 
@@ -151,21 +168,56 @@ function CompletionChapterProgress({ lessonProgress }: { lessonProgress: PlayerL
  * This keeps orientation near the score while avoiding reward-like badges or
  * ambiguous remaining-work copy.
  */
-function CompletionLessonContext({ milestone }: { milestone: PlayerMilestone | null }) {
+function CompletionLessonContext() {
   const { lessonProgress, lessonTitle } = usePlayerLessonMeta();
 
   return (
-    <div className="flex w-full max-w-md flex-col items-center gap-3 text-center">
-      <p className="text-foreground text-base leading-snug font-medium">{lessonTitle}</p>
+    <CompletionContext>
+      <CompletionContextTitle className="text-base">{lessonTitle}</CompletionContextTitle>
 
       <CompletionChapterProgress lessonProgress={lessonProgress} />
+    </CompletionContext>
+  );
+}
 
-      {milestone && (
-        <PlayerSupportingText>
-          <RemainingChaptersText count={lessonProgress.remainingChaptersInCourse} />
-        </PlayerSupportingText>
-      )}
-    </div>
+/**
+ * Picks the completed curriculum title for structural completion milestones.
+ * A chapter milestone should orient the learner around the finished chapter,
+ * while a course milestone should celebrate the finished course instead of the
+ * final lesson that happened to trigger completion.
+ */
+function getMilestoneTitle({
+  chapterTitle,
+  courseTitle,
+  milestone,
+}: {
+  chapterTitle: string;
+  courseTitle: string;
+  milestone: PlayerMilestone;
+}) {
+  if (milestone.kind === "course") {
+    return courseTitle;
+  }
+
+  return chapterTitle;
+}
+
+/**
+ * Structural milestones should be quiet and focused: the milestone label plus
+ * the curriculum title are enough. Lesson score, lesson title, and chapter
+ * position stay on the ordinary completion screen where they belong.
+ */
+function CompletionMilestoneContext({ milestone }: { milestone: PlayerMilestone }) {
+  const { chapterTitle, courseTitle } = usePlayerLessonMeta();
+  const milestoneTitle = getMilestoneTitle({ chapterTitle, courseTitle, milestone });
+
+  return (
+    <CompletionContext>
+      <MilestoneHeading milestone={milestone} />
+      <CompletionContextTitle className="text-lg sm:text-xl">
+        {milestoneTitle}
+      </CompletionContextTitle>
+    </CompletionContext>
   );
 }
 
@@ -187,10 +239,7 @@ export function CompletionScreenContent({
   if (milestone) {
     return (
       <CompletionScreen className="min-h-[60vh] justify-center gap-6 sm:gap-8">
-        <div className="flex flex-col items-center gap-3">
-          <MilestoneHeading milestone={milestone} />
-          <CompletionLessonContext milestone={milestone} />
-        </div>
+        <CompletionMilestoneContext milestone={milestone} />
 
         <div className="flex w-full flex-col gap-3">
           <AuthBranch
@@ -222,7 +271,7 @@ export function CompletionScreenContent({
         <CompletionSignal />
       )}
 
-      <CompletionLessonContext milestone={milestone} />
+      <CompletionLessonContext />
 
       <AuthBranch chapterHref={chapterHref} nextLessonHref={nextLessonHref} onRestart={onRestart} />
 

--- a/packages/player/src/player-context.tsx
+++ b/packages/player/src/player-context.tsx
@@ -49,6 +49,7 @@ export type PlayerRuntimeContextValue = {
 
 type PlayerLessonMeta = {
   chapterTitle: string;
+  courseTitle: string;
   description: string;
   kind: LessonKind;
   lessonProgress: PlayerLessonProgress;

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -32,6 +32,7 @@ export function PlayerProvider({
   lesson,
   chapterTitle,
   children,
+  courseTitle,
   lessonDescription,
   lessonProgress,
   lessonTitle,
@@ -48,6 +49,7 @@ export function PlayerProvider({
   lesson: SerializedLesson;
   chapterTitle: string;
   children: React.ReactNode;
+  courseTitle: string;
   lessonDescription: string;
   lessonProgress: PlayerLessonProgress;
   lessonTitle: string;
@@ -100,6 +102,7 @@ export function PlayerProvider({
       escape: onEscape,
       lessonMeta: {
         chapterTitle,
+        courseTitle,
         fallbackDescription: lessonDescription,
         kind: lesson.kind,
         lessonDescription: lesson.description,
@@ -117,6 +120,7 @@ export function PlayerProvider({
       lesson.kind,
       lesson.title,
       chapterTitle,
+      courseTitle,
       handleNext,
       lessonDescription,
       lessonProgress,


### PR DESCRIPTION
## Summary
- pass course title through the lesson player context
- show chapter or course title on milestone completion screens instead of the triggering lesson title
- update browser coverage to match the new completion copy and visibility rules

## Testing
- Updated browser integration coverage for chapter and course completion flows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the completed chapter or course title on milestone completion screens instead of the triggering lesson title. Pass `courseTitle` through the player context and simplify the milestone UI for clearer orientation.

- **Bug Fixes**
  - Display milestone heading with the completed chapter/course title; hide lesson title, progress bar, and “remaining chapters” text on milestone screens.
  - Pass `courseTitle` from the page to `LessonPlayerClient` and `PlayerProvider`, and expose it in the `player-context`.
  - Update e2e and player browser tests to reflect the new copy and visibility rules.
  - Remove the unused ICU “remaining chapters” message from `messages/*.po`.

<sup>Written for commit 78aa4d04bcaff736e385cc14e87c61de9f04ee8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

