### PR TITLE
feat(main): link completed language courses

### DIFF
--- a/apps/main/e2e/start.test.ts
+++ b/apps/main/e2e/start.test.ts
@@ -80,7 +80,12 @@ test.describe("Start language path", () => {
     await expect(page.getByRole("link", { name: /javanese/iu })).toBeVisible();
     await expect(page.getByRole("link", { name: /^english/iu })).not.toBeVisible();
 
-    await page.getByRole("link", { name: /javanese/iu }).click();
+    const javaneseLink = page.getByRole("link", { name: /javanese/iu });
+
+    await expect(javaneseLink).toHaveAttribute("href", "/start/speak/jv");
+    await expect(javaneseLink).toHaveAttribute("rel", "nofollow");
+
+    await javaneseLink.click();
 
     await expect(page).toHaveURL(/\/generate\/course\/[-a-f0-9]+$/u);
 
@@ -135,9 +140,16 @@ test.describe("Start language path", () => {
 
     await page.goto("/start/speak");
     await page.getByRole("searchbox", { name: /search languages/iu }).fill("Icelandic");
-    await page.getByRole("link", { name: /icelandic/iu }).click();
 
-    await expect(page).toHaveURL(new RegExp(`/b/${org.slug}/c/${course.slug}$`, "u"));
+    const courseHref = `/b/${org.slug}/c/${course.slug}`;
+    const icelandicLink = page.getByRole("link", { name: /icelandic/iu });
+
+    await expect(icelandicLink).toHaveAttribute("href", courseHref);
+    await expect(icelandicLink).not.toHaveAttribute("rel", "nofollow");
+
+    await icelandicLink.click();
+
+    await expect(page).toHaveURL(new RegExp(`${courseHref}$`, "u"));
   });
 });
 

--- a/apps/main/src/app/(catalog)/start/speak/language-list.tsx
+++ b/apps/main/src/app/(catalog)/start/speak/language-list.tsx
@@ -43,8 +43,8 @@ function LanguageOptionLink({ language }: { language: LanguageOption }) {
           "border-border/40 bg-background hover:border-foreground/20 hover:bg-muted/30 focus-visible:border-ring focus-visible:ring-ring/40 flex w-full min-w-0 items-center gap-3 rounded-lg border px-4 py-3 text-left transition-all duration-150 outline-none focus-visible:ring-[3px]",
         )}
         href={language.href}
-        prefetch={false}
-        rel="nofollow"
+        prefetch={language.prefetch}
+        rel={language.rel}
       >
         <span aria-hidden="true" className="text-2xl leading-none">
           {language.flag}

--- a/apps/main/src/app/(catalog)/start/speak/language-options.test.ts
+++ b/apps/main/src/app/(catalog)/start/speak/language-options.test.ts
@@ -19,6 +19,20 @@ describe(getLanguageOptions, () => {
     expect(languages.some((language) => language.code === "en")).toBe(false);
   });
 
+  it("links completed language courses directly and keeps ungenerated languages on the start path", () => {
+    const languages = getLanguageOptions({
+      completedLanguageCourseHrefs: { is: "/b/ai/c/icelandic" },
+      locale: "en",
+    });
+
+    const icelandic = languages.find((language) => language.code === "is");
+    const javanese = languages.find((language) => language.code === "jv");
+
+    expect(icelandic).toMatchObject({ href: "/b/ai/c/icelandic", prefetch: true, rel: undefined });
+
+    expect(javanese).toMatchObject({ href: "/start/speak/jv", prefetch: false, rel: "nofollow" });
+  });
+
   it("derives flags for supported languages without a per-language map", () => {
     const languages = [
       ...getLanguageOptions({ locale: "en" }),

--- a/apps/main/src/app/(catalog)/start/speak/language-options.ts
+++ b/apps/main/src/app/(catalog)/start/speak/language-options.ts
@@ -1,3 +1,5 @@
+import { type AiCourseHref } from "@/data/courses/course-href";
+import { type CompletedLanguageCourseHrefs } from "@/data/courses/language-course";
 import {
   type TTSSupportedLanguageCode,
   TTS_SUPPORTED_LANGUAGE_CODES,
@@ -26,9 +28,11 @@ const POPULAR_LANGUAGE_CODES_BY_LOCALE = {
 export type LanguageOption = {
   code: TTSSupportedLanguageCode;
   flag: string;
-  href: `/start/speak/${TTSSupportedLanguageCode}`;
+  href: `/start/speak/${TTSSupportedLanguageCode}` | AiCourseHref;
   name: string;
   nativeName: string;
+  prefetch: boolean;
+  rel?: "nofollow";
   searchText: string;
 };
 
@@ -76,25 +80,56 @@ function getPopularLanguageRanks(locale: string): Map<TTSSupportedLanguageCode, 
 }
 
 /**
+ * Keeps navigation rules next to the language option builder so every row has a
+ * single source of truth for its href, prefetch behavior, and crawl hint. Known
+ * completed courses should behave like normal catalog links, while ungenerated
+ * languages still point at the generation route without prefetching that GET.
+ */
+function getLanguageOptionNavigation({
+  code,
+  completedLanguageCourseHrefs,
+}: {
+  code: TTSSupportedLanguageCode;
+  completedLanguageCourseHrefs: CompletedLanguageCourseHrefs;
+}): Pick<LanguageOption, "href" | "prefetch" | "rel"> {
+  const completedCourseHref = completedLanguageCourseHrefs[code];
+
+  if (completedCourseHref) {
+    return { href: completedCourseHref, prefetch: true };
+  }
+
+  return { href: `/start/speak/${code}` as const, prefetch: false, rel: "nofollow" };
+}
+
+/**
  * Builds the language picker from the canonical TTS support list so the UI
  * cannot drift from the audio generation capability it is promising. The
  * current app language is excluded because a course where the source and
  * target language are identical does not teach a new language.
  */
-export function getLanguageOptions({ locale }: { locale: string }): LanguageOption[] {
+export function getLanguageOptions({
+  completedLanguageCourseHrefs = {},
+  locale,
+}: {
+  completedLanguageCourseHrefs?: CompletedLanguageCourseHrefs;
+  locale: string;
+}): LanguageOption[] {
   const popularLanguageRanks = getPopularLanguageRanks(locale);
 
   return TTS_SUPPORTED_LANGUAGE_CODES.filter((code) => code !== locale)
     .map((code) => {
       const name = getLanguageName({ targetLanguage: code, userLanguage: locale });
       const nativeName = getLanguageName({ targetLanguage: code });
+      const navigation = getLanguageOptionNavigation({ code, completedLanguageCourseHrefs });
 
       return {
         code,
         flag: getLanguageFlag(code),
-        href: `/start/speak/${code}` as const,
+        href: navigation.href,
         name,
         nativeName,
+        prefetch: navigation.prefetch,
+        rel: navigation.rel,
         searchText: normalizeString([code, name, nativeName].join(" ")),
       };
     })

--- a/apps/main/src/app/(catalog)/start/speak/page.tsx
+++ b/apps/main/src/app/(catalog)/start/speak/page.tsx
@@ -1,3 +1,4 @@
+import { getCompletedLanguageCourseHrefs } from "@/data/courses/language-course";
 import { type Metadata } from "next";
 import { getExtracted, getLocale } from "next-intl/server";
 import {
@@ -27,7 +28,8 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function StartSpeak() {
   const locale = await getLocale();
   const t = await getExtracted();
-  const languages = getLanguageOptions({ locale });
+  const completedLanguageCourseHrefs = await getCompletedLanguageCourseHrefs({ language: locale });
+  const languages = getLanguageOptions({ completedLanguageCourseHrefs, locale });
 
   return (
     <StartSurface>

--- a/apps/main/src/data/courses/course-start-request.ts
+++ b/apps/main/src/data/courses/course-start-request.ts
@@ -8,7 +8,7 @@ import {
   type CourseRequestScope,
   routeCourseRequest,
 } from "@zoonk/ai/tasks/courses/request-routing";
-import { type CourseStartRequest, prisma } from "@zoonk/db";
+import { type CourseStartRequest, isPrismaUniqueConstraintError, prisma } from "@zoonk/db";
 import { normalizeString } from "@zoonk/utils/string";
 import { isUuid } from "@zoonk/utils/uuid";
 import {
@@ -165,21 +165,35 @@ async function upsertCourseStartRequest({
 }): Promise<CourseStartRequestWithCourse> {
   const normalizedPrompt = normalizeString(prompt);
 
-  return prisma.courseStartRequest.upsert({
-    create: {
-      canonicalTitle: request.canonicalTitle,
-      courseMode: request.courseMode,
-      generationStatus: request.generationStatus,
-      language,
-      normalizedPrompt,
-      prompt,
-      scope: request.scope,
-      targetLanguage: request.targetLanguage,
-    },
-    include: { course: true },
-    update: {},
-    where: { languageNormalizedPrompt: { language, normalizedPrompt } },
-  });
+  try {
+    return await prisma.courseStartRequest.upsert({
+      create: {
+        canonicalTitle: request.canonicalTitle,
+        courseMode: request.courseMode,
+        generationStatus: request.generationStatus,
+        language,
+        normalizedPrompt,
+        prompt,
+        scope: request.scope,
+        targetLanguage: request.targetLanguage,
+      },
+      include: { course: true },
+      update: {},
+      where: { languageNormalizedPrompt: { language, normalizedPrompt } },
+    });
+  } catch (error) {
+    if (!isPrismaUniqueConstraintError(error)) {
+      throw error;
+    }
+
+    const cachedRequest = await findCachedStartRequest({ language, prompt });
+
+    if (!cachedRequest) {
+      throw error;
+    }
+
+    return cachedRequest;
+  }
 }
 
 /**

--- a/apps/main/src/data/courses/language-course.test.ts
+++ b/apps/main/src/data/courses/language-course.test.ts
@@ -1,0 +1,155 @@
+import { randomUUID } from "node:crypto";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { aiOrganizationFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
+import { describe, expect, it } from "vitest";
+import { getCompletedLanguageCourseHrefs } from "./language-course";
+
+/**
+ * Creates a source-language value that no seeded course should use, so each
+ * test can assert the full returned href map without depending on cleanup.
+ */
+function getUniqueSourceLanguage() {
+  return `q${randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * Builds stable test slugs with a readable prefix so failed assertions make it
+ * clear which fixture was supposed to be returned.
+ */
+function getCourseSlug(label: string) {
+  return `language-href-${label}-${randomUUID().slice(0, 8)}`;
+}
+
+describe(getCompletedLanguageCourseHrefs, () => {
+  it("returns hrefs for completed published AI language courses in the source language", async () => {
+    const organization = await aiOrganizationFixture();
+    const language = getUniqueSourceLanguage();
+    const icelandicSlug = getCourseSlug("icelandic");
+    const javaneseSlug = getCourseSlug("javanese");
+
+    await Promise.all([
+      courseFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        language,
+        organizationId: organization.id,
+        slug: icelandicSlug,
+        targetLanguage: "is",
+      }),
+      courseFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        language,
+        organizationId: organization.id,
+        slug: javaneseSlug,
+        targetLanguage: "jv",
+      }),
+    ]);
+
+    const hrefs = await getCompletedLanguageCourseHrefs({ language });
+
+    expect(hrefs).toStrictEqual({
+      is: `/b/${AI_ORG_SLUG}/c/${icelandicSlug}`,
+      jv: `/b/${AI_ORG_SLUG}/c/${javaneseSlug}`,
+    });
+  });
+
+  it("ignores courses that are not eligible completed language courses", async () => {
+    const [aiOrganization, otherOrganization] = await Promise.all([
+      aiOrganizationFixture(),
+      organizationFixture(),
+    ]);
+
+    const language = getUniqueSourceLanguage();
+    const eligibleSlug = getCourseSlug("eligible");
+
+    await Promise.all([
+      courseFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        language,
+        organizationId: aiOrganization.id,
+        slug: eligibleSlug,
+        targetLanguage: "is",
+      }),
+      courseFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        language: getUniqueSourceLanguage(),
+        organizationId: aiOrganization.id,
+        targetLanguage: "jv",
+      }),
+      courseFixture({
+        generationStatus: "completed",
+        isPublished: false,
+        language,
+        organizationId: aiOrganization.id,
+        targetLanguage: "jv",
+      }),
+      courseFixture({
+        generationStatus: "pending",
+        isPublished: true,
+        language,
+        organizationId: aiOrganization.id,
+        targetLanguage: "jv",
+      }),
+      courseFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        language,
+        organizationId: otherOrganization.id,
+        targetLanguage: "jv",
+      }),
+      courseFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        language,
+        organizationId: aiOrganization.id,
+        targetLanguage: "xx",
+      }),
+      courseFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        language,
+        organizationId: aiOrganization.id,
+        targetLanguage: null,
+      }),
+    ]);
+
+    const hrefs = await getCompletedLanguageCourseHrefs({ language });
+
+    expect(hrefs).toStrictEqual({ is: `/b/${AI_ORG_SLUG}/c/${eligibleSlug}` });
+  });
+
+  it("uses the newest completed course when a target language has duplicates", async () => {
+    const organization = await aiOrganizationFixture();
+    const language = getUniqueSourceLanguage();
+    const newerSlug = getCourseSlug("newer");
+
+    await Promise.all([
+      courseFixture({
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        generationStatus: "completed",
+        isPublished: true,
+        language,
+        organizationId: organization.id,
+        slug: getCourseSlug("older"),
+        targetLanguage: "is",
+      }),
+      courseFixture({
+        createdAt: new Date("2026-01-02T00:00:00.000Z"),
+        generationStatus: "completed",
+        isPublished: true,
+        language,
+        organizationId: organization.id,
+        slug: newerSlug,
+        targetLanguage: "is",
+      }),
+    ]);
+
+    const hrefs = await getCompletedLanguageCourseHrefs({ language });
+
+    expect(hrefs).toStrictEqual({ is: `/b/${AI_ORG_SLUG}/c/${newerSlug}` });
+  });
+});

--- a/apps/main/src/data/courses/language-course.ts
+++ b/apps/main/src/data/courses/language-course.ts
@@ -1,16 +1,54 @@
 import "server-only";
+import { type AiCourseHref, getAiCourseHref } from "@/data/courses/course-href";
 import {
   type Course,
   type CourseStartRequest,
   getAiGenerationCourseWhere,
   prisma,
 } from "@zoonk/db";
-import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
+import {
+  type TTSSupportedLanguageCode,
+  TTS_SUPPORTED_LANGUAGE_CODES,
+  isTTSSupportedLanguage,
+} from "@zoonk/utils/languages";
 import { normalizeString } from "@zoonk/utils/string";
 
 type LanguageCourseInput = { language: string; targetLanguage: string };
 
+type CompletedLanguageCourseHrefEntry = readonly [TTSSupportedLanguageCode, AiCourseHref];
+
 type LanguageCourseStartRequestInput = LanguageCourseInput & { title: string };
+
+export type CompletedLanguageCourseHrefs = Partial<Record<TTSSupportedLanguageCode, AiCourseHref>>;
+
+/**
+ * Rechecks course target languages after Prisma returns rows because the query
+ * filter guarantees the database shape, but TypeScript still sees a nullable
+ * string. Keeping this guard local lets the batched list lookup return strongly
+ * typed language keys without weakening the public type.
+ */
+function getSupportedCourseTargetLanguage(course: Course): TTSSupportedLanguageCode | null {
+  if (!isTTSSupportedLanguage(course.targetLanguage)) {
+    return null;
+  }
+
+  return course.targetLanguage;
+}
+
+/**
+ * Converts a completed course row into the language picker lookup entry. Rows
+ * without a supported target language are ignored so stale or manually edited
+ * data cannot create invalid `/start/speak` options.
+ */
+function getCompletedLanguageCourseHrefEntry(course: Course): CompletedLanguageCourseHrefEntry[] {
+  const targetLanguage = getSupportedCourseTargetLanguage(course);
+
+  if (!targetLanguage) {
+    return [];
+  }
+
+  return [[targetLanguage, getAiCourseHref(course)]];
+}
 
 /**
  * Finds the existing public AI language course before we create any workflow
@@ -31,6 +69,32 @@ export async function getCompletedLanguageCourse({
       targetLanguage,
     }),
   });
+}
+
+/**
+ * Fetches completed language course destinations for the picker in one query
+ * instead of doing one lookup per supported language. Sorting oldest to newest
+ * means duplicate target-language rows collapse to the same latest-course
+ * behavior used by `getCompletedLanguageCourse`.
+ */
+export async function getCompletedLanguageCourseHrefs({
+  language,
+}: {
+  language: string;
+}): Promise<CompletedLanguageCourseHrefs> {
+  const courses = await prisma.course.findMany({
+    orderBy: { createdAt: "asc" },
+    where: getAiGenerationCourseWhere({
+      generationStatus: "completed",
+      isPublished: true,
+      language,
+      targetLanguage: { in: [...TTS_SUPPORTED_LANGUAGE_CODES] },
+    }),
+  });
+
+  return Object.fromEntries(
+    courses.flatMap((course) => getCompletedLanguageCourseHrefEntry(course)),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- link generated language courses directly from /start/speak with prefetch enabled
- keep ungenerated language links on /start/speak/[language] without prefetching
- add data and e2e coverage for language-course link resolution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link completed language courses directly from /start/speak with prefetch, while ungenerated languages stay on /start/speak/[code] without prefetch and with rel="nofollow". Adds a single-query resolver to map completed courses and updates tests to cover link targets and attributes.

- **New Features**
  - Resolve completed course hrefs and link them from /start/speak with prefetch; otherwise keep /start/speak/[code] with rel="nofollow".
  - Pick the newest completed published course per target language; ignore unsupported targets.
  - Added unit and e2e tests for link resolution and link attributes.

- **Bug Fixes**
  - Make course start upsert resilient to unique-constraint races by returning the cached request when a conflict occurs.

<sup>Written for commit 4e759d0b826263721d8a60a66c327d1692b9d8d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

