### PR TITLE
fix(main): guard generated language codes

### DIFF
--- a/apps/main/src/data/courses/course-suggestions.test.ts
+++ b/apps/main/src/data/courses/course-suggestions.test.ts
@@ -160,7 +160,7 @@ describe("course-suggestions", () => {
     expect(result.suggestions[0]?.targetLanguage).toBe("en");
   });
 
-  it("accepts non-TTS language and uses Intl-derived title", async () => {
+  it("accepts less common supported languages and uses Intl-derived title", async () => {
     const spy = vi.spyOn(courseSuggestions, "generateCourseSuggestions");
 
     const language = "en";
@@ -177,6 +177,68 @@ describe("course-suggestions", () => {
 
     expect(result.suggestions[0]?.title).toBe("Amharic");
     expect(result.suggestions[0]?.targetLanguage).toBe("am");
+  });
+
+  it("treats invalid targetLanguageCode values as normal course suggestions", async () => {
+    const spy = vi.spyOn(courseSuggestions, "generateCourseSuggestions");
+
+    const language = "en";
+    const prompt = `invalid-target-language-${randomUUID()}`;
+
+    const title = `Zoonk ${randomUUID()}`;
+
+    const generatedSuggestions = [
+      {
+        description: "Use Zoonk to build a language-learning habit.",
+        targetLanguageCode: "多鄰國",
+        title,
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mock return type
+    spy.mockResolvedValueOnce({ data: generatedSuggestions } as never);
+
+    const result = await generateCourseSuggestions({ language, prompt });
+
+    expect(result.suggestions[0]?.title).toBe(title);
+    expect(result.suggestions[0]?.targetLanguage).toBeNull();
+
+    const dbItem = await prisma.courseSuggestion.findUnique({
+      where: { languageSlug: { language, slug: toSlug(title) } },
+    });
+
+    expect(dbItem?.title).toBe(title);
+    expect(dbItem?.targetLanguage).toBeNull();
+  });
+
+  it("normalizes regional targetLanguageCode values to supported app language codes", async () => {
+    const spy = vi.spyOn(courseSuggestions, "generateCourseSuggestions");
+
+    const language = "en";
+    const prompt = `regional-target-language-${randomUUID()}`;
+
+    const generatedSuggestions = [
+      {
+        description: "Learn Traditional Chinese for everyday conversations.",
+        targetLanguageCode: "zh-TW",
+        title: "Traditional Chinese",
+      },
+    ];
+
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- mock return type
+    spy.mockResolvedValueOnce({ data: generatedSuggestions } as never);
+
+    const result = await generateCourseSuggestions({ language, prompt });
+
+    expect(result.suggestions[0]?.title).toBe("Chinese");
+    expect(result.suggestions[0]?.targetLanguage).toBe("zh");
+
+    const dbItem = await prisma.courseSuggestion.findUnique({
+      where: { languageSlug: { language, slug: toSlug("Chinese") } },
+    });
+
+    expect(dbItem?.title).toBe("Chinese");
+    expect(dbItem?.targetLanguage).toBe("zh");
   });
 
   it("deduplicates suggestions with the same targetLanguageCode", async () => {

--- a/apps/main/src/data/courses/course-suggestions.ts
+++ b/apps/main/src/data/courses/course-suggestions.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { generateCourseSuggestions as generateTask } from "@zoonk/ai/tasks/courses/suggestions";
 import { type CourseSuggestion, getAiGenerationCourseWhere, prisma } from "@zoonk/db";
-import { getLanguageName } from "@zoonk/utils/languages";
+import { getLanguageName, isTTSSupportedLanguage } from "@zoonk/utils/languages";
 import { normalizeString, removeLocaleSuffix, toSlug } from "@zoonk/utils/string";
 import { isUuid } from "@zoonk/utils/uuid";
 
@@ -18,6 +18,12 @@ async function findSearchPrompt(params: { language: string; prompt: string }) {
 }
 
 type SuggestionInput = { title: string; description: string; targetLanguage: string | null };
+
+type GeneratedSuggestion = {
+  description: string;
+  targetLanguageCode: string | null;
+  title: string;
+};
 
 async function upsertSearchPromptWithSuggestions(input: {
   language: string;
@@ -78,24 +84,73 @@ async function upsertSearchPromptWithSuggestions(input: {
   });
 }
 
-function resolveLanguageSuggestion(
-  suggestion: { title: string; description: string; targetLanguageCode: string | null },
-  language: string,
-): SuggestionInput {
-  if (!suggestion.targetLanguageCode) {
+/**
+ * Normalizes model-generated language codes before we treat a suggestion as a
+ * language course. The prompt asks for ISO 639-1 codes, but model output is
+ * still untrusted: values such as `zh-TW`, `traditional-chinese`, or the raw
+ * learner input can otherwise reach `Intl.DisplayNames` and crash the page with
+ * `RangeError: invalid_argument`.
+ */
+function normalizeGeneratedTargetLanguage({
+  targetLanguageCode,
+}: {
+  targetLanguageCode: string | null;
+}): string | null {
+  const language = getBaseLanguageCode({ targetLanguageCode });
+
+  if (!language || !isTTSSupportedLanguage(language)) {
+    return null;
+  }
+
+  return language;
+}
+
+/**
+ * Extracts the base language subtag from BCP 47-like model output. Region and
+ * script variants such as `zh-Hant-TW` still describe the same app-level target
+ * language, while malformed values should become `null` so the suggestion stays
+ * a normal course suggestion instead of crashing.
+ */
+function getBaseLanguageCode({
+  targetLanguageCode,
+}: {
+  targetLanguageCode: string | null;
+}): string | null {
+  if (!targetLanguageCode) {
+    return null;
+  }
+
+  try {
+    return new Intl.Locale(targetLanguageCode.trim()).language ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Converts one AI suggestion into the database shape we trust. Language-course
+ * suggestions get a deterministic localized title from our language utilities;
+ * malformed language codes stay as ordinary course suggestions with the model's
+ * original title and a null target language.
+ */
+function resolveLanguageSuggestion({
+  language,
+  suggestion,
+}: {
+  language: string;
+  suggestion: GeneratedSuggestion;
+}): SuggestionInput {
+  const targetLanguage = normalizeGeneratedTargetLanguage({
+    targetLanguageCode: suggestion.targetLanguageCode,
+  });
+
+  if (!targetLanguage) {
     return { description: suggestion.description, targetLanguage: null, title: suggestion.title };
   }
 
-  const title = getLanguageName({
-    targetLanguage: suggestion.targetLanguageCode,
-    userLanguage: language,
-  });
+  const title = getLanguageName({ targetLanguage, userLanguage: language });
 
-  return {
-    description: suggestion.description,
-    targetLanguage: suggestion.targetLanguageCode,
-    title,
-  };
+  return { description: suggestion.description, targetLanguage, title };
 }
 
 function deduplicateByTargetLanguage(suggestions: SuggestionInput[]): SuggestionInput[] {
@@ -138,7 +193,7 @@ export async function generateCourseSuggestions({
 
   const { data } = await generateTask({ language, prompt });
 
-  const resolved = data.map((item) => resolveLanguageSuggestion(item, language));
+  const resolved = data.map((suggestion) => resolveLanguageSuggestion({ language, suggestion }));
   const deduplicated = deduplicateByTargetLanguage(resolved);
 
   return upsertSearchPromptWithSuggestions({ language, prompt, suggestions: deduplicated });


### PR DESCRIPTION
## Summary

- Normalize model-generated target language codes before deriving course suggestion titles
- Treat invalid target language codes as normal course suggestions
- Add regression coverage for invalid and regional target language codes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize and guard generated target language codes in course suggestions to prevent crashes and produce correct, localized titles. Invalid codes are treated as normal suggestions; regional codes are mapped to base languages (e.g., zh-TW -> zh).

- **Bug Fixes**
  - Parse and normalize codes with `Intl.Locale`; map region/script variants to base language; ignore malformed values.
  - Only accept supported TTS languages via `isTTSSupportedLanguage`; others keep the original title with a null `targetLanguage`.
  - Derive titles with `getLanguageName`; add regression tests for invalid and regional codes.

<sup>Written for commit b8572eafa23a1445c402cbca466a97ebaa66f0db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

