### PR TITLE
fix(ai): retry long audio that use system instructions

### DIFF
--- a/packages/ai/src/tasks/audio/generate-language-audio.prompt.md
+++ b/packages/ai/src/tasks/audio/generate-language-audio.prompt.md
@@ -1,3 +1,1 @@
-Speak clearly at a moderate pace suitable for language learners. Enunciate each word precisely.
-
 Some words may look like English words but they are {{LANGUAGE}} words and must be pronounced according to {{LANGUAGE}} phonology. For example, "fruit" in Dutch is pronounced "frœyt", not the English "froot."

--- a/packages/ai/src/tasks/audio/generate-language-audio.test.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateLanguageAudio } from "./generate-language-audio";
+
+const { generateWithGeminiMock, generateWithOpenAIMock } = vi.hoisted(() => ({
+  generateWithGeminiMock: vi.fn(),
+  generateWithOpenAIMock: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("./generate-language-audio.prompt.md", () => ({
+  default:
+    'Some words may look like English words but they are {{LANGUAGE}} words and must be pronounced according to {{LANGUAGE}} phonology. For example, "fruit" in Dutch is pronounced "frœyt", not the English "froot."',
+}));
+
+vi.mock("./generate-language-audio-alphabet-symbol.prompt.md", () => ({ default: "" }));
+
+vi.mock("./provider-gemini", () => ({ generateWithGemini: generateWithGeminiMock }));
+
+vi.mock("./provider-openai", () => ({ generateWithOpenAI: generateWithOpenAIMock }));
+
+describe(generateLanguageAudio, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generateWithGeminiMock.mockResolvedValue({ audio: new Uint8Array([1, 2, 3]), format: "wav" });
+  });
+
+  it("skips prompt instructions for normal English audio", async () => {
+    const result = await generateLanguageAudio({ language: "en", text: "fruit" });
+
+    expect(result.error).toBeNull();
+
+    expect(generateWithGeminiMock).toHaveBeenCalledExactlyOnceWith({
+      languageCode: "en",
+      text: "fruit",
+      voice: "Kore",
+    });
+  });
+
+  it("keeps prompt instructions for non-English audio", async () => {
+    const result = await generateLanguageAudio({ language: "nl", text: "fruit" });
+    const call = generateWithGeminiMock.mock.calls[0]?.[0];
+
+    expect(result.error).toBeNull();
+    expect(call).toStrictEqual(expect.objectContaining({ languageCode: "nl", text: "fruit" }));
+    expect(call?.instructions).toContain("Some words may look like English words");
+  });
+});

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -12,7 +12,9 @@ import { generateWithOpenAI } from "./provider-openai";
 const DEFAULT_VOICE: TTSVoice = "Kore";
 const MAX_ATTEMPTS_PER_PROVIDER = 3;
 const INITIAL_BACKOFF_MS = 1000;
-const READ_ALOUD_TEMPLATE = "The following text is {{LANGUAGE}}. Read it aloud in {{LANGUAGE}}.";
+
+const READ_ALOUD_TEMPLATE =
+  "The following text is {{LANGUAGE}}. Speak clearly at a moderate pace suitable for language learners. Enunciate each word precisely; read it aloud in {{LANGUAGE}}.";
 
 type AudioFormat = "opus" | "wav";
 
@@ -26,6 +28,7 @@ const usagePrompts = { alphabetSymbol: alphabetSymbolPrompt } satisfies Record<
 
 type AudioProvider = (params: {
   instructions: string;
+  languageCode?: string;
   text: string;
   voice: TTSVoice;
 }) => Promise<AudioResult>;
@@ -90,10 +93,12 @@ function buildAttemptSchedule(
  */
 async function generateWithFallback({
   instructions,
+  languageCode,
   text,
   voice,
 }: {
   instructions: string;
+  languageCode?: string;
   text: string;
   voice: TTSVoice;
 }): Promise<AudioResult> {
@@ -112,7 +117,12 @@ async function generateWithFallback({
     }
 
     try {
-      return await attempt.generate({ instructions, text, voice });
+      return await attempt.generate({
+        instructions,
+        ...(languageCode ? { languageCode } : {}),
+        text,
+        voice,
+      });
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error));
     }
@@ -141,5 +151,12 @@ export async function generateLanguageAudio({
 }): Promise<SafeReturn<AudioResult>> {
   const instructions = buildInstructions({ languageCode: language, usage });
 
-  return safeAsync(() => generateWithFallback({ instructions, text, voice }));
+  return safeAsync(() =>
+    generateWithFallback({
+      instructions,
+      ...(language ? { languageCode: language } : {}),
+      text,
+      voice,
+    }),
+  );
 }

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -27,7 +27,7 @@ const usagePrompts = { alphabetSymbol: alphabetSymbolPrompt } satisfies Record<
 >;
 
 type AudioProvider = (params: {
-  instructions: string;
+  instructions?: string;
   languageCode?: string;
   text: string;
   voice: TTSVoice;
@@ -36,9 +36,25 @@ type AudioProvider = (params: {
 type ScheduledAttempt = { backoffMs: number; generate: AudioProvider; name: string };
 
 /**
- * Expands the base TTS prompt with optional usage-specific instructions.
- * Keeping the usage structured avoids passing learner-facing romanization or
- * pronunciation hints into the audio model, which can make output less stable.
+ * Skips prompt guidance for normal English word and sentence audio because the
+ * extra instructions exist to prevent non-English words from being read with
+ * English pronunciation. Usage-specific audio, such as alphabet symbols, still
+ * gets guidance because the text may not be a normal word.
+ */
+function shouldBuildInstructions({
+  languageCode,
+  usage,
+}: {
+  languageCode?: string;
+  usage?: LanguageAudioUsage;
+}) {
+  return Boolean(usage) || Boolean(languageCode && languageCode !== "en");
+}
+
+/**
+ * Expands the TTS prompt with optional usage-specific instructions. Keeping the
+ * usage structured avoids passing learner-facing romanization or pronunciation
+ * hints into the audio model, which can make output less stable.
  */
 function buildInstructions({
   languageCode,
@@ -46,21 +62,24 @@ function buildInstructions({
 }: {
   languageCode?: string;
   usage?: LanguageAudioUsage;
-}): string {
+}): string | undefined {
+  if (!shouldBuildInstructions({ languageCode, usage })) {
+    return undefined;
+  }
+
   const languageName = languageCode
     ? getPromptLanguageName({ language: languageCode })
     : getPromptLanguageName({ language: "en" });
 
+  const languagePrompt =
+    languageCode && languageCode !== "en"
+      ? promptTemplate.replaceAll("{{LANGUAGE}}", () => languageName)
+      : "";
+
   const usagePrompt = usage ? usagePrompts[usage] : "";
   const readAloudPrompt = READ_ALOUD_TEMPLATE.replaceAll("{{LANGUAGE}}", () => languageName);
 
-  return [
-    promptTemplate.replaceAll("{{LANGUAGE}}", () => languageName),
-    usagePrompt,
-    readAloudPrompt,
-  ]
-    .filter(Boolean)
-    .join("\n\n");
+  return [languagePrompt, usagePrompt, readAloudPrompt].filter(Boolean).join("\n\n");
 }
 
 /**
@@ -97,7 +116,7 @@ async function generateWithFallback({
   text,
   voice,
 }: {
-  instructions: string;
+  instructions?: string;
   languageCode?: string;
   text: string;
   voice: TTSVoice;
@@ -118,7 +137,7 @@ async function generateWithFallback({
 
     try {
       return await attempt.generate({
-        instructions,
+        ...(instructions ? { instructions } : {}),
         ...(languageCode ? { languageCode } : {}),
         text,
         voice,
@@ -153,7 +172,7 @@ export async function generateLanguageAudio({
 
   return safeAsync(() =>
     generateWithFallback({
-      instructions,
+      ...(instructions ? { instructions } : {}),
       ...(language ? { languageCode: language } : {}),
       text,
       voice,

--- a/packages/ai/src/tasks/audio/provider-gemini.test.ts
+++ b/packages/ai/src/tasks/audio/provider-gemini.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateWithGemini } from "./provider-gemini";
+
+const { generateContentMock, GoogleGenAIMock } = vi.hoisted(() => {
+  const generateContent = vi.fn();
+
+  class GoogleGenAI {
+    models = { generateContent };
+  }
+
+  return { GoogleGenAIMock: vi.fn(GoogleGenAI), generateContentMock: generateContent };
+});
+
+vi.mock("@google/genai", () => ({ GoogleGenAI: GoogleGenAIMock }));
+
+const MAX_EXPECTED_WAV_BYTES = 850 * 1024;
+const WAV_HEADER_BYTES = 44;
+
+/**
+ * Builds the smallest Gemini response shape the provider reads. The provider
+ * only needs base64 PCM bytes, so tests can control audio size without making
+ * network calls or depending on the real SDK response class.
+ */
+function createGeminiAudioResponse({ audioData }: { audioData: string }) {
+  return { candidates: [{ content: { parts: [{ inlineData: { data: audioData } }] } }] };
+}
+
+/**
+ * Creates fake PCM data because Gemini returns raw PCM that production wraps in
+ * a WAV header. The byte length lets tests exercise the same size guard that
+ * protects uploads from prompt-leak audio.
+ */
+function createPcmBase64({ byteLength }: { byteLength: number }) {
+  return Buffer.alloc(byteLength).toString("base64");
+}
+
+describe(generateWithGemini, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    generateContentMock.mockResolvedValue(
+      createGeminiAudioResponse({ audioData: createPcmBase64({ byteLength: 3 }) }),
+    );
+  });
+
+  it("keeps Gemini TTS instructions in content before the exact text to speak", async () => {
+    const instructions = "Use Dutch phonology.";
+    const text = "fruit";
+
+    const result = await generateWithGemini({
+      instructions,
+      languageCode: "nl",
+      text,
+      voice: "Kore",
+    });
+
+    expect(result.format).toBe("wav");
+    expect(GoogleGenAIMock).toHaveBeenCalledWith({ apiKey: process.env.GEMINI_API_KEY });
+
+    expect(generateContentMock).toHaveBeenCalledExactlyOnceWith({
+      config: {
+        responseModalities: ["AUDIO"],
+        speechConfig: {
+          languageCode: "nl",
+          voiceConfig: { prebuiltVoiceConfig: { voiceName: "Kore" } },
+        },
+      },
+      contents: [{ parts: [{ text: `${instructions}\n\nText to speak exactly:\n${text}` }] }],
+      model: "gemini-2.5-flash-preview-tts",
+    });
+  });
+
+  it("rejects oversized Gemini audio so fallback providers can retry", async () => {
+    const oversizedPcmBytes = MAX_EXPECTED_WAV_BYTES - WAV_HEADER_BYTES + 1;
+
+    generateContentMock.mockResolvedValueOnce(
+      createGeminiAudioResponse({ audioData: createPcmBase64({ byteLength: oversizedPcmBytes }) }),
+    );
+
+    await expect(
+      generateWithGemini({ instructions: "Use Dutch phonology.", text: "fruit", voice: "Kore" }),
+    ).rejects.toThrow("Gemini TTS returned oversized audio");
+  });
+});

--- a/packages/ai/src/tasks/audio/provider-gemini.test.ts
+++ b/packages/ai/src/tasks/audio/provider-gemini.test.ts
@@ -70,6 +70,26 @@ describe(generateWithGemini, () => {
     });
   });
 
+  it("sends only the text when no TTS instructions are needed", async () => {
+    const text = "fruit";
+
+    const result = await generateWithGemini({ languageCode: "en", text, voice: "Kore" });
+
+    expect(result.format).toBe("wav");
+
+    expect(generateContentMock).toHaveBeenCalledExactlyOnceWith({
+      config: {
+        responseModalities: ["AUDIO"],
+        speechConfig: {
+          languageCode: "en",
+          voiceConfig: { prebuiltVoiceConfig: { voiceName: "Kore" } },
+        },
+      },
+      contents: [{ parts: [{ text }] }],
+      model: "gemini-2.5-flash-preview-tts",
+    });
+  });
+
   it("rejects oversized Gemini audio so fallback providers can retry", async () => {
     const oversizedPcmBytes = MAX_EXPECTED_WAV_BYTES - WAV_HEADER_BYTES + 1;
 

--- a/packages/ai/src/tasks/audio/provider-gemini.ts
+++ b/packages/ai/src/tasks/audio/provider-gemini.ts
@@ -16,7 +16,11 @@ const MAX_GEMINI_AUDIO_BYTES = 850 * 1024;
  * small target after the instructions instead of leaving it to infer what text
  * should be spoken from the whole prompt.
  */
-function buildGeminiPrompt({ instructions, text }: { instructions: string; text: string }) {
+function buildGeminiPrompt({ instructions, text }: { instructions?: string; text: string }) {
+  if (!instructions) {
+    return text;
+  }
+
   return `${instructions}\n\nText to speak exactly:\n${text}`;
 }
 
@@ -47,7 +51,7 @@ export async function generateWithGemini({
   text,
   voice,
 }: {
-  instructions: string;
+  instructions?: string;
   languageCode?: string;
   text: string;
   voice: TTSVoice;

--- a/packages/ai/src/tasks/audio/provider-gemini.ts
+++ b/packages/ai/src/tasks/audio/provider-gemini.ts
@@ -5,6 +5,37 @@ import { wrapPCMInWAV } from "./wrap-pcm-in-wav";
 
 const MODEL = "gemini-2.5-flash-preview-tts";
 
+/* oxlint-disable-next-line no-magic-numbers -- 850 KiB is the prompt-leak failure threshold observed in generated audio files. */
+const MAX_GEMINI_AUDIO_BYTES = 850 * 1024;
+
+/**
+ * Keeps Gemini TTS guidance in the prompt content because the speech-generation
+ * docs show style, accent, and pacing control as natural-language text in
+ * `contents`, and runtime checks show `systemInstruction` can be ignored by the
+ * TTS model for language pronunciation. The final labeled line gives Gemini a
+ * small target after the instructions instead of leaving it to infer what text
+ * should be spoken from the whole prompt.
+ */
+function buildGeminiPrompt({ instructions, text }: { instructions: string; text: string }) {
+  return `${instructions}\n\nText to speak exactly:\n${text}`;
+}
+
+/**
+ * Rejects Gemini audio that is too long to be a normal word or learner
+ * sentence. When Gemini starts reading prompt instructions, the raw PCM output
+ * becomes much larger than expected, so treating the size as a provider
+ * failure lets the shared fallback path regenerate clean audio.
+ */
+function assertExpectedAudioSize(audio: Uint8Array) {
+  if (audio.byteLength <= MAX_GEMINI_AUDIO_BYTES) {
+    return;
+  }
+
+  throw new Error(
+    `Gemini TTS returned oversized audio: ${audio.byteLength} bytes. Expected at most ${MAX_GEMINI_AUDIO_BYTES} bytes.`,
+  );
+}
+
 /**
  * Generates audio using the Google GenAI SDK with a Gemini TTS model.
  * Returns WAV audio because Gemini outputs raw PCM which needs
@@ -12,10 +43,12 @@ const MODEL = "gemini-2.5-flash-preview-tts";
  */
 export async function generateWithGemini({
   instructions,
+  languageCode,
   text,
   voice,
 }: {
   instructions: string;
+  languageCode?: string;
   text: string;
   voice: TTSVoice;
 }): Promise<AudioResult> {
@@ -24,9 +57,12 @@ export async function generateWithGemini({
   const response = await client.models.generateContent({
     config: {
       responseModalities: ["AUDIO"],
-      speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName: voice } } },
+      speechConfig: {
+        ...(languageCode ? { languageCode } : {}),
+        voiceConfig: { prebuiltVoiceConfig: { voiceName: voice } },
+      },
     },
-    contents: [{ parts: [{ text: `${instructions}\n\n${text}` }] }],
+    contents: [{ parts: [{ text: buildGeminiPrompt({ instructions, text }) }] }],
     model: MODEL,
   });
 
@@ -37,5 +73,8 @@ export async function generateWithGemini({
   }
 
   const pcmBytes = new Uint8Array(Buffer.from(audioData, "base64"));
-  return { audio: wrapPCMInWAV(pcmBytes), format: "wav" };
+  const wavAudio = wrapPCMInWAV(pcmBytes);
+  assertExpectedAudioSize(wavAudio);
+
+  return { audio: wavAudio, format: "wav" };
 }

--- a/packages/ai/src/tasks/audio/provider-openai.ts
+++ b/packages/ai/src/tasks/audio/provider-openai.ts
@@ -20,13 +20,13 @@ export async function generateWithOpenAI({
   instructions,
   text,
 }: {
-  instructions: string;
+  instructions?: string;
   languageCode?: string;
   text: string;
   voice: TTSVoice;
 }): Promise<AudioResult> {
   const { audio } = await generateSpeech({
-    instructions,
+    ...(instructions ? { instructions } : {}),
     model: MODEL,
     outputFormat: "opus",
     text,

--- a/packages/ai/src/tasks/audio/provider-openai.ts
+++ b/packages/ai/src/tasks/audio/provider-openai.ts
@@ -21,6 +21,7 @@ export async function generateWithOpenAI({
   text,
 }: {
   instructions: string;
+  languageCode?: string;
   text: string;
   voice: TTSVoice;
 }): Promise<AudioResult> {


### PR DESCRIPTION
## Summary

- keep Gemini TTS instructions in prompt content with the exact text labeled at the end
- pass the target language code through Gemini speech config
- reject oversized Gemini audio so fallback generation can retry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Gemini TTS language audio by keeping guidance in the prompt content, passing the target `languageCode`, and rejecting oversized audio so fallback providers can retry. Skips guidance for normal English audio to reduce prompt bleed; updates read‑aloud pacing and adds tests.

- **Bug Fixes**
  - Keep TTS guidance in `contents` with a labeled “Text to speak exactly” line.
  - Omit instructions for English word/sentence audio; include for non‑English or special usages.
  - Send `languageCode` in Gemini `speechConfig` and thread it through fallback providers.
  - Guard against oversized Gemini audio to force fallback; add unit tests for prompt shape, size checks, and English‑skip behavior.

<sup>Written for commit c8fc734cd943d7b331694a327c35df9561487793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

