### PR TITLE
fix(main): preserve continue targets after review completions

### DIFF
--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -7,7 +7,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
 import { userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
-import { expect, test } from "./fixtures";
+import { type Page, expect, test } from "./fixtures";
 
 async function createCourseWithThreeLessons() {
   const org = await getAiOrganization();
@@ -64,15 +64,70 @@ async function createCourseWithThreeLessons() {
     title: `After Next ${uniqueId}`,
   });
 
-  // Add a static step to lesson 1 so we can complete it
-  await stepFixture({
-    content: { text: `Step body ${uniqueId}`, title: `Step Title ${uniqueId}`, variant: "text" },
-    isPublished: true,
-    lessonId: lesson1.id,
-    position: 0,
-  });
+  // Add static steps to the lessons completed through the player in these tests.
+  await Promise.all([
+    stepFixture({
+      content: {
+        text: `Review step body ${uniqueId}`,
+        title: `Review Step Title ${uniqueId}`,
+        variant: "text",
+      },
+      isPublished: true,
+      lessonId: lesson0.id,
+      position: 0,
+    }),
+    stepFixture({
+      content: { text: `Step body ${uniqueId}`, title: `Step Title ${uniqueId}`, variant: "text" },
+      isPublished: true,
+      lessonId: lesson1.id,
+      position: 0,
+    }),
+  ]);
 
-  return { course, lesson0, lesson1, lesson2, uniqueId };
+  return { chapter, course, lesson0, lesson1, lesson2, uniqueId };
+}
+
+/**
+ * The completion action persists progress in `after()`, so tests that need
+ * the following navigation to read fresh progress must wait for the database
+ * row rather than only the server action response.
+ */
+async function expectLessonCompleted({ lessonId, userId }: { lessonId: string; userId: string }) {
+  await expect(async () => {
+    const progress = await prisma.lessonProgress.findUnique({
+      where: { userLesson: { lessonId, userId } },
+    });
+
+    expect(progress?.completedAt).not.toBeNull();
+  }).toPass({ timeout: 10_000 });
+}
+
+/**
+ * Static text lessons complete after one keyboard continue action. Waiting on
+ * the server action response plus the DB row keeps the next navigation from
+ * racing the background persistence work.
+ */
+async function completeStaticLesson({
+  lessonId,
+  page,
+  userId,
+}: {
+  lessonId: string;
+  page: Page;
+  userId: string;
+}) {
+  const serverActionResponse = page.waitForResponse(
+    (resp) => resp.request().method() === "POST" && resp.ok(),
+  );
+
+  await expect(async () => {
+    await page.keyboard.press("ArrowRight");
+    await expect(page.getByRole("status")).toBeVisible({ timeout: 1000 });
+  }).toPass({ timeout: 10_000 });
+
+  await expect(page.getByRole("status").getByText("Completed", { exact: true })).toBeVisible();
+  await serverActionResponse;
+  await expectLessonCompleted({ lessonId, userId });
 }
 
 test.describe("Continue Learning Revalidation", () => {
@@ -143,6 +198,65 @@ test.describe("Continue Learning Revalidation", () => {
     await expect(
       page.getByText(new RegExp(`Next:.*After Next ${uniqueId}`, "u")).first(),
     ).toBeVisible();
+
+    await browserContext.close();
+  });
+
+  test("chapter continue link stays on the furthest incomplete lesson after review", async ({
+    baseURL,
+    browser,
+  }) => {
+    const user = await createE2EUser(baseURL!);
+    const browserContext = await browser.newContext({ storageState: user.storageState });
+    const page = await browserContext.newPage();
+
+    const { chapter, course, lesson0, lesson1, lesson2, uniqueId } =
+      await createCourseWithThreeLessons();
+
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: lesson0.id,
+        userId: user.id,
+      }),
+      userProgressFixture({ totalBrainPower: 100n, userId: user.id }),
+      prisma.courseUser.create({ data: { courseId: course.id, userId: user.id } }),
+      prisma.course.update({ data: { userCount: { increment: 1 } }, where: { id: course.id } }),
+    ]);
+
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+
+    const staleContinueLink = page.getByRole("link", { name: "Continue 1 of 3 lessons completed" });
+
+    await expect(staleContinueLink).toHaveAttribute(
+      "href",
+      `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson1.slug}`,
+    );
+
+    await staleContinueLink.click();
+    await page.waitForURL(new RegExp(`/l/e2e-cl-reval-current-${uniqueId}$`, "u"));
+    await completeStaticLesson({ lessonId: lesson1.id, page, userId: user.id });
+
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson0.slug}`);
+    await completeStaticLesson({ lessonId: lesson0.id, page, userId: user.id });
+
+    await page.getByRole("link", { name: /all lessons/iu }).click();
+    await page.waitForURL(new RegExp(`e2e-cl-reval-chapter-${uniqueId}$`, "u"));
+
+    const currentContinueLink = page.getByRole("link", {
+      name: "Continue 2 of 3 lessons completed",
+    });
+
+    await expect(currentContinueLink).toHaveAttribute(
+      "href",
+      `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson2.slug}`,
+    );
+
+    await expect(currentContinueLink).not.toHaveAttribute(
+      "href",
+      `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson1.slug}`,
+    );
 
     await browserContext.close();
   });

--- a/apps/main/e2e/continue-lesson-link.test.ts
+++ b/apps/main/e2e/continue-lesson-link.test.ts
@@ -133,6 +133,105 @@ async function createTestCourseWithPendingFirstLesson() {
 }
 
 /**
+ * Review-link tests need a course where the first chapter can be either
+ * partially or fully complete, and the final chapter ends with a review lesson.
+ * That lets the assertions distinguish missing work, chapter review, and
+ * course review without repeating catalog setup in each test.
+ */
+async function createTestCourseWithReviewChapters() {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: org.id,
+    slug: `e2e-cal-review-course-${uniqueId}`,
+    title: `E2E CAL Review Course ${uniqueId}`,
+  });
+
+  const [firstChapter, secondChapter] = await Promise.all([
+    chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-cal-review-ch1-${uniqueId}`,
+      title: `E2E CAL Review Ch1 ${uniqueId}`,
+    }),
+    chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: org.id,
+      position: 1,
+      slug: `e2e-cal-review-ch2-${uniqueId}`,
+      title: `E2E CAL Review Ch2 ${uniqueId}`,
+    }),
+  ]);
+
+  const [firstLesson, firstMiddleLesson, firstReviewLesson, secondLesson, secondReviewLesson] =
+    await Promise.all([
+      lessonFixture({
+        chapterId: firstChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+        slug: `e2e-cal-review-l1-${uniqueId}`,
+        title: `E2E CAL Review L1 ${uniqueId}`,
+      }),
+      lessonFixture({
+        chapterId: firstChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: org.id,
+        position: 1,
+        slug: `e2e-cal-review-l1b-${uniqueId}`,
+        title: `E2E CAL Review L1B ${uniqueId}`,
+      }),
+      lessonFixture({
+        chapterId: firstChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "review",
+        organizationId: org.id,
+        position: 2,
+        slug: `e2e-cal-review-r1-${uniqueId}`,
+        title: `E2E CAL Review R1 ${uniqueId}`,
+      }),
+      lessonFixture({
+        chapterId: secondChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+        slug: `e2e-cal-review-l2-${uniqueId}`,
+        title: `E2E CAL Review L2 ${uniqueId}`,
+      }),
+      lessonFixture({
+        chapterId: secondChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "review",
+        organizationId: org.id,
+        position: 1,
+        slug: `e2e-cal-review-r2-${uniqueId}`,
+        title: `E2E CAL Review R2 ${uniqueId}`,
+      }),
+    ]);
+
+  return {
+    course,
+    firstChapter,
+    firstLesson,
+    firstMiddleLesson,
+    firstReviewLesson,
+    secondChapter,
+    secondLesson,
+    secondReviewLesson,
+  };
+}
+
+/**
  * Lesson-type preferences are user-specific, so this helper creates a fresh
  * browser user and stores the hidden kinds before the page renders. That keeps
  * this regression isolated from the shared authenticated worker users.
@@ -510,73 +609,97 @@ test.describe("Continue Lesson Link", () => {
     );
   });
 
-  test("chapter page shows Continue linking to next chapter when completed", async ({
+  test("chapter page shows Review linking to the current chapter review when completed", async ({
     authenticatedPage,
     withProgressUser,
   }) => {
-    const org = await getAiOrganization();
-    const uniqueId = randomUUID().slice(0, 8);
+    const {
+      course,
+      firstChapter,
+      firstLesson,
+      firstMiddleLesson,
+      firstReviewLesson,
+      secondChapter,
+    } = await createTestCourseWithReviewChapters();
 
-    const course = await courseFixture({
-      isPublished: true,
-      organizationId: org.id,
-      slug: `e2e-cal-chcomp-${uniqueId}`,
-      title: `E2E CAL ChComp ${uniqueId}`,
-    });
-
-    const [chapter1, chapter2] = await Promise.all([
-      chapterFixture({
-        courseId: course.id,
-        isPublished: true,
-        organizationId: org.id,
-        position: 0,
-        slug: `e2e-cal-chcomp-ch1-${uniqueId}`,
-        title: `E2E CAL ChComp Ch1 ${uniqueId}`,
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: firstLesson.id,
+        userId: withProgressUser.id,
       }),
-      chapterFixture({
-        courseId: course.id,
-        isPublished: true,
-        organizationId: org.id,
-        position: 1,
-        slug: `e2e-cal-chcomp-ch2-${uniqueId}`,
-        title: `E2E CAL ChComp Ch2 ${uniqueId}`,
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-02"),
+        durationSeconds: 60,
+        lessonId: firstMiddleLesson.id,
+        userId: withProgressUser.id,
       }),
-    ]);
-
-    const [lesson1] = await Promise.all([
-      lessonFixture({
-        chapterId: chapter1.id,
-        isPublished: true,
-        organizationId: org.id,
-        position: 0,
-        slug: `e2e-cal-chcomp-l1-${uniqueId}`,
-        title: `E2E CAL ChComp L1 ${uniqueId}`,
-      }),
-      lessonFixture({
-        chapterId: chapter2.id,
-        isPublished: true,
-        organizationId: org.id,
-        position: 0,
-        slug: `e2e-cal-chcomp-l2-${uniqueId}`,
-        title: `E2E CAL ChComp L2 ${uniqueId}`,
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-03"),
+        durationSeconds: 60,
+        lessonId: firstReviewLesson.id,
+        userId: withProgressUser.id,
       }),
     ]);
 
-    await lessonProgressFixture({
-      completedAt: new Date(),
-      durationSeconds: 60,
-      lessonId: lesson1.id,
-      userId: withProgressUser.id,
-    });
+    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${firstChapter.slug}`);
 
-    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter1.slug}`);
+    const reviewLink = getContinueActionLink({ label: "Review", page: authenticatedPage });
+    await expect(reviewLink).toBeVisible();
+
+    await expect(reviewLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${firstChapter.slug}/l/${firstReviewLesson.slug}`,
+    );
+
+    await expect(reviewLink).not.toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${secondChapter.slug}`,
+    );
+  });
+
+  test("chapter page keeps Continue on the first incomplete lesson after final review", async ({
+    authenticatedPage,
+    withProgressUser,
+  }) => {
+    const {
+      course,
+      firstChapter,
+      firstLesson,
+      firstMiddleLesson,
+      firstReviewLesson,
+      secondChapter,
+    } = await createTestCourseWithReviewChapters();
+
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: firstLesson.id,
+        userId: withProgressUser.id,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-02"),
+        durationSeconds: 60,
+        lessonId: firstReviewLesson.id,
+        userId: withProgressUser.id,
+      }),
+    ]);
+
+    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${firstChapter.slug}`);
 
     const continueLink = getContinueActionLink({ label: "Continue", page: authenticatedPage });
     await expect(continueLink).toBeVisible();
 
     await expect(continueLink).toHaveAttribute(
       "href",
-      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter2.slug}`,
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${firstChapter.slug}/l/${firstMiddleLesson.slug}`,
+    );
+
+    await expect(continueLink).not.toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${secondChapter.slug}`,
     );
   });
 
@@ -584,18 +707,57 @@ test.describe("Continue Lesson Link", () => {
     authenticatedPage,
     withProgressUser,
   }) => {
-    const { lesson, course } = await createTestCourseWithLesson();
+    const {
+      course,
+      firstLesson,
+      firstMiddleLesson,
+      firstReviewLesson,
+      secondChapter,
+      secondLesson,
+      secondReviewLesson,
+    } = await createTestCourseWithReviewChapters();
 
-    await lessonProgressFixture({
-      completedAt: new Date(),
-      durationSeconds: 60,
-      lessonId: lesson.id,
-      userId: withProgressUser.id,
-    });
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: firstLesson.id,
+        userId: withProgressUser.id,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-02"),
+        durationSeconds: 60,
+        lessonId: firstMiddleLesson.id,
+        userId: withProgressUser.id,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-03"),
+        durationSeconds: 60,
+        lessonId: firstReviewLesson.id,
+        userId: withProgressUser.id,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-04"),
+        durationSeconds: 60,
+        lessonId: secondLesson.id,
+        userId: withProgressUser.id,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-05"),
+        durationSeconds: 60,
+        lessonId: secondReviewLesson.id,
+        userId: withProgressUser.id,
+      }),
+    ]);
 
     await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
     const reviewLink = getContinueActionLink({ label: "Review", page: authenticatedPage });
     await expect(reviewLink).toBeVisible();
+
+    await expect(reviewLink).toHaveAttribute(
+      "href",
+      `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${secondChapter.slug}/l/${secondReviewLesson.slug}`,
+    );
   });
 });

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -9,7 +9,6 @@ import {
 import { getChapter } from "@/data/chapters/get-chapter";
 import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
 import { getUserHiddenLessonKinds } from "@/data/users/lesson-filter-settings";
-import { getNextChapterInCourse } from "@zoonk/core/lessons/next-chapter-in-course";
 import { getSession } from "@zoonk/core/users/session/get";
 import { type Lesson, type LessonKind } from "@zoonk/db";
 import { Grid, GridToolbar } from "@zoonk/ui/components/grid";
@@ -71,16 +70,9 @@ export default async function ChapterPage({
     notFound();
   }
 
-  const [lessons, nextChapter] = await Promise.all([
-    listChapterLessons({ chapterId: chapter.id }),
-    getNextChapterInCourse({ chapterPosition: chapter.position, courseId: chapter.courseId }),
-  ]);
+  const lessons = await listChapterLessons({ chapterId: chapter.id });
 
   const shouldShowCreateChapterPrompt = brandSlug === AI_ORG_SLUG && lessons.length === 0;
-
-  const completedHref = nextChapter
-    ? (`/b/${nextChapter.brandSlug}/c/${nextChapter.courseSlug}/ch/${nextChapter.chapterSlug}` as const)
-    : undefined;
 
   const firstVisibleLesson = getFirstVisibleLesson({ hiddenLessonKinds, lessons });
 
@@ -103,7 +95,6 @@ export default async function ChapterPage({
               <Suspense fallback={<ContinueLessonLinkSkeleton />}>
                 <ContinueLessonLink
                   chapterId={chapter.id}
-                  completedHref={completedHref}
                   excludedLessonKinds={hiddenLessonKinds}
                   fallbackHref={fallbackHref}
                 />

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/submit-completion-action.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/submit-completion-action.ts
@@ -38,10 +38,13 @@ export async function submitCompletion(rawInput: CompletionInput): Promise<void>
 
   // Revalidate outside after() so the signal is included in the RSC response.
   // This tells the client Router Cache to purge "/", ensuring the next
-  // client-side navigation fetches fresh data from the server.
+  // client-side navigation fetches fresh data from the server. Catalog pages
+  // need the same signal because their Continue links are derived from lesson
+  // progress and can otherwise keep pointing at the old lesson.
   // Placing it inside after() would run it after the response is sent,
   // meaning the client never receives the invalidation signal.
   revalidatePath("/");
+  revalidatePath("/(catalog)", "layout");
 
   after(async () => {
     try {

--- a/apps/main/src/data/courses/get-continue-learning.test.ts
+++ b/apps/main/src/data/courses/get-continue-learning.test.ts
@@ -617,7 +617,7 @@ describe("authenticated users", () => {
     });
   });
 
-  it("returns the next pending lesson target after the latest completed lesson", async () => {
+  it("returns the next pending lesson target after the completed lesson", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
 

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/knip/schema.json",
-  "ignore": ["**/*.d.**.ts", ".agents/**", ".claude/**"],
+  "ignore": ["**/*.d.**.ts"],
   "ignoreIssues": { "**/.next/**/types/routes.d.ts": ["types"] },
   "ignoreWorkspaces": ["packages/e2e!", "packages/testing!"],
   "ignoreBinaries": ["stripe", "build-and-start", "turbo!"],

--- a/packages/core/src/lessons/find-last-completed.test.ts
+++ b/packages/core/src/lessons/find-last-completed.test.ts
@@ -77,7 +77,7 @@ describe(findLastCompleted, () => {
     expect(result).toBeNull();
   });
 
-  it("returns the most recently completed lesson", async () => {
+  it("returns the furthest completed lesson in course order", async () => {
     const user = await userFixture();
     const uid = user.id;
 
@@ -138,7 +138,57 @@ describe(findLastCompleted, () => {
     expect(result).toHaveProperty("orgSlug");
   });
 
-  it("ignores completed excluded lesson kinds when choosing the latest completion", async () => {
+  it("keeps the furthest completion when an earlier lesson was reviewed later", async () => {
+    const user = await userFixture();
+    const uid = user.id;
+
+    const course = await courseFixture({ isPublished: true, organizationId: orgId });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: orgId,
+      position: 0,
+    });
+
+    const [reviewedLesson, furthestLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: orgId,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: orgId,
+        position: 1,
+      }),
+    ]);
+
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-03"),
+        durationSeconds: 60,
+        lessonId: reviewedLesson.id,
+        userId: uid,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-02"),
+        durationSeconds: 60,
+        lessonId: furthestLesson.id,
+        userId: uid,
+      }),
+    ]);
+
+    const result = await findLastCompleted(uid, { courseId: course.id });
+
+    expect(result).toMatchObject({ lessonId: furthestLesson.id, lessonPosition: 1 });
+  });
+
+  it("ignores completed excluded lesson kinds when choosing the furthest completion", async () => {
     const [user, course] = await Promise.all([
       userFixture(),
       courseFixture({ isPublished: true, organizationId: orgId }),

--- a/packages/core/src/lessons/find-last-completed.ts
+++ b/packages/core/src/lessons/find-last-completed.ts
@@ -38,8 +38,10 @@ function getScopeLessonWhere({
 }
 
 /**
- * Finds the user's most recently completed lesson in a scope and returns the
- * position data needed to locate the next lesson in course order.
+ * Finds the furthest lesson the user completed in the current course order and
+ * returns the position data needed to locate the next lesson. Review attempts
+ * can happen on earlier lessons later in time, so tree position must define the
+ * continuation frontier before completion recency is used as a tie-breaker.
  */
 export async function findLastCompleted(
   userId: string,
@@ -54,9 +56,9 @@ export async function findLastCompleted(
         },
       },
       orderBy: [
-        { completedAt: "desc" },
         { lesson: { chapter: { position: "desc" } } },
         { lesson: { position: "desc" } },
+        { completedAt: "desc" },
       ],
       where: {
         completedAt: { not: null },

--- a/packages/core/src/player/commands/submit-lesson-completion.test.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.test.ts
@@ -219,6 +219,141 @@ describe(submitLessonCompletion, () => {
     expect(courseCompletion).not.toBeNull();
   });
 
+  it("does not mark chapter or course complete when only the final lesson is completed", async () => {
+    const user = await userFixture();
+    const userId = user.id;
+
+    const publishedCourse = await courseFixture({ isPublished: true, organizationId: org.id });
+
+    const chapter = await chapterFixture({
+      courseId: publishedCourse.id,
+      isPublished: true,
+      organizationId: org.id,
+    });
+
+    const [firstLesson, finalLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "quiz",
+        organizationId: org.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        kind: "quiz",
+        organizationId: org.id,
+        position: 1,
+      }),
+    ]);
+
+    await submitLessonCompletion({
+      durationSeconds: 15,
+      lessonId: finalLesson.id,
+      localDate: todayLocalDate(),
+      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+      startedAt: new Date(Date.now() - 15_000),
+      stepResults: [stepResult(true)],
+      userId,
+    });
+
+    const [firstLessonCompletion, finalLessonCompletion, chapterCompletion, courseCompletion] =
+      await Promise.all([
+        prisma.lessonProgress.findUnique({
+          where: { userLesson: { lessonId: firstLesson.id, userId } },
+        }),
+        prisma.lessonProgress.findUnique({
+          where: { userLesson: { lessonId: finalLesson.id, userId } },
+        }),
+        prisma.chapterCompletion.findUnique({
+          where: { userChapterCompletion: { chapterId: chapter.id, userId } },
+        }),
+        prisma.courseCompletion.findUnique({
+          where: { userCourseCompletion: { courseId: publishedCourse.id, userId } },
+        }),
+      ]);
+
+    expect(firstLessonCompletion).toBeNull();
+    expect(finalLessonCompletion?.completedAt).not.toBeNull();
+    expect(chapterCompletion).toBeNull();
+    expect(courseCompletion).toBeNull();
+  });
+
+  it("does not mark course complete when only the final chapter is completed", async () => {
+    const user = await userFixture();
+    const userId = user.id;
+
+    const publishedCourse = await courseFixture({ isPublished: true, organizationId: org.id });
+
+    const [firstChapter, finalChapter] = await Promise.all([
+      chapterFixture({
+        courseId: publishedCourse.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: publishedCourse.id,
+        isPublished: true,
+        organizationId: org.id,
+        position: 1,
+      }),
+    ]);
+
+    const [firstChapterLesson, finalChapterLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: firstChapter.id,
+        isPublished: true,
+        kind: "quiz",
+        organizationId: org.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: finalChapter.id,
+        isPublished: true,
+        kind: "quiz",
+        organizationId: org.id,
+        position: 0,
+      }),
+    ]);
+
+    await submitLessonCompletion({
+      durationSeconds: 15,
+      lessonId: finalChapterLesson.id,
+      localDate: todayLocalDate(),
+      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+      startedAt: new Date(Date.now() - 15_000),
+      stepResults: [stepResult(true)],
+      userId,
+    });
+
+    const [
+      firstChapterLessonCompletion,
+      finalChapterCompletion,
+      firstChapterCompletion,
+      courseCompletion,
+    ] = await Promise.all([
+      prisma.lessonProgress.findUnique({
+        where: { userLesson: { lessonId: firstChapterLesson.id, userId } },
+      }),
+      prisma.chapterCompletion.findUnique({
+        where: { userChapterCompletion: { chapterId: finalChapter.id, userId } },
+      }),
+      prisma.chapterCompletion.findUnique({
+        where: { userChapterCompletion: { chapterId: firstChapter.id, userId } },
+      }),
+      prisma.courseCompletion.findUnique({
+        where: { userCourseCompletion: { courseId: publishedCourse.id, userId } },
+      }),
+    ]);
+
+    expect(firstChapterLessonCompletion).toBeNull();
+    expect(finalChapterCompletion).not.toBeNull();
+    expect(firstChapterCompletion).toBeNull();
+    expect(courseCompletion).toBeNull();
+  });
+
   it("creates UserProgress with correct BP increment and energy delta", async () => {
     const user = await userFixture();
     const userId = user.id;
@@ -365,6 +500,37 @@ describe(submitLessonCompletion, () => {
 
     const userProgress = await prisma.userProgress.findUnique({ where: { userId } });
     expect(Number(userProgress?.totalBrainPower)).toBe(20);
+  });
+
+  it("re-completion preserves the original lesson completion metadata", async () => {
+    const user = await userFixture();
+    const userId = user.id;
+
+    const baseInput = {
+      durationSeconds: 10,
+      lessonId: lesson.id,
+
+      localDate: todayLocalDate(),
+      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
+      startedAt: new Date(Date.now() - 10_000),
+      stepResults: [stepResult(true)],
+      userId,
+    };
+
+    await submitLessonCompletion(baseInput);
+
+    const firstProgress = await prisma.lessonProgress.findUniqueOrThrow({
+      where: { userLesson: { lessonId: lesson.id, userId } },
+    });
+
+    await submitLessonCompletion({ ...baseInput, durationSeconds: 25 });
+
+    const secondProgress = await prisma.lessonProgress.findUniqueOrThrow({
+      where: { userLesson: { lessonId: lesson.id, userId } },
+    });
+
+    expect(secondProgress.completedAt).toStrictEqual(firstProgress.completedAt);
+    expect(secondProgress.durationSeconds).toBe(10);
   });
 
   it("static lesson increments staticCompleted, not interactiveCompleted", async () => {

--- a/packages/core/src/player/commands/submit-lesson-completion.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.ts
@@ -67,8 +67,17 @@ export async function submitLessonCompletion(input: {
         startedAt: input.startedAt,
         userId: input.userId,
       },
-      update: { completedAt: now, durationSeconds: input.durationSeconds },
+      update: {},
       where: { userLesson: { lessonId: input.lessonId, userId: input.userId } },
+    });
+
+    // A review completion is fresh practice, not a new first-completion event.
+    // Only start-only rows should cross the completed boundary here; completed rows
+    // keep their original timestamp and duration so continue links and completion
+    // metrics do not move backward when a learner revisits an earlier lesson.
+    await tx.lessonProgress.updateMany({
+      data: { completedAt: now, durationSeconds: input.durationSeconds },
+      where: { completedAt: null, lessonId: input.lessonId, userId: input.userId },
     });
 
     const { courseId } = await syncDurableCurriculumCompletion(tx, {

--- a/packages/core/src/progress/get-active-catalog-target.test.ts
+++ b/packages/core/src/progress/get-active-catalog-target.test.ts
@@ -156,7 +156,7 @@ describe(getActiveCatalogTarget, () => {
     expect(result).toBeNull();
   });
 
-  it("uses the next lesson after the latest completed lesson", async () => {
+  it("uses the next lesson after the furthest completed lesson", async () => {
     const [user, tree] = await Promise.all([userFixture(), createCourseTree()]);
     const [completedLesson, nextLesson, startedLesson] = tree.lessons;
 

--- a/packages/core/src/progress/get-continue-lesson-target.test.ts
+++ b/packages/core/src/progress/get-continue-lesson-target.test.ts
@@ -1,4 +1,4 @@
-import { type LessonKind } from "@zoonk/db";
+import { type LessonKind, prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
@@ -12,6 +12,15 @@ type CourseTree = {
   chapter: Awaited<ReturnType<typeof chapterFixture>>;
   course: Awaited<ReturnType<typeof courseFixture>>;
   lessons: Awaited<ReturnType<typeof lessonFixture>>[];
+};
+
+type TwoChapterCourseTree = {
+  course: Awaited<ReturnType<typeof courseFixture>>;
+  firstChapter: Awaited<ReturnType<typeof chapterFixture>>;
+  firstLesson: Awaited<ReturnType<typeof lessonFixture>>;
+  reviewLesson: Awaited<ReturnType<typeof lessonFixture>>;
+  secondChapter: Awaited<ReturnType<typeof chapterFixture>>;
+  secondLesson: Awaited<ReturnType<typeof lessonFixture>>;
 };
 
 describe(getContinueLessonTarget, () => {
@@ -58,6 +67,57 @@ describe(getContinueLessonTarget, () => {
     return { chapter, course, lessons };
   }
 
+  /**
+   * Completed-course review needs a final chapter with a real review lesson.
+   * Keeping that shape in one helper makes the tests assert product behavior
+   * instead of the mechanics of creating multi-chapter fixture data.
+   */
+  async function createTwoChapterCourseTree(): Promise<TwoChapterCourseTree> {
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
+    const [firstChapter, secondChapter] = await Promise.all([
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const [firstLesson, secondLesson, reviewLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: firstChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: secondChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: secondChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "review",
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    return { course, firstChapter, firstLesson, reviewLesson, secondChapter, secondLesson };
+  }
+
   it("returns first lesson when unauthenticated", async () => {
     const { chapter, course, lessons } = await createCourseTree();
 
@@ -100,7 +160,7 @@ describe(getContinueLessonTarget, () => {
     });
   });
 
-  it("returns next lesson after the latest completed lesson", async () => {
+  it("returns next lesson after the furthest completed lesson", async () => {
     const [user, tree] = await Promise.all([userFixture(), createCourseTree()]);
     const [completedLesson, nextLesson] = tree.lessons;
 
@@ -127,7 +187,7 @@ describe(getContinueLessonTarget, () => {
     });
   });
 
-  it("continues from the latest visible completion when a newer hidden lesson is completed", async () => {
+  it("continues from the furthest visible completion when a newer hidden lesson is completed", async () => {
     const [user, tree] = await Promise.all([
       userFixture(),
       createCourseTree({
@@ -213,7 +273,7 @@ describe(getContinueLessonTarget, () => {
     expect(result).not.toMatchObject({ lessonSlug: hiddenLesson?.slug });
   });
 
-  it("returns the latest completed lesson as review state when the course is complete", async () => {
+  it("returns the furthest completed lesson as review state when the course is complete", async () => {
     const [user, tree] = await Promise.all([userFixture(), createCourseTree()]);
     const [lesson1, lesson2] = tree.lessons;
 
@@ -245,6 +305,66 @@ describe(getContinueLessonTarget, () => {
       hasStarted: true,
       lessonPosition: 1,
       lessonSlug: lesson2?.slug,
+    });
+  });
+
+  it("returns the last chapter review lesson when a durable course is complete", async () => {
+    const [user, tree] = await Promise.all([userFixture(), createTwoChapterCourseTree()]);
+
+    await prisma.courseCompletion.create({ data: { courseId: tree.course.id, userId: user.id } });
+
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getContinueLessonTarget({ headers, scope: { courseId: tree.course.id } });
+
+    expect(result).toStrictEqual({
+      brandSlug: organization.slug,
+      canPrefetch: true,
+      chapterSlug: tree.secondChapter.slug,
+      completed: true,
+      courseSlug: tree.course.slug,
+      hasStarted: true,
+      lessonPosition: 1,
+      lessonSlug: tree.reviewLesson.slug,
+    });
+  });
+
+  it("returns an earlier incomplete course lesson before reviewing the final completion", async () => {
+    const [user, tree] = await Promise.all([
+      userFixture(),
+      createCourseTree({ lessonStatuses: ["completed", "completed", "completed"] }),
+    ]);
+
+    const [completedLesson, incompleteLesson, finalLesson] = tree.lessons;
+
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: completedLesson?.id ?? "",
+        userId: user.id,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-02"),
+        durationSeconds: 60,
+        lessonId: finalLesson?.id ?? "",
+        userId: user.id,
+      }),
+    ]);
+
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getContinueLessonTarget({ headers, scope: { courseId: tree.course.id } });
+
+    expect(result).toStrictEqual({
+      brandSlug: organization.slug,
+      canPrefetch: true,
+      chapterSlug: tree.chapter.slug,
+      completed: false,
+      courseSlug: tree.course.slug,
+      hasStarted: true,
+      lessonPosition: 1,
+      lessonSlug: incompleteLesson?.slug,
     });
   });
 
@@ -325,6 +445,48 @@ describe(getContinueLessonTarget, () => {
       hasStarted: true,
       lessonPosition: 1,
       lessonSlug: nextLesson?.slug,
+    });
+  });
+
+  it("returns an earlier incomplete chapter lesson before reviewing the final completion", async () => {
+    const [user, tree] = await Promise.all([
+      userFixture(),
+      createCourseTree({ lessonStatuses: ["completed", "completed", "completed"] }),
+    ]);
+
+    const [completedLesson, incompleteLesson, finalLesson] = tree.lessons;
+
+    await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-01"),
+        durationSeconds: 60,
+        lessonId: completedLesson?.id ?? "",
+        userId: user.id,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date("2024-01-02"),
+        durationSeconds: 60,
+        lessonId: finalLesson?.id ?? "",
+        userId: user.id,
+      }),
+    ]);
+
+    const headers = await signInAs(user.email, user.password);
+
+    const result = await getContinueLessonTarget({
+      headers,
+      scope: { chapterId: tree.chapter.id },
+    });
+
+    expect(result).toStrictEqual({
+      brandSlug: organization.slug,
+      canPrefetch: true,
+      chapterSlug: tree.chapter.slug,
+      completed: false,
+      courseSlug: tree.course.slug,
+      hasStarted: true,
+      lessonPosition: 1,
+      lessonSlug: incompleteLesson?.slug,
     });
   });
 

--- a/packages/core/src/progress/get-next-lesson-state.ts
+++ b/packages/core/src/progress/get-next-lesson-state.ts
@@ -110,6 +110,16 @@ export async function getNextLessonStateForUser({
       return buildOpenLessonState({ hasStarted, lesson: forwardLesson });
     }
 
+    const firstIncompleteLesson = getFirstIncompleteLesson({
+      courseCompleted,
+      durableChapterIds,
+      rows: effectiveRows,
+    });
+
+    if (firstIncompleteLesson) {
+      return buildOpenLessonState({ hasStarted, lesson: firstIncompleteLesson });
+    }
+
     const reviewLesson = getReviewLesson({ after, rows: effectiveRows });
 
     return buildCompletedScopeState({
@@ -138,7 +148,7 @@ export async function getNextLessonStateForUser({
 /**
  * Once a learner reaches a review state, UI surfaces should keep that state
  * anchored to one concrete lesson row. For a normal completed scope that is
- * the first structural lesson; for forward-only started navigation it is the
+ * the last structural lesson; for forward-only started navigation it is the
  * anchored lesson passed in by the caller.
  */
 function buildCompletedScopeState({
@@ -148,30 +158,30 @@ function buildCompletedScopeState({
   rows: EffectiveLessonProgressRow[];
   scopeDurablyCompleted: boolean;
 }): NextLessonState {
-  const [firstRow] = rows;
+  const row = rows.at(-1);
 
-  if (!firstRow) {
+  if (!row) {
     throw new Error("Cannot build completed lesson state without lesson rows");
   }
 
   return {
-    brandSlug: firstRow.brandSlug,
-    canPrefetch: canPrefetchLesson({ row: firstRow }),
-    chapterId: firstRow.chapterId,
-    chapterPosition: firstRow.chapterPosition,
-    chapterSlug: firstRow.chapterSlug,
-    chapterTitle: firstRow.chapterTitle,
+    brandSlug: row.brandSlug,
+    canPrefetch: canPrefetchLesson({ row }),
+    chapterId: row.chapterId,
+    chapterPosition: row.chapterPosition,
+    chapterSlug: row.chapterSlug,
+    chapterTitle: row.chapterTitle,
     completed: true,
-    courseId: firstRow.courseId,
-    courseSlug: firstRow.courseSlug,
+    courseId: row.courseId,
+    courseSlug: row.courseSlug,
     hasStarted: true,
-    lessonDescription: firstRow.lessonDescription,
+    lessonDescription: row.lessonDescription,
     lessonHasPendingContent: false,
-    lessonId: firstRow.lessonId,
-    lessonKind: firstRow.lessonKind,
-    lessonPosition: firstRow.lessonPosition,
-    lessonSlug: firstRow.lessonSlug,
-    lessonTitle: firstRow.lessonTitle,
+    lessonId: row.lessonId,
+    lessonKind: row.lessonKind,
+    lessonPosition: row.lessonPosition,
+    lessonSlug: row.lessonSlug,
+    lessonTitle: row.lessonTitle,
     scopeDurablyCompleted,
   };
 }


### PR DESCRIPTION
## Summary
- Keep continue-learning targets anchored to the furthest completed lesson instead of the most recent timestamp
- Prevent review completions from moving completion metadata backward and force catalog revalidation after lesson completion
- Expand e2e and core tests to cover review lessons, final-course review state, and completion recomputation

## Testing
- Added coverage for continue-link behavior across chapter and course review states
- Added core tests for furthest-completion ordering and idempotent completion updates
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors Continue and Review targets to the furthest completed lesson in course order, so reviewing earlier lessons no longer moves the target backward. Also revalidates catalog routes after completion and preserves original completion metadata to keep links and completion state correct.

- **Bug Fixes**
  - Rank completions by chapter/lesson position, then timestamp, in `findLastCompleted`.
  - In `get-next-lesson-state`, open the first incomplete lesson before showing review; anchor completed state to the last structural lesson.
  - In `submitLessonCompletion`, keep the original `completedAt` and `durationSeconds`; only set them when crossing completion for the first time.
  - Revalidate `/` and `/(catalog)` after lesson completion to refresh Continue/Review links.
  - Remove next-chapter fallback from the chapter page; `ContinueLessonLink` drives navigation.
  - Add e2e and core tests covering review lessons, final-course review state, and re-completion behavior.

<sup>Written for commit b620cfffa50bb0ab53a1d4a59e4880da98862ac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

