### PR TITLE
fix(api): reject same-language course generation

### DIFF
--- a/apps/api/e2e/workflows-course-generation.test.ts
+++ b/apps/api/e2e/workflows-course-generation.test.ts
@@ -52,6 +52,33 @@ test.describe("Course Generation Workflow API", () => {
     await apiContext.dispose();
   });
 
+  test("rejects language course requests with the same user and target language", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+
+    const startRequest = await courseStartRequestFixture({
+      canonicalTitle: `E2E Same Language Course ${uniqueId}`,
+      generationStatus: "completed",
+      language: "en",
+      scope: "language",
+      targetLanguage: "en",
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/workflows/course-generation/trigger", {
+      data: { courseStartRequestId: startRequest.id },
+    });
+
+    expect(response.status()).toBe(400);
+
+    const body = await response.json();
+
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("BAD_REQUEST");
+
+    await apiContext.dispose();
+  });
+
   test("returns validation error when courseStartRequestId is missing", async () => {
     const { apiContext } = await createAuthenticatedApiContext({
       baseURL,

--- a/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
@@ -1,7 +1,9 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
 import { courseGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
+import { getCourseStartRequestGenerationError } from "@/workflows/course-generation/_utils/course-start-request-validation";
 import { courseGenerationWorkflow } from "@/workflows/course-generation/course-generation-workflow";
+import { prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";
 
@@ -10,6 +12,20 @@ export async function POST(request: NextRequest) {
 
   if (!parsed.success) {
     return errors.validation(parsed.error);
+  }
+
+  const courseStartRequest = await prisma.courseStartRequest.findUnique({
+    where: { id: parsed.data.courseStartRequestId },
+  });
+
+  if (!courseStartRequest) {
+    return errors.notFound();
+  }
+
+  const generationError = getCourseStartRequestGenerationError(courseStartRequest);
+
+  if (generationError) {
+    return errors.badRequest(generationError);
   }
 
   const run = await start(courseGenerationWorkflow, [parsed.data.courseStartRequestId]);

--- a/apps/api/src/workflows/course-generation/_utils/course-start-request-validation.ts
+++ b/apps/api/src/workflows/course-generation/_utils/course-start-request-validation.ts
@@ -1,0 +1,32 @@
+import { type CourseStartRequest } from "@zoonk/db";
+
+const SAME_LANGUAGE_COURSE_ERROR = "Language course source and target languages must be different";
+
+/**
+ * Language courses are only useful when the learner language and learned
+ * language differ. The main app prevents selecting the current locale, but the
+ * API and workflow need the same rule because requests can be started outside
+ * that page.
+ */
+function isSameLanguageCourseRequest(
+  request: Pick<CourseStartRequest, "language" | "scope" | "targetLanguage">,
+): boolean {
+  return request.scope === "language" && request.targetLanguage === request.language;
+}
+
+/**
+ * Explains why a persisted start request cannot enter course generation. The
+ * database also stores redirect, waitlist, unsafe, and invalid language records,
+ * so the API route and workflow step share this check before creating courses.
+ */
+export function getCourseStartRequestGenerationError(request: CourseStartRequest): string | null {
+  if (!(request.canonicalTitle && request.generationStatus)) {
+    return "Course start request is not generatable";
+  }
+
+  if (isSameLanguageCourseRequest(request)) {
+    return SAME_LANGUAGE_COURSE_ERROR;
+  }
+
+  return null;
+}

--- a/apps/api/src/workflows/course-generation/steps/get-course-start-request-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-start-request-step.test.ts
@@ -41,4 +41,17 @@ describe(getCourseStartRequestStep, () => {
       expect.objectContaining({ status: "error", step: "getCourseStartRequest" }),
     );
   });
+
+  it("throws FatalError when a language request uses the same user and target language", async () => {
+    const request = await courseStartRequestFixture({
+      canonicalTitle: `Same Language Request ${randomUUID()}`,
+      language: "en",
+      scope: "language",
+      targetLanguage: "en",
+    });
+
+    await expect(getCourseStartRequestStep(request.id)).rejects.toThrow(
+      "Language course source and target languages must be different",
+    );
+  });
 });

--- a/apps/api/src/workflows/course-generation/steps/get-course-start-request-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-start-request-step.ts
@@ -2,6 +2,7 @@ import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type CourseStartRequest, type GenerationStatus, prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
+import { getCourseStartRequestGenerationError } from "../_utils/course-start-request-validation";
 
 export type GeneratableCourseStartRequest = CourseStartRequest & {
   canonicalTitle: string;
@@ -16,8 +17,10 @@ export type GeneratableCourseStartRequest = CourseStartRequest & {
 export function assertGeneratableCourseStartRequest(
   request: CourseStartRequest,
 ): asserts request is GeneratableCourseStartRequest {
-  if (!(request.canonicalTitle && request.generationStatus)) {
-    throw new FatalError("Course start request is not generatable");
+  const generationError = getCourseStartRequestGenerationError(request);
+
+  if (generationError) {
+    throw new FatalError(generationError);
   }
 }
 


### PR DESCRIPTION
## Summary

- reject language course generation when learner and target languages match
- share validation between the API trigger and workflow step
- add workflow and API e2e coverage


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents generating a language course when the learner language equals the target language. Adds a shared validator so the API trigger and workflow reject invalid requests early.

- **Bug Fixes**
  - API trigger validates the start request; returns 404 if not found and 400 BAD_REQUEST for same-language requests.
  - Workflow step throws a FatalError with a clear message for invalid same-language requests.
  - Added e2e and unit tests to cover API and workflow validation.

<sup>Written for commit 020d6f6a1db1daf34692c4cfa966e6be5bd9f3e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

