### PR TITLE
fix(main): improve belt progress contrast

### DIFF
--- a/apps/main/src/app/(progress)/level/level-progression.tsx
+++ b/apps/main/src/app/(progress)/level/level-progression.tsx
@@ -76,7 +76,12 @@ export async function LevelProgression({ currentBelt }: { currentBelt: BeltLevel
           <div className="flex flex-col gap-1">
             <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
               <div
-                className={cn("h-full transition-all", BELT_BG_CLASSES[currentBelt.color])}
+                className={cn(
+                  "h-full transition-all",
+                  BELT_BG_CLASSES[currentBelt.color],
+                  currentBelt.color === "white" && "ring-border ring-1 ring-inset dark:ring-0",
+                  currentBelt.color === "black" && "dark:ring-1 dark:ring-white/20 dark:ring-inset",
+                )}
                 style={{ width: `${progressPercentage}%` }}
               />
             </div>


### PR DESCRIPTION
## Summary

- add a subtle inset edge to white belt progress in light mode
- add a matching dark-mode edge for black belt progress

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve belt progress bar contrast for better readability across themes. Adds a subtle inset ring to white belts in light mode and a matching dark-mode ring for black belts, making progress more visible against the muted background.

<sup>Written for commit 974f97e5630053fe0f3328911c1f3611e5e6058f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

