### PR TITLE
fix(utils): preserve symbolic course slugs

### DIFF
--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -212,6 +212,15 @@ describe(toSlug, () => {
     expect(toSlug("わけ・はず")).toBe("わけはず");
   });
 
+  it("preserves common symbolic course names", () => {
+    expect(toSlug("C++")).toBe("c-plus-plus");
+    expect(toSlug("C#")).toBe("c-sharp");
+    expect(toSlug("F#")).toBe("f-sharp");
+    expect(toSlug(".NET")).toBe("dot-net");
+    expect(toSlug("Learn .NET")).toBe("learn-dot-net");
+    expect(toSlug("Hello! @World #1")).toBe("hello-world-1");
+  });
+
   it("edge cases", () => {
     expect(toSlug("")).toBe("");
     expect(toSlug("   ")).toBe("");

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -14,6 +14,9 @@ export function normalizeString(str: string): string {
 export function toSlug(str: string): string {
   return removeAccents(str.trim())
     .normalize("NFC")
+    .replaceAll(/(?<prefix>^|\s)\.(?=\p{L})/gu, "$<prefix>dot ")
+    .replaceAll("+", " plus ")
+    .replaceAll(/(?<=[\p{L}\p{N}])#/gu, " sharp ")
     .toLowerCase()
     .replaceAll(/[^\p{L}\p{N}\p{M}\s-]/gu, "")
     .replaceAll(/\s+/gu, "-")


### PR DESCRIPTION
## Summary

- Preserve common symbolic course names in generated slugs, including C++, C#, F#, and .NET
- Add slug regression coverage while keeping regular punctuation behavior unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves symbolic course names in slug generation. C++, C#, F#, and .NET now become c-plus-plus, c-sharp, f-sharp, and dot-net, with other punctuation rules unchanged.

- **Bug Fixes**
  - Map leading `.` before letters to "dot" (e.g., ".NET" -> "dot-net").
  - Convert `+` to "plus" and `#` after letters/digits to "sharp".
  - Add regression tests for these cases.

<sup>Written for commit abd178b98fcfc0c53e5e0cc34b2eb8a7776b4389. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

