### PR TITLE
feat(main): auto-select clear learn suggestions

### DIFF
--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { prisma } from "@zoonk/db";
 import { type Page, type Route } from "@zoonk/e2e/fixtures";
 import { searchPromptWithSuggestionsFixture } from "@zoonk/testing/fixtures/course-suggestions";
@@ -134,6 +135,57 @@ test.describe("Learn Form", () => {
 });
 
 test.describe("Course Suggestions", () => {
+  test("redirects to generate page when there is only one suggestion", async ({ page }) => {
+    await mockCourseGenerationWorkflow(page);
+
+    const singlePrompt = `single suggestion ${randomUUID()}`;
+
+    const fixture = await searchPromptWithSuggestionsFixture({
+      prompt: singlePrompt,
+      suggestions: [
+        { description: `Only course for ${singlePrompt}`, title: `Course for ${singlePrompt}` },
+      ],
+    });
+
+    const onlySuggestion = fixture.suggestions[0];
+
+    if (!onlySuggestion) {
+      throw new Error("No single suggestion created by fixture");
+    }
+
+    await page.goto(`/learn/${encodeURIComponent(singlePrompt)}`);
+
+    await expect(page).toHaveURL(new RegExp(`/generate/cs/${onlySuggestion.id}$`, "u"));
+  });
+
+  test("redirects to exact prompt match when there are multiple suggestions", async ({ page }) => {
+    await mockCourseGenerationWorkflow(page);
+
+    const uniqueId = randomUUID().slice(0, 8);
+    const exactPrompt = `biology ${uniqueId}`;
+
+    const fixture = await searchPromptWithSuggestionsFixture({
+      prompt: exactPrompt,
+      suggestions: [
+        {
+          description: `Adjacent course for ${exactPrompt}`,
+          title: `Advanced biology ${uniqueId}`,
+        },
+        { description: `Exact course for ${exactPrompt}`, title: `Biology ${uniqueId}` },
+      ],
+    });
+
+    const exactSuggestion = fixture.suggestions[1];
+
+    if (!exactSuggestion) {
+      throw new Error("No exact suggestion created by fixture");
+    }
+
+    await page.goto(`/learn/${encodeURIComponent(exactPrompt)}`);
+
+    await expect(page).toHaveURL(new RegExp(`/generate/cs/${exactSuggestion.id}$`, "u"));
+  });
+
   test("shows suggestions to unauthenticated users", async ({ page }) => {
     await page.goto(`/learn/${encodeURIComponent(prompt)}`);
 

--- a/apps/main/src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
+++ b/apps/main/src/app/(catalog)/learn/[prompt]/course-suggestions.tsx
@@ -10,9 +10,37 @@ import {
   ContainerTitle,
 } from "@zoonk/ui/components/container";
 import { ItemGroup } from "@zoonk/ui/components/item";
+import { normalizeString } from "@zoonk/utils/string";
 import { getExtracted, getLocale } from "next-intl/server";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { CourseSuggestionItem } from "./course-suggestion-item";
+
+type AutomaticCourseSuggestion = { id: string; title: string };
+
+/**
+ * The learn results page should only ask learners to choose when there is a real
+ * choice to make. A single suggestion or an exact title match means the prompt
+ * already identifies one course, so returning that suggestion lets the page send
+ * the learner straight into course generation.
+ */
+function getAutomaticCourseSuggestion({
+  prompt,
+  suggestions,
+}: {
+  prompt: string;
+  suggestions: AutomaticCourseSuggestion[];
+}): AutomaticCourseSuggestion | null {
+  if (suggestions.length === 1) {
+    return suggestions[0] ?? null;
+  }
+
+  const normalizedPrompt = normalizeString(prompt);
+
+  return (
+    suggestions.find((suggestion) => normalizeString(suggestion.title) === normalizedPrompt) ?? null
+  );
+}
 
 export async function CourseSuggestions({ prompt }: { prompt: string }) {
   const locale = await getLocale();
@@ -22,6 +50,12 @@ export async function CourseSuggestions({ prompt }: { prompt: string }) {
     getSession(),
     generateCourseSuggestions({ language: locale, prompt }),
   ]);
+
+  const automaticSuggestion = getAutomaticCourseSuggestion({ prompt, suggestions });
+
+  if (automaticSuggestion) {
+    redirect(`/generate/cs/${automaticSuggestion.id}`);
+  }
 
   return (
     <Container variant="narrow">


### PR DESCRIPTION
## Summary

- Redirect learn results directly to generation when there is a single suggestion
- Redirect to generation when a suggestion title exactly matches the learner prompt
- Add e2e coverage for both automatic selection paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-selects clear learn suggestions to cut a click: when there’s only one suggestion or a title exactly matches the prompt, learners are redirected straight to generation.

- **New Features**
  - Redirect `/learn/[prompt]` to `/generate/cs/:id` when:
    - only one suggestion is returned, or
    - a suggestion title matches the prompt (case/diacritics-insensitive via `normalizeString` from `@zoonk/utils/string`).
  - Added e2e tests covering both automatic selection paths.

<sup>Written for commit 0392868d26f37e72c2c31c13a499fcc4a7f9e205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

