### PR TITLE
fix(main): improve hero trial copy

### DIFF
--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -222,8 +222,12 @@ msgid "i7IHHZ"
 msgstr "Start free"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "pjKGpc"
-msgstr "No credit card required. No commitment."
+msgid "u3noaU"
+msgstr "No credit card required."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "b6dFV2"
+msgstr "No commitment required."
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -222,8 +222,12 @@ msgid "i7IHHZ"
 msgstr "Prueba gratis"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "pjKGpc"
-msgstr "No necesitas tarjeta de crédito. Sin compromiso."
+msgid "u3noaU"
+msgstr "No necesitas tarjeta de crédito."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "b6dFV2"
+msgstr "Pruébalo sin compromiso."
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -222,8 +222,12 @@ msgid "i7IHHZ"
 msgstr "Teste grátis"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "pjKGpc"
-msgstr "Não precisa de cartão de crédito. Sem compromisso."
+msgid "u3noaU"
+msgstr "Não precisa de cartão de crédito."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "b6dFV2"
+msgstr "Teste sem compromisso."
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx

--- a/apps/main/src/app/(catalog)/(home)/hero.tsx
+++ b/apps/main/src/app/(catalog)/(home)/hero.tsx
@@ -37,8 +37,9 @@ export async function Hero() {
           {t("Start free")}
         </Link>
 
-        <p className="text-muted-foreground text-sm">
-          {t("No credit card required. No commitment.")}
+        <p className="text-muted-foreground flex flex-col items-center text-sm">
+          <span>{t("No credit card required.")}</span>
+          <span>{t("No commitment required.")}</span>
         </p>
       </div>
     </main>


### PR DESCRIPTION
## Summary

- split the hero helper text into two lines
- update English, Spanish, and Portuguese trial copy so each locale reads naturally

## Verification

- pnpm --filter main build
- pnpm i18n
- pnpm turbo format:fix
- pnpm turbo lint:fix
- git diff --check

## E2E

No e2e update needed: existing home e2e tests do not assert this helper copy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the home hero trial helper into two lines and updated the English, Spanish, and Portuguese copy so each locale reads naturally. The hero now shows “No credit card required.” and “No commitment required.” on separate lines for better readability across locales.

<sup>Written for commit cf9fdc7256bfdbcc5b91bc5d8f6335e423a30882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

