### PR TITLE
feat(player): move prompt audio to navigation controls

### DIFF
--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -244,6 +244,7 @@ msgid "ZHEKO0"
 msgstr "Lektionsinhalt"
 
 #: src/components/player-shell.tsx
+#: src/components/swipe-navigable-step-layout.tsx
 msgid "41rDiT"
 msgstr "Lektionssteuerung"
 

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -244,6 +244,7 @@ msgid "ZHEKO0"
 msgstr "Lesson content"
 
 #: src/components/player-shell.tsx
+#: src/components/swipe-navigable-step-layout.tsx
 msgid "41rDiT"
 msgstr "Lesson controls"
 

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -244,6 +244,7 @@ msgid "ZHEKO0"
 msgstr "Contenido de la lección"
 
 #: src/components/player-shell.tsx
+#: src/components/swipe-navigable-step-layout.tsx
 msgid "41rDiT"
 msgstr "Controles de la lección"
 

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -244,6 +244,7 @@ msgid "ZHEKO0"
 msgstr "Contenu de la leçon"
 
 #: src/components/player-shell.tsx
+#: src/components/swipe-navigable-step-layout.tsx
 msgid "41rDiT"
 msgstr "Contrôles de la leçon"
 

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -244,6 +244,7 @@ msgid "ZHEKO0"
 msgstr "Conteúdo da aula"
 
 #: src/components/player-shell.tsx
+#: src/components/swipe-navigable-step-layout.tsx
 msgid "41rDiT"
 msgstr "Controles da aula"
 

--- a/packages/player/src/_browser-tests/player-alphabet.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-alphabet.browser.test.tsx
@@ -82,9 +82,13 @@ describe("player browser integration: alphabet", () => {
     await expect.element(card.getByText("like b in book")).toBeInTheDocument();
     await expect.element(card.getByText("initial")).toBeInTheDocument();
     await expect.element(card.getByText("بـ")).toBeInTheDocument();
+
+    await expect
+      .element(card.getByRole("button", { name: /play pronunciation/iu }))
+      .not.toBeInTheDocument();
   });
 
-  it("plays alphabet audio without moving to the next card", async () => {
+  it("plays alphabet audio from desktop controls without moving to the next card", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         kind: "alphabet",
@@ -120,12 +124,13 @@ describe("player browser integration: alphabet", () => {
       viewer: buildAuthenticatedViewer(),
     });
 
+    const controls = page.getByRole("toolbar", { name: /lesson controls/iu });
     const currentCard = page.getByRole("region", { name: /alphabet: ب/iu });
 
-    await currentCard.getByRole("button", { name: /play pronunciation/iu }).click();
+    await controls.getByRole("button", { name: /play pronunciation/iu }).click();
 
     await expect
-      .element(currentCard.getByRole("button", { name: /pause pronunciation/iu }))
+      .element(controls.getByRole("button", { name: /pause pronunciation/iu }))
       .toBeInTheDocument();
 
     await expect.element(currentCard).toBeInTheDocument();

--- a/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
@@ -37,9 +37,15 @@ describe("player browser integration: vocabulary", () => {
     await expect.element(page.getByText(/^ola$/u)).toBeInTheDocument();
     await expect.element(page.getByText("OH-lah")).toBeInTheDocument();
     await expect.element(page.getByText("Hello")).toBeInTheDocument();
+
+    const card = page.getByRole("region", { name: /vocabulary: Hola/iu });
+
+    await expect
+      .element(card.getByRole("button", { name: /play pronunciation/iu }))
+      .not.toBeInTheDocument();
   });
 
-  it("plays vocabulary audio without moving to the next card", async () => {
+  it("plays vocabulary audio from desktop controls without moving to the next card", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         kind: "vocabulary",
@@ -73,12 +79,13 @@ describe("player browser integration: vocabulary", () => {
       viewer: buildAuthenticatedViewer(),
     });
 
+    const controls = page.getByRole("toolbar", { name: /lesson controls/iu });
     const currentCard = page.getByRole("region", { name: /vocabulary: Hola/iu });
 
-    await currentCard.getByRole("button", { name: /play pronunciation/iu }).click();
+    await controls.getByRole("button", { name: /play pronunciation/iu }).click();
 
     await expect
-      .element(currentCard.getByRole("button", { name: /pause pronunciation/iu }))
+      .element(controls.getByRole("button", { name: /pause pronunciation/iu }))
       .toBeInTheDocument();
 
     await expect.element(currentCard).toBeInTheDocument();
@@ -122,20 +129,22 @@ describe("player browser integration: vocabulary", () => {
       viewer: buildAuthenticatedViewer(),
     });
 
-    const firstCard = page.getByRole("region", { name: /vocabulary: Hola/iu });
+    const controls = page.getByRole("toolbar", { name: /lesson controls/iu });
 
-    await firstCard.getByRole("button", { name: /play pronunciation/iu }).click();
+    await controls.getByRole("button", { name: /play pronunciation/iu }).click();
 
     await expect
-      .element(firstCard.getByRole("button", { name: /pause pronunciation/iu }))
+      .element(controls.getByRole("button", { name: /pause pronunciation/iu }))
       .toBeInTheDocument();
 
     fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
 
     const secondCard = page.getByRole("region", { name: /vocabulary: Adios/iu });
 
+    await expect.element(secondCard).toBeInTheDocument();
+
     await expect
-      .element(secondCard.getByRole("button", { name: /pause pronunciation/iu }))
+      .element(controls.getByRole("button", { name: /pause pronunciation/iu }))
       .toBeInTheDocument();
   });
 
@@ -173,12 +182,12 @@ describe("player browser integration: vocabulary", () => {
       viewer: buildAuthenticatedViewer(),
     });
 
-    const firstCard = page.getByRole("region", { name: /vocabulary: Hola/iu });
+    const controls = page.getByRole("toolbar", { name: /lesson controls/iu });
 
-    await firstCard.getByRole("button", { name: /play pronunciation/iu }).click();
+    await controls.getByRole("button", { name: /play pronunciation/iu }).click();
 
     await expect
-      .element(firstCard.getByRole("button", { name: /pause pronunciation/iu }))
+      .element(controls.getByRole("button", { name: /pause pronunciation/iu }))
       .toBeInTheDocument();
 
     mockNextAudioPlayFailure();
@@ -186,12 +195,14 @@ describe("player browser integration: vocabulary", () => {
 
     const secondCard = page.getByRole("region", { name: /vocabulary: Adios/iu });
 
+    await expect.element(secondCard).toBeInTheDocument();
+
     await expect
-      .element(secondCard.getByRole("button", { name: /play pronunciation/iu }))
+      .element(controls.getByRole("button", { name: /play pronunciation/iu }))
       .toBeInTheDocument();
 
     await expect
-      .element(secondCard.getByRole("button", { name: /pause pronunciation/iu }))
+      .element(controls.getByRole("button", { name: /pause pronunciation/iu }))
       .not.toBeInTheDocument();
   });
 
@@ -240,8 +251,8 @@ describe("player browser integration: vocabulary", () => {
         .toBeInTheDocument();
 
       await expect
-        .element(currentCard.getByRole("button", { name: /pause pronunciation/iu }))
-        .toBeInTheDocument();
+        .element(currentCard.getByRole("button", { name: /play pronunciation/iu }))
+        .not.toBeInTheDocument();
 
       await expect
         .element(page.getByRole("region", { name: /vocabulary: Adios/iu }))

--- a/packages/player/src/components/alphabet-step.tsx
+++ b/packages/player/src/components/alphabet-step.tsx
@@ -3,7 +3,6 @@
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { useExtracted } from "next-intl";
-import { PlayAudioButton } from "./play-audio-button";
 import { PlayerReadScene, PlayerReadSceneStack } from "./player-read-scene";
 
 type AlphabetContent = ReturnType<typeof getAlphabetContent>;
@@ -86,8 +85,6 @@ export function AlphabetStep({ step }: { step: SerializedStep }) {
         className="flex w-full flex-col gap-6"
         role="region"
       >
-        {content.audioUrl && <PlayAudioButton audioUrl={content.audioUrl} size="sm" />}
-
         <PlayerReadSceneStack className="gap-3">
           <AlphabetSymbol>{content.symbol}</AlphabetSymbol>
           <AlphabetReading pronunciation={content.pronunciation} readingAid={content.readingAid} />

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -49,11 +49,13 @@ function usePlayAudioButtonState({ audioUrl, preload }: { audioUrl: string; prel
 
 export function PlayAudioButton({
   audioUrl,
+  className,
   preload = true,
   size = "md",
   variant = "filled",
 }: {
   audioUrl: string;
+  className?: string;
   preload?: boolean;
   size?: "sm" | "md";
   variant?: PlayAudioButtonVariant;
@@ -67,7 +69,10 @@ export function PlayAudioButton({
   if (variant === "text") {
     return (
       <button
-        className="text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-sm transition-colors"
+        className={cn(
+          "text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-sm transition-colors",
+          className,
+        )}
         onClick={handleClick}
         type="button"
       >
@@ -81,6 +86,7 @@ export function PlayAudioButton({
     return (
       <Button
         aria-label={label}
+        className={className}
         onClick={handleClick}
         size={size === "md" ? "icon-lg" : "icon"}
         type="button"
@@ -98,6 +104,7 @@ export function PlayAudioButton({
         "bg-primary text-primary-foreground flex items-center justify-center rounded-full transition-all duration-150",
         "hover:bg-primary/90 focus-visible:ring-ring/50 outline-none hover:scale-105 focus-visible:ring-[3px] active:scale-95",
         size === "md" ? "size-14" : "size-12",
+        className,
       )}
       onClick={handleClick}
       type="button"

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -133,6 +133,7 @@ export function StageContent() {
         onNavigateNext={actions.navigateNext}
         onNavigatePrev={actions.navigatePrev}
         onSelectAnswer={actions.selectAnswer}
+        promptAudioUrl={screen.bottomBar?.audioUrl}
         result={state.phase === "feedback" ? currentResult : undefined}
         selectedAnswer={selectedAnswer}
         step={currentStep}

--- a/packages/player/src/components/step-renderer.tsx
+++ b/packages/player/src/components/step-renderer.tsx
@@ -31,6 +31,7 @@ type StepRendererProps = {
   onNavigateNext: () => void;
   onNavigatePrev: () => void;
   onSelectAnswer: (stepId: string, answer: SelectedAnswer | null) => void;
+  promptAudioUrl?: string | null;
   result?: StepResult;
   selectedAnswer?: SelectedAnswer;
   step: SerializedStep;
@@ -153,6 +154,7 @@ export function StepRenderer({
   onNavigateNext,
   onNavigatePrev,
   onSelectAnswer,
+  promptAudioUrl,
   result,
   selectedAnswer,
   step,
@@ -187,6 +189,7 @@ export function StepRenderer({
       key={`step-${step.id}`}
       onNavigateNext={onNavigateNext}
       onNavigatePrev={onNavigatePrev}
+      promptAudioUrl={promptAudioUrl}
     >
       {content}
     </SwipeNavigableStepLayout>

--- a/packages/player/src/components/swipe-navigable-step-layout.tsx
+++ b/packages/player/src/components/swipe-navigable-step-layout.tsx
@@ -1,20 +1,22 @@
 "use client";
 
 import { Button } from "@zoonk/ui/components/button";
-import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type TouchEvent, useEffect, useRef } from "react";
+import { PlayAudioButton } from "./play-audio-button";
 import { NavigableStepLayout } from "./step-layouts";
 
 const SWIPE_DISTANCE_THRESHOLD = 48;
 const SWIPE_HORIZONTAL_RATIO = 1.05;
 const VIEWPORT_ZOOM_SCALE_THRESHOLD = 1.01;
 
+const DESKTOP_NAVIGATION_CONTROL_CLASS =
+  "bg-background/95 text-foreground border-border/70 ring-border/30 hover:bg-background hover:border-border size-11 opacity-95 shadow-lg ring-1 shadow-black/5 backdrop-blur-md transition-[background-color,border-color,opacity,scale,box-shadow] hover:opacity-100 hover:shadow-xl focus-visible:opacity-100 [&_svg]:size-5";
+
 type SwipeGesture = { startX: number; startY: number; touchId: number };
 
 export type SwipeNavigableStepFrame = "default" | "media";
-type DesktopNavigationSide = "previous" | "next";
 
 /**
  * Image-backed read steps need the swipe surface to use the full stage width
@@ -37,23 +39,20 @@ function getNavigableFrameClass(frame: SwipeNavigableStepFrame) {
  */
 function DesktopNavigationButton({
   "aria-label": ariaLabel,
+  "aria-keyshortcuts": ariaKeyshortcuts,
   children,
   onClick,
-  side,
 }: {
   "aria-label": string;
+  "aria-keyshortcuts": string;
   children: React.ReactNode;
   onClick: () => void;
-  side: DesktopNavigationSide;
 }) {
   return (
     <Button
       aria-label={ariaLabel}
-      aria-keyshortcuts={side === "previous" ? "ArrowLeft" : "ArrowRight"}
-      className={cn(
-        "bg-background/95 text-foreground border-border/70 ring-border/30 hover:bg-background hover:border-border absolute top-1/2 z-20 hidden size-11 -translate-y-1/2 opacity-95 shadow-lg ring-1 shadow-black/5 backdrop-blur-md transition-[background-color,border-color,color,opacity,scale,box-shadow] hover:opacity-100 hover:shadow-xl focus-visible:opacity-100 lg:flex [&_svg]:size-5",
-        side === "previous" ? "left-4 xl:left-6" : "right-4 xl:right-6",
-      )}
+      aria-keyshortcuts={ariaKeyshortcuts}
+      className={DESKTOP_NAVIGATION_CONTROL_CLASS}
       onClick={onClick}
       size="icon-lg"
       type="button"
@@ -61,6 +60,64 @@ function DesktopNavigationButton({
     >
       {children}
     </Button>
+  );
+}
+
+/**
+ * Desktop users usually move the pointer between prompt audio and the next
+ * arrow. Keeping those controls in one floating toolbar reduces that travel
+ * while preserving the content-level play button for learners who focus on the
+ * card itself.
+ */
+function DesktopNavigationToolbar({
+  canNavigatePrev,
+  onNavigateNext,
+  onNavigatePrev,
+  promptAudioUrl,
+}: {
+  canNavigatePrev: boolean;
+  onNavigateNext: () => void;
+  onNavigatePrev: () => void;
+  promptAudioUrl?: string | null;
+}) {
+  const t = useExtracted();
+
+  return (
+    <div
+      aria-label={t("Lesson controls")}
+      className="pointer-events-none absolute inset-x-4 top-1/2 z-20 hidden -translate-y-1/2 items-center justify-between lg:flex xl:inset-x-6"
+      role="toolbar"
+    >
+      <div className="pointer-events-auto flex min-w-11 justify-start">
+        {canNavigatePrev && (
+          <DesktopNavigationButton
+            aria-label={t("Previous step")}
+            aria-keyshortcuts="ArrowLeft"
+            onClick={onNavigatePrev}
+          >
+            <ChevronLeftIcon />
+          </DesktopNavigationButton>
+        )}
+      </div>
+
+      <div className="pointer-events-auto flex items-center gap-2">
+        {promptAudioUrl && (
+          <PlayAudioButton
+            audioUrl={promptAudioUrl}
+            className={DESKTOP_NAVIGATION_CONTROL_CLASS}
+            variant="outline"
+          />
+        )}
+
+        <DesktopNavigationButton
+          aria-label={t("Next step")}
+          aria-keyshortcuts="ArrowRight"
+          onClick={onNavigateNext}
+        >
+          <ChevronRightIcon />
+        </DesktopNavigationButton>
+      </div>
+    </div>
   );
 }
 
@@ -142,14 +199,15 @@ export function SwipeNavigableStepLayout({
   frame = "default",
   onNavigateNext,
   onNavigatePrev,
+  promptAudioUrl,
 }: {
   canNavigatePrev: boolean;
   children: React.ReactNode;
   frame?: SwipeNavigableStepFrame;
   onNavigateNext: () => void;
   onNavigatePrev: () => void;
+  promptAudioUrl?: string | null;
 }) {
-  const t = useExtracted();
   const gestureRef = useRef<SwipeGesture | null>(null);
   const endHandlerRef = useRef<((event: globalThis.TouchEvent) => void) | null>(null);
   const cancelHandlerRef = useRef<(() => void) | null>(null);
@@ -289,19 +347,12 @@ export function SwipeNavigableStepLayout({
     <NavigableStepLayout className={getNavigableFrameClass(frame)} onTouchStart={handleTouchStart}>
       <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-center">{children}</div>
 
-      {canNavigatePrev && (
-        <DesktopNavigationButton
-          aria-label={t("Previous step")}
-          onClick={onNavigatePrev}
-          side="previous"
-        >
-          <ChevronLeftIcon />
-        </DesktopNavigationButton>
-      )}
-
-      <DesktopNavigationButton aria-label={t("Next step")} onClick={onNavigateNext} side="next">
-        <ChevronRightIcon />
-      </DesktopNavigationButton>
+      <DesktopNavigationToolbar
+        canNavigatePrev={canNavigatePrev}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrev={onNavigatePrev}
+        promptAudioUrl={promptAudioUrl}
+      />
     </NavigableStepLayout>
   );
 }

--- a/packages/player/src/components/vocabulary-step.tsx
+++ b/packages/player/src/components/vocabulary-step.tsx
@@ -2,7 +2,6 @@
 
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { useExtracted } from "next-intl";
-import { PlayAudioButton } from "./play-audio-button";
 import { PlayerReadScene, PlayerReadSceneBody, PlayerReadSceneStack } from "./player-read-scene";
 import { RomanizationText } from "./romanization-text";
 
@@ -21,8 +20,6 @@ export function VocabularyStep({ step }: { step: SerializedStep }) {
         role="region"
         className="flex flex-col gap-6"
       >
-        {word.audioUrl && <PlayAudioButton audioUrl={word.audioUrl} size="sm" />}
-
         <PlayerReadSceneStack className="gap-2">
           <p className="text-4xl font-bold tracking-tight sm:text-5xl">{word.word}</p>
 


### PR DESCRIPTION
## Summary
- move navigable prompt audio into the desktop navigation controls
- keep mobile prompt audio in the bottom controls
- remove duplicate in-card play buttons from vocabulary and alphabet cards

## Tests
- pnpm --filter @zoonk/player test
- pnpm --filter @zoonk/player typecheck
- pnpm --filter @zoonk/player extract:messages
- pnpm --filter @zoonk/player i18n
- pnpm --filter @zoonk/player i18n:lint
- pnpm lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved prompt audio playback to a new desktop navigation toolbar so learners can play audio and move between steps from one place. Mobile keeps prompt audio in the bottom controls; removed in-card play buttons from alphabet and vocabulary steps.

- **New Features**
  - Added a floating desktop toolbar with previous/play/next controls, keyboard shortcuts, and an ARIA "Lesson controls" toolbar.
  - Plumbed `promptAudioUrl` through `StageContent` → `StepRenderer` → `SwipeNavigableStepLayout`, updated `PlayAudioButton` to accept `className`, refreshed browser tests in `@zoonk/player`, and added i18n message references.

<sup>Written for commit 3c7b3bcbd43c2e81e0c24306690607ef3372a376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

