### PR TITLE
feat(main): improve home landing copy

### DIFF
--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -128,7 +128,7 @@ test.describe("Command Palette - Unauthenticated", () => {
       .click();
 
     // Verify user sees home page content
-    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn what matters/iu })).toBeVisible();
   });
 
   test("selecting Courses shows courses content", async ({ page }) => {
@@ -265,7 +265,7 @@ test.describe("Command Palette - Course Search", () => {
     });
 
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn what matters/iu })).toBeVisible();
     await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
@@ -487,7 +487,7 @@ test.describe("Command Palette - Keyboard Navigation", () => {
     await page.keyboard.press("Enter");
 
     // Verify user sees home page content
-    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn what matters/iu })).toBeVisible();
   });
 
   test("focus trap within dialog", async ({ page }) => {

--- a/apps/main/e2e/home.test.ts
+++ b/apps/main/e2e/home.test.ts
@@ -16,7 +16,7 @@ test.describe("Home Page - Unauthenticated", () => {
 
     const hero = page.getByRole("main");
 
-    await expect(hero.getByRole("heading", { name: /change your life/iu })).toBeVisible();
+    await expect(hero.getByRole("heading", { name: /learn what matters/iu })).toBeVisible();
 
     const startFreeLink = hero.getByRole("link", { name: "Start free" });
 
@@ -127,7 +127,7 @@ test.describe("Home Page - Authenticated", () => {
     ).toBeVisible();
 
     await expect(
-      authenticatedPage.getByRole("heading", { name: /change your life/iu }),
+      authenticatedPage.getByRole("heading", { name: /learn what matters/iu }),
     ).not.toBeVisible();
   });
 
@@ -137,7 +137,7 @@ test.describe("Home Page - Authenticated", () => {
     await expect(userWithoutProgress.getByText(/continue learning/iu)).not.toBeVisible();
 
     await expect(
-      userWithoutProgress.getByRole("heading", { name: /change your life/iu }),
+      userWithoutProgress.getByRole("heading", { name: /learn what matters/iu }),
     ).toBeVisible();
 
     await expect(userWithoutProgress.getByRole("link", { name: "Start free" })).toBeVisible();
@@ -213,7 +213,7 @@ test.describe("Home Page - Authenticated", () => {
 
     await expect(page.getByRole("heading", { name: /continue learning/iu }).first()).toBeVisible();
 
-    await expect(page.getByRole("heading", { name: /change your life/iu })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn what matters/iu })).not.toBeVisible();
 
     await expect(
       page.getByRole("link", { name: new RegExp(`Next:.*E2E Pending Lesson ${uniqueId}`, "u") }),

--- a/apps/main/e2e/locale.test.ts
+++ b/apps/main/e2e/locale.test.ts
@@ -13,7 +13,7 @@ test.describe("Locale Behavior - English", () => {
     await expect(nav.getByRole("link", { exact: true, name: "Learn" })).toBeVisible();
 
     // Hero heading should be in English
-    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn what matters/iu })).toBeVisible();
   });
 });
 
@@ -25,7 +25,7 @@ test.describe("Locale Behavior - Portuguese", () => {
     const nav = page.getByRole("navigation");
 
     // Wait for Portuguese hero heading to confirm locale is loaded
-    await expect(page.getByRole("heading", { name: /mude de vida/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /aprenda o que importa/iu })).toBeVisible();
 
     // Navbar should be in Portuguese (scoped to navigation to avoid hero links)
     await expect(nav.getByRole("link", { exact: true, name: "Cursos" })).toBeVisible();

--- a/apps/main/e2e/navbar.test.ts
+++ b/apps/main/e2e/navbar.test.ts
@@ -8,14 +8,14 @@ test.describe("Navbar - Unauthenticated", () => {
     // Scope to navigation to avoid conflicts with links in main content
     await page.getByRole("navigation").getByRole("link", { name: /home/iu }).click();
 
-    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn what matters/iu })).toBeVisible();
   });
 
   test("Courses link navigates to courses page", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn what matters/iu })).toBeVisible();
 
-    // Scope to navigation to avoid conflicts with "Explore courses" in hero
+    // Scope to navigation to avoid conflicts with links in main content
     await page.getByRole("navigation").getByRole("link", { exact: true, name: "Courses" }).click();
 
     await expect(page.getByRole("heading", { name: /explore courses/iu })).toBeVisible();
@@ -23,9 +23,9 @@ test.describe("Navbar - Unauthenticated", () => {
 
   test("Learn link navigates to learn page", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn what matters/iu })).toBeVisible();
 
-    // Scope to navigation to avoid conflicts with "Learn anything" in hero
+    // Scope to navigation to avoid conflicts with links in main content
     await page.getByRole("navigation").getByRole("link", { exact: true, name: "Learn" }).click();
 
     await expect(page.getByRole("heading", { name: /learn anything/iu })).toBeVisible();

--- a/apps/main/e2e/settings-navbar.test.ts
+++ b/apps/main/e2e/settings-navbar.test.ts
@@ -5,7 +5,7 @@ test.describe("Settings Navbar", () => {
     await page.goto("/subscription");
     await page.getByRole("link", { name: /home page/iu }).click();
 
-    await expect(page.getByRole("heading", { name: /change your life/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /learn what matters/iu })).toBeVisible();
   });
 
   test("displays all settings navigation pills", async ({ page }) => {

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -210,12 +210,12 @@ msgid "C7ROJx"
 msgstr "Your energy is {value}%"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "FQFGyy"
-msgstr "Change your life"
+msgid "F7f6bJ"
+msgstr "Learn what matters"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "XgGQQP"
-msgstr "Pass your exams, learn a language, build skills, and land your dream job. Zoonk helps you change your life."
+msgid "mFdKy1"
+msgstr "Pass exams. Learn languages. Build skills. Land the job you want. Studying with Zoonk is simple, clear, and practical."
 
 #: src/app/(catalog)/(home)/hero.tsx
 msgid "i7IHHZ"
@@ -228,6 +228,127 @@ msgstr "No credit card required."
 #: src/app/(catalog)/(home)/hero.tsx
 msgid "b6dFV2"
 msgstr "No commitment required."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "W_1wLS"
+msgstr "Why does studying feel so hard?"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "rUC9KA"
+msgstr "Too many lessons make simple ideas complicated. Too much studying turns into memorizing without understanding. And with videos, PDFs, notes, and AI chats everywhere, you still do not know where to start."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "yd8MxR"
+msgstr "Zoonk keeps it simple: short lessons, plain language, everyday examples, quizzes, exercises, and real situations that help you understand the theory in practice."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "GLMfdK"
+msgstr "Tell Zoonk your goal and follow one step at a time instead of juggling videos, PDFs, notes, and random chats."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "dcyc_u"
+msgstr "A path, not a pile of tabs"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "bvynQk"
+msgstr "Hard topics are broken down without jargon, fluff, or lectures that make simple ideas feel impossible."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "rBBKNr"
+msgstr "Plain language, no academic noise"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "77gA5w"
+msgstr "See how ideas show up in everyday situations, work problems, and decisions you actually need to make."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "xKYp3h"
+msgstr "Real examples, not abstract theory"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "iuNq-Z"
+msgstr "Use quizzes, exercises, examples, and scenarios to solve problems instead of just watching explanations."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "MR0hb4"
+msgstr "Practice that makes you think"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "8iVdxW"
+msgstr "See what you got right, what still needs work, and whether you are keeping a study rhythm, so you know what to do next."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "_EUvRF"
+msgstr "Feedback that shows what to fix"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "SDH1bI"
+msgstr "How Zoonk helps"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "wUXg4Q"
+msgstr "No boring lectures. No pointless memorizing."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "tbojsI"
+msgstr "Learn 70 languages. See pronunciation in a way that makes sense in your language, so words click faster."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "We_5D-"
+msgstr "Learn languages"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "zfV50G"
+msgstr "Need a prerequisite for a course, project, or job? Build the skill with clear lessons and practical exercises."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "5rp9p5"
+msgstr "Build skills"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "po_f41"
+msgstr "Stop hunting for the right video or PDF. Follow a course that explains, practices, and tracks your progress in one place."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "F-T3y7"
+msgstr "Follow guided courses"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "54l-im"
+msgstr "Prepare with a path that shows what to study, what is already strong, and what needs work, with simulations, quizzes, and practical explanations."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "dP8fUZ"
+msgstr "Soon"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "-MB81o"
+msgstr "Prepare for exams"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "Ca4yug"
+msgstr "A course focused on your goals, level, interests, hobbies, and real context, with examples that feel made for you."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "eosMlL"
+msgstr "Personalized lessons"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "T0Zjcm"
+msgstr "Use Zoonk for what matters"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "fDYYaI"
+msgstr "Start with the goal that matters now"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "Cs8rf9"
+msgstr "Available now"
+
+#: src/app/(catalog)/(home)/hero.tsx
+#: src/app/(catalog)/p/[courseId]/page.tsx
+msgid "e61Jf3"
+msgstr "Coming soon"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
@@ -617,10 +738,6 @@ msgstr "No courses yet"
 #: src/app/(catalog)/my/user-course-list.tsx
 msgid "azX41u"
 msgstr "Start learning something new today."
-
-#: src/app/(catalog)/p/[courseId]/page.tsx
-msgid "e61Jf3"
-msgstr "Coming soon"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 msgid "dtRj3N"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -210,12 +210,12 @@ msgid "C7ROJx"
 msgstr "Tu energía es {value}%"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "FQFGyy"
-msgstr "Cambia tu vida"
+msgid "F7f6bJ"
+msgstr "Aprende lo que importa"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "XgGQQP"
-msgstr "Aprueba tus exámenes, aprende un idioma, desarrolla habilidades y consigue el trabajo de tus sueños. Zoonk te ayuda a cambiar tu vida."
+msgid "mFdKy1"
+msgstr "Aprueba exámenes. Aprende idiomas. Desarrolla habilidades. Consigue el trabajo que quieres. Estudiar con Zoonk es fácil, claro y práctico."
 
 #: src/app/(catalog)/(home)/hero.tsx
 msgid "i7IHHZ"
@@ -228,6 +228,127 @@ msgstr "No necesitas tarjeta de crédito."
 #: src/app/(catalog)/(home)/hero.tsx
 msgid "b6dFV2"
 msgstr "Pruébalo sin compromiso."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "W_1wLS"
+msgstr "¿Por qué estudiar se siente tan difícil?"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "rUC9KA"
+msgstr "Muchas clases complican lo que debería ser simple. Mucho estudio se vuelve memorización sin sentido. Y con videos, PDFs, notas e IA por todas partes, sigues sin saber por dónde empezar."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "yd8MxR"
+msgstr "Zoonk lo deja simple: lecciones cortas, lenguaje claro, ejemplos del día a día, cuestionarios, ejercicios y situaciones reales para entender la teoría en la práctica."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "GLMfdK"
+msgstr "Dile a Zoonk tu objetivo y sigue un paso a la vez, sin saltar entre videos, PDFs, notas y chats de IA."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "dcyc_u"
+msgstr "Un camino, no mil pestañas abiertas"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "bvynQk"
+msgstr "Dividimos temas difíciles sin jerga, sin vueltas y sin clases que complican lo que debería ser simple."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "rBBKNr"
+msgstr "Lenguaje simple, sin ruido académico"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "77gA5w"
+msgstr "Ve cómo las ideas aparecen en el día a día, en el trabajo y en las decisiones que necesitas resolver."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "xKYp3h"
+msgstr "Ejemplos reales, no teoría suelta"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "iuNq-Z"
+msgstr "Usa cuestionarios, ejercicios, ejemplos y escenarios para resolver problemas en vez de solo mirar explicaciones."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "MR0hb4"
+msgstr "Práctica que te hace pensar"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "8iVdxW"
+msgstr "Ve qué acertaste, qué necesitas mejorar y si mantienes el ritmo, para saber cuál es el próximo paso."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "_EUvRF"
+msgstr "Feedback para no estudiar a ciegas"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "SDH1bI"
+msgstr "Cómo ayuda Zoonk"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "wUXg4Q"
+msgstr "Basta de clases aburridas y memorización sin sentido"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "tbojsI"
+msgstr "Aprende 70 idiomas. Ve la pronunciación de una forma que tiene sentido en tu idioma, para hablar sin trabarte."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "We_5D-"
+msgstr "Aprende idiomas"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "zfV50G"
+msgstr "¿Necesitas un requisito para una clase, proyecto o trabajo? Desarrolla la habilidad con lecciones claras y ejercicios prácticos."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "5rp9p5"
+msgstr "Desarrolla habilidades"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "po_f41"
+msgstr "Deja de buscar el video o PDF correcto. Sigue un curso que explica, te pone a practicar y sigue tu progreso en un solo lugar."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "F-T3y7"
+msgstr "Sigue cursos guiados"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "54l-im"
+msgstr "Prepárate con un camino que muestra qué estudiar, qué ya está bien y qué necesitas reforzar, con simulacros, cuestionarios y explicaciones prácticas."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "dP8fUZ"
+msgstr "Pronto"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "-MB81o"
+msgstr "Prepárate para exámenes"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "Ca4yug"
+msgstr "Un curso enfocado en tus objetivos, nivel, intereses, hobbies y contexto, con ejemplos que tengan sentido para ti."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "eosMlL"
+msgstr "Lecciones personalizadas"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "T0Zjcm"
+msgstr "Usa Zoonk para lo que importa"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "fDYYaI"
+msgstr "Empieza por el objetivo que importa ahora"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "Cs8rf9"
+msgstr "Disponible ahora"
+
+#: src/app/(catalog)/(home)/hero.tsx
+#: src/app/(catalog)/p/[courseId]/page.tsx
+msgid "e61Jf3"
+msgstr "Próximamente"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
@@ -617,10 +738,6 @@ msgstr "Aún no hay cursos"
 #: src/app/(catalog)/my/user-course-list.tsx
 msgid "azX41u"
 msgstr "Comienza a aprender algo nuevo hoy."
-
-#: src/app/(catalog)/p/[courseId]/page.tsx
-msgid "e61Jf3"
-msgstr "Próximamente"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 msgid "dtRj3N"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -210,12 +210,12 @@ msgid "C7ROJx"
 msgstr "Sua energia está em {value}%"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "FQFGyy"
-msgstr "Mude de vida"
+msgid "F7f6bJ"
+msgstr "Aprenda o que importa"
 
 #: src/app/(catalog)/(home)/hero.tsx
-msgid "XgGQQP"
-msgstr "Passe no concurso, aprenda um idioma, desenvolva habilidades e conquiste o trabalho dos sonhos. O Zoonk te ajuda a mudar de vida."
+msgid "mFdKy1"
+msgstr "Passe nas provas. Aprenda idiomas. Desenvolva habilidades. Conquiste o trabalho dos sonhos. Estudar com o Zoonk é fácil, claro e prático."
 
 #: src/app/(catalog)/(home)/hero.tsx
 msgid "i7IHHZ"
@@ -228,6 +228,127 @@ msgstr "Não precisa de cartão de crédito."
 #: src/app/(catalog)/(home)/hero.tsx
 msgid "b6dFV2"
 msgstr "Teste sem compromisso."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "W_1wLS"
+msgstr "Por que estudar parece tão difícil?"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "rUC9KA"
+msgstr "Muita aula complica o que deveria ser simples. Muito estudo vira decoreba. E, com vídeo, PDF, anotação e IA pra todo lado, você continua sem saber por onde começar."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "yd8MxR"
+msgstr "O Zoonk deixa tudo mastigadinho: aulas curtas, linguagem simples, exemplos do dia a dia, quizzes, exercícios e situações reais para entender a teoria na prática."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "GLMfdK"
+msgstr "Diga seu objetivo e siga um passo de cada vez, sem ficar pulando entre vídeo, PDF, anotação e chat de IA."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "dcyc_u"
+msgstr "Um caminho, não mil abas abertas"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "bvynQk"
+msgstr "A gente quebra assuntos difíceis sem jargão, sem enrolação e sem aula que complica o que deveria ser simples."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "rBBKNr"
+msgstr "Linguagem simples, sem ruído acadêmico"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "77gA5w"
+msgstr "Veja como as ideias aparecem no dia a dia, no trabalho e nas decisões que você precisa resolver."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "xKYp3h"
+msgstr "Exemplos reais, não teoria solta"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "iuNq-Z"
+msgstr "Use quizzes, exercícios, exemplos e cenários para resolver problemas em vez de só assistir explicação."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "MR0hb4"
+msgstr "Prática que faz pensar"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "8iVdxW"
+msgstr "Veja o que você acertou, o que precisa melhorar e se está mantendo ritmo, pra saber o próximo passo."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "_EUvRF"
+msgstr "Feedback pra não estudar no escuro"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "SDH1bI"
+msgstr "Como o Zoonk ajuda"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "wUXg4Q"
+msgstr "Chega de aula chata e decoreba sem sentido"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "tbojsI"
+msgstr "Aprenda 70 idiomas. Veja a pronúncia do jeito que faz sentido no seu idioma, pra falar sem travar."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "We_5D-"
+msgstr "Aprenda idiomas"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "zfV50G"
+msgstr "Precisa de um pré-requisito para uma matéria, projeto ou vaga? Desenvolva a habilidade com aulas claras e exercícios práticos."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "5rp9p5"
+msgstr "Desenvolva habilidades"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "po_f41"
+msgstr "Pare de caçar o vídeo ou PDF certo. Siga um curso que explica, te coloca para praticar e acompanha seu progresso em um só lugar."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "F-T3y7"
+msgstr "Siga cursos guiados"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "54l-im"
+msgstr "Prepare-se com um caminho que mostra o que estudar, o que já tá bom e o que precisa reforçar, com simulados, quizzes e explicações práticas."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "dP8fUZ"
+msgstr "Em breve"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "-MB81o"
+msgstr "Prepare-se para provas"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "Ca4yug"
+msgstr "Um curso focado nos seus objetivos, nível, interesses, hobbies e realidade, com exemplos que fazem sentido pra você."
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "eosMlL"
+msgstr "Aulas personalizadas"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "T0Zjcm"
+msgstr "Use o Zoonk para o que importa"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "fDYYaI"
+msgstr "Comece pelo objetivo que importa agora"
+
+#: src/app/(catalog)/(home)/hero.tsx
+msgid "Cs8rf9"
+msgstr "Disponível agora"
+
+#: src/app/(catalog)/(home)/hero.tsx
+#: src/app/(catalog)/p/[courseId]/page.tsx
+msgid "e61Jf3"
+msgstr "Em breve"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
@@ -617,10 +738,6 @@ msgstr "Ainda não há cursos"
 #: src/app/(catalog)/my/user-course-list.tsx
 msgid "azX41u"
 msgstr "Comece a aprender algo novo hoje."
-
-#: src/app/(catalog)/p/[courseId]/page.tsx
-msgid "e61Jf3"
-msgstr "Em breve"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 msgid "dtRj3N"

--- a/apps/main/src/app/(catalog)/(home)/hero.tsx
+++ b/apps/main/src/app/(catalog)/(home)/hero.tsx
@@ -1,28 +1,127 @@
 import { buttonVariants } from "@zoonk/ui/components/button";
-import { SparklesIcon } from "lucide-react";
+import { cn } from "@zoonk/ui/lib/utils";
+import {
+  BookOpenIcon,
+  BrainIcon,
+  BriefcaseBusinessIcon,
+  CompassIcon,
+  GraduationCapIcon,
+  LanguagesIcon,
+  ListChecksIcon,
+  type LucideIcon,
+  RouteIcon,
+  SparklesIcon,
+  TargetIcon,
+  TrendingUpIcon,
+} from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import Link from "next/link";
 import { HeroTracker } from "./hero-tracker";
 
+type LandingItem = {
+  description: string;
+  icon: LucideIcon;
+  iconClassName: string;
+  label?: string;
+  title: string;
+};
+
 /**
- * Shows the zero-progress home state for people who need a concrete reason to
- * start learning before they understand how Zoonk creates personalized courses.
+ * Keeps each marketing section on the same quiet rhythm so the page can grow
+ * beyond the hero without feeling like a separate, busier landing-page system.
  */
-export async function Hero() {
+function LandingSection({ children, className, ...props }: React.ComponentProps<"section">) {
+  return (
+    <section
+      className={cn("mx-auto flex w-full max-w-5xl flex-col gap-10 px-4 py-14 md:py-20", className)}
+      {...props}
+    >
+      {children}
+    </section>
+  );
+}
+
+/**
+ * Centers section copy in a narrow measure because these blocks need to sell
+ * one idea at a time before the supporting feature items appear.
+ */
+function LandingSectionHeader({ children, className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div className={cn("mx-auto flex max-w-3xl flex-col gap-4 text-center", className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Reuses one spacious grid for both product benefits and use cases so the
+ * repeated icon/text pattern feels intentional instead of decorative.
+ */
+function LandingItemGrid({ children, className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("grid gap-x-10 gap-y-12 md:grid-cols-2 lg:grid-cols-3", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Presents one reason to believe in Zoonk without heavy card chrome. The icon
+ * gives each idea a quick scanning anchor while the text carries the actual sale.
+ */
+function LandingItemCard({ item }: { item: LandingItem }) {
+  const Icon = item.icon;
+
+  return (
+    <article className="flex flex-col gap-4">
+      <div
+        className={cn(
+          "flex size-10 items-center justify-center rounded-full [&>svg]:size-5",
+          item.iconClassName,
+        )}
+      >
+        <Icon aria-hidden="true" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <h3 className="text-foreground/90 text-base font-semibold tracking-tight">
+            {item.title}
+          </h3>
+
+          {item.label && (
+            <span className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-[0.6875rem] font-medium">
+              {item.label}
+            </span>
+          )}
+        </div>
+
+        <p className="text-muted-foreground text-sm leading-6">{item.description}</p>
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Keeps the first screen focused on aspiration and one action. The supporting
+ * sections explain the problem and mechanism only after the user sees the outcome.
+ */
+async function HeroIntro() {
   const t = await getExtracted();
 
   return (
-    <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center gap-8 px-4 py-16 md:py-24">
-      <HeroTracker />
-
-      <div className="flex flex-col items-center gap-4 text-center">
-        <h1 className="text-foreground/90 text-3xl font-semibold tracking-tight text-balance md:text-5xl md:tracking-tighter">
-          {t("Change your life")}
+    <section className="mx-auto flex w-full max-w-3xl flex-col items-center gap-8 px-4 py-16 text-center md:py-24">
+      <div className="flex flex-col items-center gap-4">
+        <h1 className="text-foreground/90 text-4xl font-semibold tracking-tight text-balance md:text-6xl">
+          {t("Learn what matters")}
         </h1>
 
-        <p className="text-muted-foreground text-lg text-balance md:text-xl">
+        <p className="text-muted-foreground text-lg leading-8 text-balance md:text-xl md:leading-9">
           {t(
-            "Pass your exams, learn a language, build skills, and land your dream job. Zoonk helps you change your life.",
+            "Pass exams. Learn languages. Build skills. Land the job you want. Studying with Zoonk is simple, clear, and practical.",
           )}
         </p>
       </div>
@@ -42,6 +141,219 @@ export async function Hero() {
           <span>{t("No commitment required.")}</span>
         </p>
       </div>
+    </section>
+  );
+}
+
+/**
+ * Names the real learning pain before listing features, so the page sells the
+ * cost of scattered learning instead of jumping straight into product mechanics.
+ */
+async function LearningProblemSection() {
+  const t = await getExtracted();
+
+  return (
+    <LandingSection className="border-border/60 border-t">
+      <LandingSectionHeader>
+        <h2 className="text-foreground/90 text-2xl font-semibold tracking-tight text-balance md:text-4xl">
+          {t("Why does studying feel so hard?")}
+        </h2>
+
+        <p className="text-muted-foreground text-base leading-8 text-balance md:text-lg">
+          {t(
+            "Too many lessons make simple ideas complicated. Too much studying turns into memorizing without understanding. And with videos, PDFs, notes, and AI chats everywhere, you still do not know where to start.",
+          )}
+        </p>
+
+        <p className="text-foreground/80 text-base leading-8 text-balance md:text-lg">
+          {t(
+            "Zoonk keeps it simple: short lessons, plain language, everyday examples, quizzes, exercises, and real situations that help you understand the theory in practice.",
+          )}
+        </p>
+      </LandingSectionHeader>
+    </LandingSection>
+  );
+}
+
+/**
+ * Shows how the product fixes the learning problem using shipped capabilities:
+ * path structure, clear explanations, active practice, visible progress, and continuity.
+ */
+async function SolutionSection() {
+  const t = await getExtracted();
+
+  const solutionItems: LandingItem[] = [
+    {
+      description: t(
+        "Tell Zoonk your goal and follow one step at a time instead of juggling videos, PDFs, notes, and random chats.",
+      ),
+      icon: RouteIcon,
+      iconClassName: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
+      title: t("A path, not a pile of tabs"),
+    },
+    {
+      description: t(
+        "Hard topics are broken down without jargon, fluff, or lectures that make simple ideas feel impossible.",
+      ),
+      icon: BookOpenIcon,
+      iconClassName: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+      title: t("Plain language, no academic noise"),
+    },
+    {
+      description: t(
+        "See how ideas show up in everyday situations, work problems, and decisions you actually need to make.",
+      ),
+      icon: CompassIcon,
+      iconClassName: "bg-rose-500/10 text-rose-600 dark:text-rose-400",
+      title: t("Real examples, not abstract theory"),
+    },
+    {
+      description: t(
+        "Use quizzes, exercises, examples, and scenarios to solve problems instead of just watching explanations.",
+      ),
+      icon: TargetIcon,
+      iconClassName: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+      title: t("Practice that makes you think"),
+    },
+    {
+      description: t(
+        "See what you got right, what still needs work, and whether you are keeping a study rhythm, so you know what to do next.",
+      ),
+      icon: TrendingUpIcon,
+      iconClassName: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
+      title: t("Feedback that shows what to fix"),
+    },
+  ];
+
+  return (
+    <LandingSection>
+      <LandingSectionHeader>
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {t("How Zoonk helps")}
+        </p>
+
+        <h2 className="text-foreground/90 text-2xl font-semibold tracking-tight text-balance md:text-4xl">
+          {t("No boring lectures. No pointless memorizing.")}
+        </h2>
+      </LandingSectionHeader>
+
+      <LandingItemGrid>
+        {solutionItems.map((item) => (
+          <LandingItemCard item={item} key={item.title} />
+        ))}
+      </LandingItemGrid>
+    </LandingSection>
+  );
+}
+
+/**
+ * Separates available learning outcomes from upcoming promises so the page can
+ * be ambitious without implying exams or personalization are already shipped.
+ */
+async function OpportunitySection() {
+  const t = await getExtracted();
+
+  const availableItems: LandingItem[] = [
+    {
+      description: t(
+        "Learn 70 languages. See pronunciation in a way that makes sense in your language, so words click faster.",
+      ),
+      icon: LanguagesIcon,
+      iconClassName: "bg-sky-500/10 text-sky-600 dark:text-sky-400",
+      title: t("Learn languages"),
+    },
+    {
+      description: t(
+        "Need a prerequisite for a course, project, or job? Build the skill with clear lessons and practical exercises.",
+      ),
+      icon: BrainIcon,
+      iconClassName: "bg-lime-500/10 text-lime-700 dark:text-lime-400",
+      title: t("Build skills"),
+    },
+    {
+      description: t(
+        "Stop hunting for the right video or PDF. Follow a course that explains, practices, and tracks your progress in one place.",
+      ),
+      icon: ListChecksIcon,
+      iconClassName: "bg-cyan-500/10 text-cyan-700 dark:text-cyan-400",
+      title: t("Follow guided courses"),
+    },
+  ];
+
+  const comingSoonItems: LandingItem[] = [
+    {
+      description: t(
+        "Prepare with a path that shows what to study, what is already strong, and what needs work, with simulations, quizzes, and practical explanations.",
+      ),
+      icon: GraduationCapIcon,
+      iconClassName: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
+      label: t("Soon"),
+      title: t("Prepare for exams"),
+    },
+    {
+      description: t(
+        "A course focused on your goals, level, interests, hobbies, and real context, with examples that feel made for you.",
+      ),
+      icon: BriefcaseBusinessIcon,
+      iconClassName: "bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400",
+      label: t("Soon"),
+      title: t("Personalized lessons"),
+    },
+  ];
+
+  return (
+    <LandingSection>
+      <LandingSectionHeader>
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          {t("Use Zoonk for what matters")}
+        </p>
+
+        <h2 className="text-foreground/90 text-2xl font-semibold tracking-tight text-balance md:text-4xl">
+          {t("Start with the goal that matters now")}
+        </h2>
+      </LandingSectionHeader>
+
+      <div className="flex flex-col gap-12">
+        <div className="flex flex-col gap-6">
+          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            {t("Available now")}
+          </p>
+
+          <LandingItemGrid>
+            {availableItems.map((item) => (
+              <LandingItemCard item={item} key={item.title} />
+            ))}
+          </LandingItemGrid>
+        </div>
+
+        <div className="flex flex-col gap-6">
+          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            {t("Coming soon")}
+          </p>
+
+          <LandingItemGrid className="lg:grid-cols-2">
+            {comingSoonItems.map((item) => (
+              <LandingItemCard item={item} key={item.title} />
+            ))}
+          </LandingItemGrid>
+        </div>
+      </div>
+    </LandingSection>
+  );
+}
+
+/**
+ * Shows the zero-progress home state for people who need a concrete reason to
+ * start learning before they understand how Zoonk turns a goal into progress.
+ */
+export function Hero() {
+  return (
+    <main className="flex w-full flex-1 flex-col pb-12">
+      <HeroTracker />
+      <HeroIntro />
+      <LearningProblemSection />
+      <SolutionSection />
+      <OpportunitySection />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Rework the home hero into a cleaner landing page with problem, solution, and use-case sections
- Refresh English, Spanish, and Portuguese copy with a more direct learner-focused tone
- Update E2E assertions for the new home headline

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the home landing into a focused, learner-first page with problem, solution, and use‑case sections. Updated copy in English, Spanish, and Portuguese, and aligned E2E tests with the new headline.

- New Features
  - New modular hero: `HeroIntro`, `LearningProblemSection`, `SolutionSection`, `OpportunitySection`.
  - Shared components for layout: `LandingSection`, `LandingSectionHeader`, `LandingItemGrid`, `LandingItemCard`.
  - Fresh EN/ES/PT copy (new `.po` messages), headline changed to “Learn what matters”.

- Refactors
  - Updated E2E tests to assert the new headline and scope nav link queries to the navigation region.
  - Streamlined styles and iconized items for consistent, scannable sections.

<sup>Written for commit 27867d20d101018ed3b9da11487572625bc216a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

