### PR TITLE
fix(main): filter command palette by language

### DIFF
--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -1,9 +1,12 @@
 import { randomUUID } from "node:crypto";
+import { setLocale } from "@zoonk/e2e/fixtures/locale";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { normalizeString } from "@zoonk/utils/string";
 import { type Page, expect, test } from "./fixtures";
+
+const SEARCH_CONTROL_NAME = /search|pesquisar/iu;
 
 async function createTestCourse() {
   const org = await getAiOrganization();
@@ -22,11 +25,75 @@ async function createTestCourse() {
 }
 
 /**
+ * The command palette searches courses and chapters together, so locale
+ * filtering needs a mixed catalog setup where both result kinds share the same
+ * query in different languages.
+ */
+async function createLocalizedSearchCatalog() {
+  const org = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+  const enCourseTitle = `E2E Locale EN ${uniqueId}`;
+  const ptCourseTitle = `E2E Locale PT ${uniqueId}`;
+  const enChapterTitle = `E2E Locale Chapter EN ${uniqueId}`;
+  const ptChapterTitle = `E2E Locale Chapter PT ${uniqueId}`;
+
+  const [enCourse, ptCourse] = await Promise.all([
+    courseFixture({
+      description: `English locale result ${uniqueId}`,
+      isPublished: true,
+      language: "en",
+      normalizedTitle: normalizeString(enCourseTitle),
+      organizationId: org.id,
+      slug: `e2e-locale-en-${uniqueId}`,
+      title: enCourseTitle,
+    }),
+    courseFixture({
+      description: `Portuguese locale result ${uniqueId}`,
+      isPublished: true,
+      language: "pt",
+      normalizedTitle: normalizeString(ptCourseTitle),
+      organizationId: org.id,
+      slug: `e2e-locale-pt-${uniqueId}`,
+      title: ptCourseTitle,
+    }),
+  ]);
+
+  await Promise.all([
+    chapterFixture({
+      courseId: enCourse.id,
+      description: `English chapter locale result ${uniqueId}`,
+      isPublished: true,
+      language: "en",
+      normalizedTitle: normalizeString(enChapterTitle),
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-locale-chapter-en-${uniqueId}`,
+      title: enChapterTitle,
+    }),
+    chapterFixture({
+      courseId: ptCourse.id,
+      description: `Portuguese chapter locale result ${uniqueId}`,
+      isPublished: true,
+      language: "pt",
+      normalizedTitle: normalizeString(ptChapterTitle),
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-locale-chapter-pt-${uniqueId}`,
+      title: ptChapterTitle,
+    }),
+  ]);
+
+  return { enChapterTitle, enCourseTitle, ptChapterTitle, ptCourseTitle, uniqueId };
+}
+
+/**
  * Opens the command palette through the real navbar trigger so tests interact
  * with the same hydrated chrome learners use.
  */
 async function openCommandPalette(page: Page) {
-  const searchButton = page.getByRole("navigation").getByRole("button", { name: /search/iu });
+  const searchButton = page
+    .getByRole("navigation")
+    .getByRole("button", { name: SEARCH_CONTROL_NAME });
 
   await expect(async () => {
     await searchButton.click();
@@ -427,6 +494,34 @@ test.describe("Command Palette - Course Search", () => {
     for (const partialTitle of partialMatchTitles) {
       expect(firstOptionText!.startsWith(partialTitle)).toBe(false);
     }
+  });
+
+  test("shows only results from the active app language", async ({ page }) => {
+    const { enChapterTitle, enCourseTitle, ptChapterTitle, ptCourseTitle, uniqueId } =
+      await createLocalizedSearchCatalog();
+
+    await setLocale(page, "pt");
+    await page.goto("/");
+    await openCommandPalette(page);
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByPlaceholder(SEARCH_CONTROL_NAME).fill(uniqueId);
+
+    await expect(
+      dialog.getByRole("option", { name: new RegExp(`^${ptCourseTitle}`, "u") }),
+    ).toBeVisible();
+
+    await expect(
+      dialog.getByRole("option", { name: new RegExp(`^${ptChapterTitle}`, "u") }),
+    ).toBeVisible();
+
+    await expect(
+      dialog.getByRole("option", { name: new RegExp(`^${enCourseTitle}`, "u") }),
+    ).not.toBeVisible();
+
+    await expect(
+      dialog.getByRole("option", { name: new RegExp(`^${enChapterTitle}`, "u") }),
+    ).not.toBeVisible();
   });
 });
 

--- a/apps/main/src/app/(catalog)/_components/search-courses-action.ts
+++ b/apps/main/src/app/(catalog)/_components/search-courses-action.ts
@@ -39,11 +39,13 @@ export type ChapterSearchResult = {
  */
 export async function searchCatalogAction(params: {
   query: string;
-  language?: string;
+  language: string;
 }): Promise<CatalogSearchResults> {
+  const searchParams = { filterByLanguage: true, language: params.language, query: params.query };
+
   const [courses, chapters] = await Promise.all([
-    searchCourses(params),
-    searchChapters({ ...params, limit: COMMAND_PALETTE_CHAPTER_LIMIT }),
+    searchCourses(searchParams),
+    searchChapters({ ...searchParams, limit: COMMAND_PALETTE_CHAPTER_LIMIT }),
   ]);
 
   return {

--- a/packages/core/src/_utils/search-language-filter.ts
+++ b/packages/core/src/_utils/search-language-filter.ts
@@ -1,0 +1,18 @@
+/**
+ * Search APIs can use language as either a ranking preference or a strict
+ * filter. This helper keeps the strict-filter rule consistent for catalog
+ * surfaces that must never show another language once a locale is known.
+ */
+export function getSearchLanguageFilter({
+  filterByLanguage,
+  language,
+}: {
+  filterByLanguage?: boolean;
+  language?: string;
+}) {
+  if (!filterByLanguage || !language) {
+    return {};
+  }
+
+  return { language };
+}

--- a/packages/core/src/chapters/search-chapters.test.ts
+++ b/packages/core/src/chapters/search-chapters.test.ts
@@ -125,6 +125,55 @@ describe(searchChapters, () => {
     expect(result).toHaveLength(5);
   });
 
+  it("filters by language when language filtering is requested", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const searchTerm = `chapterlanguage${uniqueId}`;
+
+    const [enCourse, ptCourse] = await Promise.all([
+      courseFixture({ isPublished: true, language: "en", organizationId: brandOrg.id }),
+      courseFixture({ isPublished: true, language: "pt", organizationId: brandOrg.id }),
+    ]);
+
+    const [enChapter, ptChapter] = await Promise.all([
+      chapterFixture({
+        courseId: enCourse.id,
+        isPublished: true,
+        language: "en",
+        normalizedTitle: normalizeString(searchTerm),
+        organizationId: brandOrg.id,
+        title: searchTerm,
+      }),
+      chapterFixture({
+        courseId: ptCourse.id,
+        isPublished: true,
+        language: "pt",
+        normalizedTitle: normalizeString(searchTerm),
+        organizationId: brandOrg.id,
+        title: searchTerm,
+      }),
+    ]);
+
+    const enResult = await searchChapters({
+      filterByLanguage: true,
+      language: "en",
+      query: searchTerm,
+    });
+
+    const ptResult = await searchChapters({
+      filterByLanguage: true,
+      language: "pt",
+      query: searchTerm,
+    });
+
+    const enIds = enResult.map((chapter) => chapter.id);
+    const ptIds = ptResult.map((chapter) => chapter.id);
+
+    expect(enIds).toContain(enChapter.id);
+    expect(enIds).not.toContain(ptChapter.id);
+    expect(ptIds).not.toContain(enChapter.id);
+    expect(ptIds).toContain(ptChapter.id);
+  });
+
   it("returns only published chapters from published brand courses", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const searchTerm = `chaptervisibility${uniqueId}`;

--- a/packages/core/src/chapters/search-chapters.ts
+++ b/packages/core/src/chapters/search-chapters.ts
@@ -7,6 +7,7 @@ import {
 } from "@zoonk/db";
 import { clampQueryItems } from "@zoonk/db/utils";
 import { normalizeString } from "@zoonk/utils/string";
+import { getSearchLanguageFilter } from "../_utils/search-language-filter";
 
 type ChapterFindManyArgs = NonNullable<Parameters<typeof prisma.chapter.findMany>[0]>;
 type ChapterSearchWhere = ChapterFindManyArgs["where"];
@@ -27,6 +28,7 @@ const DEFAULT_CHAPTER_SEARCH_LIMIT = 5;
  * ranks exact title matches ahead of partial title and description matches.
  */
 export async function searchChapters(params: {
+  filterByLanguage?: boolean;
   query: string;
   language?: string;
   limit?: number;
@@ -39,6 +41,12 @@ export async function searchChapters(params: {
   }
 
   const baseWhere = getPublishedChapterWhere({
+    chapterWhere: {
+      ...getSearchLanguageFilter({
+        filterByLanguage: params.filterByLanguage,
+        language: params.language,
+      }),
+    },
     courseWhere: { organization: { kind: "brand" } as const },
   });
 

--- a/packages/core/src/courses/search-courses.test.ts
+++ b/packages/core/src/courses/search-courses.test.ts
@@ -134,6 +134,48 @@ describe(searchCourses, () => {
     expect(ptResult[0]?.language).toBe("pt");
   });
 
+  it("filters by language when language filtering is requested", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const searchTerm = `langfilter${uniqueId}`;
+
+    const [enCourse, ptCourse] = await Promise.all([
+      courseFixture({
+        isPublished: true,
+        language: "en",
+        normalizedTitle: searchTerm,
+        organizationId: brandOrg.id,
+        title: searchTerm,
+      }),
+      courseFixture({
+        isPublished: true,
+        language: "pt",
+        normalizedTitle: searchTerm,
+        organizationId: brandOrg.id,
+        title: searchTerm,
+      }),
+    ]);
+
+    const enResult = await searchCourses({
+      filterByLanguage: true,
+      language: "en",
+      query: searchTerm,
+    });
+
+    const ptResult = await searchCourses({
+      filterByLanguage: true,
+      language: "pt",
+      query: searchTerm,
+    });
+
+    const enIds = enResult.map((course) => course.id);
+    const ptIds = ptResult.map((course) => course.id);
+
+    expect(enIds).toContain(enCourse.id);
+    expect(enIds).not.toContain(ptCourse.id);
+    expect(ptIds).not.toContain(enCourse.id);
+    expect(ptIds).toContain(ptCourse.id);
+  });
+
   it("returns all languages when no language is specified", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const searchTerm = `nolang${uniqueId}`;

--- a/packages/core/src/courses/search-courses.ts
+++ b/packages/core/src/courses/search-courses.ts
@@ -3,10 +3,12 @@ import { type Course, type Organization, getPublishedCourseWhere, prisma } from 
 import { MAX_QUERY_ITEMS, clampQueryItems } from "@zoonk/db/utils";
 import { DEFAULT_SEARCH_LIMIT, mergeSearchResults } from "@zoonk/utils/search";
 import { normalizeString } from "@zoonk/utils/string";
+import { getSearchLanguageFilter } from "../_utils/search-language-filter";
 
 type CourseWithOrganization = Course & { organization: Organization };
 
 export async function searchCourses(params: {
+  filterByLanguage?: boolean;
   query: string;
   language?: string;
   limit?: number;
@@ -20,7 +22,13 @@ export async function searchCourses(params: {
     return [];
   }
 
-  const baseWhere = getPublishedCourseWhere({ organization: { kind: "brand" } as const });
+  const baseWhere = getPublishedCourseWhere({
+    organization: { kind: "brand" } as const,
+    ...getSearchLanguageFilter({
+      filterByLanguage: params.filterByLanguage,
+      language: params.language,
+    }),
+  });
 
   const [exactMatch, containsMatches] = await Promise.all([
     prisma.course.findFirst({


### PR DESCRIPTION
## Summary

- filter command palette course and chapter search to the active app language
- add shared core search language filtering and regression coverage
- update command palette e2e coverage for localized results

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters command palette results to the active app language so learners only see courses and chapters in their locale. Adds a shared strict language filter in core search and updates tests for coverage.

- **Bug Fixes**
  - Applied strict language filtering in `searchCourses` and `searchChapters` via `getSearchLanguageFilter`.
  - Command palette passes `{ filterByLanguage: true, language }` to both searches.
  - Added e2e and unit tests to verify localized results and prevent regressions.

<sup>Written for commit 63abd0be246261e2238eea5a9ba7e658100e619f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

