### PR TITLE
fix(main): improve locked content copy

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -626,8 +626,8 @@ test.describe("Chapter - No Lessons", () => {
     await page.goto(noLessonsChapterUrl);
 
     await expect(page).toHaveURL(noLessonsChapterUrl);
-    await expect(page.getByText(/chapter not available/iu)).toBeVisible();
-    await expect(page.getByText(/hasn't been created yet/iu)).toBeVisible();
+    await expect(page.getByText(/create this chapter/iu)).toBeVisible();
+    await expect(page.getByText(/create it to see all of its lessons/iu)).toBeVisible();
 
     const generateLink = page.getByRole("link", { name: /create chapter/iu });
 

--- a/apps/main/e2e/continue-lesson-link.test.ts
+++ b/apps/main/e2e/continue-lesson-link.test.ts
@@ -295,7 +295,7 @@ test.describe("Continue Lesson Link", () => {
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page.getByText(/lesson not available/iu)).toBeVisible();
+    await expect(page.getByText(/create this lesson/iu)).toBeVisible();
 
     await expect(page.getByRole("link", { name: /create lesson/iu })).toHaveAttribute(
       "href",

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -556,7 +556,12 @@ test.describe("Lesson Player Page", () => {
 
     await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(authenticatedPage.getByText(/upgrade to keep learning/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/unlock the rest of this course/iu)).toBeVisible();
+
+    await expect(
+      authenticatedPage.getByText(/free accounts include the first 10 lessons/iu),
+    ).toBeVisible();
+
     await expect(authenticatedPage.getByRole("link", { name: /upgrade/iu })).toBeVisible();
   });
 
@@ -571,7 +576,11 @@ test.describe("Lesson Player Page", () => {
 
     await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(authenticatedPage.getByText(/upgrade to keep learning/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/unlock the rest of this course/iu)).toBeVisible();
+
+    await expect(
+      authenticatedPage.getByText(/free accounts include the first 10 lessons/iu),
+    ).toBeVisible();
   });
 
   test("close link has correct href", async ({ page }) => {
@@ -593,8 +602,8 @@ test.describe("Lesson Player Page", () => {
 
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page.getByText(/lesson not available/iu)).toBeVisible();
-    await expect(page.getByText(/hasn't been created yet/iu)).toBeVisible();
+    await expect(page.getByText(/create this lesson/iu)).toBeVisible();
+    await expect(page.getByText(/create it to start learning/iu)).toBeVisible();
     const generateLink = page.getByRole("link", { name: /create lesson/iu });
 
     await expect(generateLink).toBeVisible();
@@ -614,8 +623,13 @@ test.describe("Lesson Player Page", () => {
 
     await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${practice.slug}`);
 
-    await expect(authenticatedPage.getByText("Lesson not available")).toBeVisible();
-    await expect(authenticatedPage.getByText("This lesson hasn't been created yet.")).toBeVisible();
+    await expect(authenticatedPage.getByText("Create this lesson")).toBeVisible();
+
+    await expect(
+      authenticatedPage.getByText(
+        "This lesson is part of the course, but it hasn't been created yet. Create it to start learning.",
+      ),
+    ).toBeVisible();
 
     const generateLink = authenticatedPage.getByRole("link", { name: "Create lesson" });
 
@@ -657,10 +671,12 @@ test.describe("Lesson Player Page", () => {
 
     await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${review.slug}`);
 
-    await expect(authenticatedPage.getByText("Review locked")).toBeVisible();
+    await expect(authenticatedPage.getByText("Create lessons before reviewing")).toBeVisible();
 
     await expect(
-      authenticatedPage.getByText("Create earlier lessons first, then come back to review."),
+      authenticatedPage.getByText(
+        "Review unlocks after the earlier lessons in this chapter have been created.",
+      ),
     ).toBeVisible();
 
     const requiredLessonLink = authenticatedPage.getByRole("link", { name: "Create lesson" });
@@ -757,7 +773,7 @@ test.describe("Lesson Player Page", () => {
 
     await page.goto(`/b/${org.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page.getByText(/lesson not available/iu)).toBeVisible();
+    await expect(page.getByText(/create this lesson/iu)).toBeVisible();
     await expect(page.getByRole("link", { name: /create lesson/iu })).not.toBeVisible();
   });
 

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -284,12 +284,12 @@ msgid "_lCW0j"
 msgstr "{percentage} richtige Antworten"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "9SgWiD"
-msgstr "Kapitel nicht verfügbar"
+msgid "QhvU1f"
+msgstr "Dieses Kapitel erstellen"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "ml8Duy"
-msgstr "Dieses Kapitel wurde noch nicht erstellt."
+msgid "YQGe0H"
+msgstr "Dieses Kapitel ist Teil des Kurses, wurde aber noch nicht erstellt. Erstelle es, um alle Lektionen zu sehen."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 msgid "3IOFp2"
@@ -1182,12 +1182,12 @@ msgid "l1XTI5"
 msgstr "Folge uns"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "A_VPtF"
-msgstr "Lektion nicht verfügbar"
+msgid "rCpmYD"
+msgstr "Diese Lektion erstellen"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "bHscXj"
-msgstr "Diese Lektion wurde noch nicht erstellt."
+msgid "AtnLyn"
+msgstr "Diese Lektion ist Teil des Kurses, wurde aber noch nicht erstellt. Erstelle sie, um mit dem Lernen zu beginnen."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
@@ -1201,24 +1201,24 @@ msgid "_N8rYN"
 msgstr "Zurück zum Kapitel"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "3pyC1G"
-msgstr "Für diese Lektion ist ein aktives Abonnement erforderlich."
+msgid "rPcS-X"
+msgstr "Kostenlose Konten enthalten die ersten 10 Lektionen in jedem Kurs. Upgrade für unbegrenzten Zugriff auf jede Lektion in jedem Kurs."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "xu3uCX"
-msgstr "Upgrade, um weiterzulernen"
+msgid "ZnMcrz"
+msgstr "Den Rest dieses Kurses freischalten"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "mA7vCW"
-msgstr "Wiederholung gesperrt"
+msgid "A_uNk-"
+msgstr "Erstelle Lektionen, bevor du mit der Überprüfung beginnst"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "Qy4EsI"
 msgstr "Noch nichts zu wiederholen"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "lOdIcU"
-msgstr "Erstelle zuerst frühere Lektionen, komm dann zum Wiederholen zurück."
+msgid "4w9Y_P"
+msgstr "Die Überprüfung wird freigeschaltet, nachdem die vorherigen Lektionen in diesem Kapitel erstellt wurden."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -284,12 +284,12 @@ msgid "_lCW0j"
 msgstr "{percentage} correct answers"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "9SgWiD"
-msgstr "Chapter not available"
+msgid "QhvU1f"
+msgstr "Create this chapter"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "ml8Duy"
-msgstr "This chapter hasn't been created yet."
+msgid "YQGe0H"
+msgstr "This chapter is part of the course, but it hasn't been created yet. Create it to see all of its lessons."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 msgid "3IOFp2"
@@ -1182,12 +1182,12 @@ msgid "l1XTI5"
 msgstr "Follow us"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "A_VPtF"
-msgstr "Lesson not available"
+msgid "rCpmYD"
+msgstr "Create this lesson"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "bHscXj"
-msgstr "This lesson hasn't been created yet."
+msgid "AtnLyn"
+msgstr "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
@@ -1201,24 +1201,24 @@ msgid "_N8rYN"
 msgstr "Back to chapter"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "3pyC1G"
-msgstr "This lesson requires an active subscription."
+msgid "rPcS-X"
+msgstr "Free accounts include the first 10 lessons in each course. Upgrade for unlimited access to every lesson in every course."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "xu3uCX"
-msgstr "Upgrade to keep learning"
+msgid "ZnMcrz"
+msgstr "Unlock the rest of this course"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "mA7vCW"
-msgstr "Review locked"
+msgid "A_uNk-"
+msgstr "Create lessons before reviewing"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "Qy4EsI"
 msgstr "Nothing to review yet"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "lOdIcU"
-msgstr "Create earlier lessons first, then come back to review."
+msgid "4w9Y_P"
+msgstr "Review unlocks after the earlier lessons in this chapter have been created."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -284,12 +284,12 @@ msgid "_lCW0j"
 msgstr "{percentage} respuestas correctas"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "9SgWiD"
-msgstr "Capítulo no disponible"
+msgid "QhvU1f"
+msgstr "Crear este capítulo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "ml8Duy"
-msgstr "Este capítulo aún no se ha creado."
+msgid "YQGe0H"
+msgstr "Este capítulo forma parte del curso, pero todavía no se ha creado. Créalo para ver todas sus lecciones."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 msgid "3IOFp2"
@@ -1182,12 +1182,12 @@ msgid "l1XTI5"
 msgstr "Síguenos"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "A_VPtF"
-msgstr "Lección no disponible"
+msgid "rCpmYD"
+msgstr "Crear esta lección"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "bHscXj"
-msgstr "Esta lección aún no se ha creado."
+msgid "AtnLyn"
+msgstr "Esta lección forma parte del curso, pero todavía no se ha creado. Créala para empezar a estudiar."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
@@ -1201,24 +1201,24 @@ msgid "_N8rYN"
 msgstr "Volver al capítulo"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "3pyC1G"
-msgstr "Esta lección requiere una suscripción activa."
+msgid "rPcS-X"
+msgstr "Las cuentas gratis incluyen las primeras 10 lecciones de cada curso. Actualiza para tener acceso ilimitado a todas las lecciones de todos los cursos."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "xu3uCX"
-msgstr "Suscríbete para seguir aprendiendo"
+msgid "ZnMcrz"
+msgstr "Desbloquea el resto de este curso"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "mA7vCW"
-msgstr "Repaso bloqueado"
+msgid "A_uNk-"
+msgstr "Crea lecciones antes de revisar"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "Qy4EsI"
 msgstr "Nada para repasar todavía"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "lOdIcU"
-msgstr "Crea primero las lecciones anteriores y vuelve para repasar."
+msgid "4w9Y_P"
+msgstr "La revisión se desbloquea después de que se hayan creado las lecciones anteriores de este capítulo."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -284,12 +284,12 @@ msgid "_lCW0j"
 msgstr "{percentage} réponses correctes"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "9SgWiD"
-msgstr "Chapitre non disponible"
+msgid "QhvU1f"
+msgstr "Créer ce chapitre"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "ml8Duy"
-msgstr "Ce chapitre n'a pas encore été créé."
+msgid "YQGe0H"
+msgstr "Ce chapitre fait partie du cours, mais il n’a pas encore été créé. Crée-le pour voir toutes ses leçons."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 msgid "3IOFp2"
@@ -1182,12 +1182,12 @@ msgid "l1XTI5"
 msgstr "Suis‑nous"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "A_VPtF"
-msgstr "Leçon indisponible"
+msgid "rCpmYD"
+msgstr "Créer cette leçon"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "bHscXj"
-msgstr "Cette leçon n'a pas encore été créée."
+msgid "AtnLyn"
+msgstr "Cette leçon fait partie du cours, mais elle n’a pas encore été créée. Crée-la pour commencer à apprendre."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
@@ -1201,24 +1201,24 @@ msgid "_N8rYN"
 msgstr "Retour au chapitre"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "3pyC1G"
-msgstr "Cette leçon nécessite un abonnement actif."
+msgid "rPcS-X"
+msgstr "Les comptes gratuits incluent les 10 premières leçons de chaque cours. Passe à la version supérieure pour un accès illimité à toutes les leçons de tous les cours."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "xu3uCX"
-msgstr "Passe à un abonnement pour continuer"
+msgid "ZnMcrz"
+msgstr "Débloque le reste de ce cours"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "mA7vCW"
-msgstr "Révision verrouillée"
+msgid "A_uNk-"
+msgstr "Crée des leçons avant de réviser"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "Qy4EsI"
 msgstr "Rien à réviser pour l'instant"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "lOdIcU"
-msgstr "Crée d'abord les leçons précédentes, puis reviens pour réviser."
+msgid "4w9Y_P"
+msgstr "La révision se débloque après la création des leçons précédentes de ce chapitre."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -284,12 +284,12 @@ msgid "_lCW0j"
 msgstr "{percentage} de respostas corretas"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "9SgWiD"
-msgstr "Capítulo indisponível"
+msgid "QhvU1f"
+msgstr "Criar este capítulo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "ml8Duy"
-msgstr "Este capítulo ainda não foi criado."
+msgid "YQGe0H"
+msgstr "Este capítulo faz parte do curso, mas ainda não foi criado. Crie ele para ver todas as aulas."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 msgid "3IOFp2"
@@ -1182,12 +1182,12 @@ msgid "l1XTI5"
 msgstr "Siga-nos"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "A_VPtF"
-msgstr "Aula indisponível"
+msgid "rCpmYD"
+msgstr "Criar esta aula"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "bHscXj"
-msgstr "Esta aula ainda não foi criada."
+msgid "AtnLyn"
+msgstr "Esta aula faz parte do curso, mas ainda não foi criada. Crie ela para começar a estudar."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
@@ -1201,24 +1201,24 @@ msgid "_N8rYN"
 msgstr "Voltar ao capítulo"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "3pyC1G"
-msgstr "Esta aula exige uma assinatura ativa."
+msgid "rPcS-X"
+msgstr "Contas grátis incluem as 10 primeiras aulas de cada curso. Faça upgrade para ter acesso ilimitado a todas as aulas de todos os cursos."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "xu3uCX"
-msgstr "Assine para continuar aprendendo"
+msgid "ZnMcrz"
+msgstr "Desbloqueie o resto do curso"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "mA7vCW"
-msgstr "Revisão bloqueada"
+msgid "A_uNk-"
+msgstr "Crie aulas antes de revisar"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "Qy4EsI"
 msgstr "Nada para revisar ainda"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "lOdIcU"
-msgstr "Crie as aulas anteriores primeiro e depois volte para revisar."
+msgid "4w9Y_P"
+msgstr "A revisão será liberada depois que as aulas anteriores deste capítulo forem criadas."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
@@ -26,9 +26,13 @@ export async function ChapterNotGenerated({ chapterId }: { chapterId: string }) 
           <SparklesIcon />
         </EmptyMedia>
 
-        <EmptyTitle>{t("Chapter not available")}</EmptyTitle>
+        <EmptyTitle>{t("Create this chapter")}</EmptyTitle>
 
-        <EmptyDescription>{t("This chapter hasn't been created yet.")}</EmptyDescription>
+        <EmptyDescription>
+          {t(
+            "This chapter is part of the course, but it hasn't been created yet. Create it to see all of its lessons.",
+          )}
+        </EmptyDescription>
       </EmptyHeader>
 
       <EmptyContent>

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
@@ -35,9 +35,13 @@ export async function LessonNotGenerated({
           <SparklesIcon />
         </EmptyMedia>
 
-        <EmptyTitle>{t("Lesson not available")}</EmptyTitle>
+        <EmptyTitle>{t("Create this lesson")}</EmptyTitle>
 
-        <EmptyDescription>{t("This lesson hasn't been created yet.")}</EmptyDescription>
+        <EmptyDescription>
+          {t(
+            "This lesson is part of the course, but it hasn't been created yet. Create it to start learning.",
+          )}
+        </EmptyDescription>
       </EmptyHeader>
 
       <EmptyContent>

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -107,8 +107,10 @@ async function getLessonAccessGate({
         <UpgradeCTA
           backHref={backHref}
           backLabel={t("Back to chapter")}
-          description={t("This lesson requires an active subscription.")}
-          title={t("Upgrade to keep learning")}
+          description={t(
+            "Free accounts include the first 10 lessons in each course. Upgrade for unlimited access to every lesson in every course.",
+          )}
+          title={t("Unlock the rest of this course")}
         />
       </ContainerBody>
     </Container>

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
@@ -31,12 +31,14 @@ export async function ReviewLessonEmpty({
         </EmptyMedia>
 
         <EmptyTitle>
-          {isWaitingForGeneration ? t("Review locked") : t("Nothing to review yet")}
+          {isWaitingForGeneration
+            ? t("Create lessons before reviewing")
+            : t("Nothing to review yet")}
         </EmptyTitle>
 
         <EmptyDescription>
           {isWaitingForGeneration
-            ? t("Create earlier lessons first, then come back to review.")
+            ? t("Review unlocks after the earlier lessons in this chapter have been created.")
             : t("There are no practice questions to review yet.")}
         </EmptyDescription>
       </EmptyHeader>

--- a/apps/main/src/data/sitemaps/chapters.ts
+++ b/apps/main/src/data/sitemaps/chapters.ts
@@ -6,7 +6,7 @@ import { SITEMAP_BATCH_SIZE } from "./courses";
  * Search engines should only receive chapter URLs that have real public lesson
  * content behind them. Pending, running, and failed chapters are still useful
  * in the app because learners can start generation from those pages, but adding
- * them to the sitemap asks Google to index empty "chapter not available" pages.
+ * them to the sitemap asks Google to index empty chapter creation pages.
  */
 const sitemapChapterWhere = getPublishedChapterWhere({
   chapterWhere: { generationStatus: "completed" },


### PR DESCRIPTION
## Summary
- Improve copy for not-yet-created chapters, lessons, and reviews
- Explain the free lesson limit in the subscription gate
- Update localized messages and e2e expectations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved locked-content messaging to encourage creating missing chapters/lessons and clarified the upgrade gate by stating free accounts include the first 10 lessons. Updated localized strings and e2e tests to match the new copy.

- **Refactors**
  - Replaced “not available” with “Create this chapter/lesson” and clearer descriptions.
  - Updated review state copy to “Create lessons before reviewing” and explained unlock condition.
  - Changed upgrade CTA to “Unlock the rest of this course” and added the free 10‑lesson note.
  - Synced `*.po` locales and adjusted e2e expectations (plus a minor sitemap comment tweak).

<sup>Written for commit 6d4d78b42cb0e6db9cba90186036fd3006bbc81e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

