### PR TITLE
test(e2e): use chrome channels

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
-
       - name: Run database migrations
         run: pnpm --filter @zoonk/db db:deploy
 

--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -12,13 +12,10 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
-      options: --ipc=host
     env:
       BETTER_AUTH_SECRET: test-secret-for-ci
-      DATABASE_URL: postgres://postgres:postgres@db:5432/zoonk_e2e
-      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@db:5432/zoonk_e2e
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
+      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@localhost:5432/zoonk_e2e
       E2E_TESTING: "true"
       NEXT_PUBLIC_APP_DOMAIN: localhost:4000
       NEXT_PUBLIC_API_URL: http://localhost:4000
@@ -74,9 +71,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Configure database host for container networking
-        run: sed -i 's/@localhost:5432/@db:5432/g' packages/db/.env.e2e
 
       - name: Setup database
         run: pnpm --filter @zoonk/db db:setup:e2e

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -12,17 +12,14 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    container:
-      image: mcr.microsoft.com/playwright:v1.60.0-noble
-      options: --ipc=host
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2, 3]
     env:
       BETTER_AUTH_SECRET: test-secret-for-ci
-      DATABASE_URL: postgres://postgres:postgres@db:5432/zoonk_e2e
-      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@db:5432/zoonk_e2e
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
+      DATABASE_URL_UNPOOLED: postgres://postgres:postgres@localhost:5432/zoonk_e2e
       E2E_TESTING: "true"
       NEXT_PUBLIC_APP_DOMAIN: localhost:3000
       NEXT_PUBLIC_API_URL: http://localhost:4000
@@ -77,9 +74,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Configure database host for container networking
-        run: sed -i 's/@localhost:5432/@db:5432/g' packages/db/.env.e2e
 
       - name: Setup database
         run: pnpm --filter @zoonk/db db:setup:e2e

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { type Browser, type Page } from "@playwright/test";
 import { request } from "@zoonk/e2e/fixtures";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { createE2EUser } from "@zoonk/e2e/fixtures/users";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
@@ -504,9 +505,10 @@ test.describe("Lesson Completion UX", () => {
   });
 
   test("completed lesson shows check indicator in chapter lesson list", async ({
-    authenticatedPage,
-    withProgressUser,
+    baseURL,
+    browser,
   }) => {
+    const user = await createE2EUser(baseURL!);
     const org = await getAiOrganization();
     const uniqueId = randomUUID().slice(0, 8);
 
@@ -549,41 +551,43 @@ test.describe("Lesson Completion UX", () => {
       title: pendingLessonTitle,
     });
 
-    await stepFixture({
-      content: { text: `Completed content ${uniqueId}`, title: `Completed ${uniqueId}` },
-      isPublished: true,
-      kind: "static",
-      lessonId: completedLesson.id,
-    });
+    await Promise.all([
+      stepFixture({
+        content: { text: `Completed content ${uniqueId}`, title: `Completed ${uniqueId}` },
+        isPublished: true,
+        kind: "static",
+        lessonId: completedLesson.id,
+      }),
+      stepFixture({
+        content: { text: `Pending content ${uniqueId}`, title: `Pending ${uniqueId}` },
+        isPublished: true,
+        kind: "static",
+        lessonId: pendingLesson.id,
+      }),
+      lessonProgressFixture({
+        completedAt: new Date(),
+        durationSeconds: 60,
+        lessonId: completedLesson.id,
+        userId: user.id,
+      }),
+    ]);
 
-    await stepFixture({
-      content: { text: `Pending content ${uniqueId}`, title: `Pending ${uniqueId}` },
-      isPublished: true,
-      kind: "static",
-      lessonId: pendingLesson.id,
-    });
+    const browserContext = await browser.newContext({ storageState: user.storageState });
+    const page = await browserContext.newPage();
 
-    await lessonProgressFixture({
-      completedAt: new Date(),
-      durationSeconds: 60,
-      lessonId: completedLesson.id,
-      userId: withProgressUser.id,
-    });
+    try {
+      await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`);
 
-    await authenticatedPage.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`);
-    await authenticatedPage.waitForLoadState("networkidle");
+      const completedItem = page.getByRole("link", { name: new RegExp(completedLessonTitle, "u") });
 
-    const completedItem = authenticatedPage.getByRole("link", {
-      name: new RegExp(completedLessonTitle, "u"),
-    });
+      await expect(completedItem).toBeVisible();
+      await expect(completedItem.getByText(/^completed$/iu)).toBeVisible();
 
-    await expect(completedItem).toBeVisible();
-    await expect(completedItem.getByText(/^completed$/iu)).toBeVisible();
+      const pendingItem = page.getByRole("link", { name: new RegExp(pendingLessonTitle, "u") });
 
-    const pendingItem = authenticatedPage.getByRole("link", {
-      name: new RegExp(pendingLessonTitle, "u"),
-    });
-
-    await expect(pendingItem).toBeVisible();
+      await expect(pendingItem).toBeVisible();
+    } finally {
+      await browserContext.close();
+    }
   });
 });

--- a/apps/main/e2e/score.test.ts
+++ b/apps/main/e2e/score.test.ts
@@ -1,3 +1,4 @@
+import { createE2EUser } from "@zoonk/e2e/fixtures/users";
 import { expect, test } from "./fixtures";
 
 test.describe("Score Page", () => {
@@ -129,12 +130,18 @@ test.describe("Score Page", () => {
   });
 
   test.describe("Users Without Progress", () => {
-    test("sees prompt to start learning", async ({ userWithoutProgress }) => {
-      await userWithoutProgress.goto("/score");
+    test("sees prompt to start learning", async ({ baseURL, browser }) => {
+      const user = await createE2EUser(baseURL!, { orgRole: "member" });
+      const context = await browser.newContext({ storageState: user.storageState });
+      const page = await context.newPage();
 
-      await expect(
-        userWithoutProgress.getByText(/start learning to track your progress/iu),
-      ).toBeVisible();
+      try {
+        await page.goto("/score");
+
+        await expect(page.getByText(/start learning to track your progress/iu)).toBeVisible();
+      } finally {
+        await context.close();
+      }
     });
   });
 });

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -18,7 +18,11 @@ export function createBaseConfig(options: {
     reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"]],
     retries: process.env.CI ? 2 : 0,
     testDir: options.testDir,
-    use: { screenshot: "only-on-failure", trace: "on-first-retry", video: "retain-on-failure" },
+    use: {
+      screenshot: process.env.CI ? "off" : "only-on-failure",
+      trace: process.env.CI ? "off" : "on-first-retry",
+      video: process.env.CI ? "off" : "retain-on-failure",
+    },
     webServer: {
       command: "pnpm start -p 0",
       env: {

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -14,7 +14,7 @@ export function createBaseConfig(options: {
     forbidOnly: Boolean(process.env.CI),
     fullyParallel: true,
     globalSetup: options.globalSetup,
-    projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+    projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"], channel: "chrome" } }],
     reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"]],
     retries: process.env.CI ? 2 : 0,
     testDir: options.testDir,

--- a/packages/e2e/src/base.config.ts
+++ b/packages/e2e/src/base.config.ts
@@ -5,6 +5,11 @@ const E2E_DATABASE_URL =
 
 const E2E_API_URL = "http://localhost:49152";
 
+const CHROMIUM_PROJECT = {
+  name: "chromium",
+  use: { ...devices["Desktop Chrome"], ...(process.env.CI ? { channel: "chrome" as const } : {}) },
+};
+
 export function createBaseConfig(options: {
   globalSetup?: string;
   testDir: string;
@@ -14,7 +19,7 @@ export function createBaseConfig(options: {
     forbidOnly: Boolean(process.env.CI),
     fullyParallel: true,
     globalSetup: options.globalSetup,
-    projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"], channel: "chrome" } }],
+    projects: [CHROMIUM_PROJECT],
     reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"]],
     retries: process.env.CI ? 2 : 0,
     testDir: options.testDir,

--- a/packages/player/vitest.config.mts
+++ b/packages/player/vitest.config.mts
@@ -42,7 +42,7 @@ export default defineConfig({
             enabled: true,
             headless: true,
             instances: [{ browser: "chromium", name: "chromium" }],
-            provider: playwright(),
+            provider: playwright({ launchOptions: { channel: "chrome" } }),
           },
           include: browserTests,
           name: "browser",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run e2e and browser tests against Chrome (via Playwright’s chrome channel) in CI and remove the Playwright container. Tests now create users and auth state explicitly to reduce flakiness and speed up CI.

- **Refactors**
  - Use `channel: "chrome"` in Playwright config and Vitest browser runner.
  - Drop the `mcr.microsoft.com/playwright` container; run on `ubuntu-latest`.
  - Point DB URLs to `localhost` and remove container networking steps.
  - Disable screenshots, traces, and videos in CI (kept locally on failure).
  - Create users via `createE2EUser` and pass `storageState` to new contexts; replace `authenticatedPage`/`withProgressUser`.

<sup>Written for commit a9aad0bd6a1790482087fdd069ec422a20715a79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

