### PR TITLE
fix(ci): avoid caching next dev outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -32,11 +32,11 @@
     "//#quality:fix": { "dependsOn": ["//#lint:fix", "//#format:fix"] },
     "build": {
       "dependsOn": ["db:generate", "db:deploy", "^build"],
-      "outputs": [".next/**", "!.next/cache/**", "messages/**"]
+      "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**", "messages/**"]
     },
     "build:e2e": {
       "dependsOn": ["db:generate", "^build:e2e"],
-      "outputs": [".next-e2e/**", "!.next-e2e/cache/**", "messages/**"]
+      "outputs": [".next-e2e/**", "!.next-e2e/cache/**", "!.next-e2e/dev/**", "messages/**"]
     },
     "db:deploy": { "cache": false },
     "db:generate": {


### PR DESCRIPTION
## Summary

- exclude Next dev output folders from Turbo build artifacts
- keep production and e2e build outputs cacheable without packaging stale dev caches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude Next.js dev output folders from `turbo` build artifacts to avoid caching/restoring stale dev files while keeping production and e2e outputs cached. Adds `!.next/dev/**` and `!.next-e2e/dev/**` to `turbo.json` outputs.

<sup>Written for commit e081eb8e41c7aebf380e39612e38973a4c19a102. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

