### PR TITLE
fix(player): improve inline feedback corrections

### DIFF
--- a/packages/core/src/player/contracts/check-answer.test.ts
+++ b/packages/core/src/player/contracts/check-answer.test.ts
@@ -62,7 +62,7 @@ describe(checkFillBlankAnswer, () => {
 
   it("returns correct for exact match", () => {
     expect(checkFillBlankAnswer(content, ["hablo", "español"])).toStrictEqual({
-      correctAnswer: null,
+      correctAnswer: "Yo hablo español.",
       feedback: "Use first person singular.",
       isCorrect: true,
     });
@@ -70,7 +70,7 @@ describe(checkFillBlankAnswer, () => {
 
   it("returns correct for case-insensitive match", () => {
     expect(checkFillBlankAnswer(content, ["HABLO", "ESPAÑOL"])).toStrictEqual({
-      correctAnswer: null,
+      correctAnswer: "Yo hablo español.",
       feedback: "Use first person singular.",
       isCorrect: true,
     });
@@ -78,7 +78,7 @@ describe(checkFillBlankAnswer, () => {
 
   it("returns correct with trimmed whitespace", () => {
     expect(checkFillBlankAnswer(content, ["  hablo  ", " español "])).toStrictEqual({
-      correctAnswer: null,
+      correctAnswer: "Yo hablo español.",
       feedback: "Use first person singular.",
       isCorrect: true,
     });
@@ -86,7 +86,7 @@ describe(checkFillBlankAnswer, () => {
 
   it("returns incorrect for wrong answer", () => {
     expect(checkFillBlankAnswer(content, ["habla", "español"])).toStrictEqual({
-      correctAnswer: null,
+      correctAnswer: "Yo hablo español.",
       feedback: "Use first person singular.",
       isCorrect: false,
     });
@@ -94,7 +94,7 @@ describe(checkFillBlankAnswer, () => {
 
   it("returns incorrect when user provides extra answers", () => {
     expect(checkFillBlankAnswer(content, ["hablo", "español", "extra"])).toStrictEqual({
-      correctAnswer: null,
+      correctAnswer: "Yo hablo español.",
       feedback: "Use first person singular.",
       isCorrect: false,
     });

--- a/packages/core/src/player/contracts/check-answer.ts
+++ b/packages/core/src/player/contracts/check-answer.ts
@@ -13,6 +13,18 @@ export type AnswerResult = {
   feedback: string | null;
 };
 
+/**
+ * Fill-blank feedback should show the full sentence learners were trying to
+ * build, not only the isolated blank values. Replaying the template with the
+ * canonical answers gives the player one readable correction string.
+ */
+function getFillBlankCorrectAnswer(content: FillBlankStepContent): string {
+  return content.template
+    .split("[BLANK]")
+    .map((segment, index) => `${segment}${content.answers[index] ?? ""}`)
+    .join("");
+}
+
 export function checkMultipleChoiceAnswer(
   content: MultipleChoiceStepContent,
   selectedOptionId: string,
@@ -31,6 +43,7 @@ export function checkFillBlankAnswer(
   content: FillBlankStepContent,
   userAnswers: string[],
 ): AnswerResult {
+  const correctAnswer = getFillBlankCorrectAnswer(content);
   const isSameLength = content.answers.length === userAnswers.length;
 
   const isCorrect =
@@ -39,7 +52,7 @@ export function checkFillBlankAnswer(
       (answer, index) => answer.toLowerCase() === (userAnswers[index] ?? "").trim().toLowerCase(),
     );
 
-  return { correctAnswer: null, feedback: content.feedback, isCorrect };
+  return { correctAnswer, feedback: content.feedback, isCorrect };
 }
 
 export function checkSingleMatchPair(

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -180,6 +180,7 @@ msgid "3nOd8f"
 msgstr "Your answer:"
 
 #: src/components/feedback-answer-blocks.tsx
+#: src/components/inline-feedback.tsx
 msgid "QAJ_Tl"
 msgstr "Correct answer:"
 
@@ -198,10 +199,6 @@ msgstr "Blank {position}: {item}. Tap to remove."
 #: src/components/fill-blank-step.tsx
 msgid "FmmJ_j"
 msgstr "Blank {position}"
-
-#: src/components/fill-blank-step.tsx
-msgid "xvWuPP"
-msgstr "Correct answer: {answer}"
 
 #: src/components/inline-feedback.tsx
 msgid "HvLGEN"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -180,6 +180,7 @@ msgid "3nOd8f"
 msgstr "Tu respuesta:"
 
 #: src/components/feedback-answer-blocks.tsx
+#: src/components/inline-feedback.tsx
 msgid "QAJ_Tl"
 msgstr "Respuesta correcta:"
 
@@ -198,10 +199,6 @@ msgstr "Espacio {position}: {item}. Toca para quitar."
 #: src/components/fill-blank-step.tsx
 msgid "FmmJ_j"
 msgstr "Espacio {position}"
-
-#: src/components/fill-blank-step.tsx
-msgid "xvWuPP"
-msgstr "Respuesta correcta: {answer}"
 
 #: src/components/inline-feedback.tsx
 msgid "HvLGEN"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -180,6 +180,7 @@ msgid "3nOd8f"
 msgstr "Sua resposta:"
 
 #: src/components/feedback-answer-blocks.tsx
+#: src/components/inline-feedback.tsx
 msgid "QAJ_Tl"
 msgstr "Resposta correta:"
 
@@ -198,10 +199,6 @@ msgstr "Espaço {position}: {item}. Toque para remover."
 #: src/components/fill-blank-step.tsx
 msgid "FmmJ_j"
 msgstr "Espaço {position}"
-
-#: src/components/fill-blank-step.tsx
-msgid "xvWuPP"
-msgstr "Resposta correta: {answer}"
 
 #: src/components/inline-feedback.tsx
 msgid "HvLGEN"

--- a/packages/player/src/_browser-tests/player-choice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-choice.browser.test.tsx
@@ -368,13 +368,17 @@ describe("player browser integration: choice steps", () => {
     await page.getByRole("radio", { name: "Dog" }).click();
     await page.getByRole("button", { name: /check/iu }).click();
 
+    const feedback = page.getByRole("region", { name: /answer feedback/iu });
+
+    await expect.element(feedback).toBeInTheDocument();
+
     await expect
-      .element(page.getByRole("region", { name: /answer feedback/iu }))
+      .element(page.getByRole("radio", { name: "Cat" }).getByText("Correct answer"))
       .toBeInTheDocument();
 
-    await expect.element(page.getByRole("radio", { name: "Cat" })).toBeInTheDocument();
-    await expect.element(page.getByText(/correct answer/iu)).toBeInTheDocument();
-    await expect.element(page.getByText(/your answer/iu)).toBeInTheDocument();
+    await expect
+      .element(page.getByRole("radio", { name: "Dog" }).getByText("Your answer"))
+      .toBeInTheDocument();
   });
 
   it("replaces {{NAME}} placeholders for authenticated viewers", async () => {

--- a/packages/player/src/components/feedback-answer-blocks.tsx
+++ b/packages/player/src/components/feedback-answer-blocks.tsx
@@ -20,17 +20,10 @@ function AnswerLine({
     <div
       className={cn(
         "flex items-start gap-2 rounded-lg px-3 py-2 text-sm",
-        variant === "correct" ? "bg-success/10" : "bg-destructive/10",
+        variant === "correct" ? "bg-success/10 text-success" : "bg-destructive/10 text-destructive",
       )}
     >
-      <span
-        className={cn(
-          "mt-0.5 shrink-0",
-          variant === "correct" ? "text-success" : "text-destructive",
-        )}
-      >
-        {icon}
-      </span>
+      <span className="mt-0.5 shrink-0">{icon}</span>
       <div>
         <span className="text-muted-foreground">{label}</span>{" "}
         <span className="font-medium">{children}</span>

--- a/packages/player/src/components/fill-blank-step.tsx
+++ b/packages/player/src/components/fill-blank-step.tsx
@@ -191,12 +191,6 @@ function WordBank({
   );
 }
 
-function getCorrectSentence(template: string, answers: string[]): string {
-  return template
-    .split("[BLANK]")
-    .reduce((acc, segment, index) => acc + segment + (answers[index] ?? ""), "");
-}
-
 function isComplete(blanks: (string | null)[]): blanks is string[] {
   return blanks.every((blank) => blank !== null);
 }
@@ -212,7 +206,6 @@ export function FillBlankStep({
   selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
 }) {
-  const t = useExtracted();
   const content = useMemo(() => parseStepContent("fillBlank", step.content), [step.content]);
   const blankCount = content.answers.length;
   const hasResult = result !== undefined;
@@ -273,8 +266,6 @@ export function FillBlankStep({
     [blanks, onSelectAnswer, selectedAnswer, step.id],
   );
 
-  const isIncorrect = result && !result.result.isCorrect;
-
   return (
     <InteractiveStepLayout>
       {content.question && <QuestionText>{content.question}</QuestionText>}
@@ -296,17 +287,7 @@ export function FillBlankStep({
         options={step.fillBlankOptions}
       />
 
-      {result && (
-        <InlineFeedback result={result}>
-          {isIncorrect && (
-            <p className="text-muted-foreground text-sm">
-              {t("Correct answer: {answer}", {
-                answer: getCorrectSentence(content.template, content.answers),
-              })}
-            </p>
-          )}
-        </InlineFeedback>
-      )}
+      {result && <InlineFeedback result={result} />}
     </InteractiveStepLayout>
   );
 }

--- a/packages/player/src/components/inline-feedback.tsx
+++ b/packages/player/src/components/inline-feedback.tsx
@@ -14,6 +14,7 @@ export function InlineFeedback({
 }) {
   const t = useExtracted();
   const isCorrect = result.result.isCorrect;
+  const correctAnswer = result.result.correctAnswer;
   const feedback = result.result.feedback;
 
   return (
@@ -28,6 +29,13 @@ export function InlineFeedback({
       {feedback && (
         <p className="text-muted-foreground text-sm">
           <PlayerRichText text={feedback} />
+        </p>
+      )}
+
+      {!isCorrect && correctAnswer && (
+        <p className="text-sm">
+          <span className="text-muted-foreground">{t("Correct answer:")}</span>{" "}
+          <span className="text-success font-medium">{correctAnswer}</span>
         </p>
       )}
 


### PR DESCRIPTION
Improve player answer feedback by using success contrast for correct answer rows and moving fill-blank correction text into the shared inline feedback path.

Keep select-image and sort-order corrections on their existing visual surfaces to avoid duplicate feedback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved player answer feedback: correct answer rows now use success contrast, and fill‑blank steps show the full correct sentence inline. Kept select‑image and sort‑order corrections on their existing surfaces to avoid duplicate feedback.

- **Bug Fixes**
  - Core: `checkFillBlankAnswer` now returns a full `correctAnswer` by replaying the template with canonical answers.
  - UI/i18n: `InlineFeedback` renders "Correct answer:" from a shared key for incorrect fill‑blank attempts; removed duplicate logic and old string from `FillBlankStep`.
  - UI: Answer rows now use success/destructive text for better contrast.
  - Tests: Updated unit and browser tests for new inline feedback and labels.

<sup>Written for commit c1f7845fc16bdefa774393efa890bcb92d5ce8a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

