### PR TITLE
feat(main): show continue progress percentages

### DIFF
--- a/apps/main/e2e/chapter-progress.test.ts
+++ b/apps/main/e2e/chapter-progress.test.ts
@@ -93,8 +93,9 @@ test.describe("Chapter Progress Indicators", () => {
     ).toBeVisible();
 
     const main = authenticatedPage.getByRole("main");
-    await expect(main.getByRole("link", { name: "Start 0 of 3 lessons completed" })).toBeVisible();
-    await expect(main.getByText("0/3")).toBeVisible();
+    const startLink = main.getByRole("link", { name: "Start 0% complete" });
+    await expect(startLink).toBeVisible();
+    await expect(startLink.getByText("0%", { exact: true })).toBeVisible();
     await expect(main.getByText(/^completed$/iu)).toHaveCount(0);
     await expect(main.getByText(/\d+\/\d+ done/u)).toHaveCount(0);
   });
@@ -132,11 +133,10 @@ test.describe("Chapter Progress Indicators", () => {
 
     const main = authenticatedPage.getByRole("main");
 
-    await expect(
-      main.getByRole("link", { name: "Continue 1 of 3 lessons completed" }),
-    ).toBeVisible();
+    const continueLink = main.getByRole("link", { name: "Continue 33% complete" });
+    await expect(continueLink).toBeVisible();
 
-    await expect(main.getByText("1/3")).toBeVisible();
+    await expect(continueLink.getByText("33%", { exact: true })).toBeVisible();
     await expect(main.getByText(/^completed$/iu)).toHaveCount(1);
     await expect(main.getByText(/\d+\/\d+ done/u)).toHaveCount(0);
   });

--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -138,7 +138,7 @@ test.describe("Continue Learning Revalidation", () => {
     const user = await createE2EUser(baseURL!);
     const browserContext = await browser.newContext({ storageState: user.storageState });
     const page = await browserContext.newPage();
-    const { lesson0, course, uniqueId } = await createCourseWithThreeLessons();
+    const { lesson0, lesson1, course, uniqueId } = await createCourseWithThreeLessons();
 
     // Pre-complete lesson 0 so getContinueLearning returns this course with lesson 1 as "next"
     await Promise.all([
@@ -167,23 +167,8 @@ test.describe("Continue Learning Revalidation", () => {
     await page.waitForURL(new RegExp(`/l/e2e-cl-reval-current-${uniqueId}$`, "u"));
     await page.waitForLoadState("networkidle");
 
-    // Listen for the server action response BEFORE triggering completion.
-    // The server action (submitCompletion) is fire-and-forget from the UI,
-    // so waitForResponse is the only way to know it finished and revalidatePath ran.
-    const serverActionResponse = page.waitForResponse(
-      (resp) => resp.request().method() === "POST" && resp.ok(),
-    );
-
-    // 3. Complete the static lesson — retry handles hydration delay under parallel load
-    await expect(async () => {
-      await page.keyboard.press("ArrowRight");
-      await expect(page.getByRole("status")).toBeVisible({ timeout: 1000 });
-    }).toPass({ timeout: 10_000 });
-
-    await expect(page.getByText(/completed/iu)).toBeVisible();
-
-    // Wait for the server action response (includes the revalidatePath signal for Router Cache)
-    await serverActionResponse;
+    // 3. Complete the static lesson and wait for durable progress before navigating again.
+    await completeStaticLesson({ lessonId: lesson1.id, page, userId: user.id });
 
     // 4. Click "All Lessons" (client-side navigation)
     await page.getByRole("link", { name: /all lessons/iu }).click();
@@ -227,7 +212,7 @@ test.describe("Continue Learning Revalidation", () => {
 
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}`);
 
-    const staleContinueLink = page.getByRole("link", { name: "Continue 1 of 3 lessons completed" });
+    const staleContinueLink = page.getByRole("link", { name: "Continue 33% complete" });
 
     await expect(staleContinueLink).toHaveAttribute(
       "href",
@@ -244,9 +229,7 @@ test.describe("Continue Learning Revalidation", () => {
     await page.getByRole("link", { name: /all lessons/iu }).click();
     await page.waitForURL(new RegExp(`e2e-cl-reval-chapter-${uniqueId}$`, "u"));
 
-    const currentContinueLink = page.getByRole("link", {
-      name: "Continue 2 of 3 lessons completed",
-    });
+    const currentContinueLink = page.getByRole("link", { name: "Continue 67% complete" });
 
     await expect(currentContinueLink).toHaveAttribute(
       "href",

--- a/apps/main/e2e/continue-lesson-link.test.ts
+++ b/apps/main/e2e/continue-lesson-link.test.ts
@@ -27,7 +27,7 @@ function getContinueActionLink({ label, page }: { label: ContinueActionLabel; pa
  * helper keeps that accessible-name detail in one place.
  */
 function getContinueActionName({ label }: { label: ContinueActionLabel }) {
-  return new RegExp(`^${label}(?: \\d+ of \\d+ (?:chapters|lessons) completed)?$`, "iu");
+  return new RegExp(`^${label}(?: \\d+% complete)?$`, "iu");
 }
 
 async function createTestCourseWithLesson() {
@@ -524,7 +524,7 @@ test.describe("Continue Lesson Link", () => {
 
     const chapterContinueLink = page
       .getByRole("main")
-      .getByRole("link", { name: "Continue 1 of 2 lessons completed" });
+      .getByRole("link", { name: "Continue 50% complete" });
 
     const nextVisibleLessonTitle = nextVisibleLesson.title ?? nextVisibleLesson.slug;
 
@@ -565,6 +565,7 @@ test.describe("Continue Lesson Link", () => {
     const [chapter1, chapter2] = await Promise.all([
       chapterFixture({
         courseId: course.id,
+        generationStatus: "completed",
         isPublished: true,
         organizationId: org.id,
         position: 0,
@@ -573,6 +574,7 @@ test.describe("Continue Lesson Link", () => {
       }),
       chapterFixture({
         courseId: course.id,
+        generationStatus: "pending",
         isPublished: true,
         organizationId: org.id,
         position: 1,
@@ -600,7 +602,7 @@ test.describe("Continue Lesson Link", () => {
 
     await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}`);
 
-    const continueLink = getContinueActionLink({ label: "Continue", page: authenticatedPage });
+    const continueLink = authenticatedPage.getByRole("link", { name: "Continue 50% complete" });
     await expect(continueLink).toBeVisible();
 
     await expect(continueLink).toHaveAttribute(

--- a/apps/main/e2e/course-progress.test.ts
+++ b/apps/main/e2e/course-progress.test.ts
@@ -249,8 +249,9 @@ test.describe("Course Progress Indicators", () => {
     ).toBeVisible();
 
     const main = authenticatedPage.getByRole("main");
-    await expect(main.getByRole("link", { name: "Start 0 of 3 chapters completed" })).toBeVisible();
-    await expect(main.getByText("0/3")).toBeVisible();
+    const startLink = main.getByRole("link", { name: "Start 0% complete" });
+    await expect(startLink).toBeVisible();
+    await expect(startLink.getByText("0%", { exact: true })).toBeVisible();
     await expect(main.getByText(/^completed$/iu)).toHaveCount(0);
     await expect(main.getByText(/\d+\/\d+ done/u)).toHaveCount(0);
   });
@@ -276,15 +277,14 @@ test.describe("Course Progress Indicators", () => {
 
     const main = authenticatedPage.getByRole("main");
 
-    await expect(
-      main.getByRole("link", { name: "Review 3 of 3 chapters completed" }),
-    ).toBeVisible();
+    const reviewLink = main.getByRole("link", { name: "Review 100% complete" });
+    await expect(reviewLink).toBeVisible();
 
-    await expect(main.getByText("3/3")).toBeVisible();
+    await expect(reviewLink.getByText("100%", { exact: true })).toBeVisible();
     await expect(authenticatedPage.getByRole("main").getByText(/^completed$/iu)).toHaveCount(3);
   });
 
-  test("shows chapter fraction even when only lessons are partially completed", async ({
+  test("shows lesson percentage when only lessons are partially completed", async ({
     authenticatedPage,
     withProgressUser,
   }) => {
@@ -303,11 +303,10 @@ test.describe("Course Progress Indicators", () => {
 
     const main = authenticatedPage.getByRole("main");
 
-    await expect(
-      main.getByRole("link", { name: "Continue 0 of 3 chapters completed" }),
-    ).toBeVisible();
+    const continueLink = main.getByRole("link", { name: "Continue 29% complete" });
+    await expect(continueLink).toBeVisible();
 
-    await expect(main.getByText("0/3")).toBeVisible();
+    await expect(continueLink.getByText("29%", { exact: true })).toBeVisible();
     await expect(authenticatedPage.getByText("1/3 done")).toBeVisible();
     await expect(authenticatedPage.getByText("1/2 done")).toBeVisible();
   });
@@ -373,9 +372,7 @@ test.describe("Course Progress Indicators", () => {
 
     const main = page.getByRole("main");
 
-    await expect(
-      main.getByRole("link", { name: "Review 1 of 1 chapters completed" }),
-    ).toBeVisible();
+    await expect(main.getByRole("link", { name: "Review 100% complete" })).toBeVisible();
 
     const chapterLink = main.getByRole("link", { name: new RegExp(chapter.title, "u") });
 

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1778,12 +1778,8 @@ msgid "Gs9Kfp"
 msgstr "Back to top"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "4gKxIm"
-msgstr "{completed} of {total} chapters completed"
-
-#: src/components/catalog/continue-lesson-link.tsx
-msgid "grFxqs"
-msgstr "{completed} of {total} lessons completed"
+msgid "AvySqa"
+msgstr "{percent}% complete"
 
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1778,12 +1778,8 @@ msgid "Gs9Kfp"
 msgstr "Volver arriba"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "4gKxIm"
-msgstr "{completed} de {total} capítulos completados"
-
-#: src/components/catalog/continue-lesson-link.tsx
-msgid "grFxqs"
-msgstr "{completed} de {total} lecciones completadas"
+msgid "AvySqa"
+msgstr "{percent}% completado"
 
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1778,12 +1778,8 @@ msgid "Gs9Kfp"
 msgstr "Voltar ao topo"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "4gKxIm"
-msgstr "{completed} de {total} capítulos concluídos"
-
-#: src/components/catalog/continue-lesson-link.tsx
-msgid "grFxqs"
-msgstr "{completed} de {total} aulas concluídas"
+msgid "AvySqa"
+msgstr "{percent}% concluído"
 
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
@@ -145,7 +145,7 @@ export async function LessonList({
   const session = await getSession();
 
   const [completionData, activeTarget] = await Promise.all([
-    getCatalogLessonProgress(chapterId, hiddenLessonKinds),
+    getCatalogLessonProgress({ chapterId, excludedLessonKinds: hiddenLessonKinds }),
     getActiveCatalogTarget({ excludedLessonKinds: hiddenLessonKinds, scope: { chapterId } }),
   ]);
 

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
@@ -184,7 +184,7 @@ export async function ChapterList({
   const t = await getExtracted();
 
   const [completionData, activeTarget] = await Promise.all([
-    getCatalogChapterProgress(courseId, hiddenLessonKinds),
+    getCatalogChapterProgress({ courseId, excludedLessonKinds: hiddenLessonKinds }),
     getActiveCatalogTarget({ excludedLessonKinds: hiddenLessonKinds, scope: { courseId } }),
   ]);
 

--- a/apps/main/src/components/catalog/continue-lesson-link.tsx
+++ b/apps/main/src/components/catalog/continue-lesson-link.tsx
@@ -38,20 +38,16 @@ function getScope(props: {
 }
 
 /**
- * Progress can start at zero, but it still needs a valid total before it is
- * worth replacing the arrow. Clamping the completed count keeps stale or
- * duplicated completion rows from making the compact fraction impossible.
+ * Progress can start at zero, but it still needs a valid percentage before it
+ * is worth replacing the arrow. Clamping keeps stale data from leaking an
+ * impossible value into the compact suffix.
  */
 function getVisibleProgress({ progress }: { progress?: ContinueLessonProgress | null }) {
-  if (!progress || progress.totalItems <= 0) {
+  if (!progress) {
     return null;
   }
 
-  return {
-    completedItems: Math.min(Math.max(progress.completedItems, 0), progress.totalItems),
-    totalItems: progress.totalItems,
-    unit: progress.unit,
-  };
+  return { percentComplete: Math.min(Math.max(progress.percentComplete, 0), 100) };
 }
 
 /**
@@ -67,18 +63,18 @@ function getContinueLessonProgress({
   scope: LessonScope;
 }) {
   if ("courseId" in scope) {
-    return getCourseContinueProgress(scope.courseId, excludedLessonKinds);
+    return getCourseContinueProgress({ courseId: scope.courseId, excludedLessonKinds });
   }
 
   if ("chapterId" in scope) {
-    return getChapterContinueProgress(scope.chapterId, excludedLessonKinds);
+    return getChapterContinueProgress({ chapterId: scope.chapterId, excludedLessonKinds });
   }
 
   return Promise.resolve(null);
 }
 
 /**
- * The visible suffix is intentionally just a fraction so the mobile CTA stays
+ * The visible suffix is intentionally just a percent so the mobile CTA stays
  * compact, while the hidden text gives screen readers the full meaning.
  */
 function ContinueLessonLinkContent({
@@ -139,17 +135,8 @@ export async function ContinueLessonLink<Href extends string, CompletedHref exte
 
   const progressContent = visibleProgress
     ? {
-        ariaLabel:
-          visibleProgress.unit === "chapters"
-            ? t("{completed} of {total} chapters completed", {
-                completed: String(visibleProgress.completedItems),
-                total: String(visibleProgress.totalItems),
-              })
-            : t("{completed} of {total} lessons completed", {
-                completed: String(visibleProgress.completedItems),
-                total: String(visibleProgress.totalItems),
-              }),
-        text: `${visibleProgress.completedItems}/${visibleProgress.totalItems}`,
+        ariaLabel: t("{percent}% complete", { percent: String(visibleProgress.percentComplete) }),
+        text: `${visibleProgress.percentComplete}%`,
       }
     : null;
 

--- a/apps/main/src/data/progress/_utils/continue-progress-percent.test.ts
+++ b/apps/main/src/data/progress/_utils/continue-progress-percent.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CourseContinueProgressChapter,
+  calculateCourseContinueProgressPercent,
+  calculateProgressPercent,
+} from "./continue-progress-percent";
+
+describe(calculateProgressPercent, () => {
+  it("returns an integer percentage for completed items", () => {
+    expect(calculateProgressPercent({ completedItems: 1, totalItems: 3 })).toBe(33);
+  });
+
+  it("keeps partial progress below 100 until every item is complete", () => {
+    expect(calculateProgressPercent({ completedItems: 199, totalItems: 200 })).toBe(99);
+  });
+
+  it("keeps tiny non-zero progress visible", () => {
+    expect(calculateProgressPercent({ completedItems: 1, totalItems: 300 })).toBe(1);
+  });
+
+  it("returns null when there is no total to measure", () => {
+    expect(calculateProgressPercent({ completedItems: 0, totalItems: 0 })).toBeNull();
+  });
+});
+
+describe(calculateCourseContinueProgressPercent, () => {
+  it("uses actual lesson totals when every chapter is generated", () => {
+    expect(
+      calculateCourseContinueProgressPercent({
+        chapters: [
+          { completedLessons: 3, generationStatus: "completed", totalLessons: 3 },
+          { completedLessons: 1, generationStatus: "completed", totalLessons: 2 },
+          { completedLessons: 0, generationStatus: "completed", totalLessons: 2 },
+        ],
+      }),
+    ).toBe(57);
+  });
+
+  it("estimates missing chapters from generated chapter lesson counts", () => {
+    expect(
+      calculateCourseContinueProgressPercent({
+        chapters: [
+          { completedLessons: 1, generationStatus: "completed", totalLessons: 3 },
+          { completedLessons: 1, generationStatus: "completed", totalLessons: 2 },
+          { completedLessons: 0, generationStatus: "pending", totalLessons: 0 },
+        ],
+      }),
+    ).toBe(25);
+  });
+
+  it("never estimates below the lesson rows that already exist", () => {
+    const chapters: CourseContinueProgressChapter[] = [
+      { completedLessons: 1, generationStatus: "completed", totalLessons: 1 },
+      { completedLessons: 0, generationStatus: "pending", totalLessons: 4 },
+    ];
+
+    expect(calculateCourseContinueProgressPercent({ chapters })).toBe(20);
+  });
+});

--- a/apps/main/src/data/progress/_utils/continue-progress-percent.ts
+++ b/apps/main/src/data/progress/_utils/continue-progress-percent.ts
@@ -1,0 +1,175 @@
+export type CourseContinueProgressChapter = {
+  completedLessons: number;
+  generationStatus: string;
+  totalLessons: number;
+};
+
+const GENERATED_CHAPTER_STATUS = "completed";
+const MAX_PERCENT = 100;
+const MIN_VISIBLE_STARTED_PERCENT = 1;
+const MAX_INCOMPLETE_PERCENT = 99;
+
+/**
+ * Converts completed and total item counts into the integer percentage shown in
+ * catalog CTAs.
+ */
+export function calculateProgressPercent({
+  completedItems,
+  totalItems,
+}: {
+  completedItems: number;
+  totalItems: number;
+}) {
+  const normalizedTotalItems = normalizeCount({ value: totalItems });
+
+  if (normalizedTotalItems === 0) {
+    return null;
+  }
+
+  const normalizedCompletedItems = clampCompletedItems({
+    completedItems,
+    totalItems: normalizedTotalItems,
+  });
+
+  if (normalizedCompletedItems === 0) {
+    return 0;
+  }
+
+  if (normalizedCompletedItems >= normalizedTotalItems) {
+    return MAX_PERCENT;
+  }
+
+  const roundedPercent = Math.round((normalizedCompletedItems / normalizedTotalItems) * 100);
+
+  return Math.min(Math.max(roundedPercent, MIN_VISIBLE_STARTED_PERCENT), MAX_INCOMPLETE_PERCENT);
+}
+
+/**
+ * Estimates course completion from generated chapter sizes because later
+ * chapters often exist before their lesson rows have been generated.
+ */
+export function calculateCourseContinueProgressPercent({
+  chapters,
+}: {
+  chapters: CourseContinueProgressChapter[];
+}) {
+  return calculateProgressPercent({
+    completedItems: countCompletedLessons({ chapters }),
+    totalItems: estimateCourseTotalLessons({ chapters }),
+  });
+}
+
+/**
+ * Counts cannot be negative in the database, but this helper keeps stale or
+ * hand-built test inputs from leaking impossible values into the percentage.
+ */
+function normalizeCount({ value }: { value: number }) {
+  return Math.max(Math.round(value), 0);
+}
+
+/**
+ * Completed progress must never exceed the denominator shown to learners,
+ * otherwise stale duplicate progress rows could display more than 100%.
+ */
+function clampCompletedItems({
+  completedItems,
+  totalItems,
+}: {
+  completedItems: number;
+  totalItems: number;
+}) {
+  return Math.min(normalizeCount({ value: completedItems }), totalItems);
+}
+
+/**
+ * Course completion is lesson-based, so the numerator is the visible completed
+ * lessons from every published chapter row.
+ */
+function countCompletedLessons({ chapters }: { chapters: CourseContinueProgressChapter[] }) {
+  return sumCounts({ values: chapters.map((chapter) => getCompletedLessonCount(chapter)) });
+}
+
+/**
+ * Course progress should use the actual visible lesson count after every
+ * chapter is generated, and only estimate while the course still has pending
+ * chapters.
+ */
+function estimateCourseTotalLessons({ chapters }: { chapters: CourseContinueProgressChapter[] }) {
+  if (areAllChaptersGenerated({ chapters })) {
+    return countTotalLessons({ chapters });
+  }
+
+  return estimateTotalLessonsFromGeneratedChapters({ chapters });
+}
+
+/**
+ * Generated chapters are the best sample for future chapter size because their
+ * lesson lists have already reached the user-facing shape.
+ */
+function estimateTotalLessonsFromGeneratedChapters({
+  chapters,
+}: {
+  chapters: CourseContinueProgressChapter[];
+}) {
+  const generatedChapters = chapters.filter((chapter) => isGeneratedChapter(chapter));
+  const actualLessonTotal = countTotalLessons({ chapters });
+  const generatedLessonTotal = countTotalLessons({ chapters: generatedChapters });
+
+  if (generatedChapters.length === 0 || generatedLessonTotal === 0) {
+    return actualLessonTotal;
+  }
+
+  const estimatedLessonTotal = Math.round(
+    (generatedLessonTotal / generatedChapters.length) * chapters.length,
+  );
+
+  return Math.max(actualLessonTotal, estimatedLessonTotal);
+}
+
+/**
+ * A generated chapter has completed its chapter-generation workflow, so its
+ * visible lesson count is stable enough to use in the course estimate.
+ */
+function isGeneratedChapter(chapter: CourseContinueProgressChapter) {
+  return chapter.generationStatus === GENERATED_CHAPTER_STATUS;
+}
+
+/**
+ * The denominator uses visible lesson totals, including zero for generated
+ * chapters where the learner's filters hide every lesson.
+ */
+function countTotalLessons({ chapters }: { chapters: CourseContinueProgressChapter[] }) {
+  return sumCounts({ values: chapters.map((chapter) => getTotalLessonCount(chapter)) });
+}
+
+/**
+ * Mapping through a named helper keeps the lesson-count normalization rule
+ * reusable between actual totals and generated-chapter samples.
+ */
+function getTotalLessonCount(chapter: CourseContinueProgressChapter) {
+  return normalizeCount({ value: chapter.totalLessons });
+}
+
+/**
+ * Completed lesson counts need their own accessor so the numerator and
+ * denominator rules stay visibly separate.
+ */
+function getCompletedLessonCount(chapter: CourseContinueProgressChapter) {
+  return normalizeCount({ value: chapter.completedLessons });
+}
+
+/**
+ * Summing normalized counts in one helper keeps callers declarative and avoids
+ * repeating reduce arithmetic throughout the progress rules.
+ */
+function sumCounts({ values }: { values: number[] }) {
+  return values.reduce((total, value) => total + normalizeCount({ value }), 0);
+}
+
+/**
+ * An empty chapter list should not be treated as fully generated; it has no
+ * denominator, so callers should hide progress instead of showing 100%.
+ */
+function areAllChaptersGenerated({ chapters }: { chapters: CourseContinueProgressChapter[] }) {
+  return chapters.length > 0 && chapters.every((chapter) => isGeneratedChapter(chapter));
+}

--- a/apps/main/src/data/progress/catalog-progress.test.ts
+++ b/apps/main/src/data/progress/catalog-progress.test.ts
@@ -1,0 +1,290 @@
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, it } from "vitest";
+import {
+  getCatalogChapterProgress,
+  getCatalogLessonProgress,
+  getChapterContinueProgress,
+  getCourseContinueProgress,
+} from "./catalog-progress";
+
+const catalogContext = await createAuthenticatedCatalogContext();
+
+/**
+ * Catalog progress functions accept request headers for tests, matching the
+ * lower-level progress helpers they wrap while keeping server components on
+ * the default `next/headers` path.
+ */
+async function createAuthenticatedCatalogContext() {
+  const [organization, user] = await Promise.all([organizationFixture(), userFixture()]);
+  const headers = await signInAs(user.email, user.password);
+
+  return { headers, organization, user };
+}
+
+/**
+ * React cache can hold the no-argument session lookup for the current test
+ * worker, so all catalog progress tests share one authenticated learner while
+ * still creating their own course data.
+ */
+function getAuthenticatedCatalogContext() {
+  return catalogContext;
+}
+
+/**
+ * Course-level tests need a published course plus three published chapters so
+ * they can prove exact totals and pending-chapter estimates without relying on
+ * seed data.
+ */
+async function createPublishedCourseChapters({
+  chapter3GenerationStatus = "completed",
+  organizationId,
+}: {
+  chapter3GenerationStatus?: "completed" | "pending";
+  organizationId: string;
+}) {
+  const course = await courseFixture({ isPublished: true, organizationId });
+
+  const [chapter1, chapter2, chapter3] = await Promise.all([
+    chapterFixture({
+      courseId: course.id,
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId,
+      position: 0,
+    }),
+    chapterFixture({
+      courseId: course.id,
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId,
+      position: 1,
+    }),
+    chapterFixture({
+      courseId: course.id,
+      generationStatus: chapter3GenerationStatus,
+      isPublished: true,
+      organizationId,
+      position: 2,
+    }),
+  ]);
+
+  return { chapter1, chapter2, chapter3, course };
+}
+
+/**
+ * Lesson fixtures are created in chapter order so progress rows can assert the
+ * same ordering learners see in catalog lists.
+ */
+async function createPublishedLessons({
+  chapterId,
+  count,
+  organizationId,
+}: {
+  chapterId: string;
+  count: number;
+  organizationId: string;
+}) {
+  return Promise.all(
+    Array.from({ length: count }, (_, position) =>
+      lessonFixture({ chapterId, isPublished: true, organizationId, position }),
+    ),
+  );
+}
+
+/**
+ * Completion rows are the learner-facing source of truth for catalog progress,
+ * so tests write the same records the player completion path would persist.
+ */
+async function completeLessons({ lessonIds, userId }: { lessonIds: string[]; userId: string }) {
+  await Promise.all(
+    lessonIds.map((lessonId) =>
+      lessonProgressFixture({ completedAt: new Date(), durationSeconds: 60, lessonId, userId }),
+    ),
+  );
+}
+
+describe("catalog progress data", () => {
+  it("returns lesson progress rows for the chapter grid", async () => {
+    const { headers, organization, user } = getAuthenticatedCatalogContext();
+    const { chapter1 } = await createPublishedCourseChapters({ organizationId: organization.id });
+
+    const [completedLesson, pendingLesson] = await createPublishedLessons({
+      chapterId: chapter1.id,
+      count: 2,
+      organizationId: organization.id,
+    });
+
+    if (!completedLesson || !pendingLesson) {
+      throw new Error("Expected the chapter lesson fixtures to be created");
+    }
+
+    await completeLessons({ lessonIds: [completedLesson.id], userId: user.id });
+
+    await expect(
+      getCatalogLessonProgress({ chapterId: chapter1.id, headers }),
+    ).resolves.toStrictEqual([
+      { isCompleted: true, lessonId: completedLesson.id },
+      { isCompleted: false, lessonId: pendingLesson.id },
+    ]);
+  });
+
+  it("returns chapter progress rows for the course grid", async () => {
+    const { headers, organization, user } = getAuthenticatedCatalogContext();
+
+    const { chapter1, chapter2, chapter3, course } = await createPublishedCourseChapters({
+      organizationId: organization.id,
+    });
+
+    const [chapter1Lessons, chapter2Lessons] = await Promise.all([
+      createPublishedLessons({ chapterId: chapter1.id, count: 2, organizationId: organization.id }),
+      createPublishedLessons({ chapterId: chapter2.id, count: 1, organizationId: organization.id }),
+    ]);
+
+    const [chapter1Lesson] = chapter1Lessons;
+    const [chapter2Lesson] = chapter2Lessons;
+
+    if (!chapter1Lesson || !chapter2Lesson) {
+      throw new Error("Expected each chapter to have a lesson fixture");
+    }
+
+    await completeLessons({ lessonIds: [chapter1Lesson.id, chapter2Lesson.id], userId: user.id });
+
+    await expect(
+      getCatalogChapterProgress({ courseId: course.id, headers }),
+    ).resolves.toStrictEqual([
+      { chapterId: chapter1.id, completedLessons: 1, totalLessons: 2 },
+      { chapterId: chapter2.id, completedLessons: 1, totalLessons: 1 },
+      { chapterId: chapter3.id, completedLessons: 0, totalLessons: 0 },
+    ]);
+  });
+
+  it("returns exact chapter continue percentages", async () => {
+    const { headers, organization, user } = getAuthenticatedCatalogContext();
+    const { chapter1 } = await createPublishedCourseChapters({ organizationId: organization.id });
+
+    const [completedLesson] = await createPublishedLessons({
+      chapterId: chapter1.id,
+      count: 3,
+      organizationId: organization.id,
+    });
+
+    if (!completedLesson) {
+      throw new Error("Expected a completed lesson fixture");
+    }
+
+    await completeLessons({ lessonIds: [completedLesson.id], userId: user.id });
+
+    await expect(
+      getChapterContinueProgress({ chapterId: chapter1.id, headers }),
+    ).resolves.toStrictEqual({ percentComplete: 33 });
+  });
+
+  it("returns exact course continue percentages when every chapter is generated", async () => {
+    const { headers, organization, user } = getAuthenticatedCatalogContext();
+
+    const { chapter1, chapter2, chapter3, course } = await createPublishedCourseChapters({
+      organizationId: organization.id,
+    });
+
+    const [chapter1Lessons, chapter2Lessons] = await Promise.all([
+      createPublishedLessons({ chapterId: chapter1.id, count: 3, organizationId: organization.id }),
+      createPublishedLessons({ chapterId: chapter2.id, count: 2, organizationId: organization.id }),
+      createPublishedLessons({ chapterId: chapter3.id, count: 2, organizationId: organization.id }),
+    ]);
+
+    const [chapter1Lesson1, chapter1Lesson2, chapter1Lesson3] = chapter1Lessons;
+    const [chapter2Lesson1] = chapter2Lessons;
+
+    if (!chapter1Lesson1 || !chapter1Lesson2 || !chapter1Lesson3 || !chapter2Lesson1) {
+      throw new Error("Expected completed lesson fixtures for exact course progress");
+    }
+
+    await completeLessons({
+      lessonIds: [chapter1Lesson1.id, chapter1Lesson2.id, chapter1Lesson3.id, chapter2Lesson1.id],
+      userId: user.id,
+    });
+
+    await expect(
+      getCourseContinueProgress({ courseId: course.id, headers }),
+    ).resolves.toStrictEqual({ percentComplete: 57 });
+  });
+
+  it("estimates course continue percentages while later chapters are pending", async () => {
+    const { headers, organization, user } = getAuthenticatedCatalogContext();
+
+    const { chapter1, chapter2, course } = await createPublishedCourseChapters({
+      chapter3GenerationStatus: "pending",
+      organizationId: organization.id,
+    });
+
+    const [chapter1Lessons, chapter2Lessons] = await Promise.all([
+      createPublishedLessons({ chapterId: chapter1.id, count: 3, organizationId: organization.id }),
+      createPublishedLessons({ chapterId: chapter2.id, count: 2, organizationId: organization.id }),
+    ]);
+
+    const [chapter1Lesson] = chapter1Lessons;
+    const [chapter2Lesson] = chapter2Lessons;
+
+    if (!chapter1Lesson || !chapter2Lesson) {
+      throw new Error("Expected completed lesson fixtures for estimated course progress");
+    }
+
+    await completeLessons({ lessonIds: [chapter1Lesson.id, chapter2Lesson.id], userId: user.id });
+
+    await expect(
+      getCourseContinueProgress({ courseId: course.id, headers }),
+    ).resolves.toStrictEqual({ percentComplete: 25 });
+  });
+
+  it("applies hidden lesson-kind filters across catalog and continue progress", async () => {
+    const { headers, organization, user } = getAuthenticatedCatalogContext();
+
+    const { chapter1, course } = await createPublishedCourseChapters({
+      organizationId: organization.id,
+    });
+
+    const [visibleLesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter1.id,
+        isPublished: true,
+        kind: "explanation",
+        organizationId: organization.id,
+        position: 0,
+      }),
+      lessonFixture({
+        chapterId: chapter1.id,
+        isPublished: true,
+        kind: "quiz",
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    await completeLessons({ lessonIds: [visibleLesson.id], userId: user.id });
+
+    await expect(
+      getCatalogLessonProgress({ chapterId: chapter1.id, excludedLessonKinds: ["quiz"], headers }),
+    ).resolves.toStrictEqual([{ isCompleted: true, lessonId: visibleLesson.id }]);
+
+    await expect(
+      getCatalogChapterProgress({ courseId: course.id, excludedLessonKinds: ["quiz"], headers }),
+    ).resolves.toContainEqual({ chapterId: chapter1.id, completedLessons: 1, totalLessons: 1 });
+
+    await expect(
+      getChapterContinueProgress({
+        chapterId: chapter1.id,
+        excludedLessonKinds: ["quiz"],
+        headers,
+      }),
+    ).resolves.toStrictEqual({ percentComplete: 100 });
+
+    await expect(
+      getCourseContinueProgress({ courseId: course.id, excludedLessonKinds: ["quiz"], headers }),
+    ).resolves.toStrictEqual({ percentComplete: 100 });
+  });
+});

--- a/apps/main/src/data/progress/catalog-progress.ts
+++ b/apps/main/src/data/progress/catalog-progress.ts
@@ -13,12 +13,13 @@ import {
 } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
+import {
+  type CourseContinueProgressChapter,
+  calculateCourseContinueProgressPercent,
+  calculateProgressPercent,
+} from "./_utils/continue-progress-percent";
 
-export type ContinueLessonProgress = {
-  completedItems: number;
-  totalItems: number;
-  unit: "chapters" | "lessons";
-};
+export type ContinueLessonProgress = { percentComplete: number };
 
 /**
  * Course and chapter page components can independently ask for chapter-card
@@ -26,16 +27,22 @@ export type ContinueLessonProgress = {
  * server render from issuing duplicate progress queries.
  */
 const cachedCatalogChapterProgress = cache(
-  async (courseId: string, ...excludedLessonKinds: LessonKind[]) =>
-    getChapterProgress({ courseId, excludedLessonKinds }),
+  async (courseId: string, headers: Headers | undefined, ...excludedLessonKinds: LessonKind[]) =>
+    getChapterProgress({ courseId, excludedLessonKinds, headers }),
 );
 
-export function getCatalogChapterProgress(
-  courseId: string,
-  excludedLessonKinds: LessonKind[] = [],
-) {
+export function getCatalogChapterProgress({
+  courseId,
+  excludedLessonKinds = [],
+  headers,
+}: {
+  courseId: string;
+  excludedLessonKinds?: LessonKind[];
+  headers?: Headers;
+}) {
   return cachedCatalogChapterProgress(
     courseId,
+    headers,
     ...getLessonKindExclusionCacheArgs({ excludedLessonKinds }),
   );
 }
@@ -46,16 +53,22 @@ export function getCatalogChapterProgress(
  * boundaries independent without paying for the query twice in one render.
  */
 const cachedCatalogLessonProgress = cache(
-  async (chapterId: string, ...excludedLessonKinds: LessonKind[]) =>
-    getLessonProgress({ chapterId, excludedLessonKinds }),
+  async (chapterId: string, headers: Headers | undefined, ...excludedLessonKinds: LessonKind[]) =>
+    getLessonProgress({ chapterId, excludedLessonKinds, headers }),
 );
 
-export function getCatalogLessonProgress(
-  chapterId: string,
-  excludedLessonKinds: LessonKind[] = [],
-) {
+export function getCatalogLessonProgress({
+  chapterId,
+  excludedLessonKinds = [],
+  headers,
+}: {
+  chapterId: string;
+  excludedLessonKinds?: LessonKind[];
+  headers?: Headers;
+}) {
   return cachedCatalogLessonProgress(
     chapterId,
+    headers,
     ...getLessonKindExclusionCacheArgs({ excludedLessonKinds }),
   );
 }
@@ -69,27 +82,38 @@ export function getCatalogLessonProgress(
 const cachedCourseContinueProgress = cache(
   async (
     courseId: string,
+    headers: Headers | undefined,
     ...excludedLessonKinds: LessonKind[]
-  ): Promise<ContinueLessonProgress> => {
-    const [chapterProgressRows, totalItems] = await Promise.all([
-      cachedCatalogChapterProgress(courseId, ...excludedLessonKinds),
-      countPublishedCourseChapters(courseId),
+  ): Promise<ContinueLessonProgress | null> => {
+    const [chapterProgressRows, chapters] = await Promise.all([
+      cachedCatalogChapterProgress(courseId, headers, ...excludedLessonKinds),
+      listPublishedCourseChaptersForProgress({ courseId }),
     ]);
 
-    return {
-      completedItems: countCompletedChapterProgressRows({ rows: chapterProgressRows }),
-      totalItems,
-      unit: "chapters",
-    };
+    const progressRowsByChapterId = new Map(chapterProgressRows.map((row) => [row.chapterId, row]));
+
+    const progressChapters = chapters.map((chapter) =>
+      getCourseContinueProgressChapter({ chapter, progressRowsByChapterId }),
+    );
+
+    return toContinueLessonProgress({
+      percentComplete: calculateCourseContinueProgressPercent({ chapters: progressChapters }),
+    });
   },
 );
 
-export function getCourseContinueProgress(
-  courseId: string,
-  excludedLessonKinds: LessonKind[] = [],
-) {
+export function getCourseContinueProgress({
+  courseId,
+  excludedLessonKinds = [],
+  headers,
+}: {
+  courseId: string;
+  excludedLessonKinds?: LessonKind[];
+  headers?: Headers;
+}) {
   return cachedCourseContinueProgress(
     courseId,
+    headers,
     ...getLessonKindExclusionCacheArgs({ excludedLessonKinds }),
   );
 }
@@ -102,55 +126,88 @@ export function getCourseContinueProgress(
 const cachedChapterContinueProgress = cache(
   async (
     chapterId: string,
+    headers: Headers | undefined,
     ...excludedLessonKinds: LessonKind[]
-  ): Promise<ContinueLessonProgress> => {
+  ): Promise<ContinueLessonProgress | null> => {
     const [progressRows, totalItems] = await Promise.all([
-      cachedCatalogLessonProgress(chapterId, ...excludedLessonKinds),
+      cachedCatalogLessonProgress(chapterId, headers, ...excludedLessonKinds),
       countPublishedChapterLessons({ chapterId, excludedLessonKinds }),
     ]);
 
-    return {
-      completedItems: progressRows.filter((row) => row.isCompleted).length,
-      totalItems,
-      unit: "lessons",
-    };
+    return toContinueLessonProgress({
+      percentComplete: calculateProgressPercent({
+        completedItems: progressRows.filter((row) => row.isCompleted).length,
+        totalItems,
+      }),
+    });
   },
 );
 
-export function getChapterContinueProgress(
-  chapterId: string,
-  excludedLessonKinds: LessonKind[] = [],
-) {
+export function getChapterContinueProgress({
+  chapterId,
+  excludedLessonKinds = [],
+  headers,
+}: {
+  chapterId: string;
+  excludedLessonKinds?: LessonKind[];
+  headers?: Headers;
+}) {
   return cachedChapterContinueProgress(
     chapterId,
+    headers,
     ...getLessonKindExclusionCacheArgs({ excludedLessonKinds }),
   );
 }
 
 /**
- * Empty chapters should not count as completed just because there are no
- * visible lessons left after filtering. They stay at zero progress until the
- * course has at least one visible completed lesson in that chapter.
+ * The UI only needs a visible percentage. Returning null lets callers keep the
+ * existing no-progress fallback when there is no useful denominator.
  */
-function countCompletedChapterProgressRows({
-  rows,
+function toContinueLessonProgress({
+  percentComplete,
 }: {
-  rows: Awaited<ReturnType<typeof getCatalogChapterProgress>>;
-}) {
-  return rows.filter((row) => row.totalLessons > 0 && row.completedLessons >= row.totalLessons)
-    .length;
+  percentComplete: number | null;
+}): ContinueLessonProgress | null {
+  if (percentComplete === null) {
+    return null;
+  }
+
+  return { percentComplete };
 }
 
 /**
- * Course progress needs the visible chapter total even when none of those
- * chapters have generated lesson content yet.
+ * Course estimates need chapter generation status in addition to the lesson
+ * progress rows, because pending chapters may not have lesson rows yet.
  */
-async function countPublishedCourseChapters(courseId: string) {
+async function listPublishedCourseChaptersForProgress({ courseId }: { courseId: string }) {
   const { data } = await safeAsync(() =>
-    prisma.chapter.count({ where: getPublishedChapterWhere({ chapterWhere: { courseId } }) }),
+    prisma.chapter.findMany({
+      orderBy: { position: "asc" },
+      where: getPublishedChapterWhere({ chapterWhere: { courseId } }),
+    }),
   );
 
-  return data ?? 0;
+  return data ?? [];
+}
+
+/**
+ * The course estimate consumes one row per published chapter, so chapters with
+ * no visible lessons still contribute their generation status and zero counts.
+ */
+function getCourseContinueProgressChapter({
+  chapter,
+  progressRowsByChapterId,
+}: {
+  chapter: Awaited<ReturnType<typeof listPublishedCourseChaptersForProgress>>[number];
+  progressRowsByChapterId: Map<string, { completedLessons: number; totalLessons: number }>;
+}): CourseContinueProgressChapter {
+  const progress = progressRowsByChapterId.get(chapter.id);
+
+  return {
+    completedLessons: progress?.completedLessons ?? 0,
+    generationStatus: chapter.generationStatus,
+    totalLessons: progress?.totalLessons ?? 0,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- show continue CTA progress as percentages instead of fractions
- estimate course progress when future chapters are not generated yet
- add catalog progress data coverage for exported progress helpers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show continue progress as percentages instead of fractions, with clear ARIA text like “33% complete.” Course progress now estimates totals when later chapters aren’t generated yet.

- New Features
  - Continue CTA shows “{percent}% complete” (en/es/pt) and hides the suffix when no denominator exists.
  - Course percent is estimated from generated chapter sizes until all chapters are generated; clamps partial progress to 1–99% and shows 100% only when fully complete.
  - Added `calculateProgressPercent` and course estimation utils with unit tests; expanded catalog progress tests; updated E2E to assert percent-based labels.

- Migration
  - `ContinueLessonProgress` now returns `{ percentComplete: number }`.
  - API changes (object args; optional `headers`; `excludedLessonKinds` renamed):
    - `getCatalogLessonProgress({ chapterId, excludedLessonKinds, headers })`
    - `getCatalogChapterProgress({ courseId, excludedLessonKinds, headers })`
    - `getChapterContinueProgress({ chapterId, excludedLessonKinds, headers })`
    - `getCourseContinueProgress({ courseId, excludedLessonKinds, headers })`

<sup>Written for commit 841c2cae23e034506062de34048ea4b30edf3ff1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

