### PR TITLE
feat(core): shuffle translation lesson steps

### DIFF
--- a/packages/core/src/player/contracts/playable-lesson-steps.ts
+++ b/packages/core/src/player/contracts/playable-lesson-steps.ts
@@ -15,22 +15,36 @@ export function isLimitedLanguageSentenceLesson(kind: LessonKind): boolean {
 }
 
 /**
+ * Translation lessons are generated from the same chapter words as vocabulary
+ * lessons. Shuffling the full set keeps that companion lesson from replaying
+ * the vocabulary order while still practicing every generated word.
+ */
+function isShuffledFullLesson(kind: LessonKind): boolean {
+  return kind === "translation";
+}
+
+/**
  * Chooses the steps that one player session should show. The database can keep
  * more generated sentence steps for reuse, while the player receives a shuffled
- * six-step slice for reading and listening lessons only. Other lesson kinds
- * keep their full ordered step list because their steps are authored as one
- * complete lesson flow.
+ * six-step slice for reading and listening lessons. Translation keeps every
+ * step but shuffles the order because it reuses the vocabulary lesson's words.
+ * Other lesson kinds keep their full ordered step list because their steps are
+ * authored as one complete lesson flow.
  */
 export function getPlayableLessonSteps<Step>({
   lesson,
 }: {
   lesson: { kind: LessonKind; steps: readonly Step[] };
 }): Step[] {
-  if (!isLimitedLanguageSentenceLesson(lesson.kind)) {
-    return [...lesson.steps];
+  if (isLimitedLanguageSentenceLesson(lesson.kind)) {
+    return shuffle(lesson.steps).slice(0, LANGUAGE_SENTENCE_STEP_LIMIT);
   }
 
-  return shuffle(lesson.steps).slice(0, LANGUAGE_SENTENCE_STEP_LIMIT);
+  if (isShuffledFullLesson(lesson.kind)) {
+    return shuffle(lesson.steps);
+  }
+
+  return [...lesson.steps];
 }
 
 /**

--- a/packages/core/src/player/contracts/prepare-lesson-data.test.ts
+++ b/packages/core/src/player/contracts/prepare-lesson-data.test.ts
@@ -650,6 +650,20 @@ describe(preparePlayerLessonData, () => {
     );
   });
 
+  it("shuffles every translation lesson step during serialization", () => {
+    shuffleMock.mockImplementationOnce((items) => items.toReversed());
+
+    const steps = Array.from({ length: LANGUAGE_SENTENCE_STEP_LIMIT + 2 }, (_, index) =>
+      makeStep({ id: String(index + 1), kind: "translation", position: index }),
+    );
+
+    const result = prepare({ lesson: makeLesson(steps, { kind: "translation" }) });
+
+    expect(result.steps.map((step) => step.id)).toStrictEqual(
+      steps.toReversed().map((step) => step.id),
+    );
+  });
+
   it("keeps every step for non-sentence lesson kinds", () => {
     const steps = Array.from({ length: 8 }, (_, index) =>
       makeStep({


### PR DESCRIPTION
## Summary
- shuffle translation lesson steps during player serialization
- keep reading/listening capped behavior unchanged and preserve all translation steps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shuffles translation lesson steps during player serialization to avoid repeating the vocabulary order while keeping all steps. Reading and listening keep their six-step cap and existing behavior.

- New Features
  - Translation lessons: shuffle the full step list; no steps are dropped.
  - Reading/listening still shuffled and limited to 6; other lesson kinds unchanged.

<sup>Written for commit e265fef3d1b2416efee036aaede39ad493b97431. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

