### PR TITLE
feat(player): limit language sentence lessons

### DIFF
--- a/packages/core/src/player/commands/submit-player-completion.test.ts
+++ b/packages/core/src/player/commands/submit-player-completion.test.ts
@@ -4,6 +4,7 @@ import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { chapterSentenceFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { describe, expect, it } from "vitest";
@@ -14,6 +15,7 @@ const TEST_SECONDS_PER_MINUTE = 60;
 const TEST_COMPLETION_CAP_MINUTES = 30;
 const TEST_COMPLETION_CAP_SECONDS = TEST_COMPLETION_CAP_MINUTES * TEST_SECONDS_PER_MINUTE;
 
+const LANGUAGE_SENTENCE_STEP_LIMIT = 6;
 const REVIEW_TARGET_STEP_COUNT = 10;
 const REVIEW_SUBMITTED_STEP_COUNT = REVIEW_TARGET_STEP_COUNT + 1;
 
@@ -23,6 +25,9 @@ type CompletableLessonVisibility = {
   lessonIsPublished?: boolean;
   organizationKind?: string;
 };
+
+type LanguageSentenceCompletionStep = { answerText: string; id: string };
+type LanguageSentenceLessonKind = "listening" | "reading";
 
 const inaccessibleLessonCases: { name: string; visibility: CompletableLessonVisibility }[] = [
   { name: "course", visibility: { courseIsPublished: false } },
@@ -122,6 +127,107 @@ async function createTwoStepMultipleChoiceLesson(params: {
   );
 
   return { lesson, steps };
+}
+
+/**
+ * Reading and listening lessons can store a larger generated sentence bank than
+ * the player shows in one run. This fixture creates independently valid
+ * sentence-backed steps so completion tests can prove the server accepts the
+ * six-step player subset without accepting too few answers.
+ */
+async function createLanguageSentenceLesson(params: {
+  chapterId: string;
+  kind: LanguageSentenceLessonKind;
+  organizationId: string;
+  stepCount: number;
+}) {
+  const lesson = await lessonFixture({
+    chapterId: params.chapterId,
+    isPublished: true,
+    kind: params.kind,
+    organizationId: params.organizationId,
+    position: 0,
+  });
+
+  const steps = await Promise.all(
+    Array.from({ length: params.stepCount }, (_, position) =>
+      createLanguageSentenceStep({
+        chapterId: params.chapterId,
+        kind: params.kind,
+        lessonId: lesson.id,
+        organizationId: params.organizationId,
+        position,
+      }),
+    ),
+  );
+
+  return { lesson, steps };
+}
+
+/**
+ * Server validation checks reading against the target-language sentence and
+ * listening against the learner-language translation. Returning the exact
+ * answer text with the step id lets forged completion payloads answer each
+ * step correctly without depending on player UI code.
+ */
+async function createLanguageSentenceStep(params: {
+  chapterId: string;
+  kind: LanguageSentenceLessonKind;
+  lessonId: string;
+  organizationId: string;
+  position: number;
+}): Promise<LanguageSentenceCompletionStep> {
+  const sentenceText = `word${params.position}`;
+  const translationText = `translation${params.position}`;
+
+  const sentence = await sentenceFixture({
+    organizationId: params.organizationId,
+    sentence: sentenceText,
+  });
+
+  const chapterSentence = await chapterSentenceFixture({
+    chapterId: params.chapterId,
+    sentenceId: sentence.id,
+    sourceLessonId: params.lessonId,
+    translation: translationText,
+  });
+
+  const step = await stepFixture({
+    chapterSentenceId: chapterSentence.id,
+    content: {},
+    isPublished: true,
+    kind: params.kind,
+    lessonId: params.lessonId,
+    position: params.position,
+    sentenceId: sentence.id,
+  });
+
+  return {
+    answerText: getLanguageSentenceAnswerText({ kind: params.kind, sentenceText, translationText }),
+    id: step.id,
+  };
+}
+
+/**
+ * Reading asks the learner to reconstruct the target sentence, while listening
+ * asks them to reconstruct its learner-language translation from audio. Keeping
+ * this distinction explicit prevents listening tests from accidentally reusing
+ * reading's answer text.
+ */
+function getLanguageSentenceAnswerText({
+  kind,
+  sentenceText,
+  translationText,
+}: {
+  kind: LanguageSentenceLessonKind;
+  sentenceText: string;
+  translationText: string;
+}): string {
+  if (kind === "reading") {
+    return sentenceText;
+  }
+
+  return translationText;
 }
 
 /**
@@ -262,6 +368,65 @@ function buildCompletionInputForSteps(params: {
       params.stepIds.map((stepId) => buildStepTimingEntry({ startedAt, stepId })),
     ),
   };
+}
+
+/**
+ * Reading and listening completion payloads use arranged words rather than
+ * option ids, so this keeps the sentence-cap tests focused on answer coverage
+ * instead of multiple-choice fixture assumptions.
+ */
+function buildLanguageSentenceCompletionInput(params: {
+  kind: LanguageSentenceLessonKind;
+  lessonId: string;
+  startedAt?: number;
+  steps: LanguageSentenceCompletionStep[];
+}): CompletionInput {
+  const startedAt = params.startedAt ?? Date.now() - 10_000;
+
+  return {
+    answers: Object.fromEntries(
+      params.steps.map((step) => buildLanguageSentenceAnswerEntry({ kind: params.kind, step })),
+    ),
+    lessonId: params.lessonId,
+    localDate: todayLocalDate(),
+    startedAt,
+    stepTimings: Object.fromEntries(
+      params.steps.map((step) => buildStepTimingEntry({ startedAt, stepId: step.id })),
+    ),
+  };
+}
+
+/**
+ * The fixture answer text is a single token, so the correct sentence-bank
+ * answer is the one-word arrangement containing that exact text.
+ */
+function buildLanguageSentenceAnswerEntry({
+  kind,
+  step,
+}: {
+  kind: LanguageSentenceLessonKind;
+  step: LanguageSentenceCompletionStep;
+}): [string, CompletionInput["answers"][string]] {
+  return [step.id, buildLanguageSentenceAnswer({ kind, step })];
+}
+
+/**
+ * Returning concrete discriminated-union members keeps the completion input
+ * typed exactly like the player submission instead of relying on a widened
+ * `reading | listening` kind.
+ */
+function buildLanguageSentenceAnswer({
+  kind,
+  step,
+}: {
+  kind: LanguageSentenceLessonKind;
+  step: LanguageSentenceCompletionStep;
+}): CompletionInput["answers"][string] {
+  if (kind === "reading") {
+    return { arrangedWords: [step.answerText], kind: "reading" };
+  }
+
+  return { arrangedWords: [step.answerText], kind: "listening" };
 }
 
 /**
@@ -521,6 +686,125 @@ describe(submitPlayerCompletion, () => {
     expect(writes.lessonProgress).toBeNull();
     expect(writes.stepAttempts).toHaveLength(0);
     expect(writes.userProgress).toBeNull();
+  });
+
+  it("persists reading completion when the six visible sentence answers are submitted", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, steps } = await createLanguageSentenceLesson({
+      chapterId: chapter.id,
+      kind: "reading",
+      organizationId: organization.id,
+      stepCount: LANGUAGE_SENTENCE_STEP_LIMIT + 2,
+    });
+
+    const visibleSteps = steps.slice(0, LANGUAGE_SENTENCE_STEP_LIMIT);
+
+    await submitPlayerCompletion({
+      input: buildLanguageSentenceCompletionInput({
+        kind: "reading",
+        lessonId: lesson.id,
+        steps: visibleSteps,
+      }),
+      userId: user.id,
+    });
+
+    const [lessonProgress, stepAttempts] = await Promise.all([
+      prisma.lessonProgress.findUnique({
+        where: { userLesson: { lessonId: lesson.id, userId: user.id } },
+      }),
+      prisma.stepAttempt.findMany({
+        where: { stepId: { in: steps.map((step) => step.id) }, userId: user.id },
+      }),
+    ]);
+
+    expect(lessonProgress?.completedAt).toBeInstanceOf(Date);
+    expect(stepAttempts).toHaveLength(LANGUAGE_SENTENCE_STEP_LIMIT);
+
+    expect(new Set(stepAttempts.map((attempt) => attempt.stepId))).toStrictEqual(
+      new Set(visibleSteps.map((step) => step.id)),
+    );
+  });
+
+  it("persists listening completion when the six visible translated sentence answers are submitted", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, steps } = await createLanguageSentenceLesson({
+      chapterId: chapter.id,
+      kind: "listening",
+      organizationId: organization.id,
+      stepCount: LANGUAGE_SENTENCE_STEP_LIMIT + 2,
+    });
+
+    const visibleSteps = steps.slice(0, LANGUAGE_SENTENCE_STEP_LIMIT);
+
+    await submitPlayerCompletion({
+      input: buildLanguageSentenceCompletionInput({
+        kind: "listening",
+        lessonId: lesson.id,
+        steps: visibleSteps,
+      }),
+      userId: user.id,
+    });
+
+    const [lessonProgress, stepAttempts] = await Promise.all([
+      prisma.lessonProgress.findUnique({
+        where: { userLesson: { lessonId: lesson.id, userId: user.id } },
+      }),
+      prisma.stepAttempt.findMany({
+        where: { stepId: { in: steps.map((step) => step.id) }, userId: user.id },
+      }),
+    ]);
+
+    expect(lessonProgress?.completedAt).toBeInstanceOf(Date);
+    expect(stepAttempts).toHaveLength(LANGUAGE_SENTENCE_STEP_LIMIT);
+
+    expect(new Set(stepAttempts.map((attempt) => attempt.stepId))).toStrictEqual(
+      new Set(visibleSteps.map((step) => step.id)),
+    );
+  });
+
+  it("rejects reading completion when fewer than six visible sentence answers are submitted", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, steps } = await createLanguageSentenceLesson({
+      chapterId: chapter.id,
+      kind: "reading",
+      organizationId: organization.id,
+      stepCount: LANGUAGE_SENTENCE_STEP_LIMIT + 2,
+    });
+
+    const partialSteps = steps.slice(0, LANGUAGE_SENTENCE_STEP_LIMIT - 1);
+
+    await submitPlayerCompletion({
+      input: buildLanguageSentenceCompletionInput({
+        kind: "reading",
+        lessonId: lesson.id,
+        steps: partialSteps,
+      }),
+      userId: user.id,
+    });
+
+    const [lessonProgress, stepAttempts] = await Promise.all([
+      prisma.lessonProgress.findUnique({
+        where: { userLesson: { lessonId: lesson.id, userId: user.id } },
+      }),
+      prisma.stepAttempt.findMany({
+        where: { stepId: { in: steps.map((step) => step.id) }, userId: user.id },
+      }),
+    ]);
+
+    expect(lessonProgress).toBeNull();
+    expect(stepAttempts).toHaveLength(0);
   });
 
   it("persists completion when every interactive answer is present but incorrect", async () => {

--- a/packages/core/src/player/commands/submit-player-completion.ts
+++ b/packages/core/src/player/commands/submit-player-completion.ts
@@ -1,11 +1,15 @@
 import "server-only";
-import { type StepKind, prisma } from "@zoonk/db";
+import { type LessonKind, type StepKind, prisma } from "@zoonk/db";
 import {
   getCappedLessonDurationSeconds,
   getCappedStepAttemptDurationSeconds,
 } from "../contracts/completion-duration";
 import { type CompletionInput } from "../contracts/completion-input-schema";
 import { computeLessonScore } from "../contracts/compute-score";
+import {
+  getExpectedPlayerAnswerCount,
+  isLimitedLanguageSentenceLesson,
+} from "../contracts/playable-lesson-steps";
 import { countAnswerableSteps, validateAnswers } from "../contracts/validate-answers";
 import { getReviewValidationData } from "../queries/get-review-steps";
 import { getCompletableLessonWhere } from "./_utils/completable-lesson";
@@ -20,6 +24,8 @@ type StepWithSentence = {
   word: { id: string } | null;
   sentence: { id: string; sentence: string } | null;
 };
+
+type RegularLessonValidationData = { expectedStepCount: number; steps: StepWithSentence[] };
 
 /**
  * Attaches chapter-scoped sentence translation data to steps.
@@ -56,6 +62,55 @@ function hasCompleteAnswerCoverage(params: {
 }
 
 /**
+ * Reading and listening players submit only the shuffled sentence subset they
+ * showed, while older or forged clients can still submit more step ids from the
+ * stored bank. Filtering to submitted lesson steps and capping at the visible
+ * answer count lets valid six-step sessions complete without weakening the
+ * all-answers requirement for other lesson kinds.
+ */
+function getSubmittedLimitedLanguageSteps({
+  expectedStepCount,
+  steps,
+  submittedStepIds,
+}: {
+  expectedStepCount: number;
+  steps: StepWithSentence[];
+  submittedStepIds: Set<string>;
+}): StepWithSentence[] {
+  return steps.filter((step) => submittedStepIds.has(step.id)).slice(0, expectedStepCount);
+}
+
+/**
+ * Normal lessons validate against their full stored step list, but reading and
+ * listening lessons are now sentence-bank sessions. This helper keeps the
+ * server's required answer count aligned with the player payload selection
+ * without applying the cap to quizzes, practice, review, or static lessons.
+ */
+function getRegularLessonValidationData({
+  lessonKind,
+  steps,
+  submittedStepIds,
+}: {
+  lessonKind: LessonKind;
+  steps: StepWithSentence[];
+  submittedStepIds: Set<string>;
+}): RegularLessonValidationData {
+  const expectedStepCount = getExpectedPlayerAnswerCount({
+    answerableStepCount: countAnswerableSteps(steps),
+    lessonKind,
+  });
+
+  if (!isLimitedLanguageSentenceLesson(lessonKind)) {
+    return { expectedStepCount, steps };
+  }
+
+  return {
+    expectedStepCount,
+    steps: getSubmittedLimitedLanguageSteps({ expectedStepCount, steps, submittedStepIds }),
+  };
+}
+
+/**
  * The app shell should only orchestrate request-specific concerns such as auth,
  * cache revalidation, and background execution. This command owns the shared
  * completion workflow: validate the submission and persist authoritative
@@ -83,13 +138,16 @@ export async function submitPlayerCompletion(params: {
     return;
   }
 
+  const submittedStepIds = new Set(Object.keys(params.input.answers));
+
   const validationData =
     lesson.kind === "review"
-      ? await getReviewValidationData({
-          lessonId: lesson.id,
-          stepIds: Object.keys(params.input.answers),
-        })
-      : { expectedStepCount: countAnswerableSteps(lesson.steps), steps: lesson.steps };
+      ? await getReviewValidationData({ lessonId: lesson.id, stepIds: [...submittedStepIds] })
+      : getRegularLessonValidationData({
+          lessonKind: lesson.kind,
+          steps: lesson.steps,
+          submittedStepIds,
+        });
 
   const rawStepsForValidation = validationData.steps;
 

--- a/packages/core/src/player/contracts/playable-lesson-steps.ts
+++ b/packages/core/src/player/contracts/playable-lesson-steps.ts
@@ -1,0 +1,55 @@
+import { type LessonKind } from "@zoonk/db";
+import { shuffle } from "@zoonk/utils/shuffle";
+
+const LANGUAGE_SENTENCE_STEP_LIMIT = 6;
+
+/**
+ * Reading and listening lessons are generated as reusable sentence banks, but
+ * one player run should feel like a short practice session instead of exposing
+ * every stored sentence. Keeping the kind check in one helper lets the payload
+ * serializer and completion validator agree on which lessons use the sentence
+ * bank cap.
+ */
+export function isLimitedLanguageSentenceLesson(kind: LessonKind): boolean {
+  return kind === "reading" || kind === "listening";
+}
+
+/**
+ * Chooses the steps that one player session should show. The database can keep
+ * more generated sentence steps for reuse, while the player receives a shuffled
+ * six-step slice for reading and listening lessons only. Other lesson kinds
+ * keep their full ordered step list because their steps are authored as one
+ * complete lesson flow.
+ */
+export function getPlayableLessonSteps<Step>({
+  lesson,
+}: {
+  lesson: { kind: LessonKind; steps: readonly Step[] };
+}): Step[] {
+  if (!isLimitedLanguageSentenceLesson(lesson.kind)) {
+    return [...lesson.steps];
+  }
+
+  return shuffle(lesson.steps).slice(0, LANGUAGE_SENTENCE_STEP_LIMIT);
+}
+
+/**
+ * Completion validation still needs a server-side answer count, because the
+ * browser only submits answers for the steps it showed. Reading and listening
+ * lessons should require the same capped number the serializer can expose,
+ * while shorter banks and all other lesson kinds keep their natural required
+ * answer count.
+ */
+export function getExpectedPlayerAnswerCount({
+  answerableStepCount,
+  lessonKind,
+}: {
+  answerableStepCount: number;
+  lessonKind: LessonKind;
+}): number {
+  if (!isLimitedLanguageSentenceLesson(lessonKind)) {
+    return answerableStepCount;
+  }
+
+  return Math.min(answerableStepCount, LANGUAGE_SENTENCE_STEP_LIMIT);
+}

--- a/packages/core/src/player/contracts/prepare-lesson-data.test.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.test.ts
@@ -5,6 +5,8 @@ import { preparePlayerLessonData } from "./prepare-lesson-data";
 
 vi.mock("@zoonk/utils/shuffle", () => ({ shuffle: vi.fn(<T>(items: T[]) => items) }));
 
+const LANGUAGE_SENTENCE_STEP_LIMIT = 6;
+
 type PreparePlayerLessonInput = Parameters<typeof preparePlayerLessonData>[0];
 type LessonInput = PreparePlayerLessonInput["lesson"];
 type RawStep = LessonInput["steps"][number];
@@ -612,6 +614,63 @@ describe(preparePlayerLessonData, () => {
     const selectImageContent = parseStepContent("selectImage", selectImageStep.content);
 
     expect(selectImageContent.options.map(({ id }) => id)).toStrictEqual(["image-2", "image-1"]);
+  });
+
+  it("shuffles and caps reading lesson steps during serialization", () => {
+    shuffleMock.mockImplementationOnce((items) => items.toReversed());
+
+    const steps = Array.from({ length: LANGUAGE_SENTENCE_STEP_LIMIT + 2 }, (_, index) =>
+      makeStep({ id: String(index + 1), kind: "reading", position: index }),
+    );
+
+    const result = prepare({ lesson: makeLesson(steps, { kind: "reading" }) });
+
+    expect(result.steps.map((step) => step.id)).toStrictEqual(
+      steps
+        .toReversed()
+        .slice(0, LANGUAGE_SENTENCE_STEP_LIMIT)
+        .map((step) => step.id),
+    );
+  });
+
+  it("shuffles and caps listening lesson steps during serialization", () => {
+    shuffleMock.mockImplementationOnce((items) => items.toReversed());
+
+    const steps = Array.from({ length: LANGUAGE_SENTENCE_STEP_LIMIT + 2 }, (_, index) =>
+      makeStep({ id: String(index + 1), kind: "listening", position: index }),
+    );
+
+    const result = prepare({ lesson: makeLesson(steps, { kind: "listening" }) });
+
+    expect(result.steps.map((step) => step.id)).toStrictEqual(
+      steps
+        .toReversed()
+        .slice(0, LANGUAGE_SENTENCE_STEP_LIMIT)
+        .map((step) => step.id),
+    );
+  });
+
+  it("keeps every step for non-sentence lesson kinds", () => {
+    const steps = Array.from({ length: 8 }, (_, index) =>
+      makeStep({
+        content: { text: `Step ${index + 1}`, title: `Step ${index + 1}`, variant: "text" },
+        id: String(index + 1),
+        position: index,
+      }),
+    );
+
+    const result = prepare({ lesson: makeLesson(steps, { kind: "explanation" }) });
+
+    expect(result.steps.map((step) => step.id)).toStrictEqual([
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+    ]);
   });
 
   it("builds reading and listening word banks from stored distractors only", () => {

--- a/packages/core/src/player/contracts/prepare-lesson-data.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.ts
@@ -23,6 +23,7 @@ import {
   toSentenceWordInputs,
 } from "./_utils/lesson-data-mappers";
 import { buildSentenceWordOptions, buildWordBankOptions } from "./build-word-bank-options";
+import { getPlayableLessonSteps } from "./playable-lesson-steps";
 import {
   type TranslationOption,
   buildDistractorWordLookup,
@@ -325,7 +326,9 @@ function buildSerializedLesson(
  * serialization, shuffling, or derived option building after ids were standardized to UUIDs.
  */
 export function preparePlayerLessonData(params: PreparePlayerLessonInput): SerializedLesson {
-  const steps = params.steps ?? params.lesson.steps;
+  const steps = getPlayableLessonSteps({
+    lesson: { kind: params.lesson.kind, steps: params.steps ?? params.lesson.steps },
+  });
 
   return buildSerializedLesson(
     {


### PR DESCRIPTION
## Summary

Limit reading and listening lesson player sessions to a shuffled six-step slice while keeping the generated sentence bank intact.

Align completion validation so reading and listening submissions are accepted for the visible sentence subset, with coverage for both lesson kinds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit reading and listening lessons to a shuffled six-step run and validate completion against the visible subset. The larger sentence bank stays intact for reuse; all other lesson kinds are unchanged.

- **New Features**
  - Player now shuffles and caps reading/listening steps to six via `getPlayableLessonSteps` in `preparePlayerLessonData`.
  - Server validation uses `getExpectedPlayerAnswerCount` and filters to submitted step ids for these kinds, accepting exactly the six visible answers.
  - Added tests covering acceptance for six submitted sentence answers and rejection when fewer are sent.

<sup>Written for commit 2946827a63f3e07526e84cece103f9ccd316aaeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

