### PR TITLE
chore(db): update course mode enum

### DIFF
--- a/apps/main/src/data/courses/get-continue-learning.test.ts
+++ b/apps/main/src/data/courses/get-continue-learning.test.ts
@@ -466,7 +466,7 @@ describe("authenticated users", () => {
 
     const course = await courseFixture({
       isPublished: true,
-      mode: "quickLesson",
+      mode: "quick",
       organizationId: null,
       userId: user.id,
     });

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -37,10 +37,11 @@ enum StepKind {
 }
 
 enum CourseMode {
+  exam
   full
-  quickLesson  @map("quick_lesson")
+  overview
   personalized
-  examPrep     @map("exam_prep")
+  quick
 }
 
 enum SubscriptionProvider {

--- a/packages/db/src/prisma/migrations/20260616170301_update_course_mode_enum/migration.sql
+++ b/packages/db/src/prisma/migrations/20260616170301_update_course_mode_enum/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The values [quick_lesson,exam_prep] on the enum `CourseMode` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "CourseMode_new" AS ENUM ('exam', 'full', 'overview', 'personalized', 'quick');
+ALTER TABLE "public"."courses" ALTER COLUMN "mode" DROP DEFAULT;
+ALTER TABLE "courses" ALTER COLUMN "mode" TYPE "CourseMode_new" USING ("mode"::text::"CourseMode_new");
+ALTER TYPE "CourseMode" RENAME TO "CourseMode_old";
+ALTER TYPE "CourseMode_new" RENAME TO "CourseMode";
+DROP TYPE "public"."CourseMode_old";
+ALTER TABLE "courses" ALTER COLUMN "mode" SET DEFAULT 'full';
+COMMIT;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the `CourseMode` enum to match current product modes. Added `exam` and `overview`, replaced `quickLesson` with `quick`, removed legacy DB values, and set default to `full`.

- **Migration**
  - Update app references and tests: `CourseMode.quickLesson` -> `CourseMode.quick`, `CourseMode.examPrep` -> `CourseMode.exam`.
  - Remap existing rows before migrating:
    - UPDATE courses SET mode = 'quick' WHERE mode = 'quick_lesson';
    - UPDATE courses SET mode = 'exam' WHERE mode = 'exam_prep';

<sup>Written for commit 6caedbc963309a98fd5502cda7d33a21e765a5d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

