### PR TITLE
feat(main): update home hero copy

### DIFF
--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -128,7 +128,7 @@ test.describe("Command Palette - Unauthenticated", () => {
       .click();
 
     // Verify user sees home page content
-    await expect(page.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
   });
 
   test("selecting Courses shows courses content", async ({ page }) => {
@@ -265,7 +265,7 @@ test.describe("Command Palette - Course Search", () => {
     });
 
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
     await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
@@ -487,7 +487,7 @@ test.describe("Command Palette - Keyboard Navigation", () => {
     await page.keyboard.press("Enter");
 
     // Verify user sees home page content
-    await expect(page.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
   });
 
   test("focus trap within dialog", async ({ page }) => {

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -16,17 +16,17 @@ test.describe("Home Page - Unauthenticated", () => {
 
     const hero = page.getByRole("main");
 
-    await expect(hero.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
+    await expect(hero.getByRole("heading", { name: /change your life/iu })).toBeVisible();
 
-    const exploreCoursesLink = hero.getByRole("link", { name: "Explore courses" });
+    const startFreeLink = hero.getByRole("link", { name: "Start free" });
 
-    await expect(exploreCoursesLink).toHaveAttribute("href", "/courses");
+    await expect(startFreeLink).toHaveAttribute("href", "/learn");
 
     await expect(
       hero.getByRole("link", { name: "Log in to save your progress" }),
     ).not.toBeVisible();
 
-    await hero.getByRole("link", { exact: true, name: "Create a course with AI" }).click();
+    await startFreeLink.click();
 
     await expect(page).toHaveURL(/\/learn$/u);
     await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();
@@ -127,7 +127,7 @@ test.describe("Home Page - Authenticated", () => {
     ).toBeVisible();
 
     await expect(
-      authenticatedPage.getByRole("heading", { name: /learn anything with ai/iu }),
+      authenticatedPage.getByRole("heading", { name: /change your life/iu }),
     ).not.toBeVisible();
   });
 
@@ -137,10 +137,10 @@ test.describe("Home Page - Authenticated", () => {
     await expect(userWithoutProgress.getByText(/continue learning/iu)).not.toBeVisible();
 
     await expect(
-      userWithoutProgress.getByRole("heading", { name: /learn anything with ai/iu }),
+      userWithoutProgress.getByRole("heading", { name: /change your life/iu }),
     ).toBeVisible();
 
-    await expect(userWithoutProgress.getByRole("link", { name: "Explore courses" })).toBeVisible();
+    await expect(userWithoutProgress.getByRole("link", { name: "Start free" })).toBeVisible();
 
     await expect(
       userWithoutProgress.getByRole("link", { name: "Log in to save your progress" }),

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -213,7 +213,7 @@ test.describe("Home Page - Authenticated", () => {
 
     await expect(page.getByRole("heading", { name: /continue learning/iu }).first()).toBeVisible();
 
-    await expect(page.getByRole("heading", { name: /learn anything with ai/iu })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: /change your life/iu })).not.toBeVisible();
 
     await expect(
       page.getByRole("link", { name: new RegExp(`Next:.*E2E Pending Lesson ${uniqueId}`, "u") }),

--- a/apps/main/e2e/locale.test.ts
+++ b/apps/main/e2e/locale.test.ts
@@ -13,7 +13,7 @@ test.describe("Locale Behavior - English", () => {
     await expect(nav.getByRole("link", { exact: true, name: "Learn" })).toBeVisible();
 
     // Hero heading should be in English
-    await expect(page.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
   });
 });
 
@@ -25,9 +25,7 @@ test.describe("Locale Behavior - Portuguese", () => {
     const nav = page.getByRole("navigation");
 
     // Wait for Portuguese hero heading to confirm locale is loaded
-    await expect(
-      page.getByRole("heading", { name: /aprenda qualquer coisa com ia/iu }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: /mude de vida/iu })).toBeVisible();
 
     // Navbar should be in Portuguese (scoped to navigation to avoid hero links)
     await expect(nav.getByRole("link", { exact: true, name: "Cursos" })).toBeVisible();

--- a/apps/main/e2e/navbar.test.ts
+++ b/apps/main/e2e/navbar.test.ts
@@ -8,12 +8,12 @@ test.describe("Navbar - Unauthenticated", () => {
     // Scope to navigation to avoid conflicts with links in main content
     await page.getByRole("navigation").getByRole("link", { name: /home/iu }).click();
 
-    await expect(page.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
   });
 
   test("Courses link navigates to courses page", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
 
     // Scope to navigation to avoid conflicts with "Explore courses" in hero
     await page.getByRole("navigation").getByRole("link", { exact: true, name: "Courses" }).click();
@@ -23,7 +23,7 @@ test.describe("Navbar - Unauthenticated", () => {
 
   test("Learn link navigates to learn page", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
 
     // Scope to navigation to avoid conflicts with "Learn anything" in hero
     await page.getByRole("navigation").getByRole("link", { exact: true, name: "Learn" }).click();

--- a/apps/main/e2e/settings-navbar.test.ts
+++ b/apps/main/e2e/settings-navbar.test.ts
@@ -5,7 +5,7 @@ test.describe("Settings Navbar", () => {
     await page.goto("/subscription");
     await page.getByRole("link", { name: /home page/iu }).click();
 
-    await expect(page.getByRole("heading", { name: /learn anything with ai/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
   });
 
   test("displays all settings navigation pills", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -210,22 +210,20 @@ msgid "C7ROJx"
 msgstr "Your energy is {value}%"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "qvmpye"
-msgstr "Learn anything with AI"
+msgid "FQFGyy"
+msgstr "Change your life"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "VcxnWX"
-msgstr "Interactive courses built for you. Just tell us what you want to learn."
+msgid "XgGQQP"
+msgstr "Pass your exams, learn a language, build skills, and land your dream job. Zoonk helps you change your life."
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "jHCDDq"
-msgstr "Create a course with AI"
+msgid "i7IHHZ"
+msgstr "Start free"
 
 #: src/app/(catalog)/(home)/hero.tsx
-#: src/app/(catalog)/courses/page.tsx
-#: src/app/(catalog)/my/user-course-list.tsx
-msgid "s-Ncqj"
-msgstr "Explore courses"
+msgid "pjKGpc"
+msgstr "No credit card required. No commitment."
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
@@ -407,6 +405,11 @@ msgstr "Explore all Zoonk courses to learn anything using AI. Find interactive l
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
 msgstr "Online Courses using AI"
+
+#: src/app/(catalog)/courses/page.tsx
+#: src/app/(catalog)/my/user-course-list.tsx
+msgid "s-Ncqj"
+msgstr "Explore courses"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -210,22 +210,20 @@ msgid "C7ROJx"
 msgstr "Tu energía es {value}%"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "qvmpye"
-msgstr "Aprende cualquier cosa con IA"
+msgid "FQFGyy"
+msgstr "Cambia tu vida"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "VcxnWX"
-msgstr "Cursos interactivos creados para ti. Solo dinos qué quieres aprender."
+msgid "XgGQQP"
+msgstr "Aprueba tus exámenes, aprende un idioma, desarrolla habilidades y consigue el trabajo de tus sueños. Zoonk te ayuda a cambiar tu vida."
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "jHCDDq"
-msgstr "Crear un curso con IA"
+msgid "i7IHHZ"
+msgstr "Prueba gratis"
 
 #: src/app/(catalog)/(home)/hero.tsx
-#: src/app/(catalog)/courses/page.tsx
-#: src/app/(catalog)/my/user-course-list.tsx
-msgid "s-Ncqj"
-msgstr "Explorar cursos"
+msgid "pjKGpc"
+msgstr "No necesitas tarjeta de crédito. Sin compromiso."
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
@@ -407,6 +405,11 @@ msgstr "Explora todos los cursos de Zoonk para aprender cualquier cosa usando IA
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
 msgstr "Cursos en línea con IA"
+
+#: src/app/(catalog)/courses/page.tsx
+#: src/app/(catalog)/my/user-course-list.tsx
+msgid "s-Ncqj"
+msgstr "Explorar cursos"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -210,22 +210,20 @@ msgid "C7ROJx"
 msgstr "Sua energia está em {value}%"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "qvmpye"
-msgstr "Aprenda qualquer coisa com IA"
+msgid "FQFGyy"
+msgstr "Mude de vida"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "VcxnWX"
-msgstr "Cursos interativos criados para você. Apenas nos diga o que você quer aprender."
+msgid "XgGQQP"
+msgstr "Passe no concurso, aprenda um idioma, desenvolva habilidades e conquiste o trabalho dos sonhos. O Zoonk te ajuda a mudar de vida."
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "jHCDDq"
-msgstr "Criar um curso com IA"
+msgid "i7IHHZ"
+msgstr "Teste grátis"
 
 #: src/app/(catalog)/(home)/hero.tsx
-#: src/app/(catalog)/courses/page.tsx
-#: src/app/(catalog)/my/user-course-list.tsx
-msgid "s-Ncqj"
-msgstr "Explorar cursos"
+msgid "pjKGpc"
+msgstr "Não precisa de cartão de crédito. Sem compromisso."
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
@@ -407,6 +405,11 @@ msgstr "Explore todos os cursos do Zoonk para aprender qualquer coisa usando IA.
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
 msgstr "Cursos online usando IA"
+
+#: src/app/(catalog)/courses/page.tsx
+#: src/app/(catalog)/my/user-course-list.tsx
+msgid "s-Ncqj"
+msgstr "Explorar cursos"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"

--- a/apps/main/src/app/(catalog)/(home)/hero.tsx
+++ b/apps/main/src/app/(catalog)/(home)/hero.tsx
@@ -1,12 +1,12 @@
 import { buttonVariants } from "@zoonk/ui/components/button";
-import { ArrowRightIcon, SparklesIcon } from "lucide-react";
+import { SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 import { HeroTracker } from "./hero-tracker";
 
 /**
- * Shows the zero-progress home state with one action for creating a new course
- * and one action for browsing existing courses.
+ * Shows the zero-progress home state for people who need a concrete reason to
+ * start learning before they understand how Zoonk creates personalized courses.
  */
 export async function Hero() {
   const t = await getExtracted();
@@ -17,32 +17,29 @@ export async function Hero() {
 
       <div className="flex flex-col items-center gap-4 text-center">
         <h1 className="text-foreground/90 text-3xl font-semibold tracking-tight text-balance md:text-5xl md:tracking-tighter">
-          {t("Learn anything with AI")}
+          {t("Change your life")}
         </h1>
 
-        <p className="text-muted-foreground max-w-md text-lg text-pretty md:text-xl">
-          {t("Interactive courses built for you. Just tell us what you want to learn.")}
+        <p className="text-muted-foreground text-lg text-balance md:text-xl">
+          {t(
+            "Pass your exams, learn a language, build skills, and land your dream job. Zoonk helps you change your life.",
+          )}
         </p>
       </div>
 
-      <div className="flex flex-col gap-3 sm:flex-row sm:gap-4">
+      <div className="flex flex-col items-center gap-3">
         <Link
           className={buttonVariants({ className: "gap-2", size: "lg", variant: "default" })}
           href="/learn"
           prefetch
         >
           <SparklesIcon aria-hidden="true" />
-          {t("Create a course with AI")}
+          {t("Start free")}
         </Link>
 
-        <Link
-          className={buttonVariants({ className: "gap-2", size: "lg", variant: "outline" })}
-          href="/courses"
-          prefetch
-        >
-          {t("Explore courses")}
-          <ArrowRightIcon aria-hidden="true" />
-        </Link>
+        <p className="text-muted-foreground text-sm">
+          {t("No credit card required. No commitment.")}
+        </p>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

- Update the home hero to focus on user outcomes
- Replace the two hero CTAs with a single free-start CTA
- Refresh EN, ES, and PT translations plus home e2e expectations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the home hero to focus on outcomes: headline changed to “Change your life,” with outcome-focused subcopy, a single “Start free” CTA to /learn, and “No credit card required. No commitment.” Added EN/ES/PT translations and updated e2e tests across home, navbar, command palette, locale, and settings for both unauthenticated and authenticated states.

<sup>Written for commit e26405ce5222aa2845f466cee39b5b042dd7bfce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

