### PR TITLE
feat(player): add guest progress warning

### DIFF
--- a/apps/main/e2e/auth-callback.test.ts
+++ b/apps/main/e2e/auth-callback.test.ts
@@ -122,6 +122,32 @@ test.describe("Auth Callback", () => {
     expect(stateCookie?.value).toBe(state);
   });
 
+  test("drops backslash-based network-path return targets when starting login", async ({
+    context,
+    page,
+  }) => {
+    const baseURL = getBaseURL();
+    const authUrls: string[] = [];
+    const unsafeNextPath = String.raw`/\\evil.example/path`;
+
+    await page.route("**/auth/login**", async (route) => {
+      authUrls.push(route.request().url());
+      await route.fulfill({ body: "Auth app", contentType: "text/html", status: 200 });
+    });
+
+    await page.goto(`/login?next=${encodeURIComponent(unsafeNextPath)}`);
+    await expect.poll(() => authUrls.length).toBe(1);
+
+    const authUrl = getInterceptedAuthUrl(authUrls);
+    const callbackUrl = getRequiredSearchParam({ name: "redirectTo", url: authUrl });
+    const state = getRequiredSearchParam({ name: "state", url: callbackUrl });
+    const cookies = await context.cookies(baseURL);
+    const stateCookie = cookies.find((cookie) => cookie.name === ONE_TIME_TOKEN_LOGIN_STATE_COOKIE);
+
+    expect(new URL(callbackUrl).searchParams.get("next")).toBeNull();
+    expect(stateCookie?.value).toBe(state);
+  });
+
   test("redirects to home and sets session on valid token", async ({ browser }) => {
     const baseURL = getBaseURL();
     const user = await createE2EUser(baseURL);
@@ -158,6 +184,26 @@ test.describe("Auth Callback", () => {
     );
 
     await page.waitForURL(/\/level$/u);
+
+    await ctx.close();
+  });
+
+  test("redirects to home for backslash-based network-path return targets", async ({ browser }) => {
+    const baseURL = getBaseURL();
+    const user = await createE2EUser(baseURL);
+    const token = await generateOneTimeToken(baseURL, user);
+    const unsafeNextPath = String.raw`/\\evil.example/path`;
+
+    const ctx = await browser.newContext({ baseURL });
+    const state = await createLoginState({ baseURL, context: ctx });
+
+    const response = await ctx.request.get(
+      `/auth/callback?state=${encodeURIComponent(state)}&token=${encodeURIComponent(token)}&next=${encodeURIComponent(unsafeNextPath)}`,
+      { maxRedirects: 0 },
+    );
+
+    expect(response.status()).toBe(302);
+    expect(getRedirectLocation(response)).toBe("/");
 
     await ctx.close();
   });

--- a/apps/main/e2e/auth-callback.test.ts
+++ b/apps/main/e2e/auth-callback.test.ts
@@ -99,6 +99,29 @@ test.describe("Auth Callback", () => {
     expect(stateCookie?.value).toBe(state);
   });
 
+  test("starts login with a state-bound return path", async ({ context, page }) => {
+    const baseURL = getBaseURL();
+    const authUrls: string[] = [];
+    const nextPath = "/b/ai/c/course/ch/chapter/l/lesson";
+
+    await page.route("**/auth/login**", async (route) => {
+      authUrls.push(route.request().url());
+      await route.fulfill({ body: "Auth app", contentType: "text/html", status: 200 });
+    });
+
+    await page.goto(`/login?next=${encodeURIComponent(nextPath)}`);
+    await expect.poll(() => authUrls.length).toBe(1);
+
+    const authUrl = getInterceptedAuthUrl(authUrls);
+    const callbackUrl = getRequiredSearchParam({ name: "redirectTo", url: authUrl });
+    const state = getRequiredSearchParam({ name: "state", url: callbackUrl });
+    const cookies = await context.cookies(baseURL);
+    const stateCookie = cookies.find((cookie) => cookie.name === ONE_TIME_TOKEN_LOGIN_STATE_COOKIE);
+
+    expect(new URL(callbackUrl).searchParams.get("next")).toBe(nextPath);
+    expect(stateCookie?.value).toBe(state);
+  });
+
   test("redirects to home and sets session on valid token", async ({ browser }) => {
     const baseURL = getBaseURL();
     const user = await createE2EUser(baseURL);
@@ -116,6 +139,25 @@ test.describe("Auth Callback", () => {
 
     await page.getByRole("button", { name: /user menu/iu }).click();
     await expect(page.getByText(/logout/iu)).toBeVisible();
+
+    await ctx.close();
+  });
+
+  test("redirects to the requested app path on valid token", async ({ browser }) => {
+    const baseURL = getBaseURL();
+    const user = await createE2EUser(baseURL);
+    const token = await generateOneTimeToken(baseURL, user);
+    const nextPath = "/level";
+
+    const ctx = await browser.newContext({ baseURL });
+    const state = await createLoginState({ baseURL, context: ctx });
+    const page = await ctx.newPage();
+
+    await page.goto(
+      `/auth/callback?state=${encodeURIComponent(state)}&token=${encodeURIComponent(token)}&next=${encodeURIComponent(nextPath)}`,
+    );
+
+    await page.waitForURL(/\/level$/u);
 
     await ctx.close();
   });

--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -170,8 +170,8 @@ test.describe("Continue Learning Revalidation", () => {
     // 3. Complete the static lesson and wait for durable progress before navigating again.
     await completeStaticLesson({ lessonId: lesson1.id, page, userId: user.id });
 
-    // 4. Click "All Lessons" (client-side navigation)
-    await page.getByRole("link", { name: /all lessons/iu }).click();
+    // 4. Click "Exit" (client-side navigation)
+    await page.getByRole("link", { name: /exit/iu }).click();
     await page.waitForURL(new RegExp(`e2e-cl-reval-chapter-${uniqueId}$`, "u"));
 
     // 5. Click the Home link in the navbar (client-side navigation — Router Cache)
@@ -226,7 +226,7 @@ test.describe("Continue Learning Revalidation", () => {
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson0.slug}`);
     await completeStaticLesson({ lessonId: lesson0.id, page, userId: user.id });
 
-    await page.getByRole("link", { name: /all lessons/iu }).click();
+    await page.getByRole("link", { name: /exit/iu }).click();
     await page.waitForURL(new RegExp(`e2e-cl-reval-chapter-${uniqueId}$`, "u"));
 
     const currentContinueLink = page.getByRole("link", { name: "Continue 67% complete" });

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -310,10 +310,7 @@ test.describe("Lesson Completion UX", () => {
     await browserContext.close();
   });
 
-  test("lesson complete: all lessons navigates to the chapter page", async ({
-    baseURL,
-    browser,
-  }) => {
+  test("lesson complete: exit navigates to the chapter page", async ({ baseURL, browser }) => {
     const email = await createUniqueUser(baseURL!);
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
     const { chapter, lessonUrl, uniqueId } = await createLessonCompleteScenario("lrev");
@@ -324,7 +321,7 @@ test.describe("Lesson Completion UX", () => {
 
     const completionScreen = page.getByRole("status");
 
-    await completionScreen.getByRole("link", { name: /all lessons/iu }).click();
+    await completionScreen.getByRole("link", { name: /exit/iu }).click();
     await expect(page.getByRole("heading", { level: 1, name: chapter.title })).toBeVisible();
 
     await browserContext.close();

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -70,6 +70,15 @@ async function createTestLesson(options?: {
   return { chapter, course, lesson, lessonTitle, uniqueId };
 }
 
+async function expectGuestProgressWarning(page: Page) {
+  await expect(page.getByRole("heading", { name: "Progress won't be saved" })).toBeVisible();
+}
+
+async function continueWithoutSaving(page: Page) {
+  await expectGuestProgressWarning(page);
+  await page.getByRole("button", { name: "Continue without saving" }).click();
+}
+
 /**
  * Practice lessons can be generated from explanation metadata before those
  * explanations finish generating, so the player empty state should point at
@@ -501,6 +510,7 @@ test.describe("Lesson Player Page", () => {
     });
 
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    await continueWithoutSaving(page);
 
     await expect(page.getByRole("heading", { name: `Step ${uniqueId} #0` })).toBeVisible();
     await expect(page.getByText(`Test step content ${uniqueId} #0`)).toBeVisible();
@@ -568,6 +578,7 @@ test.describe("Lesson Player Page", () => {
     const { chapter, course, lesson } = await createTestLesson({ generationStatus: "completed" });
 
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    await continueWithoutSaving(page);
 
     const closeLink = page.getByRole("link", { name: /close/iu });
 
@@ -755,7 +766,7 @@ test.describe("Lesson Player Page", () => {
 
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page.getByRole("link", { name: /close/iu })).toBeVisible();
+    await expectGuestProgressWarning(page);
 
     await page.waitForLoadState("networkidle");
     await page.keyboard.press("Escape");

--- a/apps/main/e2e/lesson-start-tracking.test.ts
+++ b/apps/main/e2e/lesson-start-tracking.test.ts
@@ -123,7 +123,7 @@ test.describe("Lesson Start Tracking", () => {
     const { lesson, url } = await createTestLesson();
 
     await page.goto(url);
-    await expect(page.getByRole("link", { name: /close/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Progress won't be saved" })).toBeVisible();
 
     const progress = await prisma.lessonProgress.findFirst({ where: { lessonId: lesson.id } });
 

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -81,6 +81,7 @@ export function LessonPlayerClient({
     chapterSlug,
     courseSlug,
     lessonProgress,
+    lessonSlug,
     nextChapter,
     nextLesson,
   });

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
@@ -41,6 +41,7 @@ describe(buildLessonPlayerModel, () => {
       brandSlug: "brand",
       chapterSlug: "chapter-1",
       courseSlug: "course",
+      lessonSlug: "current-lesson",
       nextLesson: { chapterSlug: "chapter-1", lessonSlug: "lesson-1", lessonTitle: "Lesson 1" },
     });
 
@@ -54,6 +55,7 @@ describe(buildLessonPlayerModel, () => {
       brandSlug: "brand",
       chapterSlug: "chapter-1",
       courseSlug: "course",
+      lessonSlug: "current-lesson",
       nextLesson: { chapterSlug: "chapter-1", lessonSlug: "lesson-2", lessonTitle: "Lesson 2" },
     });
 
@@ -67,6 +69,7 @@ describe(buildLessonPlayerModel, () => {
       brandSlug: "brand",
       chapterSlug: "chapter-1",
       courseSlug: "course",
+      lessonSlug: "current-lesson",
       nextLesson: { chapterSlug: "chapter-2", lessonSlug: "lesson-2", lessonTitle: "Lesson 2" },
     });
 
@@ -84,6 +87,7 @@ describe(buildLessonPlayerModel, () => {
       brandSlug: "brand",
       chapterSlug: "chapter-1",
       courseSlug: "course",
+      lessonSlug: "current-lesson",
       nextLesson: null,
     });
 
@@ -101,6 +105,7 @@ describe(buildLessonPlayerModel, () => {
       brandSlug: "brand",
       chapterSlug: "chapter-1",
       courseSlug: "course",
+      lessonSlug: "current-lesson",
       nextChapter: { brandSlug: "brand", chapterSlug: "chapter-2", courseSlug: "course" },
       nextLesson: null,
     });
@@ -112,5 +117,19 @@ describe(buildLessonPlayerModel, () => {
     });
 
     expect(model.onNextHref).toBe("/b/brand/c/course/ch/chapter-2");
+  });
+
+  it("returns a login href that brings learners back to the current lesson", () => {
+    const model = buildLessonPlayerModel({
+      brandSlug: "brand",
+      chapterSlug: "chapter-1",
+      courseSlug: "course",
+      lessonSlug: "current-lesson",
+      nextLesson: null,
+    });
+
+    expect(model.navigation.loginHref).toBe(
+      "/login?next=%2Fb%2Fbrand%2Fc%2Fcourse%2Fch%2Fchapter-1%2Fl%2Fcurrent-lesson",
+    );
   });
 });

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
@@ -113,6 +113,34 @@ function getNextLessonHref({
 }
 
 /**
+ * Builds the current player URL once so guest auth links can return learners
+ * to the exact lesson where they chose to log in. The callback only accepts
+ * app-relative paths, so this helper intentionally returns a path instead of
+ * an absolute URL.
+ */
+function getCurrentLessonHref({
+  brandSlug,
+  chapterSlug,
+  courseSlug,
+  lessonSlug,
+}: {
+  brandSlug: string;
+  chapterSlug: string;
+  courseSlug: string;
+  lessonSlug: string;
+}) {
+  return `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}` as const;
+}
+
+/**
+ * Encodes the current lesson into the login route so central-auth redirects
+ * can come back to the player instead of dropping learners on the home page.
+ */
+function getLoginHref({ currentLessonHref }: { currentLessonHref: string }) {
+  return `/login?next=${encodeURIComponent(currentLessonHref)}` as const;
+}
+
+/**
  * Chapter completion is a structural boundary, not proof that the next lesson
  * is ready. A next chapter with no lessons should still show the chapter
  * milestone and send learners to the chapter page, where generation can start.
@@ -154,6 +182,7 @@ export function buildLessonPlayerModel({
   brandSlug,
   chapterSlug,
   courseSlug,
+  lessonSlug,
   lessonProgress = DEFAULT_LESSON_PROGRESS,
   nextChapter = null,
   nextLesson,
@@ -161,12 +190,21 @@ export function buildLessonPlayerModel({
   brandSlug: string;
   chapterSlug: string;
   courseSlug: string;
+  lessonSlug: string;
   lessonProgress?: LessonProgressMeta;
   nextChapter?: NextChapter | null;
   nextLesson: NextLesson | null;
 }) {
   const chapterHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}` as const;
   const courseHref = `/b/${brandSlug}/c/${courseSlug}` as const;
+
+  const currentLessonHref = getCurrentLessonHref({
+    brandSlug,
+    chapterSlug,
+    courseSlug,
+    lessonSlug,
+  });
+
   const nextLessonHref = getNextLessonHref({ brandSlug, courseSlug, nextLesson });
 
   const nextChapterHref = getNextChapterHref({
@@ -197,7 +235,7 @@ export function buildLessonPlayerModel({
       courseHref,
       energyHref: "/energy",
       levelHref: "/level",
-      loginHref: "/login",
+      loginHref: getLoginHref({ currentLessonHref }),
       nextLessonHref,
     },
     onNextHref: nextLessonHref ?? nextChapterHref,

--- a/apps/main/src/app/login/page.tsx
+++ b/apps/main/src/app/login/page.tsx
@@ -1,10 +1,45 @@
 import { OneTimeTokenLoginRedirect } from "@zoonk/core/auth/ott/login";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
 
-export default function LoginPage() {
+type Props = PageProps<"/login">;
+
+/**
+ * Accepts only app-relative return paths for login callbacks. The central auth
+ * app already validates trusted origins, but the local login page should still
+ * avoid forwarding absolute or protocol-relative URLs as post-login targets.
+ */
+function getSafeNextPath(next: string | string[] | undefined): string | null {
+  if (typeof next !== "string") {
+    return null;
+  }
+
+  if (!next.startsWith("/") || next.startsWith("//")) {
+    return null;
+  }
+
+  return next;
+}
+
+/**
+ * Builds the callback path sent to central auth. Keeping the return target on
+ * the app callback lets the token handoff finish locally before redirecting
+ * the learner back to the lesson that started the login flow.
+ */
+function getCallbackPath(nextPath: string | null) {
+  if (!nextPath) {
+    return "/auth/callback";
+  }
+
+  return `/auth/callback?next=${encodeURIComponent(nextPath)}`;
+}
+
+export default async function LoginPage({ searchParams }: Props) {
+  const { next } = await searchParams;
+  const callbackPath = getCallbackPath(getSafeNextPath(next));
+
   return (
     <>
-      <OneTimeTokenLoginRedirect callbackPath="/auth/callback" />
+      <OneTimeTokenLoginRedirect callbackPath={callbackPath} />
       <FullPageLoading />
     </>
   );

--- a/apps/main/src/app/login/page.tsx
+++ b/apps/main/src/app/login/page.tsx
@@ -1,24 +1,8 @@
 import { OneTimeTokenLoginRedirect } from "@zoonk/core/auth/ott/login";
+import { getSafeAppRelativePath } from "@zoonk/core/auth/ott/redirect";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
 
 type Props = PageProps<"/login">;
-
-/**
- * Accepts only app-relative return paths for login callbacks. The central auth
- * app already validates trusted origins, but the local login page should still
- * avoid forwarding absolute or protocol-relative URLs as post-login targets.
- */
-function getSafeNextPath(next: string | string[] | undefined): string | null {
-  if (typeof next !== "string") {
-    return null;
-  }
-
-  if (!next.startsWith("/") || next.startsWith("//")) {
-    return null;
-  }
-
-  return next;
-}
 
 /**
  * Builds the callback path sent to central auth. Keeping the return target on
@@ -35,7 +19,7 @@ function getCallbackPath(nextPath: string | null) {
 
 export default async function LoginPage({ searchParams }: Props) {
   const { next } = await searchParams;
-  const callbackPath = getCallbackPath(getSafeNextPath(next));
+  const callbackPath = getCallbackPath(getSafeAppRelativePath(next));
 
   return (
     <>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "./auth/next": "./src/auth/next.ts",
     "./auth/ott/callback": "./src/auth/ott-callback.ts",
     "./auth/ott/login": "./src/auth/ott-login.tsx",
+    "./auth/ott/redirect": "./src/auth/ott-redirect.ts",
     "./auth/ott/state": "./src/auth/ott-state.ts",
     "./auth/stripe-prices": "./src/auth/stripe-prices.ts",
     "./auth/subscription": "./src/auth/subscription.ts",

--- a/packages/core/src/auth/ott-callback.ts
+++ b/packages/core/src/auth/ott-callback.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { type NextRequest } from "next/server";
 import { auth } from "./auth";
+import { getSafeAppRelativePath } from "./ott-redirect";
 import { ONE_TIME_TOKEN_LOGIN_STATE_COOKIE } from "./ott-state";
 
 const AUTH_ERROR_REDIRECT = "/login?error=auth";
@@ -33,16 +34,7 @@ function redirectTo(location: string): Response {
  */
 function getSafeSuccessRedirect(request: NextRequest): string {
   const nextPath = request.nextUrl.searchParams.get("next");
-
-  if (!nextPath) {
-    return AUTH_SUCCESS_REDIRECT;
-  }
-
-  if (!nextPath.startsWith("/") || nextPath.startsWith("//")) {
-    return AUTH_SUCCESS_REDIRECT;
-  }
-
-  return nextPath;
+  return getSafeAppRelativePath(nextPath) ?? AUTH_SUCCESS_REDIRECT;
 }
 
 /**

--- a/packages/core/src/auth/ott-callback.ts
+++ b/packages/core/src/auth/ott-callback.ts
@@ -27,6 +27,25 @@ function redirectTo(location: string): Response {
 }
 
 /**
+ * Returns the post-login destination requested by the app login page. Only
+ * app-relative paths are allowed here so a valid one-time token cannot become
+ * an open redirect to another origin.
+ */
+function getSafeSuccessRedirect(request: NextRequest): string {
+  const nextPath = request.nextUrl.searchParams.get("next");
+
+  if (!nextPath) {
+    return AUTH_SUCCESS_REDIRECT;
+  }
+
+  if (!nextPath.startsWith("/") || nextPath.startsWith("//")) {
+    return AUTH_SUCCESS_REDIRECT;
+  }
+
+  return nextPath;
+}
+
+/**
  * Checks the callback state before the one-time token is redeemed so attacker
  * tokens cannot force a browser into an attacker-controlled session.
  */
@@ -67,7 +86,7 @@ export async function verifyOneTimeTokenCallback(request: NextRequest): Promise<
     return redirectTo(AUTH_ERROR_REDIRECT);
   }
 
-  const headers = new Headers({ Location: AUTH_SUCCESS_REDIRECT });
+  const headers = new Headers({ Location: getSafeSuccessRedirect(request) });
   headers.append("set-cookie", getExpiredLoginStateCookie());
 
   for (const cookie of response.headers.getSetCookie()) {

--- a/packages/core/src/auth/ott-redirect.ts
+++ b/packages/core/src/auth/ott-redirect.ts
@@ -1,0 +1,18 @@
+/**
+ * Accepts only app-relative paths that browsers cannot reinterpret as
+ * network-path references. Backslashes are rejected because URL parsers
+ * normalize them as slashes, so `/\evil.com` can become `//evil.com`.
+ */
+export function getSafeAppRelativePath(
+  nextPath: string | string[] | undefined | null,
+): string | null {
+  if (typeof nextPath !== "string") {
+    return null;
+  }
+
+  if (!nextPath.startsWith("/") || nextPath.startsWith("//") || nextPath.includes("\\")) {
+    return null;
+  }
+
+  return nextPath;
+}

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -46,8 +46,8 @@ msgid "e7WNdK"
 msgstr "Word bank"
 
 #: src/components/completion-auth-branch.tsx
-msgid "Ak-bLZ"
-msgstr "All Lessons"
+msgid "E2sGaF"
+msgstr "Exit"
 
 #: src/components/completion-auth-branch.tsx
 msgid "FazwRl"
@@ -60,14 +60,8 @@ msgid "9-Ddtu"
 msgstr "Next"
 
 #: src/components/completion-auth-branch.tsx
-#: src/components/completion-milestone-actions.tsx
-msgid "e1M39C"
-msgstr "Sign up to track your progress"
-
-#: src/components/completion-auth-branch.tsx
-#: src/components/completion-milestone-actions.tsx
-msgid "M8B177"
-msgstr "Log in to save your progress"
+msgid "odXlk8"
+msgstr "Log in"
 
 #: src/components/completion-brain-power-milestone.tsx
 msgid "D7TYjj"
@@ -296,6 +290,30 @@ msgstr "Next step"
 #: src/components/translation-step.tsx
 msgid "MxLxkr"
 msgstr "Translate this word:"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "czygLT"
+msgstr "Log in to save progress"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "yBJVJw"
+msgstr "Continue without saving"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "O781mu"
+msgstr "Progress won't be saved"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "JDumQX"
+msgstr "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "rxdOwg"
+msgstr "This lesson wasn't saved"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "Wamgyz"
+msgstr "Log in before your next lesson to keep future progress, scores, levels, and Energy."
 
 #: src/components/verdict-label.tsx
 msgid "xmF49T"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -46,8 +46,8 @@ msgid "e7WNdK"
 msgstr "Banco de palabras"
 
 #: src/components/completion-auth-branch.tsx
-msgid "Ak-bLZ"
-msgstr "Todas las lecciones"
+msgid "E2sGaF"
+msgstr "Salir"
 
 #: src/components/completion-auth-branch.tsx
 msgid "FazwRl"
@@ -60,14 +60,8 @@ msgid "9-Ddtu"
 msgstr "Siguiente"
 
 #: src/components/completion-auth-branch.tsx
-#: src/components/completion-milestone-actions.tsx
-msgid "e1M39C"
-msgstr "Regístrate para seguir tu progreso"
-
-#: src/components/completion-auth-branch.tsx
-#: src/components/completion-milestone-actions.tsx
-msgid "M8B177"
-msgstr "Iniciar sesión para guardar tu progreso"
+msgid "odXlk8"
+msgstr "Iniciar sesión"
 
 #: src/components/completion-brain-power-milestone.tsx
 msgid "D7TYjj"
@@ -296,6 +290,30 @@ msgstr "Siguiente paso"
 #: src/components/translation-step.tsx
 msgid "MxLxkr"
 msgstr "Traduce esta palabra:"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "czygLT"
+msgstr "Inicia sesión para guardar tu progreso"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "yBJVJw"
+msgstr "Continuar sin guardar"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "O781mu"
+msgstr "El progreso no se guardará"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "JDumQX"
+msgstr "Puedes probar esta lección sin una cuenta, pero tu puntuación, progreso del curso, niveles y energía no se guardarán."
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "rxdOwg"
+msgstr "Esta lección no se guardó"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "Wamgyz"
+msgstr "Inicia sesión antes de tu próxima lección para conservar el progreso, las puntuaciones, los niveles y la energía en adelante."
 
 #: src/components/verdict-label.tsx
 msgid "xmF49T"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -46,8 +46,8 @@ msgid "e7WNdK"
 msgstr "Banco de palavras"
 
 #: src/components/completion-auth-branch.tsx
-msgid "Ak-bLZ"
-msgstr "Todas as aulas"
+msgid "E2sGaF"
+msgstr "Sair"
 
 #: src/components/completion-auth-branch.tsx
 msgid "FazwRl"
@@ -60,14 +60,8 @@ msgid "9-Ddtu"
 msgstr "Próxima"
 
 #: src/components/completion-auth-branch.tsx
-#: src/components/completion-milestone-actions.tsx
-msgid "e1M39C"
-msgstr "Cadastre-se para acompanhar seu progresso"
-
-#: src/components/completion-auth-branch.tsx
-#: src/components/completion-milestone-actions.tsx
-msgid "M8B177"
-msgstr "Entrar para salvar seu progresso"
+msgid "odXlk8"
+msgstr "Entrar"
 
 #: src/components/completion-brain-power-milestone.tsx
 msgid "D7TYjj"
@@ -296,6 +290,30 @@ msgstr "Próxima etapa"
 #: src/components/translation-step.tsx
 msgid "MxLxkr"
 msgstr "Traduza esta palavra:"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "czygLT"
+msgstr "Entrar para salvar seu progresso"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "yBJVJw"
+msgstr "Continuar sem salvar"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "O781mu"
+msgstr "O progresso não será salvo"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "JDumQX"
+msgstr "Você pode testar esta aula sem uma conta, mas sua pontuação, progresso no curso, níveis e Energia não serão salvos."
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "rxdOwg"
+msgstr "Esta aula não foi salva"
+
+#: src/components/unauthenticated-progress-prompt.tsx
+msgid "Wamgyz"
+msgstr "Entre antes da próxima aula para manter o progresso, as pontuações, os níveis e a Energia daqui em diante."
 
 #: src/components/verdict-label.tsx
 msgid "xmF49T"

--- a/packages/player/src/_browser-tests/player-choice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-choice.browser.test.tsx
@@ -434,7 +434,10 @@ describe("player browser integration: choice steps", () => {
           }),
         ],
       }),
+      viewer: { isAuthenticated: false, userName: null },
     });
+
+    await page.getByRole("button", { name: /continue without saving/iu }).click();
 
     await expect.element(page.getByText(/^we have a situation$/iu)).toBeInTheDocument();
     await expect.element(page.getByText("{{NAME}}")).not.toBeInTheDocument();

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -97,7 +97,7 @@ describe("player browser integration: completion", () => {
     await expect.element(completionScreen.getByRole("link", { name: "Next" })).toBeInTheDocument();
 
     await expect
-      .element(completionScreen.getByRole("link", { name: /all lessons/iu }))
+      .element(completionScreen.getByRole("link", { name: /exit/iu }))
       .toBeInTheDocument();
 
     await expect
@@ -273,7 +273,7 @@ describe("player browser integration: completion", () => {
     await expect.element(completionScreen.getByText(/\+10\s*BP/iu)).not.toBeInTheDocument();
 
     await expect
-      .element(completionScreen.getByRole("link", { name: /all lessons/iu }))
+      .element(completionScreen.getByRole("link", { name: /exit/iu }))
       .toBeInTheDocument();
 
     await expect
@@ -294,25 +294,70 @@ describe("player browser integration: completion", () => {
   it("shows guest lesson completion login prompt without rewards and falls back to /login", async () => {
     renderPlayer({
       lesson: buildCompletionQuizLesson(),
+      lessonProgress: {
+        currentLessonNumber: 2,
+        remainingChaptersInCourse: 1,
+        remainingLessonsInChapter: 3,
+        totalLessonsInChapter: 5,
+      },
+      lessonTitle: "Guest Hidden Lesson",
       navigation: buildNavigation({ loginHref: undefined, nextLessonHref: "/lesson/play" }),
-      viewer: { isAuthenticated: false, userName: null },
+      totalBrainPower: 240,
+      viewer: {
+        completionFooter: <p>Guest completion footer</p>,
+        isAuthenticated: false,
+        userName: null,
+      },
     });
+
+    const startWarning = page.getByRole("status");
+
+    await expect.element(startWarning.getByText(/progress won't be saved/iu)).toBeInTheDocument();
+
+    const startLoginLink = startWarning.getByRole("link", { name: /log in to save progress/iu });
+
+    await expect.element(startLoginLink).toHaveAttribute("href", "/login");
+
+    await expect
+      .element(page.getByRole("heading", { name: "Completion question" }))
+      .not.toBeInTheDocument();
+
+    await startWarning.getByRole("button", { name: /continue without saving/iu }).click();
+
+    await expect
+      .element(page.getByRole("heading", { name: "Completion question" }))
+      .toBeInTheDocument();
 
     await completeSingleChoiceLesson();
 
     const completionScreen = page.getByRole("status");
 
-    const loginLink = completionScreen.getByRole("link", {
-      name: /log in to save your progress/iu,
-    });
+    const loginLink = completionScreen.getByRole("link", { name: /^log in$/iu });
 
     const nextLink = completionScreen.getByRole("link", { name: "Next" });
 
-    await expect.element(completionScreen.getByText("100%")).toBeInTheDocument();
+    await expect
+      .element(completionScreen.getByText(/this lesson wasn't saved/iu))
+      .toBeInTheDocument();
 
     await expect
-      .element(completionScreen.getByText(/sign up to track your progress/iu))
+      .element(completionScreen.getByText(/log in before your next lesson/iu))
       .toBeInTheDocument();
+
+    await expect.element(completionScreen.getByText("100%")).not.toBeInTheDocument();
+    await expect.element(completionScreen.getByText(/completed/iu)).not.toBeInTheDocument();
+    await expect.element(completionScreen.getByText("Guest Hidden Lesson")).not.toBeInTheDocument();
+    await expect.element(completionScreen.getByText("Lesson 2 of 5")).not.toBeInTheDocument();
+
+    await expect
+      .element(completionScreen.getByRole("progressbar", { name: /chapter progress/iu }))
+      .not.toBeInTheDocument();
+
+    await expect.element(completionScreen.getByText(/level achieved/iu)).not.toBeInTheDocument();
+
+    await expect
+      .element(completionScreen.getByText("Guest completion footer"))
+      .not.toBeInTheDocument();
 
     await expect.element(nextLink).toBeInTheDocument();
     await expect.element(nextLink).toHaveAttribute("href", "/lesson/play");
@@ -320,7 +365,7 @@ describe("player browser integration: completion", () => {
     await expect.element(loginLink).toHaveAttribute("href", "/login");
 
     await expect
-      .element(completionScreen.getByRole("link", { name: /all lessons/iu }))
+      .element(completionScreen.getByRole("link", { name: /exit/iu }))
       .toBeInTheDocument();
 
     await expect
@@ -414,7 +459,7 @@ describe("player browser integration: completion", () => {
       .toBeInTheDocument();
   });
 
-  it("shows guest milestone actions without exposing authenticated next links", async () => {
+  it("ignores structural milestones for guest completion", async () => {
     renderPlayer({
       lesson: buildCompletionQuizLesson(),
       milestone: { kind: "chapter", nextHref: "/next-chapter", reviewHref: "/review-chapter" },
@@ -422,23 +467,24 @@ describe("player browser integration: completion", () => {
       viewer: { isAuthenticated: false, userName: null },
     });
 
+    await page.getByRole("button", { name: /continue without saving/iu }).click();
     await completeSingleChoiceLesson();
 
     const completionScreen = page.getByRole("status");
 
-    const loginLink = completionScreen.getByRole("link", {
-      name: /log in to save your progress/iu,
-    });
+    const loginLink = completionScreen.getByRole("link", { name: /^log in$/iu });
 
     await expect
-      .element(completionScreen.getByText(/sign up to track your progress/iu))
+      .element(completionScreen.getByText(/this lesson wasn't saved/iu))
       .toBeInTheDocument();
 
     await expect.element(loginLink).toHaveAttribute("href", "/sign-in");
 
+    await expect.element(completionScreen.getByText(/chapter complete/iu)).not.toBeInTheDocument();
+
     await expect
       .element(completionScreen.getByRole("link", { name: /review chapter/iu }))
-      .toBeInTheDocument();
+      .not.toBeInTheDocument();
 
     await expect
       .element(completionScreen.getByRole("link", { name: /next chapter/iu }))

--- a/packages/player/src/_test-utils/render-player.tsx
+++ b/packages/player/src/_test-utils/render-player.tsx
@@ -62,7 +62,7 @@ export function renderPlayer({
   onNext,
   progressSnapshot = null,
   totalBrainPower = 0,
-  viewer = { isAuthenticated: false, userName: null },
+  viewer = { isAuthenticated: true, userName: "Alex" },
 }: {
   lesson: SerializedLesson;
   chapterTitle?: string;

--- a/packages/player/src/components/completion-auth-branch.tsx
+++ b/packages/player/src/components/completion-auth-branch.tsx
@@ -11,7 +11,8 @@ import {
 } from "../player-context";
 import { PlayerLink } from "../player-link";
 import { PrimaryActionLink, PrimaryKbd, SecondaryKbd } from "./completion-action-link";
-import { MilestoneActions, UnauthenticatedMilestoneActions } from "./completion-milestone-actions";
+import { MilestoneActions } from "./completion-milestone-actions";
+import { UnauthenticatedCompletionPrompt } from "./unauthenticated-progress-prompt";
 
 function CompletionActions({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -48,7 +49,7 @@ function SecondaryActions({
       )}
       href={chapterHref}
     >
-      {t("All Lessons")}
+      {t("Exit")}
       {isInline ? <SecondaryKbd>Esc</SecondaryKbd> : <PrimaryKbd>Esc</PrimaryKbd>}
     </PlayerLink>
   );
@@ -130,36 +131,34 @@ function UnauthenticatedContent({
   onRestart: () => void;
 }) {
   const t = useExtracted();
-  const milestone = usePlayerMilestone();
-
-  if (milestone) {
-    return <UnauthenticatedMilestoneActions loginHref={loginHref} />;
-  }
 
   return (
-    <>
-      <p className="text-muted-foreground text-sm">{t("Sign up to track your progress")}</p>
+    <CompletionActions>
+      <UnauthenticatedCompletionPrompt />
 
-      <CompletionActions>
-        <PlayerLink
-          className={cn(
-            buttonVariants({ variant: nextLessonHref ? "outline" : undefined }),
-            "w-full",
-          )}
-          href={loginHref}
-        >
-          {t("Log in to save your progress")}
-        </PlayerLink>
+      {nextLessonHref && (
+        <ActionRow>
+          <PlayerLink
+            className={cn(buttonVariants({ size: "lg" }), "min-w-0 flex-1")}
+            href={loginHref}
+          >
+            {t("Log in")}
+          </PlayerLink>
 
-        {nextLessonHref && (
-          <PrimaryActionLink href={nextLessonHref} shortcut="Enter">
+          <PrimaryActionLink className="min-w-0 flex-1" href={nextLessonHref} shortcut="Enter">
             {t("Next")}
           </PrimaryActionLink>
-        )}
+        </ActionRow>
+      )}
 
-        <SecondaryActions chapterHref={chapterHref} onRestart={onRestart} variant="inline" />
-      </CompletionActions>
-    </>
+      {!nextLessonHref && (
+        <PlayerLink className={cn(buttonVariants({ size: "lg" }), "w-full")} href={loginHref}>
+          {t("Log in")}
+        </PlayerLink>
+      )}
+
+      <SecondaryActions chapterHref={chapterHref} onRestart={onRestart} variant="inline" />
+    </CompletionActions>
   );
 }
 

--- a/packages/player/src/components/completion-milestone-actions.tsx
+++ b/packages/player/src/components/completion-milestone-actions.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { buttonVariants } from "@zoonk/ui/components/button";
-import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
-import { type PlayerRoute, usePlayerMilestone } from "../player-context";
-import { PlayerLink } from "../player-link";
+import { usePlayerMilestone } from "../player-context";
 import { PrimaryActionLink, SecondaryActionLink } from "./completion-action-link";
 
 function NextButtonLabel() {
@@ -77,30 +74,5 @@ export function MilestoneActions() {
     <PrimaryActionLink href={milestone.reviewHref} shortcut="Esc">
       <ReviewLabel />
     </PrimaryActionLink>
-  );
-}
-
-export function UnauthenticatedMilestoneActions({ loginHref }: { loginHref: PlayerRoute }) {
-  const t = useExtracted();
-  const milestone = usePlayerMilestone();
-
-  if (!milestone) {
-    return null;
-  }
-
-  return (
-    <>
-      <p className="text-muted-foreground text-sm">{t("Sign up to track your progress")}</p>
-
-      <div className="flex w-full flex-col gap-3" data-slot="completion-actions">
-        <PlayerLink className={cn(buttonVariants(), "w-full")} href={loginHref}>
-          {t("Log in to save your progress")}
-        </PlayerLink>
-
-        <SecondaryActionLink href={milestone.reviewHref} shortcut="Esc">
-          <ReviewLabel />
-        </SecondaryActionLink>
-      </div>
-    </>
   );
 }

--- a/packages/player/src/components/completion-screen.tsx
+++ b/packages/player/src/components/completion-screen.tsx
@@ -234,7 +234,19 @@ export function CompletionScreenContent({
 }) {
   const t = useExtracted();
   const milestone = usePlayerMilestone();
-  const { completionFooter } = usePlayerViewer();
+  const { completionFooter, isAuthenticated } = usePlayerViewer();
+
+  if (!isAuthenticated) {
+    return (
+      <CompletionScreen className="min-h-[60vh] justify-center">
+        <AuthBranch
+          chapterHref={chapterHref}
+          nextLessonHref={nextLessonHref}
+          onRestart={onRestart}
+        />
+      </CompletionScreen>
+    );
+  }
 
   if (milestone) {
     return (

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -3,6 +3,7 @@ import {
   type PlayerRuntimeContextValue,
   usePlayerNavigation,
   usePlayerRuntime,
+  usePlayerViewer,
 } from "../player-context";
 import {
   getActiveCompletionMilestone,
@@ -18,6 +19,7 @@ import { FeedbackScreenContent } from "./feedback-screen";
 import { StepActionButton } from "./step-action-button";
 import { PlayerContentFrame } from "./step-layouts";
 import { StepRenderer } from "./step-renderer";
+import { UnauthenticatedStartWarningScreen } from "./unauthenticated-progress-prompt";
 
 /**
  * Renders the desktop inline action inside the shared player frame so the
@@ -72,7 +74,8 @@ function hasEmbeddedDesktopAction({
 
 export function StageContent() {
   const { actions, screen, state } = usePlayerRuntime();
-  const { chapterHref, energyHref, levelHref, nextLessonHref } = usePlayerNavigation();
+  const { chapterHref, energyHref, levelHref, loginHref, nextLessonHref } = usePlayerNavigation();
+  const { isAuthenticated } = usePlayerViewer();
 
   const activeCompletionMilestone = getActiveCompletionMilestone(state);
   const completionResult = getCompletionResult(state);
@@ -80,8 +83,17 @@ export function StageContent() {
   const currentStep = getCurrentStep(state);
   const selectedAnswer = getSelectedAnswer(state);
 
+  if (screen.kind === "startWarning") {
+    return (
+      <UnauthenticatedStartWarningScreen
+        loginHref={loginHref ?? "/login"}
+        onContinue={actions.start}
+      />
+    );
+  }
+
   if (screen.kind === "completed") {
-    if (activeCompletionMilestone) {
+    if (isAuthenticated && activeCompletionMilestone) {
       return (
         <CompletionProgressMilestoneScreen
           energyHref={energyHref}

--- a/packages/player/src/components/unauthenticated-progress-prompt.tsx
+++ b/packages/player/src/components/unauthenticated-progress-prompt.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Button, buttonVariants } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { CircleAlert } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { type PlayerRoute } from "../player-context";
+import { PlayerLink } from "../player-link";
+import { PlayerContentFrame } from "./step-layouts";
+
+/**
+ * Provides the shared visual shell for signed-out progress prompts. The copy
+ * differs between pre-play and completion states, but the layout should stay
+ * consistent so the auth warning feels like one product moment.
+ */
+function ProgressPromptFrame({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "mx-auto flex w-full max-w-md flex-col items-center gap-5 text-center",
+        className,
+      )}
+      data-slot="unauthenticated-progress-prompt"
+      {...props}
+    />
+  );
+}
+
+/**
+ * Renders the warning icon without introducing a new badge or card system.
+ * The icon gives the prompt a stronger visual anchor while keeping the screen
+ * minimal and consistent with the rest of the player.
+ */
+function ProgressPromptIcon() {
+  return <CircleAlert className="text-foreground size-11" />;
+}
+
+/**
+ * Holds the headline and explanatory copy for the prompt. Keeping this wrapper
+ * shared prevents the start and completion branches from drifting in spacing
+ * or typography as the auth copy evolves.
+ */
+function ProgressPromptCopy({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-2", className)} {...props} />;
+}
+
+/**
+ * Renders the prompt title with completion-screen scale rather than page-hero
+ * scale. The warning appears inside a lesson flow, so it should be prominent
+ * without overpowering the player.
+ */
+function ProgressPromptTitle({ children, className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <h2 className={cn("text-2xl font-semibold tracking-tight", className)} {...props}>
+      {children}
+    </h2>
+  );
+}
+
+/**
+ * Renders supporting copy for signed-out progress prompts. This is intentionally
+ * constrained to one paragraph so the choice stays easy to scan before a lesson.
+ */
+function ProgressPromptDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn("text-muted-foreground text-sm leading-6 text-balance", className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Groups the auth and continue actions for the pre-play warning. Login is the
+ * primary action because it is the only path that preserves future progress,
+ * while continuing is still available for learners who only want to try it.
+ */
+function StartWarningActions({
+  loginHref,
+  onContinue,
+}: {
+  loginHref: PlayerRoute;
+  onContinue: () => void;
+}) {
+  const t = useExtracted();
+
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <PlayerLink className={cn(buttonVariants(), "w-full")} href={loginHref}>
+        {t("Log in to save progress")}
+      </PlayerLink>
+
+      <Button className="w-full" onClick={onContinue} variant="outline">
+        {t("Continue without saving")}
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Shows the signed-out warning before any lesson step is visible. This makes
+ * the saving limitation clear before the learner invests time, and keeps the
+ * later completion screen honest about what was not persisted.
+ */
+export function UnauthenticatedStartWarningScreen({
+  loginHref,
+  onContinue,
+}: {
+  loginHref: PlayerRoute;
+  onContinue: () => void;
+}) {
+  const t = useExtracted();
+
+  return (
+    <PlayerContentFrame
+      aria-live="polite"
+      className="my-auto flex flex-col items-center"
+      role="status"
+    >
+      <ProgressPromptFrame>
+        <ProgressPromptIcon />
+
+        <ProgressPromptCopy>
+          <ProgressPromptTitle>{t("Progress won't be saved")}</ProgressPromptTitle>
+          <ProgressPromptDescription>
+            {t(
+              "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved.",
+            )}
+          </ProgressPromptDescription>
+        </ProgressPromptCopy>
+
+        <StartWarningActions loginHref={loginHref} onContinue={onContinue} />
+      </ProgressPromptFrame>
+    </PlayerContentFrame>
+  );
+}
+
+/**
+ * Shows the honest post-completion signed-out message. The completed attempt
+ * was not persisted, so this prompt points learners to log in before their
+ * next lesson instead of promising that the current result can still be saved.
+ */
+export function UnauthenticatedCompletionPrompt() {
+  const t = useExtracted();
+
+  return (
+    <ProgressPromptFrame className="gap-4">
+      <ProgressPromptCopy>
+        <ProgressPromptTitle className="text-xl">
+          {t("This lesson wasn't saved")}
+        </ProgressPromptTitle>
+        <ProgressPromptDescription>
+          {t("Log in before your next lesson to keep future progress, scores, levels, and Energy.")}
+        </ProgressPromptDescription>
+      </ProgressPromptCopy>
+    </ProgressPromptFrame>
+  );
+}

--- a/packages/player/src/player-initial-state.ts
+++ b/packages/player/src/player-initial-state.ts
@@ -19,9 +19,19 @@ export function buildInitialAnswers(steps: SerializedStep[]): Record<string, Sel
   return Object.fromEntries(entries);
 }
 
-function getInitialPhase(steps: SerializedStep[]): PlayerPhase {
+function getInitialPhase({
+  requiresStartConfirmation,
+  steps,
+}: {
+  requiresStartConfirmation: boolean;
+  steps: SerializedStep[];
+}): PlayerPhase {
   if (steps.length === 0) {
     return "completed";
+  }
+
+  if (requiresStartConfirmation) {
+    return "startWarning";
   }
 
   return "playing";
@@ -30,6 +40,7 @@ function getInitialPhase(steps: SerializedStep[]): PlayerPhase {
 export type InitialStateInput = {
   lesson: SerializedLesson;
   progressSnapshot?: PlayerProgressSnapshot | null;
+  requiresStartConfirmation?: boolean;
   shownCompletionMilestoneKeys?: PlayerCompletionMilestoneKey[];
   totalBrainPower: number;
 };
@@ -37,6 +48,7 @@ export type InitialStateInput = {
 export function createInitialState({
   lesson,
   progressSnapshot = null,
+  requiresStartConfirmation = false,
   shownCompletionMilestoneKeys = [],
   totalBrainPower,
 }: InitialStateInput): PlayerState {
@@ -49,7 +61,7 @@ export function createInitialState({
     lessonId: lesson.id,
     lessonKind: lesson.kind,
     localDate: getLocalDate(new Date(now)),
-    phase: getInitialPhase(lesson.steps),
+    phase: getInitialPhase({ requiresStartConfirmation, steps: lesson.steps }),
     progressSnapshot,
     results: {},
     selectedAnswers: buildInitialAnswers(lesson.steps),

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -66,14 +66,19 @@ export function PlayerProvider({
   const initInput: InitialStateInput = useMemo(
     () => ({
       lesson,
-      progressSnapshot: getEffectiveCompletionProgressSnapshot({
-        localDate: getLocalDate(new Date()),
-        progressSnapshot,
-      }),
-      shownCompletionMilestoneKeys: getStoredCompletionMilestoneKeys(),
-      totalBrainPower,
+      progressSnapshot: viewer.isAuthenticated
+        ? getEffectiveCompletionProgressSnapshot({
+            localDate: getLocalDate(new Date()),
+            progressSnapshot,
+          })
+        : null,
+      requiresStartConfirmation: !viewer.isAuthenticated,
+      shownCompletionMilestoneKeys: viewer.isAuthenticated
+        ? getStoredCompletionMilestoneKeys()
+        : [],
+      totalBrainPower: viewer.isAuthenticated ? totalBrainPower : 0,
     }),
-    [lesson, progressSnapshot, totalBrainPower],
+    [lesson, progressSnapshot, totalBrainPower, viewer.isAuthenticated],
   );
 
   const [state, dispatch] = useReducer(playerReducer, initInput, createInitialState);

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -91,6 +91,31 @@ describe(createInitialState, () => {
     expect(state.currentStepIndex).toBe(0);
   });
 
+  it("starts in the warning phase when the host requires start confirmation", () => {
+    const lesson = buildLesson();
+
+    const state = createInitialState({
+      lesson,
+      requiresStartConfirmation: true,
+      totalBrainPower: 0,
+    });
+
+    expect(state.phase).toBe("startWarning");
+    expect(state.currentStepIndex).toBe(0);
+  });
+
+  it("does not show the warning phase for empty lessons", () => {
+    const lesson = buildLesson({ steps: [] });
+
+    const state = createInitialState({
+      lesson,
+      requiresStartConfirmation: true,
+      totalBrainPower: 0,
+    });
+
+    expect(state.phase).toBe("completed");
+  });
+
   it("copies lessonId and steps", () => {
     const steps = [buildStep({ id: "s1" }), buildStep({ id: "s2", position: 1 })];
     const lesson = buildLesson({ steps });
@@ -188,6 +213,33 @@ describe("SELECT_ANSWER", () => {
     });
 
     expect(next.selectedAnswers["step-1"]).toStrictEqual(multipleChoiceAnswer);
+  });
+});
+
+describe("START", () => {
+  it("begins a lesson from the warning phase and resets the lesson timers", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-05T12:00:10Z"));
+
+    try {
+      const state = buildState({ phase: "startWarning", startedAt: 1000, stepStartedAt: 1000 });
+
+      const next = playerReducer(state, { type: "START" });
+
+      expect(next.phase).toBe("playing");
+      expect(next.startedAt).toBe(Date.now());
+      expect(next.stepStartedAt).toBe(Date.now());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not restart an already playing lesson", () => {
+    const state = buildState({ phase: "playing", startedAt: 1000, stepStartedAt: 1000 });
+
+    const next = playerReducer(state, { type: "START" });
+
+    expect(next).toBe(state);
   });
 });
 

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -15,7 +15,7 @@ import { describePlayerStep } from "./player-step";
 import { getPlayerStepBehavior } from "./player-step-behavior";
 import { canNavigatePrev } from "./step-navigation";
 
-export type PlayerPhase = "playing" | "feedback" | "completed";
+export type PlayerPhase = "startWarning" | "playing" | "feedback" | "completed";
 
 export type SelectedAnswer =
   | { kind: "fillBlank"; userAnswers: string[] }
@@ -56,6 +56,7 @@ export type PlayerState = {
 };
 
 export type PlayerAction =
+  | { type: "START" }
   | { type: "SELECT_ANSWER"; stepId: string; answer: SelectedAnswer }
   | { type: "CLEAR_ANSWER"; stepId: string }
   | { type: "CHECK_ANSWER"; stepId: string; result: AnswerResult }
@@ -70,6 +71,10 @@ function handleSelectAnswer(
   state: PlayerState,
   action: Extract<PlayerAction, { type: "SELECT_ANSWER" }>,
 ): PlayerState {
+  if (state.phase === "startWarning") {
+    return state;
+  }
+
   return {
     ...state,
     selectedAnswers: { ...state.selectedAnswers, [action.stepId]: action.answer },
@@ -80,8 +85,27 @@ function handleClearAnswer(
   state: PlayerState,
   action: Extract<PlayerAction, { type: "CLEAR_ANSWER" }>,
 ): PlayerState {
+  if (state.phase === "startWarning") {
+    return state;
+  }
+
   const { [action.stepId]: _, ...rest } = state.selectedAnswers;
   return { ...state, selectedAnswers: rest };
+}
+
+/**
+ * Moves a pre-lesson warning into active play and starts the lesson timers at
+ * that moment. Signed-out learners can spend time deciding whether to log in,
+ * and that hesitation should not inflate answer duration or lesson duration.
+ */
+function handleStart(state: PlayerState): PlayerState {
+  if (state.phase !== "startWarning") {
+    return state;
+  }
+
+  const now = Date.now();
+
+  return { ...state, phase: "playing", startedAt: now, stepStartedAt: now };
 }
 
 function recordStepTiming(state: PlayerState, stepId: string): Record<string, StepTiming> {
@@ -275,6 +299,9 @@ function handleComplete(state: PlayerState): PlayerState {
 
 export function playerReducer(state: PlayerState, action: PlayerAction): PlayerState {
   switch (action.type) {
+    case "START":
+      return handleStart(state);
+
     case "SELECT_ANSWER":
       return handleSelectAnswer(state, action);
 

--- a/packages/player/src/player-screen.test.ts
+++ b/packages/player/src/player-screen.test.ts
@@ -123,6 +123,22 @@ describe(getPlayerScreenModel, () => {
     expect(screen.keyboard.enterAction).toBeNull();
   });
 
+  it("uses the start warning screen before unauthenticated lessons begin", () => {
+    const screen = buildScreen({ state: buildState({ phase: "startWarning" }) });
+
+    expect(screen.kind).toBe("startWarning");
+    expect(screen.scene).toBe("startWarning");
+    expect(screen.bottomBar).toBeNull();
+    expect(screen.showChrome).toBe(false);
+
+    expect(screen.keyboard).toStrictEqual({
+      canRestart: false,
+      enterAction: null,
+      leftAction: null,
+      rightAction: null,
+    });
+  });
+
   it("keeps completed state in completion mode", () => {
     const screen = buildScreen({ state: buildState({ phase: "completed" }) });
 

--- a/packages/player/src/player-screen.ts
+++ b/packages/player/src/player-screen.ts
@@ -55,6 +55,16 @@ type PlayerCompletedScreenModel = {
   stageIsStatic: false;
 };
 
+type PlayerStartWarningScreenModel = {
+  bottomBar: null;
+  keyboard: PlayerKeyboardModel;
+  kind: "startWarning";
+  scene: "startWarning";
+  showChrome: false;
+  stageIsFullBleed: false;
+  stageIsStatic: false;
+};
+
 type PlayerFeedbackScreenModel = InPlayScreenModel & { kind: "feedbackScreen"; scene: "feedback" };
 
 type PlayerStepScreenModel = InPlayScreenModel & { kind: "step" };
@@ -62,7 +72,25 @@ type PlayerStepScreenModel = InPlayScreenModel & { kind: "step" };
 export type PlayerScreenModel =
   | PlayerCompletedScreenModel
   | PlayerFeedbackScreenModel
+  | PlayerStartWarningScreenModel
   | PlayerStepScreenModel;
+
+/**
+ * The signed-out warning is an explicit pre-play state. It has no keyboard
+ * shortcuts or bottom controls because the learner must choose between logging
+ * in and knowingly continuing without saved progress.
+ */
+function getStartWarningScreenModel(): PlayerStartWarningScreenModel {
+  return {
+    bottomBar: null,
+    keyboard: { canRestart: false, enterAction: null, leftAction: null, rightAction: null },
+    kind: "startWarning",
+    scene: "startWarning",
+    showChrome: false,
+    stageIsFullBleed: false,
+    stageIsStatic: false,
+  };
+}
 
 /**
  * A completed player exposes either an intermediate milestone or the final
@@ -233,6 +261,10 @@ function getPlayerScreenScene({
  * screen mode from scattered booleans.
  */
 export function getPlayerScreenModel(state: PlayerState): PlayerScreenModel {
+  if (state.phase === "startWarning") {
+    return getStartWarningScreenModel();
+  }
+
   if (state.phase === "completed") {
     return getCompletedScreenModel({
       hasActiveMilestone: Boolean(getActiveCompletionMilestone(state)),

--- a/packages/player/src/use-player-actions.ts
+++ b/packages/player/src/use-player-actions.ts
@@ -24,6 +24,7 @@ export type PlayerActions = {
   navigatePrev: () => void;
   restart: () => void;
   selectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  start: () => void;
 };
 
 /**
@@ -131,5 +132,17 @@ export function usePlayerActions({
     dispatchTransition({ type: "RESTART" });
   }, [dispatchTransition]);
 
-  return { check, continue: handleContinue, navigateNext, navigatePrev, restart, selectAnswer };
+  const start = useCallback(() => {
+    dispatchTransition({ type: "START" });
+  }, [dispatchTransition]);
+
+  return {
+    check,
+    continue: handleContinue,
+    navigateNext,
+    navigatePrev,
+    restart,
+    selectAnswer,
+    start,
+  };
 }


### PR DESCRIPTION
Adds a signed-out lesson warning before play and simplifies the guest completion CTA flow.\n\nAlso preserves lesson return paths after login and updates completion CTA copy from All Lessons to Exit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Progress won’t be saved” warning before lessons for signed‑out learners and simplifies guest completion. Also routes login back to the exact lesson using a safe app‑relative `next` path, and changes the completion secondary action from “All Lessons” to “Exit”.

- **New Features**
  - Added a pre‑play guest warning with “Log in to save progress” and “Continue without saving”; lesson timers start when continuing.
  - Guest completion hides rewards/progress UI and shows “This lesson wasn’t saved” with a simple “Log in” + “Next” set; “Exit” replaces “All Lessons”.
  - Player login links now include `?next=/b/.../l/<lesson>` so learners return to the current lesson after login.

- **Refactors**
  - Introduced `@zoonk/core/auth/ott/redirect` and use it in `/login` and `@zoonk/core/auth/ott-callback` to accept only safe app‑relative `next` paths (rejects `//` and backslashes).
  - `/login` now forwards a safe `next` to the callback via `callbackPath`; the callback redirects to that path on success.
  - Player initialization for guests skips progress snapshots, milestones, and brain power; added `startWarning` phase with a `START` action. Updated tests and i18n.

<sup>Written for commit 78d9f93304b51c6242bc3847ffd2be3d47c4ecfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

