### PR TITLE
fix(admin): remove free manual subscriptions

### DIFF
--- a/apps/admin/src/app/(private)/users/[id]/_actions/change-plan.ts
+++ b/apps/admin/src/app/(private)/users/[id]/_actions/change-plan.ts
@@ -3,7 +3,7 @@
 import { randomUUID } from "node:crypto";
 import { findUserActiveSubscription } from "@/data/users/find-active-subscription";
 import { assertAdmin } from "@/lib/admin-guard";
-import { prisma } from "@zoonk/db";
+import { type Subscription, prisma } from "@zoonk/db";
 import { safeAsync } from "@zoonk/utils/error";
 import { parseFormField } from "@zoonk/utils/form";
 import { revalidatePath } from "next/cache";
@@ -26,29 +26,51 @@ export async function changePlanAction(formData: FormData) {
     throw new Error("Cannot change plan unless the subscription is Zoonk-managed");
   }
 
-  const { error } = await safeAsync(() => {
-    if (existing) {
-      return prisma.subscription.update({
-        data: { periodStart: new Date(), plan, status: "active" },
-        where: { id: existing.id },
-      });
-    }
-
-    return prisma.subscription.create({
-      data: {
-        id: randomUUID(),
-        periodStart: new Date(),
-        plan,
-        provider: "zoonk",
-        referenceId: userId,
-        status: "active",
-      },
-    });
-  });
+  const { error } = await safeAsync(() => saveManualPlanChange({ existing, plan, userId }));
 
   if (error) {
     throw error;
   }
 
   revalidatePath(`/users/${userId}`);
+}
+
+/**
+ * Admin-managed paid plans are stored as Zoonk-owned active subscriptions, but
+ * the free plan is the absence of an active subscription. Keeping a
+ * Zoonk-managed row for "free" makes the learner billing page treat the account
+ * as support-managed and blocks self-serve Stripe upgrades.
+ */
+async function saveManualPlanChange({
+  existing,
+  plan,
+  userId,
+}: {
+  existing: Subscription | null;
+  plan: string;
+  userId: string;
+}) {
+  if (plan === "free") {
+    return prisma.subscription.deleteMany({
+      where: { provider: "zoonk", referenceId: userId, status: { in: ["active", "trialing"] } },
+    });
+  }
+
+  if (existing) {
+    return prisma.subscription.update({
+      data: { periodStart: new Date(), plan, status: "active" },
+      where: { id: existing.id },
+    });
+  }
+
+  return prisma.subscription.create({
+    data: {
+      id: randomUUID(),
+      periodStart: new Date(),
+      plan,
+      provider: "zoonk",
+      referenceId: userId,
+      status: "active",
+    },
+  });
 }


### PR DESCRIPTION
## Summary

- Delete Zoonk-managed active subscriptions when admin changes a user to the free plan
- Keep paid manual plan changes using the existing Zoonk-managed subscription flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Setting a user to the free plan in admin now removes Zoonk-managed active/trialing subscriptions, treating free as the absence of an active subscription. Paid manual plan changes still create/update a Zoonk-managed active subscription, fixing the billing page showing support-managed state and allowing self-serve Stripe upgrades.

<sup>Written for commit 41423b5b810af2bab680668fd0fa15749e57bc8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

