### PR TITLE
fix(player): invert inline code colors

### DIFF
--- a/packages/player/src/components/player-rich-text.tsx
+++ b/packages/player/src/components/player-rich-text.tsx
@@ -189,7 +189,7 @@ export function PlayerRichText({ text }: { text: string }) {
     if (segment.kind === "code") {
       return (
         <code
-          className="bg-muted text-foreground rounded-sm px-1 py-0.5 font-mono text-[0.85em]"
+          className="bg-foreground text-background rounded-sm px-1 py-0.5 font-mono text-[0.85em]"
           key={key}
         >
           {segment.text}


### PR DESCRIPTION
## Summary

Updates player rich-text inline code styling to use the same foreground/background inversion as grammar lesson highlights.

## Validation

Not run. CSS-only class change requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invert inline code colors in the player rich-text to match grammar lesson highlights and improve contrast. Swaps `bg-muted text-foreground` to `bg-foreground text-background` in `PlayerRichText`.

<sup>Written for commit 807746e734ee2ebef4b3e54e5bb76bdd67782de5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

