### PR TITLE
feat(player): show missed question in feedback

### DIFF
--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -175,6 +175,10 @@ msgid "QAJ_Tl"
 msgstr "Richtige Antwort:"
 
 #: src/components/feedback-screen.tsx
+msgid "kgOBET"
+msgstr "Frage"
+
+#: src/components/feedback-screen.tsx
 msgid "fpO9TK"
 msgstr "Übersetze:"
 

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -175,6 +175,10 @@ msgid "QAJ_Tl"
 msgstr "Correct answer:"
 
 #: src/components/feedback-screen.tsx
+msgid "kgOBET"
+msgstr "Question"
+
+#: src/components/feedback-screen.tsx
 msgid "fpO9TK"
 msgstr "Translate:"
 

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -175,6 +175,10 @@ msgid "QAJ_Tl"
 msgstr "Respuesta correcta:"
 
 #: src/components/feedback-screen.tsx
+msgid "kgOBET"
+msgstr "Pregunta"
+
+#: src/components/feedback-screen.tsx
 msgid "fpO9TK"
 msgstr "Traducir:"
 

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -175,6 +175,10 @@ msgid "QAJ_Tl"
 msgstr "Réponse correcte :"
 
 #: src/components/feedback-screen.tsx
+msgid "kgOBET"
+msgstr "Question"
+
+#: src/components/feedback-screen.tsx
 msgid "fpO9TK"
 msgstr "Traduire :"
 

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -175,6 +175,10 @@ msgid "QAJ_Tl"
 msgstr "Resposta correta:"
 
 #: src/components/feedback-screen.tsx
+msgid "kgOBET"
+msgstr "Pergunta"
+
+#: src/components/feedback-screen.tsx
 msgid "fpO9TK"
 msgstr "Traduzir:"
 

--- a/packages/player/src/_browser-tests/player-choice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-choice.browser.test.tsx
@@ -40,6 +40,7 @@ describe("player browser integration: choice steps", () => {
 
     await page.getByRole("button", { name: /check/iu }).click();
     await expect.element(page.getByText(/your answer:/iu)).toBeInTheDocument();
+    await expect.element(page.getByText("What is the capital of Germany?")).not.toBeInTheDocument();
 
     await page.getByRole("button", { name: /continue/iu }).click();
 
@@ -142,6 +143,48 @@ describe("player browser integration: choice steps", () => {
 
     await expect
       .element(page.getByRole("region", { name: /answer feedback/iu }))
+      .toBeInTheDocument();
+  });
+
+  it("shows the missed multiple-choice prompt on incorrect feedback", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        steps: [
+          buildSerializedStep({
+            content: {
+              context: "Review the robot's report before choosing.",
+              options: [
+                {
+                  feedback: "The oil spots point to friction, not a clean energy transfer.",
+                  id: "clean-transfer",
+                  isCorrect: false,
+                  text: "The gears are transferring energy perfectly.",
+                },
+                {
+                  feedback: "Correct",
+                  id: "friction",
+                  isCorrect: true,
+                  text: "Friction is turning useful motion into heat.",
+                },
+              ],
+              question: "What explains the robot's overheating?",
+            },
+            kind: "multipleChoice",
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await page.getByRole("radio", { name: "The gears are transferring energy perfectly." }).click();
+    await page.getByRole("button", { name: /check/iu }).click();
+
+    await expect
+      .element(page.getByText("Review the robot's report before choosing."))
+      .toBeInTheDocument();
+
+    await expect
+      .element(page.getByText("What explains the robot's overheating?"))
       .toBeInTheDocument();
   });
 

--- a/packages/player/src/components/feedback-screen.tsx
+++ b/packages/player/src/components/feedback-screen.tsx
@@ -8,8 +8,12 @@ import { getFeedbackRomanization } from "./_utils/feedback-romanization";
 import { CorrectAnswerBlock, IncorrectAnswerBlock } from "./feedback-answer-blocks";
 import { PlayAudioButton } from "./play-audio-button";
 import { PlayerFeedbackScene, PlayerFeedbackSceneMessage } from "./player-feedback-scene";
+import { PlayerRichText } from "./player-rich-text";
 import { PlayerSupportingText } from "./player-supporting-text";
 import { RomanizationText } from "./romanization-text";
+import { SectionLabel } from "./section-label";
+
+type FeedbackPromptReviewContent = { context: string | null; question: string | null };
 
 function getArrangeWordsSelectedText(result: StepResult): string | null {
   if (result.answer?.kind === "reading" || result.answer?.kind === "listening") {
@@ -76,6 +80,36 @@ function getQuestionText(result: StepResult, step?: SerializedStep): string | nu
 }
 
 /**
+ * Dedicated multiple-choice feedback replaces the original prompt, so missed
+ * answers need a small copy-only reminder of the context the learner just used.
+ * Inline feedback step kinds keep their prompt on screen and do not need this.
+ */
+function getMultipleChoicePromptReview({
+  result,
+  step,
+}: {
+  result: StepResult;
+  step?: SerializedStep;
+}): FeedbackPromptReviewContent | null {
+  if (
+    result.result.isCorrect ||
+    result.answer?.kind !== "multipleChoice" ||
+    step?.kind !== "multipleChoice"
+  ) {
+    return null;
+  }
+
+  const content = parseStepContent("multipleChoice", step.content);
+  const promptReview = { context: content.context ?? null, question: content.question ?? null };
+
+  if (!promptReview.context && !promptReview.question) {
+    return null;
+  }
+
+  return promptReview;
+}
+
+/**
  * Returns the audio URL for the feedback screen's pronunciation button.
  * Reading/listening steps use sentence audio; translation steps use word audio.
  */
@@ -89,6 +123,36 @@ function getFeedbackAudioUrl(step?: SerializedStep): string | null {
   }
 
   return null;
+}
+
+/**
+ * Shows the original missed prompt with quieter typography than the answer
+ * rows. It gives learners enough context to understand the correction without
+ * turning the feedback scene back into the full question screen.
+ */
+function FeedbackPromptReview({ prompt }: { prompt: FeedbackPromptReviewContent }) {
+  const t = useExtracted();
+
+  return (
+    <div
+      className="flex flex-col gap-1.5 text-sm leading-relaxed"
+      data-slot="feedback-prompt-review"
+    >
+      <SectionLabel>{t("Question")}</SectionLabel>
+
+      {prompt.context && (
+        <p className="text-muted-foreground">
+          <PlayerRichText text={prompt.context} />
+        </p>
+      )}
+
+      {prompt.question && (
+        <p className="text-foreground font-medium">
+          <PlayerRichText text={prompt.question} />
+        </p>
+      )}
+    </div>
+  );
 }
 
 /**
@@ -107,12 +171,15 @@ export function FeedbackScreenContent({
   const { isCorrect, feedback, correctAnswer } = result.result;
   const selectedText = getSelectedText(result, step);
   const questionText = getQuestionText(result, step);
+  const promptReview = getMultipleChoicePromptReview({ result, step });
   const rom = getFeedbackRomanization({ correctAnswer, questionText, result, selectedText, step });
   const audioUrl = getFeedbackAudioUrl(step);
 
   return (
     <PlayerFeedbackScene>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-3">
+        {promptReview && <FeedbackPromptReview prompt={promptReview} />}
+
         {questionText && (
           <div className="flex flex-col gap-1">
             <PlayerSupportingText>


### PR DESCRIPTION
## Summary

- show the original multiple-choice context and question after an incorrect answer
- keep correct-answer feedback unchanged
- add browser coverage for the missed-question feedback state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the original multiple-choice context and question on the feedback screen after an incorrect answer, so learners understand the correction. Correct-answer feedback and non-multiple-choice steps are unchanged.

- **New Features**
  - Show a compact "Question" block with the original context and prompt on incorrect multiple-choice feedback.
  - Added browser test covering the new incorrect-feedback state and ensuring it stays hidden otherwise.
  - Added i18n string for "Question" in `en`, `es`, `fr`, `de`, and `pt`.

<sup>Written for commit b9d26be5a8fbae8300e450169c7a069b0461f805. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

