### PR TITLE
chore: add vercelignore file

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,11 @@
+# Local caches and generated build outputs are not source inputs for Vercel.
+.turbo/
+**/.next/
+**/.next-e2e/
+**/coverage/
+**/playwright-report/
+**/test-results/
+**/e2e/.auth/
+.vitest-attachments/
+__screenshots__/
+.next-docs/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `.vercelignore` to exclude caches and test artifacts from Vercel deployments. This reduces upload size and speeds up builds by ignoring `.turbo/`, `.next/`, coverage, Playwright reports, and screenshots.

<sup>Written for commit 406c751e4aa029d5b92afe39934c222e8ee89a5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

