### PR TITLE
fix(i18n): don't use "-la/o" in pt-br

### DIFF
--- a/packages/i18n/.eloqnt/styleguide.pt.md
+++ b/packages/i18n/.eloqnt/styleguide.pt.md
@@ -3,7 +3,7 @@
 - Use an informal, approachable register. Address the user as "você".
 - Use Brazilian Portuguese (pt-BR) spelling and grammar.
 - Use Zoonk as masculine (o Zoonk, no Zoonk, do Zoonk, etc).
-- Translations should be like regular people in everyday language. For example:
+- Translations should be like regular people speak in everyday language. For example:
   - "You can create it" = "Você pode criar ela/ele" (not "Você pode criá-la/o")
   - using "-la" or "-lo" is too formal and not how people speak in Brazil.
 

--- a/packages/i18n/.eloqnt/styleguide.pt.md
+++ b/packages/i18n/.eloqnt/styleguide.pt.md
@@ -3,6 +3,9 @@
 - Use an informal, approachable register. Address the user as "você".
 - Use Brazilian Portuguese (pt-BR) spelling and grammar.
 - Use Zoonk as masculine (o Zoonk, no Zoonk, do Zoonk, etc).
+- Translations should be like regular people in everyday language. For example:
+  - "You can create it" = "Você pode criar ela/ele" (not "Você pode criá-la/o")
+  - using "-la" or "-lo" is too formal and not how people speak in Brazil.
 
 ## Glossary
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the pt-BR i18n style guide in `packages/i18n` to discourage “-la/-lo” (e.g., “criá-la/o”) and prefer natural phrasing like “Você pode criar ela/ele.”

Clarified with examples that “-la/-lo” is too formal for Brazilian Portuguese and fixed a minor typo.

<sup>Written for commit 4b373eba73f206753fd85c8ad85818a16ea881ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

