### PR TITLE
feat(main): show yearly subscription savings

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -959,6 +959,10 @@ msgid "NBEnVd"
 msgstr "Compare plans and manage your subscription."
 
 #: src/app/(settings)/subscription/plan-list.tsx
+msgid "PJfdJl"
+msgstr "Save up to {amount}"
+
+#: src/app/(settings)/subscription/plan-list.tsx
 msgid "KAb0Yr"
 msgstr "Switch to {plan}"
 

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -959,6 +959,10 @@ msgid "NBEnVd"
 msgstr "Compara planes y gestiona tu suscripción."
 
 #: src/app/(settings)/subscription/plan-list.tsx
+msgid "PJfdJl"
+msgstr "Ahorra hasta {amount}"
+
+#: src/app/(settings)/subscription/plan-list.tsx
 msgid "KAb0Yr"
 msgstr "Cambiar a {plan}"
 

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -959,6 +959,10 @@ msgid "NBEnVd"
 msgstr "Compare planos e gerencie sua assinatura."
 
 #: src/app/(settings)/subscription/plan-list.tsx
+msgid "PJfdJl"
+msgstr "Economize até {amount}"
+
+#: src/app/(settings)/subscription/plan-list.tsx
 msgid "KAb0Yr"
 msgstr "Mudar para {plan}"
 

--- a/apps/main/src/app/(settings)/subscription/_utils/billing-savings.test.ts
+++ b/apps/main/src/app/(settings)/subscription/_utils/billing-savings.test.ts
@@ -32,4 +32,19 @@ describe(getLargestYearlySavings, () => {
 
     expect(savings).toBeNull();
   });
+
+  it("does not compare savings amounts across different currencies", () => {
+    const savings = getLargestYearlySavings([
+      {
+        monthlyPrice: { amount: 5000, currency: "brl" },
+        yearlyPrice: { amount: 50_000, currency: "brl" },
+      },
+      {
+        monthlyPrice: { amount: 2000, currency: "usd" },
+        yearlyPrice: { amount: 12_000, currency: "usd" },
+      },
+    ]);
+
+    expect(savings).toStrictEqual({ amount: 10_000, currency: "brl" });
+  });
 });

--- a/apps/main/src/app/(settings)/subscription/_utils/billing-savings.test.ts
+++ b/apps/main/src/app/(settings)/subscription/_utils/billing-savings.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getLargestYearlySavings } from "./billing-savings";
+
+describe(getLargestYearlySavings, () => {
+  it("returns the largest yearly savings across paid plans", () => {
+    const savings = getLargestYearlySavings([
+      {
+        monthlyPrice: { amount: 1000, currency: "usd" },
+        yearlyPrice: { amount: 10_000, currency: "usd" },
+      },
+      {
+        monthlyPrice: { amount: 2000, currency: "usd" },
+        yearlyPrice: { amount: 18_000, currency: "usd" },
+      },
+    ]);
+
+    expect(savings).toStrictEqual({ amount: 6000, currency: "usd" });
+  });
+
+  it("ignores plans that cannot prove a same-currency discount", () => {
+    const savings = getLargestYearlySavings([
+      { monthlyPrice: null, yearlyPrice: null },
+      {
+        monthlyPrice: { amount: 1000, currency: "usd" },
+        yearlyPrice: { amount: 8000, currency: "brl" },
+      },
+      {
+        monthlyPrice: { amount: 1000, currency: "usd" },
+        yearlyPrice: { amount: 12_000, currency: "usd" },
+      },
+    ]);
+
+    expect(savings).toBeNull();
+  });
+});

--- a/apps/main/src/app/(settings)/subscription/_utils/billing-savings.ts
+++ b/apps/main/src/app/(settings)/subscription/_utils/billing-savings.ts
@@ -13,7 +13,17 @@ export function getLargestYearlySavings(plans: PlanPrices[]): PriceInfo | null {
     .map((plan) => getYearlySavings(plan))
     .filter((yearlySavings) => isPriceInfo(yearlySavings));
 
-  return savings.toSorted(compareSavingsDescending)[0] ?? null;
+  const displayCurrency = savings[0]?.currency;
+
+  if (!displayCurrency) {
+    return null;
+  }
+
+  const comparableSavings = savings.filter(
+    (yearlySavings) => yearlySavings.currency === displayCurrency,
+  );
+
+  return comparableSavings.toSorted(compareSavingsDescending)[0] ?? null;
 }
 
 /**

--- a/apps/main/src/app/(settings)/subscription/_utils/billing-savings.ts
+++ b/apps/main/src/app/(settings)/subscription/_utils/billing-savings.ts
@@ -1,0 +1,56 @@
+import { type PriceInfo } from "@zoonk/utils/currency";
+
+type PlanPrices = { monthlyPrice: PriceInfo | null; yearlyPrice: PriceInfo | null };
+
+/**
+ * The yearly tab needs one honest savings claim even though each paid tier has
+ * its own Stripe prices. Showing the largest proven same-currency discount
+ * lets the tab stay compact without implying savings when price data is
+ * missing, mismatched, or not actually discounted.
+ */
+export function getLargestYearlySavings(plans: PlanPrices[]): PriceInfo | null {
+  const savings = plans
+    .map((plan) => getYearlySavings(plan))
+    .filter((yearlySavings) => isPriceInfo(yearlySavings));
+
+  return savings.toSorted(compareSavingsDescending)[0] ?? null;
+}
+
+/**
+ * Stripe can return fallback prices in a different currency than the preferred
+ * locale price. Comparing different currencies would create a fake savings
+ * amount, so this only returns a discount when both prices share a currency.
+ */
+function getYearlySavings({ monthlyPrice, yearlyPrice }: PlanPrices): PriceInfo | null {
+  if (!monthlyPrice || !yearlyPrice) {
+    return null;
+  }
+
+  if (monthlyPrice.currency !== yearlyPrice.currency) {
+    return null;
+  }
+
+  const savedAmount = monthlyPrice.amount * 12 - yearlyPrice.amount;
+
+  if (savedAmount <= 0) {
+    return null;
+  }
+
+  return { amount: savedAmount, currency: yearlyPrice.currency };
+}
+
+/**
+ * This type guard keeps the public helper free to use nullable intermediate
+ * results while still returning a concrete PriceInfo object to the component.
+ */
+function isPriceInfo(value: PriceInfo | null): value is PriceInfo {
+  return value !== null;
+}
+
+/**
+ * Sorting by amount puts the strongest annual-savings claim first, which is
+ * the number shown in the compact yearly-tab badge.
+ */
+function compareSavingsDescending(a: PriceInfo, b: PriceInfo): number {
+  return b.amount - a.amount;
+}

--- a/apps/main/src/app/(settings)/subscription/plan-list.tsx
+++ b/apps/main/src/app/(settings)/subscription/plan-list.tsx
@@ -19,6 +19,7 @@ import { FREE_PLAN, getPlanTier } from "@zoonk/utils/subscription";
 import { Loader2Icon } from "lucide-react";
 import { useExtracted, useLocale } from "next-intl";
 import { useState } from "react";
+import { getLargestYearlySavings } from "./_utils/billing-savings";
 
 type PlanData = {
   annualLookupKey: string | null;
@@ -63,6 +64,13 @@ export function PlanList({
   const isLoading = state === "loading";
   const showCTA = cta.action !== "manage" || currentPlanName !== "free";
   const selectedTitle = titles[selected.name] ?? selected.name;
+  const yearlySavings = getLargestYearlySavings(plans);
+
+  const yearlySavingsLabel = yearlySavings
+    ? t("Save up to {amount}", {
+        amount: formatPrice(yearlySavings.amount, yearlySavings.currency),
+      })
+    : null;
 
   const ctaLabel = {
     cancel: t("Cancel"),
@@ -127,7 +135,15 @@ export function PlanList({
       >
         <TabsList>
           <TabsTrigger value="monthly">{t("Monthly")}</TabsTrigger>
-          <TabsTrigger value="yearly">{t("Yearly")}</TabsTrigger>
+          <TabsTrigger value="yearly">
+            {t("Yearly")}
+
+            {yearlySavingsLabel && (
+              <Badge className="h-4 px-1.5 text-[10px] leading-none" variant="success">
+                {yearlySavingsLabel}
+              </Badge>
+            )}
+          </TabsTrigger>
         </TabsList>
       </Tabs>
 
@@ -203,7 +219,7 @@ function PlanRow({
         </FieldContent>
 
         <div className="flex items-center gap-3">
-          <span className="text-muted-foreground text-sm">{displayPrice}</span>
+          <span className="text-info text-sm font-medium tabular-nums">{displayPrice}</span>
           <RadioGroupItem aria-label={title} id={`plan-${plan.name}`} value={plan.name} />
         </div>
       </Field>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,6 @@
     "./courses/search": "./src/courses/search-courses.ts",
     "./feedback/send": "./src/feedback/send-feedback-message.ts",
     "./images/optimize": "./src/images/optimize-image.ts",
-    "./images/process-and-upload": "./src/images/process-and-upload-image.ts",
     "./images/upload": "./src/images/upload-image.ts",
     "./lessons/access": "./src/lessons/access.ts",
     "./lessons/generated-companion-kinds": "./src/lessons/generated-companion-kinds.ts",

--- a/packages/ui/src/components/badge.tsx
+++ b/packages/ui/src/components/badge.tsx
@@ -17,6 +17,7 @@ const badgeVariants = cva(
         outline:
           "border-border bg-input/30 text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        success: "bg-success/10 text-success [a]:hover:bg-success/20",
       },
     },
   },

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -86,7 +86,7 @@
   --accent: var(--color-neutral-100);
   --accent-foreground: var(--color-neutral-900);
   --destructive: var(--color-pink-600);
-  --info: var(--color-blue-400);
+  --info: var(--color-blue-500);
   --warning: var(--color-amber-600);
   --success: var(--color-emerald-600);
   --border: var(--color-neutral-200);
@@ -178,7 +178,7 @@
     --accent: var(--color-neutral-800);
     --accent-foreground: var(--color-neutral-50);
     --destructive: var(--color-pink-600);
-    --info: var(--color-blue-400);
+    --info: var(--color-blue-300);
     --warning: var(--color-amber-400);
     --success: var(--color-emerald-400);
     --border: var(--color-neutral-700);
@@ -225,7 +225,7 @@
     --accent: var(--color-neutral-700);
     --accent-foreground: var(--color-white);
     --destructive: var(--color-pink-600);
-    --info: var(--color-blue-200);
+    --info: var(--color-blue-100);
     --warning: var(--color-amber-400);
     --success: var(--color-emerald-400);
     --border: var(--color-neutral-50);


### PR DESCRIPTION
## Summary
- Add a yearly savings badge to the subscription billing tabs
- Derive savings from monthly and yearly prices when the discount is provable
- Add a shared success badge variant and update subscription price styling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show yearly subscription savings with a compact “Save up to …” badge on the Yearly tab. Uses verified same-currency price comparisons to avoid misleading discounts and updates badge/price styling.

- **New Features**
  - Show a savings badge in the Yearly tab with the largest provable discount across paid plans.
  - Compute savings only when monthly and yearly prices share a currency, and pick the largest within one currency (no cross-currency comparisons).
  - Add a `success` variant to the `Badge` and improve price display (info color, tabular numerals).

- **Refactors**
  - Introduced `getLargestYearlySavings` utility with tests.
  - Adjusted `--info` color tokens for better contrast and removed the unused `packages/core` export `./images/process-and-upload`.

<sup>Written for commit 0dae126f39d621c073e936647e370326e41fd4c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

