### PR TITLE
feat(player): add prompt audio shortcut

### DIFF
--- a/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-vocabulary.browser.test.tsx
@@ -95,6 +95,55 @@ describe("player browser integration: vocabulary", () => {
       .not.toBeInTheDocument();
   });
 
+  it("plays vocabulary audio from the P keyboard shortcut", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "vocabulary",
+        steps: [
+          buildSerializedStep({
+            content: {},
+            id: "vocab-shortcut-1",
+            kind: "vocabulary",
+            word: buildSerializedWord({
+              audioUrl: "https://example.com/hola.mp3",
+              id: "word-shortcut-1",
+              translation: "Hello",
+              word: "Hola",
+            }),
+          }),
+          buildSerializedStep({
+            content: {},
+            id: "vocab-shortcut-2",
+            kind: "vocabulary",
+            position: 1,
+            word: buildSerializedWord({
+              audioUrl: "https://example.com/adios.mp3",
+              id: "word-shortcut-2",
+              translation: "Goodbye",
+              word: "Adios",
+            }),
+          }),
+        ],
+      }),
+      navigation: buildNavigation({ nextLessonHref: null }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    const currentCard = page.getByRole("region", { name: /vocabulary: Hola/iu });
+
+    fireEvent.keyDown(globalThis.window, { key: "p" });
+
+    await expect
+      .element(page.getByRole("button", { name: /pause pronunciation/iu }))
+      .toBeInTheDocument();
+
+    await expect.element(currentCard).toBeInTheDocument();
+
+    await expect
+      .element(page.getByRole("region", { name: /vocabulary: Adios/iu }))
+      .not.toBeInTheDocument();
+  });
+
   it("automatically plays the next vocabulary prompt after audio is started", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { page } from "vitest/browser";
 import { runInMobilePlayerViewport } from "../_test-utils/browser-viewport";
@@ -168,6 +169,39 @@ describe("player browser integration: word bank steps", () => {
 
       await expect.element(page.getByText("100%")).toBeInTheDocument();
     });
+  });
+
+  it("plays listening prompt audio from the P keyboard shortcut", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "listening",
+        steps: [
+          buildSerializedStep({
+            content: {},
+            kind: "listening",
+            sentence: buildSerializedSentence({
+              audioUrl: "https://example.com/audio.mp3",
+              sentence: "Hola mundo",
+              translation: "Hello world",
+            }),
+            wordBankOptions: [
+              buildWordBankOption({ word: "Hello" }),
+              buildWordBankOption({ word: "world" }),
+              buildWordBankOption({ word: "bird" }),
+            ],
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    fireEvent.keyDown(globalThis.window, { key: "p" });
+
+    await expect
+      .element(page.getByRole("button", { name: /pause pronunciation/iu }))
+      .toBeInTheDocument();
+
+    await expect.element(page.getByRole("button", { name: /check/iu })).toBeDisabled();
   });
 
   it("lets learners remove fill-blank words before checking and shows the correct-answer hint", async () => {

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -5,7 +5,7 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { PauseIcon, Volume2Icon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { useState } from "react";
-import { useSharedPlayerAudio } from "../player-audio-context";
+import { PLAYER_AUDIO_KEYBOARD_SHORTCUT, useSharedPlayerAudio } from "../player-audio-context";
 import { useWordAudio } from "../use-word-audio";
 
 type PlayAudioButtonVariant = "filled" | "outline" | "text";
@@ -26,7 +26,11 @@ function usePlayAudioButtonState({ audioUrl, preload }: { audioUrl: string; prel
   });
 
   if (sharedAudio) {
-    return { handleClick: sharedAudio.toggle, isPlaying: sharedAudio.isPlaying };
+    return {
+      handleClick: sharedAudio.toggle,
+      isPlaying: sharedAudio.isPlaying,
+      keyboardShortcut: PLAYER_AUDIO_KEYBOARD_SHORTCUT,
+    };
   }
 
   return {
@@ -44,6 +48,7 @@ function usePlayAudioButtonState({ audioUrl, preload }: { audioUrl: string; prel
       });
     },
     isPlaying,
+    keyboardShortcut: undefined,
   };
 }
 
@@ -61,7 +66,11 @@ export function PlayAudioButton({
   variant?: PlayAudioButtonVariant;
 }) {
   const t = useExtracted();
-  const { handleClick, isPlaying } = usePlayAudioButtonState({ audioUrl, preload });
+
+  const { handleClick, isPlaying, keyboardShortcut } = usePlayAudioButtonState({
+    audioUrl,
+    preload,
+  });
 
   const Icon = isPlaying ? PauseIcon : Volume2Icon;
   const label = isPlaying ? t("Pause pronunciation") : t("Play pronunciation");
@@ -69,6 +78,7 @@ export function PlayAudioButton({
   if (variant === "text") {
     return (
       <button
+        aria-keyshortcuts={keyboardShortcut}
         className={cn(
           "text-muted-foreground hover:text-foreground flex items-center gap-1.5 text-sm transition-colors",
           className,
@@ -86,6 +96,7 @@ export function PlayAudioButton({
     return (
       <Button
         aria-label={label}
+        aria-keyshortcuts={keyboardShortcut}
         className={className}
         onClick={handleClick}
         size={size === "md" ? "icon-lg" : "icon"}
@@ -100,6 +111,7 @@ export function PlayAudioButton({
   return (
     <button
       aria-label={label}
+      aria-keyshortcuts={keyboardShortcut}
       className={cn(
         "bg-primary text-primary-foreground flex items-center justify-center rounded-full transition-all duration-150",
         "hover:bg-primary/90 focus-visible:ring-ring/50 outline-none hover:scale-105 focus-visible:ring-[3px] active:scale-95",

--- a/packages/player/src/player-audio-context.tsx
+++ b/packages/player/src/player-audio-context.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { useWordAudio } from "./use-word-audio";
+
+export const PLAYER_AUDIO_KEYBOARD_SHORTCUT = "p";
 
 type PlayerAudioContextValue = {
   audioUrl: string | null;
@@ -85,6 +88,8 @@ export function PlayerAudioProvider({
     [pause, playingAudioUrl, startAudio],
   );
 
+  usePlayerAudioKeyboardShortcut({ audioUrl, onToggleAudio: toggleAudio });
+
   useEffect(() => {
     if (!audioUrl || !autoPlayAudio || hasHandledAudioPrompt || isPlaying) {
       return;
@@ -116,4 +121,29 @@ export function useSharedPlayerAudio(audioUrl: string) {
   }
 
   return { isPlaying: context.isPlaying, toggle: () => context.toggleAudio(audioUrl) };
+}
+
+/**
+ * Connects the prompt-audio keyboard shortcut to the provider-owned audio
+ * controller. Keeping this as a hook inside PlayerAudioProvider makes the
+ * shortcut part of the same state owner as desktop and mobile play buttons.
+ */
+function usePlayerAudioKeyboardShortcut({
+  audioUrl,
+  onToggleAudio,
+}: {
+  audioUrl: string | null;
+  onToggleAudio: (audioUrl: string) => void;
+}) {
+  useKeyboardCallback(
+    PLAYER_AUDIO_KEYBOARD_SHORTCUT,
+    () => {
+      if (!audioUrl) {
+        return false;
+      }
+
+      onToggleAudio(audioUrl);
+    },
+    { ignoreEditable: true, mode: "none" },
+  );
 }


### PR DESCRIPTION
## Summary
- Add a P keyboard shortcut for active prompt audio in player lessons
- Expose the shortcut on shared prompt audio buttons
- Cover vocabulary and listening shortcut playback in browser tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “P” keyboard shortcut to play/pause prompt audio in player lessons. The shortcut is exposed on shared play buttons and covered by browser tests.

- New Features
  - Press “P” to toggle pronunciation audio on vocabulary and listening steps; handled in the shared PlayerAudioProvider and used by all play buttons.
  - Expose the shortcut with `aria-keyshortcuts` on text, outline, and filled play buttons; added browser tests for vocabulary and word bank listening flows.

<sup>Written for commit 60dcdd7557e3eb9e7238de1ad651c368e8766249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

