### PR TITLE
fix(player): render math in feedback answers

### DIFF
--- a/packages/player/src/_browser-tests/player-choice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-choice.browser.test.tsx
@@ -193,6 +193,48 @@ describe("player browser integration: choice steps", () => {
     await expect.element(page.getByText("Berlin")).toBeInTheDocument();
   });
 
+  it("renders math in feedback answer rows", async () => {
+    const { container } = renderPlayer({
+      lesson: buildSerializedLesson({
+        steps: [
+          buildSerializedStep({
+            content: {
+              options: [
+                {
+                  feedback: "That uses velocity instead of acceleration.",
+                  id: "wrong-force",
+                  isCorrect: false,
+                  text: String.raw`Wrong force \(F = mv\)`,
+                },
+                {
+                  feedback: "Correct",
+                  id: "right-force",
+                  isCorrect: true,
+                  text: String.raw`Right force \(F = ma\)`,
+                },
+              ],
+              question: "Which formula matches Newton's second law?",
+            },
+            kind: "multipleChoice",
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await page.getByRole("radio", { name: /wrong force/iu }).click();
+    await page.getByRole("button", { name: /check/iu }).click();
+
+    await expect.element(page.getByRole("status")).toBeInTheDocument();
+
+    const statusText = container.textContent?.replaceAll(/\s/gu, "") ?? "";
+
+    expect(statusText).toContain("Youranswer:WrongforceF=mv");
+    expect(statusText).toContain("Correctanswer:RightforceF=ma");
+    expect(statusText).not.toContain(String.raw`\(`);
+    expect(statusText).not.toContain(String.raw`\)`);
+  });
+
   it("strips model-added wrapping quotes from multiple-choice option labels", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/components/feedback-answer-blocks.tsx
+++ b/packages/player/src/components/feedback-answer-blocks.tsx
@@ -3,7 +3,18 @@
 import { cn } from "@zoonk/ui/lib/utils";
 import { CircleCheck, CircleX } from "lucide-react";
 import { useExtracted } from "next-intl";
+import { PlayerRichText } from "./player-rich-text";
 import { RomanizationText } from "./romanization-text";
+
+/**
+ * Feedback rows repeat learner-facing answer text that may have already been
+ * shown as rich option copy during play. Rendering it through the shared rich
+ * text path keeps LaTeX, lightweight formatting, name replacement, and quote
+ * cleanup consistent between the prompt and result screens.
+ */
+function FeedbackAnswerText({ text }: { text: string }) {
+  return <PlayerRichText text={text} />;
+}
 
 function AnswerLine({
   children,
@@ -48,7 +59,9 @@ export function CorrectAnswerBlock({
       variant="correct"
     >
       <span className="flex flex-col">
-        <span>{selectedText}</span>
+        <span>
+          <FeedbackAnswerText text={selectedText} />
+        </span>
         <RomanizationText>{romanization}</RomanizationText>
       </span>
     </AnswerLine>
@@ -74,7 +87,7 @@ export function IncorrectAnswerBlock({
           label={t("Your answer:")}
           variant="incorrect"
         >
-          {selectedText}
+          <FeedbackAnswerText text={selectedText} />
         </AnswerLine>
       )}
       {correctAnswer && (
@@ -84,7 +97,9 @@ export function IncorrectAnswerBlock({
           variant="correct"
         >
           <span className="flex flex-col">
-            <span>{correctAnswer}</span>
+            <span>
+              <FeedbackAnswerText text={correctAnswer} />
+            </span>
             <RomanizationText>{romanization}</RomanizationText>
           </span>
         </AnswerLine>

--- a/packages/player/src/components/inline-feedback.tsx
+++ b/packages/player/src/components/inline-feedback.tsx
@@ -35,7 +35,9 @@ export function InlineFeedback({
       {!isCorrect && correctAnswer && (
         <p className="text-sm">
           <span className="text-muted-foreground">{t("Correct answer:")}</span>{" "}
-          <span className="text-success font-medium">{correctAnswer}</span>
+          <span className="text-success font-medium">
+            <PlayerRichText text={correctAnswer} />
+          </span>
         </p>
       )}
 


### PR DESCRIPTION
Render feedback answer text through the shared player rich-text path so KaTeX formatting works in answer rows.

Adds browser coverage for math in wrong-answer feedback rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render math (KaTeX) in feedback answer rows by routing answer text through the shared rich-text renderer, so equations display correctly after checking answers. Adds browser coverage for math in incorrect/correct feedback.

- **Bug Fixes**
  - Use `PlayerRichText` for selected and correct answers in feedback blocks and inline feedback to apply LaTeX, basic formatting, name replacement, and quote cleanup.
  - Added browser test for multiple-choice feedback to ensure rendered math and no raw LaTeX delimiters leak into the DOM.

<sup>Written for commit df4a4040bb4adb7ec7f2b64fce278226cde841df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

