### PR TITLE
feat(player): split grammar explanations by sentence

### DIFF
--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -401,6 +401,64 @@ describe("player browser integration: static steps", () => {
     await expect.element(page.getByText("Add -ed to regular verbs")).toBeInTheDocument();
   });
 
+  it("splits leading grammar explanation sentences into separate player lines", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "grammar",
+        steps: [
+          buildSerializedStep({
+            content: {
+              text: "Use el for masculine nouns. Use la for feminine nouns, e.g. la mesa. This changes the article.",
+              title: "Articles",
+              variant: "text" as const,
+            },
+            id: "grammar-explanation",
+          }),
+          buildSerializedStep({
+            content: {
+              highlight: "la",
+              romanization: null,
+              sentence: "La mesa es grande",
+              translation: "The table is big",
+              variant: "grammarExample" as const,
+            },
+            id: "grammar-example",
+            position: 1,
+          }),
+          buildSerializedStep({
+            content: {
+              text: "Keep this later note together. It is no longer part of the opening explanation.",
+              title: "Later note",
+              variant: "text" as const,
+            },
+            id: "later-static-note",
+            position: 2,
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await expect.element(page.getByRole("heading", { name: "Articles" })).toBeInTheDocument();
+    expect(screen.getByText("Use el for masculine nouns.")).toBeInTheDocument();
+    expect(screen.getByText("Use la for feminine nouns, e.g. la mesa.")).toBeInTheDocument();
+    expect(screen.getByText("This changes the article.")).toBeInTheDocument();
+
+    fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
+    fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
+
+    await expect.element(page.getByRole("heading", { name: "Later note" })).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        "Keep this later note together. It is no longer part of the opening explanation.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByText("Keep this later note together.")).not.toBeInTheDocument();
+  });
+
   it("renders generated rich text without exposing LaTeX delimiters", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/components/_utils/grammar-explanation-lines.test.ts
+++ b/packages/player/src/components/_utils/grammar-explanation-lines.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildSerializedStep } from "../../_test-utils/player-test-data";
+import {
+  getGrammarExplanationSentenceLines,
+  isInitialGrammarExplanationStep,
+} from "./grammar-explanation-lines";
+
+describe(getGrammarExplanationSentenceLines, () => {
+  it("puts each explanation sentence on its own display line", () => {
+    expect(
+      getGrammarExplanationSentenceLines(
+        "Use el for masculine nouns. Use la for feminine nouns, e.g. la mesa. This matters!",
+      ),
+    ).toStrictEqual([
+      "Use el for masculine nouns.",
+      "Use la for feminine nouns, e.g. la mesa.",
+      "This matters!",
+    ]);
+  });
+});
+
+describe(isInitialGrammarExplanationStep, () => {
+  const firstExplanationStep = buildSerializedStep({ id: "explanation-1", position: 0 });
+
+  const secondExplanationStep = buildSerializedStep({ id: "explanation-2", position: 1 });
+
+  const grammarExampleStep = buildSerializedStep({
+    content: {
+      highlight: "corre",
+      romanization: null,
+      sentence: "Ella corre rapido",
+      translation: "She runs fast",
+      variant: "grammarExample" as const,
+    },
+    id: "grammar-example",
+    position: 2,
+  });
+
+  const laterStaticStep = buildSerializedStep({ id: "later-static", position: 3 });
+
+  const steps = [firstExplanationStep, secondExplanationStep, grammarExampleStep, laterStaticStep];
+
+  it("matches every leading static text step in grammar lessons", () => {
+    expect(
+      isInitialGrammarExplanationStep({ lessonKind: "grammar", step: firstExplanationStep, steps }),
+    ).toBe(true);
+
+    expect(
+      isInitialGrammarExplanationStep({
+        lessonKind: "grammar",
+        step: secondExplanationStep,
+        steps,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match non-grammar lessons or static text after grammar examples", () => {
+    expect(
+      isInitialGrammarExplanationStep({
+        lessonKind: "explanation",
+        step: firstExplanationStep,
+        steps,
+      }),
+    ).toBe(false);
+
+    expect(
+      isInitialGrammarExplanationStep({ lessonKind: "grammar", step: laterStaticStep, steps }),
+    ).toBe(false);
+  });
+});

--- a/packages/player/src/components/_utils/grammar-explanation-lines.ts
+++ b/packages/player/src/components/_utils/grammar-explanation-lines.ts
@@ -1,0 +1,121 @@
+import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { type LessonKind } from "@zoonk/core/steps/contract/content";
+import { describePlayerStep } from "../../player-step";
+
+const FALLBACK_SENTENCE_PATTERN = /[^.!?。！？]+[.!?。！？]+(?:["')\]”’]+)?|[^.!?。！？]+$/gu;
+
+/**
+ * Removes layout-only whitespace from generated prose before each sentence is
+ * rendered as its own player line. The player already collapses whitespace in
+ * regular paragraph rendering, so this keeps the split version visually
+ * equivalent aside from the intentional sentence breaks.
+ */
+function normalizeSentenceLine(sentence: string) {
+  return sentence.replaceAll(/\s+/gu, " ").trim();
+}
+
+/**
+ * Filters empty strings after trimming generated prose. This keeps the main
+ * splitter pipeline typed as `string[]` without relying on a broad Boolean cast.
+ */
+function isSentenceLine(line: string) {
+  return line.length > 0;
+}
+
+/**
+ * Uses the browser/runtime sentence segmenter when available because it handles
+ * common grammar prose better than punctuation regexes, including abbreviations
+ * such as "e.g." that should stay inside the same sentence.
+ */
+function getSegmenterSentenceLines(text: string): string[] | null {
+  const SentenceSegmenter = Intl.Segmenter;
+
+  if (!SentenceSegmenter) {
+    return null;
+  }
+
+  return Array.from(
+    new SentenceSegmenter(undefined, { granularity: "sentence" }).segment(text),
+    ({ segment }) => segment,
+  );
+}
+
+/**
+ * Provides a small punctuation fallback for older runtimes that do not expose
+ * `Intl.Segmenter`. It is intentionally conservative and only affects grammar
+ * explanation display, not saved lesson content.
+ */
+function getFallbackSentenceLines(text: string) {
+  return text.match(FALLBACK_SENTENCE_PATTERN) ?? [text];
+}
+
+/**
+ * Splits grammar explanation prose into display lines so long generated
+ * explanations are easier to scan in the player while preserving the original
+ * text content and punctuation.
+ */
+export function getGrammarExplanationSentenceLines(text: string) {
+  const lines = (getSegmenterSentenceLines(text) ?? getFallbackSentenceLines(text))
+    .map((sentence) => normalizeSentenceLine(sentence))
+    .filter((line) => isSentenceLine(line));
+
+  return lines.length > 0 ? lines : [text];
+}
+
+/**
+ * Identifies text-only static steps. Grammar examples also use `static` steps,
+ * so the content variant is part of the rule instead of relying on step kind
+ * alone.
+ */
+function isStaticTextStep(step: SerializedStep) {
+  return describePlayerStep(step)?.kind === "staticText";
+}
+
+/**
+ * Finds the active step by id instead of trusting stored `position`, because the
+ * reducer state is already the source of truth for the order the player is
+ * rendering.
+ */
+function getStepIndex({ step, steps }: { step: SerializedStep; steps: SerializedStep[] }) {
+  return steps.findIndex((candidate) => candidate.id === step.id);
+}
+
+/**
+ * Checks that the current step still belongs to the leading static-text block.
+ * This keeps sentence splitting limited to grammar explanation steps at the
+ * start of the lesson and leaves grammar examples or any later static text
+ * untouched.
+ */
+function hasOnlyStaticTextBeforeAndIncludingStep({
+  stepIndex,
+  steps,
+}: {
+  stepIndex: number;
+  steps: SerializedStep[];
+}) {
+  return steps.slice(0, stepIndex + 1).every((step) => isStaticTextStep(step));
+}
+
+/**
+ * Returns whether a static text step should use sentence-line rendering.
+ * Grammar lessons are saved as explanation text first, followed by grammar
+ * examples and questions, so this models the product rule directly in the
+ * player without changing stored content.
+ */
+export function isInitialGrammarExplanationStep({
+  lessonKind,
+  step,
+  steps,
+}: {
+  lessonKind: LessonKind;
+  step: SerializedStep;
+  steps: SerializedStep[];
+}) {
+  const stepIndex = getStepIndex({ step, steps });
+
+  if (lessonKind !== "grammar" || stepIndex === -1) {
+    return false;
+  }
+
+  return hasOnlyStaticTextBeforeAndIncludingStep({ stepIndex, steps });
+}

--- a/packages/player/src/components/static-step.tsx
+++ b/packages/player/src/components/static-step.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { type LessonKind } from "@zoonk/core/steps/contract/content";
+import { usePlayerLessonMeta, usePlayerRuntime } from "../player-context";
 import { describePlayerStep, getPlayerStepImage } from "../player-step";
+import {
+  getGrammarExplanationSentenceLines,
+  isInitialGrammarExplanationStep,
+} from "./_utils/grammar-explanation-lines";
 import { HighlightText } from "./highlight-text";
 import {
   PlayerReadScene,
@@ -9,15 +15,55 @@ import {
   PlayerReadSceneStack,
   PlayerReadSceneTitle,
 } from "./player-read-scene";
+import { PlayerRichText } from "./player-rich-text";
 import { RomanizationText } from "./romanization-text";
 import { StaticStepLayout } from "./static-step-layout";
 import { StepIntroHero } from "./step-intro-hero-layout";
 
-function TextVariant({ title, text }: { title: string; text: string }) {
+/**
+ * Renders one display sentence with the same rich-text support as regular
+ * player copy. Grammar explanations can include target-word code markers,
+ * emphasis, or formulas, so splitting the text must not downgrade formatting.
+ */
+function SentenceLine({ sentence }: { sentence: string }) {
+  return (
+    <span className="block">
+      <PlayerRichText text={sentence} />
+    </span>
+  );
+}
+
+/**
+ * Adds a small pause between generated explanation sentences. The wrapper stays
+ * inline-compatible with the existing paragraph body while visually making each
+ * sentence scan as its own line.
+ */
+function SentenceLineGroup({ sentences }: { sentences: string[] }) {
+  return (
+    <span className="block space-y-3">
+      {sentences.map((sentence, index) => (
+        // oxlint-disable-next-line react/no-array-index-key -- Sentence lines come from immutable generated text and never reorder after render.
+        <SentenceLine key={`${sentence}-${index}`} sentence={sentence} />
+      ))}
+    </span>
+  );
+}
+
+function TextVariant({
+  sentenceLines,
+  title,
+  text,
+}: {
+  sentenceLines: string[] | null;
+  title: string;
+  text: string;
+}) {
   return (
     <PlayerReadSceneStack>
       <PlayerReadSceneTitle>{title}</PlayerReadSceneTitle>
-      <PlayerReadSceneBody>{text}</PlayerReadSceneBody>
+      <PlayerReadSceneBody>
+        {sentenceLines ? <SentenceLineGroup sentences={sentenceLines} /> : text}
+      </PlayerReadSceneBody>
     </PlayerReadSceneStack>
   );
 }
@@ -46,7 +92,39 @@ function GrammarExampleVariant({
   );
 }
 
-function StaticStepContent({ step }: { step: SerializedStep }) {
+/**
+ * Returns sentence lines only for the leading grammar explanation block. The
+ * guard keeps the visual treatment away from regular static lessons, grammar
+ * examples, and any static text that may appear after examples or questions.
+ */
+function getStaticTextSentenceLines({
+  lessonKind,
+  step,
+  steps,
+}: {
+  lessonKind: LessonKind;
+  step: SerializedStep;
+  steps: SerializedStep[];
+}) {
+  const descriptor = describePlayerStep(step);
+
+  if (
+    descriptor?.kind !== "staticText" ||
+    !isInitialGrammarExplanationStep({ lessonKind, step, steps })
+  ) {
+    return null;
+  }
+
+  return getGrammarExplanationSentenceLines(descriptor.content.text);
+}
+
+function StaticStepContent({
+  sentenceLines,
+  step,
+}: {
+  sentenceLines: string[] | null;
+  step: SerializedStep;
+}) {
   const descriptor = describePlayerStep(step);
 
   if (!descriptor) {
@@ -68,7 +146,13 @@ function StaticStepContent({ step }: { step: SerializedStep }) {
     return null;
   }
 
-  return <TextVariant text={descriptor.content.text} title={descriptor.content.title} />;
+  return (
+    <TextVariant
+      sentenceLines={sentenceLines}
+      text={descriptor.content.text}
+      title={descriptor.content.title}
+    />
+  );
 }
 
 /**
@@ -85,7 +169,15 @@ function TextOnlyStaticScene({ children }: { children: React.ReactNode }) {
 }
 
 export function StaticStep({ step }: { step: SerializedStep }) {
+  const lessonMeta = usePlayerLessonMeta();
+  const { state } = usePlayerRuntime();
   const descriptor = describePlayerStep(step);
+
+  const sentenceLines = getStaticTextSentenceLines({
+    lessonKind: lessonMeta.kind,
+    step,
+    steps: state.steps,
+  });
 
   if (descriptor?.kind === "intro") {
     return (
@@ -97,7 +189,7 @@ export function StaticStep({ step }: { step: SerializedStep }) {
     );
   }
 
-  const content = <StaticStepContent step={step} />;
+  const content = <StaticStepContent sentenceLines={sentenceLines} step={step} />;
   const image = getPlayerStepImage(descriptor);
 
   if (!image) {


### PR DESCRIPTION
## Summary
- split leading grammar explanation text into sentence lines in the player
- keep grammar examples and later static text using the existing rendering
- add helper and browser coverage for the grammar-only boundary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the leading grammar explanation into one sentence per line in the player to make long intros easier to scan. Uses `Intl.Segmenter` with a safe regex fallback; grammar examples and later static text are unchanged.

- **New Features**
  - Applies only to the opening static text in `grammar` lessons; everything after examples keeps existing rendering.
  - Each sentence renders with the rich-text component to preserve highlights, emphasis, and formulas.
  - Added utils to detect initial explanation steps and split sentences, plus unit and browser tests.

<sup>Written for commit 7b037b4f5c3b9e08b79403e360f495ed56ff2f03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

