### PR TITLE
feat(player): show keyboard shortcut hints

### DIFF
--- a/apps/api/e2e/otp.test.ts
+++ b/apps/api/e2e/otp.test.ts
@@ -64,7 +64,16 @@ test.describe("OTP Login Flow", () => {
       `/auth/otp?email=${encodeURIComponent(TEST_EMAIL)}&redirectTo=${encodeURIComponent(REDIRECT_URL)}`,
     );
 
-    await page.getByRole("link", { name: /change email/iu }).click();
+    const continueButton = page.getByRole("button", { name: /^continue$/iu });
+    const changeEmailLink = page.getByRole("link", { name: /change email/iu });
+
+    await expect(continueButton).toHaveAttribute("aria-keyshortcuts", "Enter");
+    await expect(continueButton.getByText("Enter")).toBeVisible();
+    await expect(changeEmailLink).toHaveAttribute("aria-keyshortcuts", "Escape");
+    await expect(changeEmailLink.getByText("Esc")).toBeVisible();
+
+    await page.getByRole("textbox").click();
+    await page.keyboard.press("Escape");
     await page.waitForURL(/\/auth\/login/u);
 
     await expect(

--- a/apps/api/messages/de.po
+++ b/apps/api/messages/de.po
@@ -57,6 +57,10 @@ msgstr "Weiter mit Apple"
 msgid "HkHvQv"
 msgstr "Der eingegebene Code ist falsch. Bitte versuche es erneut oder kontaktiere hello@zoonk.com"
 
+#: src/app/auth/otp/otp-form.tsx
+msgid "ChATeO"
+msgstr "E‑Mail ändern"
+
 #: src/app/auth/otp/page.tsx
 msgid "zx7CKB"
 msgstr "Schau in dein Postfach"
@@ -64,10 +68,6 @@ msgstr "Schau in dein Postfach"
 #: src/app/auth/otp/page.tsx
 msgid "LZHcmZ"
 msgstr "Gib den Code ein, den wir an {email} gesendet haben:"
-
-#: src/app/auth/otp/page.tsx
-msgid "ChATeO"
-msgstr "E‑Mail ändern"
 
 #: src/app/auth/setup/page.tsx
 msgid "CYqIel"

--- a/apps/api/messages/en.po
+++ b/apps/api/messages/en.po
@@ -57,6 +57,10 @@ msgstr "Continue with Apple"
 msgid "HkHvQv"
 msgstr "The code you entered is incorrect. Please try again or contact hello@zoonk.com"
 
+#: src/app/auth/otp/otp-form.tsx
+msgid "ChATeO"
+msgstr "Change email"
+
 #: src/app/auth/otp/page.tsx
 msgid "zx7CKB"
 msgstr "Check your email"
@@ -64,10 +68,6 @@ msgstr "Check your email"
 #: src/app/auth/otp/page.tsx
 msgid "LZHcmZ"
 msgstr "Enter the code we sent to {email}:"
-
-#: src/app/auth/otp/page.tsx
-msgid "ChATeO"
-msgstr "Change email"
 
 #: src/app/auth/setup/page.tsx
 msgid "CYqIel"

--- a/apps/api/messages/es.po
+++ b/apps/api/messages/es.po
@@ -57,6 +57,10 @@ msgstr "Continuar con Apple"
 msgid "HkHvQv"
 msgstr "El código que ingresaste es incorrecto. Inténtalo de nuevo o contacta a contacto@zoonk.com"
 
+#: src/app/auth/otp/otp-form.tsx
+msgid "ChATeO"
+msgstr "Cambiar correo"
+
 #: src/app/auth/otp/page.tsx
 msgid "zx7CKB"
 msgstr "Revisa tu correo"
@@ -64,10 +68,6 @@ msgstr "Revisa tu correo"
 #: src/app/auth/otp/page.tsx
 msgid "LZHcmZ"
 msgstr "Introduce el código que enviamos a {email}:"
-
-#: src/app/auth/otp/page.tsx
-msgid "ChATeO"
-msgstr "Cambiar correo"
 
 #: src/app/auth/setup/page.tsx
 msgid "CYqIel"

--- a/apps/api/messages/fr.po
+++ b/apps/api/messages/fr.po
@@ -57,6 +57,10 @@ msgstr "Continuer avec Apple"
 msgid "HkHvQv"
 msgstr "Le code saisi est incorrect. Réessaie ou contacte hello@zoonk.com"
 
+#: src/app/auth/otp/otp-form.tsx
+msgid "ChATeO"
+msgstr "Changer d'email"
+
 #: src/app/auth/otp/page.tsx
 msgid "zx7CKB"
 msgstr "Vérifie ton email"
@@ -64,10 +68,6 @@ msgstr "Vérifie ton email"
 #: src/app/auth/otp/page.tsx
 msgid "LZHcmZ"
 msgstr "Saisis le code que nous avons envoyé à {email} :"
-
-#: src/app/auth/otp/page.tsx
-msgid "ChATeO"
-msgstr "Changer d'email"
 
 #: src/app/auth/setup/page.tsx
 msgid "CYqIel"

--- a/apps/api/messages/pt.po
+++ b/apps/api/messages/pt.po
@@ -57,6 +57,10 @@ msgstr "Continuar com Apple"
 msgid "HkHvQv"
 msgstr "O código que você inseriu está incorreto. Tente novamente ou contate contato@zoonk.com"
 
+#: src/app/auth/otp/otp-form.tsx
+msgid "ChATeO"
+msgstr "Alterar email"
+
 #: src/app/auth/otp/page.tsx
 msgid "zx7CKB"
 msgstr "Verifique seu email"
@@ -64,10 +68,6 @@ msgstr "Verifique seu email"
 #: src/app/auth/otp/page.tsx
 msgid "LZHcmZ"
 msgstr "Digite o código que enviamos para {email}:"
-
-#: src/app/auth/otp/page.tsx
-msgid "ChATeO"
-msgstr "Alterar email"
 
 #: src/app/auth/setup/page.tsx
 msgid "CYqIel"

--- a/apps/api/src/app/auth/otp/change-email-link.tsx
+++ b/apps/api/src/app/auth/otp/change-email-link.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { ShortcutKbd } from "@zoonk/ui/components/kbd";
+import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
+import { cn } from "@zoonk/ui/lib/utils";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+/**
+ * Builds the internal login route once so the link href and Escape shortcut
+ * always send users back to the same place.
+ */
+function getChangeEmailHref(redirectTo: string) {
+  const params = new URLSearchParams({ redirectTo });
+  return `/auth/login?${params.toString()}` as const;
+}
+
+/**
+ * Lets keyboard users leave the OTP step without hunting for the secondary
+ * action, while preserving the real anchor for normal click navigation.
+ */
+export function ChangeEmailLink({
+  children,
+  redirectTo,
+}: {
+  children: React.ReactNode;
+  redirectTo: string;
+}) {
+  const href = getChangeEmailHref(redirectTo);
+  const router = useRouter();
+
+  useKeyboardCallback("Escape", () => router.push(href), { mode: "none" });
+
+  return (
+    <Link
+      aria-keyshortcuts="Escape"
+      className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+      href={href}
+    >
+      {children}
+      <ShortcutKbd>Esc</ShortcutKbd>
+    </Link>
+  );
+}

--- a/apps/api/src/app/auth/otp/otp-form.tsx
+++ b/apps/api/src/app/auth/otp/otp-form.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import { OTPError, OTPForm as OTPFormContainer, OTPInput, OTPSubmit } from "@/components/otp";
+import {
+  OTPActions,
+  OTPError,
+  OTPForm as OTPFormContainer,
+  OTPInput,
+  OTPSubmit,
+} from "@/components/otp";
 import { authClient } from "@zoonk/core/auth/client";
 import { parseFormField } from "@zoonk/utils/form";
 import { useExtracted } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { ChangeEmailLink } from "./change-email-link";
 
 export function OTPForm({ email, redirectTo }: { email: string; redirectTo: string }) {
   const router = useRouter();
@@ -43,7 +50,10 @@ export function OTPForm({ email, redirectTo }: { email: string; redirectTo: stri
         {t("The code you entered is incorrect. Please try again or contact hello@zoonk.com")}
       </OTPError>
 
-      <OTPSubmit isLoading={state === "pending"}>{t("Continue")}</OTPSubmit>
+      <OTPActions>
+        <OTPSubmit isLoading={state === "pending"}>{t("Continue")}</OTPSubmit>
+        <ChangeEmailLink redirectTo={redirectTo}>{t("Change email")}</ChangeEmailLink>
+      </OTPActions>
     </OTPFormContainer>
   );
 }

--- a/apps/api/src/app/auth/otp/page.tsx
+++ b/apps/api/src/app/auth/otp/page.tsx
@@ -1,7 +1,5 @@
 import { OTP, OTPDescription, OTPHeader, OTPTitle } from "@/components/otp";
-import { buttonVariants } from "@zoonk/ui/components/button";
 import { getExtracted } from "next-intl/server";
-import Link from "next/link";
 import { OTPForm } from "./otp-form";
 
 export default async function OTPPage({ searchParams }: PageProps<"/auth/otp">) {
@@ -19,13 +17,6 @@ export default async function OTPPage({ searchParams }: PageProps<"/auth/otp">) 
       </OTPHeader>
 
       <OTPForm email={String(email)} redirectTo={String(redirectTo)} />
-
-      <Link
-        className={buttonVariants({ variant: "outline" })}
-        href={{ pathname: "/auth/login", query: { redirectTo: String(redirectTo) } }}
-      >
-        {t("Change email")}
-      </Link>
     </OTP>
   );
 }

--- a/apps/api/src/components/otp.tsx
+++ b/apps/api/src/components/otp.tsx
@@ -7,19 +7,20 @@ import {
   InputOTPSeparator,
   InputOTPSlot,
 } from "@zoonk/ui/components/input-otp";
+import { ShortcutKbd } from "@zoonk/ui/components/kbd";
 import { Spinner } from "@zoonk/ui/components/spinner";
 import { cn } from "@zoonk/ui/lib/utils";
 
 export function OTP({ children, className }: React.ComponentProps<"div">) {
   return (
-    <div className={cn("flex w-full flex-col items-center gap-6 text-center", className)}>
+    <div className={cn("flex w-full flex-col items-start gap-6 p-4 text-left", className)}>
       {children}
     </div>
   );
 }
 
 export function OTPHeader({ children, className }: React.ComponentProps<"header">) {
-  return <header className={cn("flex flex-col items-center gap-2", className)}>{children}</header>;
+  return <header className={cn("flex flex-col items-start gap-2", className)}>{children}</header>;
 }
 
 export function OTPTitle({ children, className }: React.ComponentProps<"h1">) {
@@ -27,14 +28,20 @@ export function OTPTitle({ children, className }: React.ComponentProps<"h1">) {
 }
 
 export function OTPDescription({ children, className }: React.ComponentProps<"p">) {
-  return <p className={cn("text-center text-sm text-balance", className)}>{children}</p>;
+  return <p className={cn("text-sm text-balance", className)}>{children}</p>;
 }
 
 export function OTPForm({ children, className, ...props }: React.ComponentProps<"form">) {
   return (
-    <form className={cn("flex flex-col items-center gap-4", className)} {...props}>
+    <form className={cn("flex w-full flex-col items-start gap-4", className)} {...props}>
       {children}
     </form>
+  );
+}
+
+export function OTPActions({ children, className }: React.ComponentProps<"div">) {
+  return (
+    <div className={cn("flex w-full flex-col items-stretch gap-3", className)}>{children}</div>
   );
 }
 
@@ -70,13 +77,24 @@ export function OTPError({
 
 export function OTPSubmit({
   children,
+  className,
   isLoading,
+  disabled,
   ...props
 }: React.ComponentProps<"button"> & { isLoading?: boolean }) {
+  const isDisabled = isLoading || disabled;
+
   return (
-    <Button disabled={isLoading} type="submit" {...props}>
+    <Button
+      aria-keyshortcuts="Enter"
+      className={cn("w-full", className)}
+      disabled={isDisabled}
+      type="submit"
+      {...props}
+    >
       {isLoading && <Spinner />}
       {children}
+      <ShortcutKbd tone="inverse">Enter</ShortcutKbd>
     </Button>
   );
 }

--- a/apps/api/src/components/setup.tsx
+++ b/apps/api/src/components/setup.tsx
@@ -8,7 +8,7 @@ export function Setup({ children, className }: React.ComponentProps<"div">) {
 }
 
 export function SetupHeader({ children, className }: React.ComponentProps<"header">) {
-  return <header className={cn("flex flex-col items-center gap-2", className)}>{children}</header>;
+  return <header className={cn("flex flex-col items-start gap-2", className)}>{children}</header>;
 }
 
 export function SetupTitle({ children, className }: React.ComponentProps<"h1">) {
@@ -16,7 +16,7 @@ export function SetupTitle({ children, className }: React.ComponentProps<"h1">) 
 }
 
 export function SetupDescription({ children, className }: React.ComponentProps<"p">) {
-  return <p className={cn("text-center text-sm text-balance", className)}>{children}</p>;
+  return <p className={cn("text-sm text-pretty", className)}>{children}</p>;
 }
 
 export function SetupForm({ children, className, ...props }: React.ComponentProps<"form">) {

--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -11,6 +11,7 @@ import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
 import { getSearchInputTop, scrollSearchInputToTop } from "./catalog-search";
 import { expect, test } from "./fixtures";
+import { pressShortcutAndWaitForUrl } from "./keyboard-shortcuts";
 
 const uniqueId = randomUUID();
 const SEARCH_LESSONS_LABEL = /search lessons/iu;
@@ -380,9 +381,11 @@ test.describe("Chapter Navbar - Mobile", () => {
     const courseLink = catalogNavbar.getByRole("link", { name: /course page/iu });
     const homeLink = catalogNavbar.getByRole("link", { name: /home page/iu });
 
+    await expect(courseLink).toHaveCount(1);
     await expect(courseLink).toBeVisible();
     await expect(courseLink).toHaveAttribute("href", courseUrl);
 
+    await expect(homeLink).toHaveCount(1);
     await expect(homeLink).toBeVisible();
     await expect(homeLink).toHaveAttribute("href", "/");
 
@@ -392,7 +395,8 @@ test.describe("Chapter Navbar - Mobile", () => {
       catalogNavbar.getByRole("link", { exact: true, name: "Courses" }),
     ).not.toBeVisible();
 
-    await expect(catalogNavbar.getByRole("button", { name: /search/iu })).not.toBeVisible();
+    await expect(catalogNavbar.getByRole("link", { name: /new course/iu })).toHaveCount(0);
+    await expect(catalogNavbar.getByRole("button", { name: /search/iu })).toHaveCount(0);
     await expect(catalogNavbar.getByRole("button", { name: /user menu/iu })).not.toBeVisible();
   });
 });
@@ -632,6 +636,8 @@ test.describe("Chapter - No Lessons", () => {
     const generateLink = page.getByRole("link", { name: /create chapter/iu });
 
     await expect(generateLink).toBeVisible();
+    await expect(generateLink.getByText(/^N$/u)).toBeVisible();
+    await expect(generateLink).toHaveAttribute("aria-keyshortcuts", "n");
 
     await expect(generateLink).toHaveAttribute(
       "href",
@@ -640,9 +646,26 @@ test.describe("Chapter - No Lessons", () => {
 
     await expect(generateLink).toHaveAttribute("rel", "nofollow");
 
+    const courseLink = page.getByRole("link", { name: /back to course/iu });
+    await expect(courseLink).toBeVisible();
+    await expect(courseLink.getByText(/^Esc$/u)).toBeVisible();
+    await expect(courseLink).toHaveAttribute("aria-keyshortcuts", "Escape");
+    await expect(courseLink).toHaveAttribute("href", courseUrl);
+
     const actionsButton = page.getByRole("main").getByRole("button", { name: /more options/iu });
 
     await expect(actionsButton).toHaveCount(0);
+
+    await pressShortcutAndWaitForUrl({
+      expectedUrl: new RegExp(`/generate/ch/${noLessonsChapterId}`, "u"),
+      key: "n",
+      page,
+    });
+
+    await page.goto(noLessonsChapterUrl);
+    await expect(page.getByRole("link", { name: /back to course/iu })).toBeVisible();
+
+    await pressShortcutAndWaitForUrl({ expectedUrl: courseUrl, key: "Escape", page });
   });
 
   test("non-AI chapters with no lessons stay on the chapter page", async ({ page }) => {

--- a/apps/main/e2e/keyboard-shortcuts.ts
+++ b/apps/main/e2e/keyboard-shortcuts.ts
@@ -1,0 +1,21 @@
+import { type Page, expect } from "./fixtures";
+
+/**
+ * Shortcut listeners hydrate after server-rendered links are already visible,
+ * so tests retry the key press instead of relying on a fixed delay that would
+ * make the assertion slower and less reliable.
+ */
+export async function pressShortcutAndWaitForUrl({
+  expectedUrl,
+  key,
+  page,
+}: {
+  expectedUrl: RegExp | string;
+  key: string;
+  page: Page;
+}) {
+  await expect(async () => {
+    await page.keyboard.press(key);
+    await expect(page).toHaveURL(expectedUrl, { timeout: 1000 });
+  }).toPass({ timeout: 5000 });
+}

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -7,6 +7,7 @@ import { chapterSentenceFixture, sentenceFixture } from "@zoonk/testing/fixtures
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { chapterWordFixture, wordFixture } from "@zoonk/testing/fixtures/words";
 import { type Page, expect, test } from "./fixtures";
+import { pressShortcutAndWaitForUrl } from "./keyboard-shortcuts";
 
 async function createTestLesson(options?: {
   chapterPosition?: number;
@@ -549,12 +550,15 @@ test.describe("Lesson Player Page", () => {
   test("authenticated users without subscription see upgrade CTA from lesson eleven", async ({
     authenticatedPage,
   }) => {
-    const { chapter, course, lesson } = await createTestLesson({
+    const { chapter, course, lesson, lessonTitle, uniqueId } = await createTestLesson({
       generationStatus: "completed",
       lessonPosition: 10,
     });
 
-    await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    const lessonHref = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`;
+    const chapterHref = `/b/ai/c/${course.slug}/ch/${chapter.slug}`;
+
+    await authenticatedPage.goto(lessonHref);
 
     await expect(authenticatedPage.getByText(/unlock the rest of this course/iu)).toBeVisible();
 
@@ -562,7 +566,39 @@ test.describe("Lesson Player Page", () => {
       authenticatedPage.getByText(/free accounts include the first 10 lessons/iu),
     ).toBeVisible();
 
+    await expect(authenticatedPage.getByRole("heading", { name: lessonTitle })).not.toBeVisible();
+
+    await expect(
+      authenticatedPage.getByText(`E2E lesson description ${uniqueId}`),
+    ).not.toBeVisible();
+
+    const backLink = authenticatedPage.getByRole("link", { name: /back to chapter/iu });
+    const upgradeLink = authenticatedPage.getByRole("link", { name: /upgrade/iu });
+
+    await expect(backLink).toBeVisible();
+    await expect(backLink.getByText(/^Esc$/u)).toBeVisible();
+    await expect(backLink).toHaveAttribute("aria-keyshortcuts", "Escape");
+    await expect(backLink).toHaveAttribute("href", chapterHref);
+
+    await expect(upgradeLink).toBeVisible();
+    await expect(upgradeLink.getByText(/^Enter$/u)).toBeVisible();
+    await expect(upgradeLink).toHaveAttribute("aria-keyshortcuts", "Enter");
+    await expect(upgradeLink).toHaveAttribute("href", "/subscription");
+
+    await pressShortcutAndWaitForUrl({
+      expectedUrl: chapterHref,
+      key: "Escape",
+      page: authenticatedPage,
+    });
+
+    await authenticatedPage.goto(lessonHref);
     await expect(authenticatedPage.getByRole("link", { name: /upgrade/iu })).toBeVisible();
+
+    await pressShortcutAndWaitForUrl({
+      expectedUrl: "/subscription",
+      key: "Enter",
+      page: authenticatedPage,
+    });
   });
 
   test("authenticated users without subscription see upgrade CTA for later chapters", async ({
@@ -607,13 +643,32 @@ test.describe("Lesson Player Page", () => {
     const generateLink = page.getByRole("link", { name: /create lesson/iu });
 
     await expect(generateLink).toBeVisible();
+    await expect(generateLink.getByText(/^N$/u)).toBeVisible();
+    await expect(generateLink).toHaveAttribute("aria-keyshortcuts", "n");
     await expect(generateLink).toHaveAttribute("href", new RegExp(`/generate/l/${lesson.id}`, "u"));
     await expect(generateLink).toHaveAttribute("rel", "nofollow");
 
     const chapterLink = page.getByRole("link", { name: /back to chapter/iu });
     await expect(chapterLink).toBeVisible();
+    await expect(chapterLink.getByText(/^Esc$/u)).toBeVisible();
+    await expect(chapterLink).toHaveAttribute("aria-keyshortcuts", "Escape");
 
     await expect(chapterLink).toHaveAttribute("href", `/b/ai/c/${course.slug}/ch/${chapter.slug}`);
+
+    await pressShortcutAndWaitForUrl({
+      expectedUrl: new RegExp(`/generate/l/${lesson.id}`, "u"),
+      key: "n",
+      page,
+    });
+
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    await expect(page.getByRole("link", { name: /back to chapter/iu })).toBeVisible();
+
+    await pressShortcutAndWaitForUrl({
+      expectedUrl: `/b/ai/c/${course.slug}/ch/${chapter.slug}`,
+      key: "Escape",
+      page,
+    });
   });
 
   test("pending practice lessons link to their own generation page", async ({

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -295,6 +295,11 @@ msgstr "Dieses Kapitel ist Teil des Kurses, wurde aber noch nicht erstellt. Erst
 msgid "3IOFp2"
 msgstr "Kapitel erstellen"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+#: src/app/generate/ch/[id]/generate-chapter-content.tsx
+msgid "qrEiLa"
+msgstr "Zurück zum Kurs"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
 msgid "Ap-oRa"
 msgstr "Filter für Lektionen konnten nicht angewendet werden. Bitte versuche es erneut."
@@ -1223,10 +1228,6 @@ msgstr "Die Überprüfung wird freigeschaltet, nachdem die vorherigen Lektionen 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"
 msgstr "Es gibt noch keine Übungsfragen zum Wiederholen."
-
-#: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
-msgstr "Zurück zum Kurs"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "txNTbP"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -295,6 +295,11 @@ msgstr "This chapter is part of the course, but it hasn't been created yet. Crea
 msgid "3IOFp2"
 msgstr "Create chapter"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+#: src/app/generate/ch/[id]/generate-chapter-content.tsx
+msgid "qrEiLa"
+msgstr "Back to course"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
 msgid "Ap-oRa"
 msgstr "Could not apply lesson filters. Please try again."
@@ -1223,10 +1228,6 @@ msgstr "Review unlocks after the earlier lessons in this chapter have been creat
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"
 msgstr "There are no practice questions to review yet."
-
-#: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
-msgstr "Back to course"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "txNTbP"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -295,6 +295,11 @@ msgstr "Este capítulo forma parte del curso, pero todavía no se ha creado. Cr�
 msgid "3IOFp2"
 msgstr "Crear capítulo"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+#: src/app/generate/ch/[id]/generate-chapter-content.tsx
+msgid "qrEiLa"
+msgstr "Volver al curso"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
 msgid "Ap-oRa"
 msgstr "No se pudieron aplicar los filtros de lecciones. Inténtalo de nuevo."
@@ -1223,10 +1228,6 @@ msgstr "La revisión se desbloquea después de que se hayan creado las lecciones
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"
 msgstr "Aún no hay preguntas de práctica para repasar."
-
-#: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
-msgstr "Volver al curso"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "txNTbP"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -295,6 +295,11 @@ msgstr "Ce chapitre fait partie du cours, mais il n’a pas encore été créé.
 msgid "3IOFp2"
 msgstr "Créer le chapitre"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+#: src/app/generate/ch/[id]/generate-chapter-content.tsx
+msgid "qrEiLa"
+msgstr "Retour au cours"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
 msgid "Ap-oRa"
 msgstr "Impossible d'appliquer les filtres de leçons. Réessaie."
@@ -1223,10 +1228,6 @@ msgstr "La révision se débloque après la création des leçons précédentes 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"
 msgstr "Aucune question d'entraînement à réviser pour l'instant."
-
-#: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
-msgstr "Retour au cours"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "txNTbP"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -295,6 +295,11 @@ msgstr "Este capítulo faz parte do curso, mas ainda não foi criado. Crie ele p
 msgid "3IOFp2"
 msgstr "Criar capítulo"
 
+#: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+#: src/app/generate/ch/[id]/generate-chapter-content.tsx
+msgid "qrEiLa"
+msgstr "Voltar ao curso"
+
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
 msgid "Ap-oRa"
 msgstr "Não foi possível aplicar os filtros de aulas. Tente novamente."
@@ -1223,10 +1228,6 @@ msgstr "A revisão será liberada depois que as aulas anteriores deste capítulo
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"
 msgstr "Ainda não há perguntas práticas para revisar."
-
-#: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
-msgstr "Voltar ao curso"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "txNTbP"

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
@@ -1,4 +1,5 @@
-import { buttonVariants } from "@zoonk/ui/components/button";
+import { GenerationExitLink } from "@/components/generation/generation-exit-link";
+import { GenerationShortcutLink } from "@/components/generation/generation-shortcut-link";
 import {
   Empty,
   EmptyContent,
@@ -9,19 +10,24 @@ import {
 } from "@zoonk/ui/components/empty";
 import { SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
-import Link from "next/link";
 
 /**
  * AI chapter pages can exist before their lesson rows are generated. Showing a
  * normal page-level empty state keeps the chapter URL stable while making the
  * generation step an explicit learner action.
  */
-export async function ChapterNotGenerated({ chapterId }: { chapterId: string }) {
+export async function ChapterNotGenerated({
+  chapterId,
+  courseHref,
+}: {
+  chapterId: string;
+  courseHref: `/b/${string}/c/${string}`;
+}) {
   const t = await getExtracted();
 
   return (
     <Empty className="min-h-80 border-0">
-      <EmptyHeader>
+      <EmptyHeader align="start">
         <EmptyMedia variant="icon">
           <SparklesIcon />
         </EmptyMedia>
@@ -35,16 +41,21 @@ export async function ChapterNotGenerated({ chapterId }: { chapterId: string }) 
         </EmptyDescription>
       </EmptyHeader>
 
-      <EmptyContent>
-        <Link
-          className={buttonVariants({ variant: "outline" })}
+      <EmptyContent align="stretch">
+        <GenerationShortcutLink
           href={`/generate/ch/${chapterId}`}
           prefetch={false}
           rel="nofollow"
+          shortcut="N"
+          variant="outline"
         >
           <SparklesIcon data-icon="inline-start" />
           {t("Create chapter")}
-        </Link>
+        </GenerationShortcutLink>
+
+        <GenerationExitLink href={courseHref} shortcut="Esc">
+          {t("Back to course")}
+        </GenerationExitLink>
       </EmptyContent>
     </Empty>
   );

--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -118,7 +118,10 @@ export default async function ChapterPage({
     >
       <Grid variant="pane">
         {shouldShowCreateChapterPrompt ? (
-          <ChapterNotGenerated chapterId={chapter.id} />
+          <ChapterNotGenerated
+            chapterId={chapter.id}
+            courseHref={`/b/${brandSlug}/c/${courseSlug}`}
+          />
         ) : (
           <Suspense
             fallback={<CatalogGridSkeleton count={lessons.length} groupVariant="pane" search />}

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
@@ -1,5 +1,5 @@
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
-import { buttonVariants } from "@zoonk/ui/components/button";
+import { GenerationShortcutLink } from "@/components/generation/generation-shortcut-link";
 import {
   Empty,
   EmptyContent,
@@ -11,7 +11,6 @@ import {
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
-import Link from "next/link";
 
 export async function LessonNotGenerated({
   brandSlug,
@@ -30,7 +29,7 @@ export async function LessonNotGenerated({
 
   return (
     <Empty className="border-0">
-      <EmptyHeader>
+      <EmptyHeader align="start">
         <EmptyMedia variant="icon">
           <SparklesIcon />
         </EmptyMedia>
@@ -44,19 +43,22 @@ export async function LessonNotGenerated({
         </EmptyDescription>
       </EmptyHeader>
 
-      <EmptyContent>
+      <EmptyContent align="stretch">
         {canGenerateLesson && generationLessonId && (
-          <Link
-            className={buttonVariants({ variant: "outline" })}
+          <GenerationShortcutLink
             href={`/generate/l/${generationLessonId}`}
             prefetch={false}
             rel="nofollow"
+            shortcut="N"
+            variant="outline"
           >
             <SparklesIcon data-icon="inline-start" />
             {t("Create lesson")}
-          </Link>
+          </GenerationShortcutLink>
         )}
-        <GenerationExitLink href={chapterHref}>{t("Back to chapter")}</GenerationExitLink>
+        <GenerationExitLink href={chapterHref} shortcut="Esc">
+          {t("Back to chapter")}
+        </GenerationExitLink>
       </EmptyContent>
     </Empty>
   );

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -24,14 +24,7 @@ import { getLesson as getPlayerLesson } from "@zoonk/core/player/queries/get-les
 import { getPlayerResourceIds } from "@zoonk/core/player/queries/get-player-resource-ids";
 import { getTotalBrainPower } from "@zoonk/core/player/queries/get-total-brain-power";
 import { getSession } from "@zoonk/core/users/session/get";
-import {
-  Container,
-  ContainerBody,
-  ContainerDescription,
-  ContainerHeader,
-  ContainerHeaderGroup,
-  ContainerTitle,
-} from "@zoonk/ui/components/container";
+import { Container, ContainerBody } from "@zoonk/ui/components/container";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
@@ -75,10 +68,11 @@ async function getLessonAccessGate({
   }
 
   const backHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}` as const;
-  const lessonMeta = await getLessonDisplayMeta(lesson);
   const t = await getExtracted();
 
   if (requirement === "authentication") {
+    const lessonMeta = await getLessonDisplayMeta(lesson);
+
     return (
       <LoginRequired
         backHref={backHref}
@@ -95,15 +89,8 @@ async function getLessonAccessGate({
   }
 
   return (
-    <Container variant="narrow">
-      <ContainerHeader>
-        <ContainerHeaderGroup>
-          <ContainerTitle>{lessonMeta.title}</ContainerTitle>
-          <ContainerDescription>{lessonMeta.description}</ContainerDescription>
-        </ContainerHeaderGroup>
-      </ContainerHeader>
-
-      <ContainerBody>
+    <Container className="min-h-dvh" variant="narrow">
+      <ContainerBody className="justify-center sm:flex-1">
         <UpgradeCTA
           backHref={backHref}
           backLabel={t("Back to chapter")}

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
@@ -1,4 +1,4 @@
-import { buttonVariants } from "@zoonk/ui/components/button";
+import { GenerationShortcutLink } from "@/components/generation/generation-shortcut-link";
 import {
   Empty,
   EmptyContent,
@@ -9,7 +9,6 @@ import {
 } from "@zoonk/ui/components/empty";
 import { BookOpenCheckIcon, SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
-import Link from "next/link";
 
 /**
  * Replaces the misleading zero-step completion screen for review lessons with
@@ -25,7 +24,7 @@ export async function ReviewLessonEmpty({
 
   return (
     <Empty className="border-0">
-      <EmptyHeader>
+      <EmptyHeader align="start">
         <EmptyMedia variant="icon">
           <BookOpenCheckIcon />
         </EmptyMedia>
@@ -44,16 +43,17 @@ export async function ReviewLessonEmpty({
       </EmptyHeader>
 
       {generationLessonId && (
-        <EmptyContent>
-          <Link
-            className={buttonVariants({ variant: "outline" })}
+        <EmptyContent align="stretch">
+          <GenerationShortcutLink
             href={`/generate/l/${generationLessonId}`}
             prefetch={false}
             rel="nofollow"
+            shortcut="N"
+            variant="outline"
           >
             <SparklesIcon data-icon="inline-start" />
             {t("Create lesson")}
-          </Link>
+          </GenerationShortcutLink>
         </EmptyContent>
       )}
     </Empty>

--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -39,7 +39,9 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
             generationRunId={chapter.generationRunId}
             initialStatus={initialStatus}
           />
-          <GenerationExitLink href={backHref}>{backLabel}</GenerationExitLink>
+          <GenerationExitLink href={backHref} shortcut="Esc">
+            {backLabel}
+          </GenerationExitLink>
         </SubscriptionGate>
       </ContainerBody>
     </Container>

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -86,7 +86,9 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
           lessonSlug={lesson.slug}
           lessonTitle={lessonMeta.title}
         />
-        <GenerationExitLink href={backHref}>{backLabel}</GenerationExitLink>
+        <GenerationExitLink href={backHref} shortcut="Esc">
+          {backLabel}
+        </GenerationExitLink>
       </>
     );
 

--- a/apps/main/src/components/generation/generation-exit-link.tsx
+++ b/apps/main/src/components/generation/generation-exit-link.tsx
@@ -1,23 +1,23 @@
-import { buttonVariants } from "@zoonk/ui/components/button";
-import { cn } from "@zoonk/ui/lib/utils";
 import { type Route } from "next";
-import Link from "next/link";
+import { GenerationShortcutLink } from "./generation-shortcut-link";
 
 /**
  * Gives learners a quiet way out of generated-content waiting states. Keeping
- * this as a plain server-rendered link means streaming components can keep one
- * job: start, display, and clean up the workflow stream.
+ * this wrapper small lets generation screens opt into keyboard shortcuts
+ * without duplicating button styling at each call site.
  */
 export function GenerationExitLink<Href extends string>({
   children,
   href,
+  shortcut,
 }: {
   children: React.ReactNode;
   href: Route<Href>;
+  shortcut?: "Esc";
 }) {
   return (
-    <Link className={cn(buttonVariants(), "w-max")} href={href} prefetch>
+    <GenerationShortcutLink href={href} prefetch shortcut={shortcut}>
       {children}
-    </Link>
+    </GenerationShortcutLink>
   );
 }

--- a/apps/main/src/components/generation/generation-shortcut-link.tsx
+++ b/apps/main/src/components/generation/generation-shortcut-link.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { ShortcutKbd, type ShortcutKbdTone } from "@zoonk/ui/components/kbd";
+import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
+import { cn } from "@zoonk/ui/lib/utils";
+import { type Route } from "next";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+type GenerationShortcutLinkVariant = "default" | "outline";
+type GenerationShortcut = "Enter" | "Esc" | "N";
+
+/**
+ * Visible shortcut badges use compact labels like Esc and N, while keyboard
+ * events and `aria-keyshortcuts` both need canonical key values.
+ */
+function getShortcutKey(shortcut: GenerationShortcut): string {
+  if (shortcut === "Esc") {
+    return "Escape";
+  }
+
+  if (shortcut === "N") {
+    return "n";
+  }
+
+  return shortcut;
+}
+
+/**
+ * Filled buttons need inverse shortcut text so the hint stays readable, while
+ * outline buttons can use the normal muted shortcut style.
+ */
+function getShortcutTone(variant: GenerationShortcutLinkVariant): ShortcutKbdTone {
+  if (variant === "default") {
+    return "inverse";
+  }
+
+  return "default";
+}
+
+/**
+ * Links remain real anchors for normal navigation and prefetching, while this
+ * hook adds the matching keyboard path for users who prefer shortcuts.
+ */
+function useShortcutNavigation<Href extends string>({
+  href,
+  shortcutKey,
+}: {
+  href: Route<Href>;
+  shortcutKey?: string;
+}) {
+  const router = useRouter();
+
+  useKeyboardCallback(
+    shortcutKey ?? "",
+    () => {
+      if (!shortcutKey) {
+        return false;
+      }
+
+      router.push(href);
+    },
+    { ignoreEditable: true, mode: "none" },
+  );
+}
+
+/**
+ * Renders focused empty-state actions with an optional visible keyboard
+ * shortcut and a matching client-side keyboard navigation handler.
+ */
+export function GenerationShortcutLink<Href extends string>({
+  children,
+  className,
+  href,
+  prefetch,
+  rel,
+  shortcut,
+  variant = "default",
+}: {
+  children: React.ReactNode;
+  className?: string;
+  href: Route<Href>;
+  prefetch?: boolean;
+  rel?: string;
+  shortcut?: GenerationShortcut;
+  variant?: GenerationShortcutLinkVariant;
+}) {
+  const shortcutKey = shortcut ? getShortcutKey(shortcut) : undefined;
+  useShortcutNavigation({ href, shortcutKey });
+  const shortcutTone = getShortcutTone(variant);
+
+  return (
+    <Link
+      aria-keyshortcuts={shortcutKey}
+      className={cn(buttonVariants({ variant }), "w-full", className)}
+      href={href}
+      prefetch={prefetch}
+      rel={rel}
+    >
+      <span className="flex min-w-0 items-center justify-center gap-1.5">{children}</span>
+      {shortcut && <ShortcutKbd tone={shortcutTone}>{shortcut}</ShortcutKbd>}
+    </Link>
+  );
+}

--- a/apps/main/src/components/subscription/upgrade-cta.tsx
+++ b/apps/main/src/components/subscription/upgrade-cta.tsx
@@ -1,4 +1,4 @@
-import { buttonVariants } from "@zoonk/ui/components/button";
+import { GenerationShortcutLink } from "@/components/generation/generation-shortcut-link";
 import {
   Empty,
   EmptyContent,
@@ -7,11 +7,9 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@zoonk/ui/components/empty";
-import { cn } from "@zoonk/ui/lib/utils";
 import { SparklesIcon } from "lucide-react";
 import { type Route } from "next";
 import { getExtracted } from "next-intl/server";
-import Link from "next/link";
 
 export async function UpgradeCTA<Href extends string>({
   backHref,
@@ -28,7 +26,7 @@ export async function UpgradeCTA<Href extends string>({
 
   return (
     <Empty className="border-0">
-      <EmptyHeader>
+      <EmptyHeader align="start">
         <EmptyMedia variant="icon">
           <SparklesIcon />
         </EmptyMedia>
@@ -40,18 +38,14 @@ export async function UpgradeCTA<Href extends string>({
         </EmptyDescription>
       </EmptyHeader>
 
-      <EmptyContent>
-        <Link
-          className={cn(buttonVariants({ variant: "outline" }), "w-max")}
-          href={backHref}
-          prefetch
-        >
+      <EmptyContent align="stretch">
+        <GenerationShortcutLink href={backHref} prefetch shortcut="Esc" variant="outline">
           {backLabel}
-        </Link>
+        </GenerationShortcutLink>
 
-        <Link className={cn(buttonVariants(), "w-max")} href="/subscription" prefetch>
+        <GenerationShortcutLink href="/subscription" prefetch shortcut="Enter">
           {t("Upgrade")}
-        </Link>
+        </GenerationShortcutLink>
       </EmptyContent>
     </Empty>
   );

--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -41,7 +41,7 @@ msgid "7R_rOB"
 msgstr "Tippe Wörter an, um deine Antwort zu bilden"
 
 #: src/components/arrange-words.tsx
-#: src/components/fill-blank-step.tsx
+#: src/components/fill-blank-word-bank.tsx
 msgid "e7WNdK"
 msgstr "Wortschatz"
 

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -41,7 +41,7 @@ msgid "7R_rOB"
 msgstr "Tap words to build your answer"
 
 #: src/components/arrange-words.tsx
-#: src/components/fill-blank-step.tsx
+#: src/components/fill-blank-word-bank.tsx
 msgid "e7WNdK"
 msgstr "Word bank"
 

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -41,7 +41,7 @@ msgid "7R_rOB"
 msgstr "Toca las palabras para formar tu respuesta"
 
 #: src/components/arrange-words.tsx
-#: src/components/fill-blank-step.tsx
+#: src/components/fill-blank-word-bank.tsx
 msgid "e7WNdK"
 msgstr "Banco de palabras"
 

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -41,7 +41,7 @@ msgid "7R_rOB"
 msgstr "Tape les mots pour construire ta réponse"
 
 #: src/components/arrange-words.tsx
-#: src/components/fill-blank-step.tsx
+#: src/components/fill-blank-word-bank.tsx
 msgid "e7WNdK"
 msgstr "Banque de mots"
 

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -41,7 +41,7 @@ msgid "7R_rOB"
 msgstr "Toque nas palavras para formar sua resposta"
 
 #: src/components/arrange-words.tsx
-#: src/components/fill-blank-step.tsx
+#: src/components/fill-blank-word-bank.tsx
 msgid "e7WNdK"
 msgstr "Banco de palavras"
 

--- a/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { page } from "vitest/browser";
 import { buildSerializedLesson, buildSerializedStep } from "../_test-utils/player-test-data";
@@ -63,6 +64,45 @@ describe("player browser integration: arrangement steps", () => {
     await expect.element(page.getByRole("heading", { name: "Match the pairs." })).toBeVisible();
   });
 
+  it("matches pairs from number shortcuts", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        steps: [
+          buildSerializedStep({
+            content: {
+              pairs: [
+                { left: "Sun", right: "Day" },
+                { left: "Moon", right: "Night" },
+              ],
+              question: "Match each item",
+            },
+            id: "match-keyboard",
+            kind: "matchColumns",
+            matchColumnsRightItems: ["Day", "Night"],
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    const sun = page.getByRole("button", { name: "Sun" });
+    const day = page.getByRole("button", { name: "Day" });
+
+    await expect.element(sun.getByText(/^1$/u)).toBeInTheDocument();
+    await expect.element(sun).toHaveAttribute("aria-keyshortcuts", "1");
+
+    fireEvent.keyDown(globalThis.window, { key: "1" });
+
+    await expect.element(day.getByText(/^1$/u)).toBeInTheDocument();
+    await expect.element(day).toHaveAttribute("aria-keyshortcuts", "1");
+
+    fireEvent.keyDown(globalThis.window, { key: "1" });
+    fireEvent.keyDown(globalThis.window, { key: "2" });
+    fireEvent.keyDown(globalThis.window, { key: "2" });
+
+    await expect.element(page.getByRole("button", { name: /check/iu })).toBeEnabled();
+  });
+
   it("strips model-added wrapping quotes from match-column labels", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
@@ -89,10 +129,10 @@ describe("player browser integration: arrangement steps", () => {
     const moon = page.getByRole("button", { name: "Moon" });
     const night = page.getByRole("button", { name: "Night" });
 
-    await expect.element(sun).toHaveTextContent(/^Sun$/u);
-    await expect.element(day).toHaveTextContent(/^Day$/u);
-    await expect.element(moon).toHaveTextContent(/^Moon$/u);
-    await expect.element(night).toHaveTextContent(/^Night$/u);
+    await expect.element(sun.getByText(/^Sun$/u)).toBeInTheDocument();
+    await expect.element(day.getByText(/^Day$/u)).toBeInTheDocument();
+    await expect.element(moon.getByText(/^Moon$/u)).toBeInTheDocument();
+    await expect.element(night.getByText(/^Night$/u)).toBeInTheDocument();
 
     await sun.click();
     await day.click();

--- a/packages/player/src/_browser-tests/player-choice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-choice.browser.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { page } from "vitest/browser";
+import { runInMobilePlayerViewport } from "../_test-utils/browser-viewport";
 import { buildInlineImageUrl } from "../_test-utils/build-inline-image-url";
 import {
   buildSerializedLesson,
@@ -107,27 +108,17 @@ describe("player browser integration: choice steps", () => {
     await expect.element(page.getByText("100%")).toBeInTheDocument();
   });
 
-  it("selects an image option and shows inline feedback", async () => {
+  it("shows number shortcuts on image options", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         steps: [
           buildSerializedStep({
             content: {
               options: [
-                {
-                  feedback: "Correct cat",
-                  id: "cat",
-                  isCorrect: true,
-                  prompt: "Cat",
-                  url: "https://example.com/cat.png",
-                },
-                {
-                  feedback: "Wrong dog",
-                  id: "dog",
-                  isCorrect: false,
-                  prompt: "Dog",
-                  url: "https://example.com/dog.png",
-                },
+                { feedback: "Correct cat", id: "cat", isCorrect: true, prompt: "Cat" },
+                { feedback: "Wrong dog", id: "dog", isCorrect: false, prompt: "Dog" },
+                { feedback: "Wrong bird", id: "bird", isCorrect: false, prompt: "Bird" },
+                { feedback: "Wrong fish", id: "fish", isCorrect: false, prompt: "Fish" },
               ],
               question: "Select the cat",
             },
@@ -138,12 +129,88 @@ describe("player browser integration: choice steps", () => {
       viewer: buildAuthenticatedViewer(),
     });
 
-    await page.getByRole("radio", { name: "Cat" }).click();
+    const imageOptions = page.getByRole("radiogroup", { name: /image options/iu });
+
+    await expect
+      .element(imageOptions.getByRole("radio", { name: "Cat" }).getByText(/^1$/u))
+      .toBeInTheDocument();
+
+    await expect
+      .element(imageOptions.getByRole("radio", { name: "Fish" }).getByText(/^4$/u))
+      .toBeInTheDocument();
+
+    await expect
+      .element(imageOptions.getByRole("radio", { name: "Fish" }))
+      .toHaveAttribute("aria-keyshortcuts", "4");
+
+    await imageOptions.getByRole("radio", { name: "Cat" }).click();
     await page.getByRole("button", { name: /check/iu }).click();
+
+    await expect
+      .element(imageOptions.getByRole("radio", { name: "Cat" }).getByText(/^1$/u))
+      .toBeInTheDocument();
+
+    await expect
+      .element(imageOptions.getByRole("radio", { name: "Cat" }))
+      .toHaveAttribute("aria-keyshortcuts", "1");
 
     await expect
       .element(page.getByRole("region", { name: /answer feedback/iu }))
       .toBeInTheDocument();
+  });
+
+  it("hides image shortcut badges on mobile", async () => {
+    await runInMobilePlayerViewport(async () => {
+      renderPlayer({
+        lesson: buildSerializedLesson({
+          steps: [
+            buildSerializedStep({
+              content: {
+                options: [
+                  { feedback: "Correct cat", id: "cat", isCorrect: true, prompt: "Cat" },
+                  { feedback: "Wrong dog", id: "dog", isCorrect: false, prompt: "Dog" },
+                ],
+                question: "Select the cat",
+              },
+              kind: "selectImage",
+            }),
+          ],
+        }),
+        viewer: buildAuthenticatedViewer(),
+      });
+
+      const imageOptions = page.getByRole("radiogroup", { name: /image options/iu });
+      const catImageOption = imageOptions.getByRole("radio", { name: "Cat" });
+
+      await expect.element(catImageOption.getByText(/^1$/u)).not.toBeVisible();
+      await expect.element(catImageOption).toHaveAttribute("aria-keyshortcuts", "1");
+    });
+  });
+
+  it("keeps multiple-choice numbers visible on mobile", async () => {
+    await runInMobilePlayerViewport(async () => {
+      renderPlayer({
+        lesson: buildSerializedLesson({
+          steps: [
+            buildSerializedStep({
+              content: {
+                options: [
+                  { feedback: "Nope", id: "Paris", isCorrect: false, text: "Paris" },
+                  { feedback: "Correct", id: "Berlin", isCorrect: true, text: "Berlin" },
+                ],
+                question: "What is the capital of Germany?",
+              },
+              kind: "multipleChoice",
+            }),
+          ],
+        }),
+        viewer: buildAuthenticatedViewer(),
+      });
+
+      await expect
+        .element(page.getByRole("radio", { name: "Berlin" }).getByText(/^2$/u))
+        .toBeVisible();
+    });
   });
 
   it("shows the missed multiple-choice prompt on incorrect feedback", async () => {
@@ -186,6 +253,41 @@ describe("player browser integration: choice steps", () => {
     await expect
       .element(page.getByText("What explains the robot's overheating?"))
       .toBeInTheDocument();
+  });
+
+  it("shows compact shortcut badges and places Enter inside the enabled action button", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        steps: [
+          buildSerializedStep({
+            content: {
+              options: [
+                { feedback: "Nope", id: "Paris", isCorrect: false, text: "Paris" },
+                { feedback: "Correct", id: "Berlin", isCorrect: true, text: "Berlin" },
+              ],
+              question: "What is the capital of Germany?",
+            },
+            kind: "multipleChoice",
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await expect
+      .element(page.getByRole("link", { name: /close/iu }).getByText(/^Esc$/u))
+      .toBeInTheDocument();
+
+    await expect.element(page.getByText(/^Exit$/u)).not.toBeInTheDocument();
+
+    const checkButton = page.getByRole("button", { name: /check/iu });
+
+    await expect.element(checkButton).toHaveAttribute("aria-keyshortcuts", "Enter");
+    await expect.element(checkButton.getByText(/^Enter$/u)).toBeVisible();
+
+    await page.getByRole("radio", { name: "Berlin" }).click();
+
+    await expect.element(checkButton.getByText(/^Enter$/u)).toBeInTheDocument();
   });
 
   it("lets multiple-choice users toggle selections and shows the correct answer on mistakes", async () => {

--- a/packages/player/src/_browser-tests/player-practice.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-practice.browser.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { page } from "vitest/browser";
+import { runInMobilePlayerViewport } from "../_test-utils/browser-viewport";
 import { buildInlineImageUrl } from "../_test-utils/build-inline-image-url";
 import { buildSerializedLesson, buildSerializedStep } from "../_test-utils/player-test-data";
 import { buildAuthenticatedViewer } from "../_test-utils/player-test-viewer";
@@ -22,6 +23,64 @@ function expectImageToFillPlayerStage(image: HTMLElement) {
 }
 
 describe("player browser integration: practice lessons", () => {
+  it("shows only the bottom-bar check button on mobile practice questions", async () => {
+    await runInMobilePlayerViewport(async () => {
+      renderPlayer({
+        lesson: buildSerializedLesson({
+          kind: "practice",
+          steps: [
+            buildSerializedStep({
+              content: {
+                context: "Maya says the mismatch only appears on orders with manual discounts.",
+                image: {
+                  prompt:
+                    "A refund dashboard filtered to discounted orders with one outlier row highlighted",
+                  url: buildInlineImageUrl({
+                    label:
+                      "A refund dashboard filtered to discounted orders with one outlier row highlighted",
+                  }),
+                },
+                options: [
+                  {
+                    feedback: "Yes. Start with the shared pattern before blaming a random order.",
+                    id: "check-discounted-orders",
+                    isCorrect: true,
+                    text: "Check the discounted orders first",
+                  },
+                  {
+                    feedback: "That skips the one pattern we already know matters.",
+                    id: "inspect-latest-order",
+                    isCorrect: false,
+                    text: "Ignore discounts and inspect the latest order",
+                  },
+                ],
+                question: "What should I check first?",
+              },
+              id: "practice-question",
+              kind: "multipleChoice",
+            }),
+          ],
+        }),
+        navigation: buildNavigation({ nextLessonHref: null }),
+        viewer: buildAuthenticatedViewer(),
+      });
+
+      await page.getByRole("radio", { name: "Check the discounted orders first" }).click();
+
+      const visibleCheckButtons = screen.getAllByRole("button", { name: /check/iu });
+
+      expect(visibleCheckButtons).toHaveLength(1);
+
+      await expect
+        .element(
+          page
+            .getByRole("toolbar", { name: /lesson controls/iu })
+            .getByRole("button", { name: /check/iu }),
+        )
+        .toBeInTheDocument();
+    });
+  });
+
   it("renders a leading static scenario step and still completes with question scoring", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -85,6 +85,105 @@ describe("player browser integration: word bank steps", () => {
     await expect.element(page.getByText("100%")).toBeInTheDocument();
   });
 
+  it("toggles reading word-bank options from number shortcuts", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "reading",
+        steps: [
+          buildSerializedStep({
+            content: {},
+            kind: "reading",
+            sentence: buildSerializedSentence({
+              sentence: "Hola mundo",
+              translation: "Hello world",
+            }),
+            wordBankOptions: [
+              buildWordBankOption({ word: "Hola" }),
+              buildWordBankOption({ word: "mundo" }),
+              buildWordBankOption({ word: "gato" }),
+            ],
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    const wordBank = page.getByRole("group", { name: /word bank/iu });
+    const mundoOption = wordBank.getByRole("button", { exact: true, name: "mundo" });
+
+    await expect.element(mundoOption.getByText(/^2$/u)).toBeInTheDocument();
+    await expect.element(mundoOption).toHaveAttribute("aria-keyshortcuts", "2");
+
+    fireEvent.keyDown(globalThis.window, { key: "2" });
+
+    const answerTile = page
+      .getByRole("group", { name: /your answer/iu })
+      .getByRole("button", { name: /mundo/iu });
+
+    await expect.element(answerTile).toBeInTheDocument();
+
+    await expect.element(answerTile.getByText(/^2$/u)).toBeInTheDocument();
+    await expect.element(answerTile).toHaveAttribute("aria-keyshortcuts", "2");
+    await expect.element(mundoOption).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.keyDown(globalThis.window, { key: "2" });
+
+    await expect
+      .element(
+        page.getByRole("group", { name: /your answer/iu }).getByRole("button", { name: /mundo/iu }),
+      )
+      .not.toBeInTheDocument();
+
+    await expect.element(mundoOption).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.keyDown(globalThis.window, { key: "1" });
+    fireEvent.keyDown(globalThis.window, { key: "2" });
+
+    await expect.element(page.getByRole("button", { name: /check/iu })).toBeEnabled();
+  });
+
+  it("toggles fill-blank word-bank options from number shortcuts", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        steps: [
+          buildSerializedStep({
+            content: {
+              answers: ["cat"],
+              distractors: ["dog"],
+              feedback: "Nice work",
+              template: "The [BLANK] sleeps",
+            },
+            fillBlankOptions: [
+              buildWordBankOption({ word: "dog" }),
+              buildWordBankOption({ word: "cat" }),
+            ],
+            kind: "fillBlank",
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    const wordBank = page.getByRole("group", { name: /word bank/iu });
+    const catOption = wordBank.getByRole("button", { exact: true, name: "cat" });
+
+    await expect.element(catOption.getByText(/^2$/u)).toBeInTheDocument();
+    await expect.element(catOption).toHaveAttribute("aria-keyshortcuts", "2");
+
+    fireEvent.keyDown(globalThis.window, { key: "2" });
+
+    await expect.element(page.getByRole("button", { name: /tap to remove/iu })).toBeInTheDocument();
+    await expect.element(page.getByRole("button", { name: /check/iu })).toBeEnabled();
+
+    fireEvent.keyDown(globalThis.window, { key: "2" });
+
+    await expect
+      .element(page.getByRole("button", { name: /tap to remove/iu }))
+      .not.toBeInTheDocument();
+
+    await expect.element(page.getByRole("button", { name: /check/iu })).toBeDisabled();
+  });
+
   it("shows reading word translations from the prompt sentence", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/components/_utils/fill-blank-state.ts
+++ b/packages/player/src/components/_utils/fill-blank-state.ts
@@ -1,0 +1,33 @@
+import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
+
+type BlankValue = { sourceIndex: number | null; word: string };
+export type BlankState = (BlankValue | null)[];
+export type WordPlacement = { option: WordBankOption; sourceIndex: number };
+
+/**
+ * Fill-blank answer state tracks source tile indexes only for interaction.
+ * The selected-answer contract remains the original string array.
+ */
+export function getBlankWords(blanks: BlankState): (string | null)[] {
+  return blanks.map((blank) => blank?.word ?? null);
+}
+
+/**
+ * Complete blanks can be serialized into the public answer shape. Incomplete
+ * blanks return null so callers do not accidentally submit partial answers.
+ */
+function isComplete(blanks: BlankState): blanks is BlankValue[] {
+  return blanks.every((blank) => blank !== null);
+}
+
+/**
+ * Converts complete internal blank state back to the public answer shape. Null
+ * means the learner has not filled every blank yet.
+ */
+export function getCompletedUserAnswers(blanks: BlankState): string[] | null {
+  if (!isComplete(blanks)) {
+    return null;
+  }
+
+  return blanks.map((blank) => blank.word);
+}

--- a/packages/player/src/components/_utils/match-columns.ts
+++ b/packages/player/src/components/_utils/match-columns.ts
@@ -1,0 +1,152 @@
+export type Pair = { left: string; right: string };
+export type ItemVisualState = "correct" | "idle" | "incorrectFlash" | "selected";
+export type MatchSide = "left" | "right";
+export type MatchItemData = { id: string; label: string; side: MatchSide };
+export type MatchSelection = MatchItemData;
+export type MatchAttempt = { leftId: string; pair: Pair; rightId: string };
+
+/**
+ * Match-column content only stores display labels, and duplicate labels are
+ * valid authored content. The player still needs one identity per visible
+ * button so solving one duplicate does not lock every duplicate label.
+ */
+export function buildLeftMatchItems(pairs: Pair[]): MatchItemData[] {
+  return pairs.map((pair, index) => ({ id: `left:${index}`, label: pair.left, side: "left" }));
+}
+
+/**
+ * Right-side labels are already shuffled before they reach the component, so
+ * rendered order is the stable identity available to the player.
+ */
+export function buildRightMatchItems(labels: string[]): MatchItemData[] {
+  return labels.map((label, index) => ({ id: `right:${index}`, label, side: "right" }));
+}
+
+/**
+ * Correct and flashing states belong to a clicked visual item, not every item
+ * with the same label. This keeps duplicate labels independent.
+ */
+function getAttemptItemId({ attempt, side }: { attempt: MatchAttempt; side: MatchSide }): string {
+  return side === "left" ? attempt.leftId : attempt.rightId;
+}
+
+/**
+ * The answer contract still uses labels, while local ids remember which
+ * rendered buttons should become locked after a correct match.
+ */
+export function buildMatchAttempt({
+  current,
+  selected,
+}: {
+  current: MatchSelection;
+  selected: MatchSelection;
+}): MatchAttempt {
+  if (current.side === "left") {
+    return {
+      leftId: current.id,
+      pair: { left: current.label, right: selected.label },
+      rightId: selected.id,
+    };
+  }
+
+  return {
+    leftId: selected.id,
+    pair: { left: selected.label, right: current.label },
+    rightId: current.id,
+  };
+}
+
+/**
+ * A visible button is matched when its local id was used in a successful pair.
+ * Labels are intentionally ignored because duplicate labels need independent
+ * state.
+ */
+export function isItemMatched({
+  correctMatches,
+  item,
+}: {
+  correctMatches: MatchAttempt[];
+  item: MatchItemData;
+}): boolean {
+  return correctMatches.some(
+    (match) => getAttemptItemId({ attempt: match, side: item.side }) === item.id,
+  );
+}
+
+/**
+ * Resolves each visible item into the state used by both styling and locking.
+ */
+export function getItemVisualState({
+  correctMatches,
+  flashingMatch,
+  item,
+  selected,
+}: {
+  correctMatches: MatchAttempt[];
+  flashingMatch: MatchAttempt | null;
+  item: MatchItemData;
+  selected: MatchSelection | null;
+}): ItemVisualState {
+  if (isItemMatched({ correctMatches, item })) {
+    return "correct";
+  }
+
+  if (flashingMatch && getAttemptItemId({ attempt: flashingMatch, side: item.side }) === item.id) {
+    return "incorrectFlash";
+  }
+
+  if (selected && selected.id === item.id) {
+    return "selected";
+  }
+
+  return "idle";
+}
+
+/**
+ * Keeps the visual-state class mapping beside the state machine so each state
+ * has one styling definition.
+ */
+export function getItemClassName(state: ItemVisualState): string {
+  if (state === "correct") {
+    return "bg-success/5 border-transparent text-success opacity-75 pointer-events-none";
+  }
+
+  if (state === "incorrectFlash") {
+    return "border-destructive bg-destructive/5 animate-shake";
+  }
+
+  if (state === "selected") {
+    return "border-primary bg-primary/5";
+  }
+
+  return "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]";
+}
+
+/**
+ * Number shortcuts control one column at a time. Before a selection they pick
+ * from the left column; after a left item is selected, the same numbers pick
+ * from the right column, and vice versa for pointer-selected right items.
+ */
+export function getActiveKeyboardSide(selected: MatchSelection | null): MatchSide {
+  if (!selected) {
+    return "left";
+  }
+
+  return selected.side === "left" ? "right" : "left";
+}
+
+/**
+ * The active keyboard side determines which list receives visible number
+ * badges and which list the keydown handler reads from.
+ */
+export function getKeyboardItems({
+  activeKeyboardSide,
+  leftItems,
+  rightItems,
+}: {
+  activeKeyboardSide: MatchSide;
+  leftItems: MatchItemData[];
+  rightItems: MatchItemData[];
+}): MatchItemData[] {
+  return activeKeyboardSide === "left" ? leftItems : rightItems;
+}

--- a/packages/player/src/components/arrange-words-answer-area.tsx
+++ b/packages/player/src/components/arrange-words-answer-area.tsx
@@ -18,9 +18,11 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useCallback, useId, useMemo, useState } from "react";
 import { type StepResult } from "../player-reducer";
-import { RomanizationText } from "./romanization-text";
+import { getNumberKeyShortcut } from "../player-shortcuts";
+import { ResultKbd } from "./result-kbd";
+import { WordBankOptionContent } from "./word-bank-option-content";
 
-export type PlacedWord = WordBankOption & { id: string };
+export type PlacedWord = WordBankOption & { id: string; sourceIndex?: number };
 
 function getWordResultState(
   word: string,
@@ -39,12 +41,15 @@ function PlacedWordTile({
 }: {
   id: string;
   onClick: () => void;
-  option: WordBankOption;
+  option: PlacedWord;
   position: number;
   resultState?: "correct" | "incorrect";
 }) {
   const t = useExtracted();
   const hasResult = Boolean(resultState);
+
+  const shortcut =
+    typeof option.sourceIndex === "number" ? getNumberKeyShortcut(option.sourceIndex) : null;
 
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
     disabled: hasResult,
@@ -68,8 +73,9 @@ function PlacedWordTile({
       {...attributes}
       {...listeners}
       aria-label={ariaLabel}
+      aria-keyshortcuts={shortcut ?? undefined}
       className={cn(
-        "border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 text-base transition-all duration-150",
+        "border-border flex min-h-11 min-w-16 items-center justify-start gap-2.5 rounded-lg border px-3 py-2.5 text-left text-base transition-all duration-150",
         hasResult && "pointer-events-none",
         !hasResult &&
           "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
@@ -85,9 +91,13 @@ function PlacedWordTile({
       style={{ transform: CSS.Transform.toString(transform), transition }}
       type="button"
     >
-      <span>{option.word}</span>
+      {shortcut && (
+        <ResultKbd className="hidden lg:pointer-fine:inline-flex" isSelected>
+          {shortcut}
+        </ResultKbd>
+      )}
 
-      <RomanizationText>{option.romanization}</RomanizationText>
+      <WordBankOptionContent option={option} />
     </button>
   );
 }
@@ -95,8 +105,7 @@ function PlacedWordTile({
 function DragOverlayWord({ option }: { option: WordBankOption }) {
   return (
     <div className="bg-background border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 text-base shadow-md">
-      <span>{option.word}</span>
-      <RomanizationText>{option.romanization}</RomanizationText>
+      <WordBankOptionContent option={option} />
     </div>
   );
 }

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -5,104 +5,214 @@ import { arrayMove } from "@dnd-kit/sortable";
 import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
-import { useCallback, useId, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
+import { MAX_NUMBER_KEY_SHORTCUT, getNumberKeyShortcut } from "../player-shortcuts";
+import { useOptionKeyboard } from "../use-option-keyboard";
 import { useWordAudio } from "../use-word-audio";
 import { ArrangeWordsAnswerArea, type PlacedWord } from "./arrange-words-answer-area";
-import { RomanizationText } from "./romanization-text";
 import { InteractiveStepLayout } from "./step-layouts";
+import { WordBankOptionButton } from "./word-bank-option-content";
 
-function BankTileContent({
-  descriptionId,
-  option,
-}: {
-  descriptionId?: string;
-  option: WordBankOption;
-}) {
-  const hasDescription = Boolean(option.romanization || option.pronunciation);
-
-  return (
-    <>
-      <span>{option.word}</span>
-
-      {hasDescription && (
-        <span className="flex flex-col items-center" id={descriptionId}>
-          <RomanizationText>{option.romanization}</RomanizationText>
-
-          {option.pronunciation && (
-            <span className="text-muted-foreground text-xs">{option.pronunciation}</span>
-          )}
-        </span>
-      )}
-    </>
-  );
-}
-
-function BankTile({
-  isUsed,
-  onPlace,
-  option,
-}: {
+type WordBankTile = {
+  index: number;
   isUsed: boolean;
-  onPlace: () => void;
+  key: string;
   option: WordBankOption;
-}) {
-  const descriptionId = useId();
-  const hasDescription = Boolean(option.romanization || option.pronunciation);
+  occurrenceNumber: number;
+  shortcut: string | null;
+};
 
-  return (
-    <button
-      aria-describedby={hasDescription ? descriptionId : undefined}
-      aria-label={option.word}
-      aria-disabled={isUsed}
-      className={cn(
-        "border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 transition-all duration-150",
-        isUsed
-          ? "pointer-events-none opacity-30"
-          : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
-      )}
-      onClick={onPlace}
-      tabIndex={isUsed ? -1 : 0}
-      type="button"
-    >
-      <BankTileContent descriptionId={descriptionId} option={option} />
-    </button>
-  );
+type WordBankPlacement = { option: WordBankOption; sourceIndex: number };
+
+/**
+ * Source indexes are added when a learner chooses a tile in this session. They
+ * let duplicate words behave like distinct toggles instead of guessing from the
+ * visible word text alone.
+ */
+function hasPlacedWordSourceIndex(placedWord: PlacedWord): boolean {
+  return typeof placedWord.sourceIndex === "number";
 }
 
-function WordBank({
-  onPlace,
+/**
+ * Old saved/result answers only contain words. The occurrence number keeps that
+ * legacy shape usable by matching the first tile to the first placed copy, the
+ * second tile to the second placed copy, and so on.
+ */
+function getPlacedWordOccurrenceNumber({
+  index,
+  option,
+  words,
+}: {
+  index: number;
+  option: WordBankOption;
+  words: WordBankOption[];
+}): number {
+  return words.slice(0, index + 1).filter((item) => item.word === option.word).length;
+}
+
+/**
+ * Tile usage prefers exact source indexes when available and falls back to
+ * occurrence counting for restored answers that predate source-index tracking.
+ */
+function isWordBankTileUsed({
+  index,
+  occurrenceNumber,
+  option,
+  placedWords,
+}: {
+  index: number;
+  occurrenceNumber: number;
+  option: WordBankOption;
+  placedWords: PlacedWord[];
+}): boolean {
+  const hasSourceIndexes = placedWords.some((placedWord) => hasPlacedWordSourceIndex(placedWord));
+
+  if (hasSourceIndexes) {
+    return placedWords.some((placedWord) => placedWord.sourceIndex === index);
+  }
+
+  const usedCount = placedWords.filter((placed) => placed.word === option.word).length;
+  return usedCount >= occurrenceNumber;
+}
+
+/**
+ * Duplicate words are valid in generated word banks. Counting earlier
+ * occurrences lets each duplicate tile become unavailable only after the
+ * learner has placed that many copies of the same word.
+ */
+function getWordBankTile({
+  index,
+  option,
   placedWords,
   words,
 }: {
-  onPlace: (option: WordBankOption) => void;
-  placedWords: WordBankOption[];
+  index: number;
+  option: WordBankOption;
+  placedWords: PlacedWord[];
+  words: WordBankOption[];
+}): WordBankTile {
+  const occurrenceNumber = getPlacedWordOccurrenceNumber({ index, option, words });
+
+  return {
+    index,
+    isUsed: isWordBankTileUsed({ index, occurrenceNumber, option, placedWords }),
+    key: `bank-${option.word}-${index}`,
+    occurrenceNumber,
+    option,
+    shortcut: getNumberKeyShortcut(index),
+  };
+}
+
+/**
+ * Builds the render and keyboard model for the word bank once so pointer and
+ * number-key selection cannot disagree about which duplicate tile is still
+ * available.
+ */
+function getWordBankTiles({
+  placedWords,
+  words,
+}: {
+  placedWords: PlacedWord[];
+  words: WordBankOption[];
+}): WordBankTile[] {
+  return words.map((option, index) => getWordBankTile({ index, option, placedWords, words }));
+}
+
+/**
+ * Finds the selected answer word controlled by a bank tile. Exact source-index
+ * matches handle normal play, while occurrence matching keeps restored answers
+ * removable even though they only know the selected word text.
+ */
+function getPlacedWordIndexForTile({
+  placedWords,
+  tile,
+}: {
+  placedWords: PlacedWord[];
+  tile: WordBankTile;
+}): number | null {
+  const sourceIndexMatch = placedWords.findIndex(
+    (placedWord) => placedWord.sourceIndex === tile.index,
+  );
+
+  if (sourceIndexMatch !== -1) {
+    return sourceIndexMatch;
+  }
+
+  if (placedWords.some((placedWord) => hasPlacedWordSourceIndex(placedWord))) {
+    return null;
+  }
+
+  const matchingIndexes = placedWords.flatMap((placedWord, index) =>
+    placedWord.word === tile.option.word ? [index] : [],
+  );
+
+  return matchingIndexes[tile.occurrenceNumber - 1] ?? null;
+}
+
+function WordBank({
+  disabled,
+  onPlace,
+  onRemove,
+  placedWords,
+  words,
+}: {
+  disabled: boolean;
+  onPlace: (placement: WordBankPlacement) => void;
+  onRemove: (index: number) => void;
+  placedWords: PlacedWord[];
   words: WordBankOption[];
 }) {
   const t = useExtracted();
+  const tiles = getWordBankTiles({ placedWords, words });
+
+  const handleToggleTile = useCallback(
+    (tile: WordBankTile) => {
+      if (!tile.isUsed) {
+        onPlace({ option: tile.option, sourceIndex: tile.index });
+        return;
+      }
+
+      const placedWordIndex = getPlacedWordIndexForTile({ placedWords, tile });
+
+      if (placedWordIndex !== null) {
+        onRemove(placedWordIndex);
+      }
+    },
+    [onPlace, onRemove, placedWords],
+  );
+
+  useOptionKeyboard({
+    enabled: !disabled,
+    onSelect: (index) => {
+      const tile = tiles[index];
+
+      if (!tile) {
+        return;
+      }
+
+      handleToggleTile(tile);
+    },
+    optionCount: Math.min(words.length, MAX_NUMBER_KEY_SHORTCUT),
+  });
 
   return (
-    <div aria-label={t("Word bank")} className="flex flex-wrap gap-2.5" role="group">
-      {words.map((option, index) => {
-        const usedCount = placedWords.filter((placed) => placed.word === option.word).length;
-
-        const totalCount = words
-          .slice(0, index + 1)
-          .filter((item) => item.word === option.word).length;
-
-        const isUsed = usedCount >= totalCount;
-
-        return (
-          <BankTile
-            isUsed={isUsed}
-            // oxlint-disable-next-line react/no-array-index-key -- Words can repeat in word bank, no unique ID
-            key={`bank-${option.word}-${index}`}
-            onPlace={() => onPlace(option)}
-            option={option}
-          />
-        );
-      })}
+    <div
+      aria-label={t("Word bank")}
+      className={cn("flex flex-wrap gap-2.5", disabled && "pointer-events-none opacity-50")}
+      role="group"
+    >
+      {tiles.map((tile) => (
+        <WordBankOptionButton
+          disabled={disabled}
+          isUsed={tile.isUsed}
+          key={tile.key}
+          onToggle={() => handleToggleTile(tile)}
+          option={tile.option}
+          shortcut={tile.shortcut}
+        />
+      ))}
     </div>
   );
 }
@@ -172,13 +282,13 @@ export function ArrangeWordsInteraction({
   );
 
   const handlePlace = useCallback(
-    (option: WordBankOption) => {
+    ({ option, sourceIndex }: WordBankPlacement) => {
       if (placedWords.length >= maxAnswerLength) {
         return;
       }
 
       void play(option.audioUrl);
-      const placed: PlacedWord = { ...option, id: String(idCounter.current) };
+      const placed: PlacedWord = { ...option, id: String(idCounter.current), sourceIndex };
       idCounter.current += 1;
       const next = [...placedWords, placed];
       setPlacedWords(next);
@@ -237,7 +347,13 @@ export function ArrangeWordsInteraction({
         result={result}
       />
 
-      <WordBank onPlace={handlePlace} placedWords={placedWords} words={wordBankOptions} />
+      <WordBank
+        disabled={result !== undefined}
+        onPlace={handlePlace}
+        onRemove={handleRemove}
+        placedWords={placedWords}
+        words={wordBankOptions}
+      />
     </InteractiveStepLayout>
   );
 }

--- a/packages/player/src/components/completion-action-link.tsx
+++ b/packages/player/src/components/completion-action-link.tsx
@@ -1,21 +1,34 @@
 "use client";
 
 import { buttonVariants } from "@zoonk/ui/components/button";
-import { Kbd } from "@zoonk/ui/components/kbd";
+import { ShortcutKbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { type PlayerRoute } from "../player-context";
 import { PlayerLink } from "../player-link";
 
 export function PrimaryKbd({ children }: { children: React.ReactNode }) {
-  return (
-    <Kbd className="bg-primary-foreground/15 text-primary-foreground hidden opacity-70 lg:inline-flex">
-      {children}
-    </Kbd>
-  );
+  return <ShortcutKbd tone="inverse">{children}</ShortcutKbd>;
 }
 
 export function SecondaryKbd({ children }: { children: React.ReactNode }) {
-  return <Kbd className="hidden opacity-60 lg:inline-flex">{children}</Kbd>;
+  return <ShortcutKbd className="opacity-60">{children}</ShortcutKbd>;
+}
+
+/**
+ * Completion buttons use the short visible key label, but ARIA expects the
+ * canonical key name for keys like Escape. Keeping the conversion here avoids
+ * every completion action restating the same mapping.
+ */
+function getAriaKeyboardShortcut(shortcut: string): string {
+  if (shortcut === "Esc") {
+    return "Escape";
+  }
+
+  if (shortcut === "R") {
+    return "r";
+  }
+
+  return shortcut;
 }
 
 export function PrimaryActionLink({
@@ -31,7 +44,8 @@ export function PrimaryActionLink({
 }) {
   return (
     <PlayerLink
-      className={cn(buttonVariants({ size: "lg" }), "w-full lg:justify-between", className)}
+      aria-keyshortcuts={getAriaKeyboardShortcut(shortcut)}
+      className={cn(buttonVariants({ size: "lg" }), "w-full", className)}
       href={href}
     >
       {children}
@@ -53,7 +67,8 @@ export function SecondaryActionLink({
 }) {
   return (
     <PlayerLink
-      className={cn(buttonVariants({ variant: "outline" }), "w-full lg:justify-between", className)}
+      aria-keyshortcuts={getAriaKeyboardShortcut(shortcut)}
+      className={cn(buttonVariants({ variant: "outline" }), "w-full", className)}
       href={href}
     >
       {children}

--- a/packages/player/src/components/completion-auth-branch.tsx
+++ b/packages/player/src/components/completion-auth-branch.tsx
@@ -45,7 +45,7 @@ function SecondaryActions({
     <PlayerLink
       className={cn(
         buttonVariants({ variant: isInline ? "outline" : "default" }),
-        isInline ? "flex-1 lg:justify-between" : "w-full lg:justify-between",
+        isInline ? "flex-1" : "w-full",
       )}
       href={chapterHref}
     >
@@ -56,7 +56,8 @@ function SecondaryActions({
 
   const restartButton = (
     <Button
-      className={cn(isInline ? "flex-1" : "w-full", "lg:justify-between")}
+      aria-keyshortcuts="r"
+      className={cn(isInline ? "flex-1" : "w-full")}
       onClick={onRestart}
       variant="outline"
     >

--- a/packages/player/src/components/completion-milestone-shell.tsx
+++ b/packages/player/src/components/completion-milestone-shell.tsx
@@ -106,7 +106,7 @@ export function CompletionMilestoneContinueButton({
   onContinue: () => void;
 }) {
   return (
-    <Button className="w-full lg:justify-between" onClick={onContinue} size="lg">
+    <Button aria-keyshortcuts="Enter" className="w-full" onClick={onContinue} size="lg">
       {children}
       <PrimaryKbd>Enter</PrimaryKbd>
     </Button>

--- a/packages/player/src/components/fill-blank-step.test.tsx
+++ b/packages/player/src/components/fill-blank-step.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { type ReactNode, StrictMode, useCallback, useState } from "react";
 import { type Mock, afterEach, describe, expect, it, vi } from "vitest";
 import { buildWordBankOption } from "../_test-utils/player-test-data";
@@ -102,13 +102,8 @@ describe("fill in the blank step", () => {
     );
 
     const wordBank = screen.getByRole("group", { name: /word bank/iu });
-    const buttons = [...wordBank.querySelectorAll("button")];
-    const alphaButton = buttons.find((button) => button.textContent === "alpha");
-    const betaButton = buttons.find((button) => button.textContent === "beta");
-
-    if (!alphaButton || !betaButton) {
-      throw new Error("Expected alpha and beta buttons to render.");
-    }
+    const alphaButton = within(wordBank).getByRole("button", { name: "alpha" });
+    const betaButton = within(wordBank).getByRole("button", { name: "beta" });
 
     fireEvent.click(alphaButton);
     fireEvent.click(betaButton);
@@ -226,10 +221,8 @@ describe("fill in the blank step", () => {
     );
 
     const wordBank = screen.getByRole("group", { name: /word bank/iu });
-    const buttons = [...wordBank.querySelectorAll("button")];
-
-    expect(buttons).toHaveLength(2);
-    expect(buttons.some((btn) => btn.textContent === "Guten Morgen")).toBeTruthy();
-    expect(buttons.some((btn) => btn.textContent === "Guten Tag")).toBeTruthy();
+    expect(within(wordBank).getAllByRole("button")).toHaveLength(2);
+    expect(within(wordBank).getByRole("button", { name: "Guten Morgen" })).toBeTruthy();
+    expect(within(wordBank).getByRole("button", { name: "Guten Tag" })).toBeTruthy();
   });
 });

--- a/packages/player/src/components/fill-blank-step.tsx
+++ b/packages/player/src/components/fill-blank-step.tsx
@@ -1,15 +1,19 @@
 "use client";
 
-import {
-  type SerializedStep,
-  type WordBankOption,
-} from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { parseStepContent } from "@zoonk/core/steps/contract/content";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
+import {
+  type BlankState,
+  type WordPlacement,
+  getBlankWords,
+  getCompletedUserAnswers,
+} from "./_utils/fill-blank-state";
 import { getTemplateRomanization } from "./_utils/template-romanization";
+import { FillBlankWordBank } from "./fill-blank-word-bank";
 import { InlineFeedback } from "./inline-feedback";
 import { QuestionText } from "./question-text";
 import { RomanizationText } from "./romanization-text";
@@ -119,82 +123,6 @@ function TemplateText({
   );
 }
 
-function WordTile({
-  isUsed,
-  onPlace,
-  option,
-}: {
-  isUsed: boolean;
-  onPlace: () => void;
-  option: WordBankOption;
-}) {
-  return (
-    <button
-      aria-disabled={isUsed}
-      className={cn(
-        "border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 transition-all duration-150",
-        isUsed
-          ? "pointer-events-none opacity-50"
-          : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
-      )}
-      onClick={onPlace}
-      tabIndex={isUsed ? -1 : 0}
-      type="button"
-    >
-      <span>{option.word}</span>
-
-      <RomanizationText>{option.romanization}</RomanizationText>
-    </button>
-  );
-}
-
-function WordBank({
-  blanks,
-  disabled,
-  onPlaceWord,
-  options,
-}: {
-  blanks: (string | null)[];
-  disabled: boolean;
-  onPlaceWord: (word: string) => void;
-  options: WordBankOption[];
-}) {
-  const t = useExtracted();
-  const usedWords = blanks.filter(Boolean);
-
-  return (
-    <div
-      aria-label={t("Word bank")}
-      className={cn("flex flex-wrap gap-2.5", disabled && "pointer-events-none opacity-50")}
-      role="group"
-    >
-      {options.map((option, index) => {
-        const usedCount = usedWords.filter((used) => used === option.word).length;
-
-        const totalCount = options
-          .slice(0, index + 1)
-          .filter((item) => item.word === option.word).length;
-
-        const isUsed = usedCount >= totalCount;
-
-        return (
-          <WordTile
-            isUsed={isUsed}
-            // oxlint-disable-next-line react/no-array-index-key -- Words can repeat in word bank, no unique ID
-            key={`${option.word}-${index}`}
-            onPlace={() => onPlaceWord(option.word)}
-            option={option}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-function isComplete(blanks: (string | null)[]): blanks is string[] {
-  return blanks.every((blank) => blank !== null);
-}
-
 export function FillBlankStep({
   onSelectAnswer,
   result,
@@ -222,16 +150,16 @@ export function FillBlankStep({
     });
   }, [content.romanizations, content.answers, content.template]);
 
-  const [blanks, setBlanks] = useState<(string | null)[]>(() => {
+  const [blanks, setBlanks] = useState<BlankState>(() => {
     if (result?.answer?.kind === "fillBlank") {
-      return result.answer.userAnswers;
+      return result.answer.userAnswers.map((word) => ({ sourceIndex: null, word }));
     }
 
     return Array.from({ length: blankCount }, () => null);
   });
 
   const handlePlaceWord = useCallback(
-    (word: string) => {
+    ({ option, sourceIndex }: WordPlacement) => {
       const firstEmptyIndex = blanks.indexOf(null);
 
       if (firstEmptyIndex === -1) {
@@ -239,11 +167,13 @@ export function FillBlankStep({
       }
 
       const next = [...blanks];
-      next[firstEmptyIndex] = word;
+      next[firstEmptyIndex] = { sourceIndex, word: option.word };
       setBlanks(next);
 
-      if (isComplete(next)) {
-        onSelectAnswer(step.id, { kind: "fillBlank", userAnswers: next });
+      const userAnswers = getCompletedUserAnswers(next);
+
+      if (userAnswers) {
+        onSelectAnswer(step.id, { kind: "fillBlank", userAnswers });
       }
     },
     [blanks, onSelectAnswer, step.id],
@@ -272,7 +202,7 @@ export function FillBlankStep({
 
       <TemplateText
         answers={content.answers}
-        blanks={blanks}
+        blanks={getBlankWords(blanks)}
         hasResult={hasResult}
         onRemoveWord={handleRemoveWord}
         template={content.template}
@@ -280,10 +210,11 @@ export function FillBlankStep({
 
       <RomanizationText>{templateRomanization}</RomanizationText>
 
-      <WordBank
+      <FillBlankWordBank
         blanks={blanks}
         disabled={hasResult}
         onPlaceWord={handlePlaceWord}
+        onRemoveWord={handleRemoveWord}
         options={step.fillBlankOptions}
       />
 

--- a/packages/player/src/components/fill-blank-word-bank.tsx
+++ b/packages/player/src/components/fill-blank-word-bank.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { cn } from "@zoonk/ui/lib/utils";
+import { useExtracted } from "next-intl";
+import { useCallback } from "react";
+import { MAX_NUMBER_KEY_SHORTCUT, getNumberKeyShortcut } from "../player-shortcuts";
+import { useOptionKeyboard } from "../use-option-keyboard";
+import { type BlankState, type WordPlacement } from "./_utils/fill-blank-state";
+import { WordBankOptionButton } from "./word-bank-option-content";
+
+type WordTileData = {
+  index: number;
+  isUsed: boolean;
+  key: string;
+  occurrenceNumber: number;
+  option: WordBankOption;
+  shortcut: string | null;
+};
+
+/**
+ * Restored results do not have source indexes, so duplicates fall back to the
+ * same occurrence counting used before shortcuts were introduced.
+ */
+function getWordOccurrenceNumber({
+  index,
+  option,
+  options,
+}: {
+  index: number;
+  option: WordBankOption;
+  options: WordBankOption[];
+}): number {
+  return options.slice(0, index + 1).filter((item) => item.word === option.word).length;
+}
+
+/**
+ * Source-index matches make each numbered tile reversible. Occurrence fallback
+ * keeps server-provided answer strings readable when the component is restored
+ * from a checked result.
+ */
+function isWordTileUsed({
+  blanks,
+  index,
+  occurrenceNumber,
+  option,
+}: {
+  blanks: BlankState;
+  index: number;
+  occurrenceNumber: number;
+  option: WordBankOption;
+}): boolean {
+  const hasSourceIndexes = blanks.some((blank) => typeof blank?.sourceIndex === "number");
+
+  if (hasSourceIndexes) {
+    return blanks.some((blank) => blank?.sourceIndex === index);
+  }
+
+  const usedCount = blanks.filter((blank) => blank?.word === option.word).length;
+  return usedCount >= occurrenceNumber;
+}
+
+/**
+ * Builds one model for rendering and keyboard selection so click and number
+ * shortcuts stay aligned even when generated word banks contain duplicates.
+ */
+function getWordTileData({
+  blanks,
+  index,
+  option,
+  options,
+}: {
+  blanks: BlankState;
+  index: number;
+  option: WordBankOption;
+  options: WordBankOption[];
+}): WordTileData {
+  const occurrenceNumber = getWordOccurrenceNumber({ index, option, options });
+
+  return {
+    index,
+    isUsed: isWordTileUsed({ blanks, index, occurrenceNumber, option }),
+    key: `${option.word}-${index}`,
+    occurrenceNumber,
+    option,
+    shortcut: getNumberKeyShortcut(index),
+  };
+}
+
+/**
+ * Finds the blank controlled by a used bank tile. Exact source indexes are the
+ * normal path, with occurrence matching for restored string-only answers.
+ */
+function getBlankIndexForTile({
+  blanks,
+  tile,
+}: {
+  blanks: BlankState;
+  tile: WordTileData;
+}): number | null {
+  const sourceIndexMatch = blanks.findIndex((blank) => blank?.sourceIndex === tile.index);
+
+  if (sourceIndexMatch !== -1) {
+    return sourceIndexMatch;
+  }
+
+  if (blanks.some((blank) => typeof blank?.sourceIndex === "number")) {
+    return null;
+  }
+
+  const matchingIndexes = blanks.flatMap((blank, index) =>
+    blank?.word === tile.option.word ? [index] : [],
+  );
+
+  return matchingIndexes[tile.occurrenceNumber - 1] ?? null;
+}
+
+/**
+ * Renders the fill-blank word bank and owns its number-key toggle behavior so
+ * FillBlankStep can stay focused on the template and answer contract.
+ */
+export function FillBlankWordBank({
+  blanks,
+  disabled,
+  onPlaceWord,
+  onRemoveWord,
+  options,
+}: {
+  blanks: BlankState;
+  disabled: boolean;
+  onPlaceWord: (placement: WordPlacement) => void;
+  onRemoveWord: (blankIndex: number) => void;
+  options: WordBankOption[];
+}) {
+  const t = useExtracted();
+  const tiles = options.map((option, index) => getWordTileData({ blanks, index, option, options }));
+
+  const handleToggleTile = useCallback(
+    (tile: WordTileData) => {
+      if (!tile.isUsed) {
+        onPlaceWord({ option: tile.option, sourceIndex: tile.index });
+        return;
+      }
+
+      const blankIndex = getBlankIndexForTile({ blanks, tile });
+
+      if (blankIndex !== null) {
+        onRemoveWord(blankIndex);
+      }
+    },
+    [blanks, onPlaceWord, onRemoveWord],
+  );
+
+  useOptionKeyboard({
+    enabled: !disabled,
+    onSelect: (index) => {
+      const tile = tiles[index];
+
+      if (!tile) {
+        return;
+      }
+
+      handleToggleTile(tile);
+    },
+    optionCount: Math.min(options.length, MAX_NUMBER_KEY_SHORTCUT),
+  });
+
+  return (
+    <div
+      aria-label={t("Word bank")}
+      className={cn("flex flex-wrap gap-2.5", disabled && "pointer-events-none opacity-50")}
+      role="group"
+    >
+      {tiles.map((tile) => (
+        <WordBankOptionButton
+          disabled={disabled}
+          isUsed={tile.isUsed}
+          key={tile.key}
+          onToggle={() => handleToggleTile(tile)}
+          option={tile.option}
+          shortcut={tile.shortcut}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/player/src/components/match-columns-step.tsx
+++ b/packages/player/src/components/match-columns-step.tsx
@@ -8,148 +8,54 @@ import { useExtracted } from "next-intl";
 import { Fragment, useCallback, useMemo, useRef, useState } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type SelectedAnswer } from "../player-reducer";
+import { MAX_NUMBER_KEY_SHORTCUT, getNumberKeyShortcut } from "../player-shortcuts";
+import { useOptionKeyboard } from "../use-option-keyboard";
+import {
+  type ItemVisualState,
+  type MatchAttempt,
+  type MatchItemData,
+  type MatchSelection,
+  type MatchSide,
+  buildLeftMatchItems,
+  buildMatchAttempt,
+  buildRightMatchItems,
+  getActiveKeyboardSide,
+  getItemClassName,
+  getItemVisualState,
+  getKeyboardItems,
+  isItemMatched,
+} from "./_utils/match-columns";
 import { stripWrappingQuotes } from "./_utils/strip-wrapping-quotes";
 import { QuestionText } from "./question-text";
+import { ResultKbd } from "./result-kbd";
 import { InteractiveStepLayout } from "./step-layouts";
-
-type Pair = { left: string; right: string };
-type ItemVisualState = "correct" | "idle" | "incorrectFlash" | "selected";
-type MatchSide = "left" | "right";
 
 const FLASH_DURATION = 800;
 
-type MatchItemData = { id: string; label: string; side: MatchSide };
-type MatchSelection = MatchItemData;
-type MatchAttempt = { leftId: string; pair: Pair; rightId: string };
-
-/**
- * Match-column content only stores display labels, and duplicate labels are valid authored content.
- * The player still needs one identity per visible button so solving one duplicate does not lock every
- * other button with the same text.
- */
-function buildLeftMatchItems(pairs: Pair[]): MatchItemData[] {
-  return pairs.map((pair, index) => ({ id: `left:${index}`, label: pair.left, side: "left" }));
-}
-
-/**
- * Right-side labels are already shuffled before they reach the component, so their rendered order is
- * the only stable identity available. That is enough because equal labels are interchangeable for
- * answer checking, but each visible button must still be selectable exactly once.
- */
-function buildRightMatchItems(labels: string[]): MatchItemData[] {
-  return labels.map((label, index) => ({ id: `right:${index}`, label, side: "right" }));
-}
-
-/**
- * Correct and flashing states belong to a clicked visual item, not every item with the same label.
- * This keeps duplicate labels independent while preserving the label-only answer contract.
- */
-function getAttemptItemId({ attempt, side }: { attempt: MatchAttempt; side: MatchSide }): string {
-  return side === "left" ? attempt.leftId : attempt.rightId;
-}
-
-/**
- * The answer contract still uses labels, so the pair sent to shared checking is built from the two
- * selected buttons while the local ids remember which rendered buttons should become locked.
- */
-function buildMatchAttempt({
-  current,
-  selected,
-}: {
-  current: MatchSelection;
-  selected: MatchSelection;
-}): MatchAttempt {
-  if (current.side === "left") {
-    return {
-      leftId: current.id,
-      pair: { left: current.label, right: selected.label },
-      rightId: selected.id,
-    };
-  }
-
-  return {
-    leftId: selected.id,
-    pair: { left: selected.label, right: current.label },
-    rightId: current.id,
-  };
-}
-
-/**
- * A visible button is matched when its local id was used in a successful pair. Labels are intentionally
- * ignored here because duplicate labels need independent state.
- */
-function isItemMatched({
-  correctMatches,
-  item,
-}: {
-  correctMatches: MatchAttempt[];
-  item: MatchItemData;
-}): boolean {
-  return correctMatches.some(
-    (match) => getAttemptItemId({ attempt: match, side: item.side }) === item.id,
-  );
-}
-
-function getItemVisualState({
-  correctMatches,
-  flashingMatch,
-  item,
-  selected,
-}: {
-  correctMatches: MatchAttempt[];
-  flashingMatch: MatchAttempt | null;
-  item: MatchItemData;
-  selected: MatchSelection | null;
-}): ItemVisualState {
-  if (isItemMatched({ correctMatches, item })) {
-    return "correct";
-  }
-
-  if (flashingMatch && getAttemptItemId({ attempt: flashingMatch, side: item.side }) === item.id) {
-    return "incorrectFlash";
-  }
-
-  if (selected && selected.id === item.id) {
-    return "selected";
-  }
-
-  return "idle";
-}
-
-function getItemClassName(state: ItemVisualState): string {
-  if (state === "correct") {
-    return "bg-success/5 border-transparent text-success opacity-75 pointer-events-none";
-  }
-
-  if (state === "incorrectFlash") {
-    return "border-destructive bg-destructive/5 animate-shake";
-  }
-
-  if (state === "selected") {
-    return "border-primary bg-primary/5";
-  }
-
-  return "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]";
-}
-
 function MatchItem({
+  isShortcutActive,
   label,
   onTap,
+  shortcut,
   state,
 }: {
+  isShortcutActive: boolean;
   label: string;
   onTap: () => void;
+  shortcut: string | null;
   state: ItemVisualState;
 }) {
   const isLocked = state === "correct" || state === "incorrectFlash";
   const displayLabel = stripWrappingQuotes(label);
+  const visibleShortcut = !isLocked && isShortcutActive ? shortcut : null;
 
   return (
     <button
       aria-label={displayLabel}
+      aria-keyshortcuts={visibleShortcut ?? undefined}
       aria-pressed={state === "selected"}
       className={cn(
-        "border-border flex min-h-11 items-center rounded-lg border px-2.5 py-2.5 text-left text-sm wrap-break-word transition-all duration-150 sm:px-4 sm:py-3.5 sm:text-base",
+        "border-border flex min-h-11 items-center gap-2 rounded-lg border px-2.5 py-2.5 text-left text-sm wrap-break-word transition-all duration-150 sm:px-4 sm:py-3.5 sm:text-base",
         getItemClassName(state),
       )}
       aria-disabled={isLocked || undefined}
@@ -157,12 +63,25 @@ function MatchItem({
       onClick={onTap}
       type="button"
     >
-      <span>{displayLabel}</span>
+      {shortcut && (
+        <ResultKbd
+          className={cn(
+            "hidden shrink-0 lg:pointer-fine:inline-flex",
+            !visibleShortcut && "invisible",
+          )}
+          isSelected={state === "selected"}
+        >
+          {shortcut}
+        </ResultKbd>
+      )}
+
+      <span className="min-w-0">{displayLabel}</span>
     </button>
   );
 }
 
 function MatchGrid({
+  activeKeyboardSide,
   correctMatches,
   flashingMatch,
   leftItems,
@@ -170,6 +89,7 @@ function MatchGrid({
   rightItems,
   selected,
 }: {
+  activeKeyboardSide: MatchSide;
   correctMatches: MatchAttempt[];
   flashingMatch: MatchAttempt | null;
   leftItems: MatchItemData[];
@@ -202,8 +122,21 @@ function MatchGrid({
 
         return (
           <Fragment key={left.id}>
-            <MatchItem label={left.label} onTap={() => onTap(left)} state={leftState} />
-            <MatchItem label={right.label} onTap={() => onTap(right)} state={rightState} />
+            <MatchItem
+              isShortcutActive={activeKeyboardSide === "left"}
+              label={left.label}
+              onTap={() => onTap(left)}
+              shortcut={getNumberKeyShortcut(index)}
+              state={leftState}
+            />
+
+            <MatchItem
+              isShortcutActive={activeKeyboardSide === "right"}
+              label={right.label}
+              onTap={() => onTap(right)}
+              shortcut={getNumberKeyShortcut(index)}
+              state={rightState}
+            />
           </Fragment>
         );
       })}
@@ -235,6 +168,9 @@ export function MatchColumnsStep({
   const [flashingMatch, setFlashingMatch] = useState<MatchAttempt | null>(null);
   const [mistakes, setMistakes] = useState(0);
   const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const allMatched = correctMatches.length === content.pairs.length;
+  const activeKeyboardSide = getActiveKeyboardSide(selected);
+  const keyboardItems = getKeyboardItems({ activeKeyboardSide, leftItems, rightItems });
 
   const handleTap = useCallback(
     (item: MatchItemData) => {
@@ -292,7 +228,18 @@ export function MatchColumnsStep({
     [content, correctMatches, flashingMatch, mistakes, onSelectAnswer, selected, step.id, trigger],
   );
 
-  const allMatched = correctMatches.length === content.pairs.length;
+  useOptionKeyboard({
+    enabled: !allMatched && flashingMatch === null,
+    onSelect: (index) => {
+      const item = keyboardItems[index];
+
+      if (item) {
+        handleTap(item);
+      }
+    },
+    optionCount: Math.min(keyboardItems.length, MAX_NUMBER_KEY_SHORTCUT),
+  });
+
   const question = content.question ?? t("Match the pairs.");
 
   return (
@@ -300,6 +247,7 @@ export function MatchColumnsStep({
       <QuestionText>{question}</QuestionText>
 
       <MatchGrid
+        activeKeyboardSide={activeKeyboardSide}
         correctMatches={correctMatches}
         flashingMatch={flashingMatch}
         leftItems={leftItems}

--- a/packages/player/src/components/option-card.tsx
+++ b/packages/player/src/components/option-card.tsx
@@ -21,6 +21,7 @@ export function OptionCard({
   return (
     <button
       aria-checked={isSelected}
+      aria-keyshortcuts={String(index + 1)}
       className={cn(
         "focus-visible:border-ring focus-visible:ring-ring/50 flex w-full items-center gap-3 rounded-xl border px-4 py-3.5 text-left transition-all duration-150 outline-none focus-visible:ring-[3px]",
         !disabled && !isSelected && "border-border hover:bg-accent",

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { Button } from "@zoonk/ui/components/button";
+import { ShortcutKbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { PauseIcon, Volume2Icon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { useState } from "react";
-import { PLAYER_AUDIO_KEYBOARD_SHORTCUT, useSharedPlayerAudio } from "../player-audio-context";
+import { useSharedPlayerAudio } from "../player-audio-context";
+import { PLAYER_AUDIO_KEYBOARD_SHORTCUT } from "../player-shortcuts";
 import { useWordAudio } from "../use-word-audio";
 
 type PlayAudioButtonVariant = "filled" | "outline" | "text";
@@ -97,13 +99,17 @@ export function PlayAudioButton({
       <Button
         aria-label={label}
         aria-keyshortcuts={keyboardShortcut}
-        className={className}
+        className={cn("relative", className)}
         onClick={handleClick}
         size={size === "md" ? "icon-lg" : "icon"}
         type="button"
         variant="outline"
       >
         <Icon aria-hidden className={size === "md" ? "size-5" : "size-4"} />
+
+        {keyboardShortcut && (
+          <ShortcutKbd variant="badge">{keyboardShortcut.toUpperCase()}</ShortcutKbd>
+        )}
       </Button>
     );
   }
@@ -113,7 +119,7 @@ export function PlayAudioButton({
       aria-label={label}
       aria-keyshortcuts={keyboardShortcut}
       className={cn(
-        "bg-primary text-primary-foreground flex items-center justify-center rounded-full transition-all duration-150",
+        "bg-primary text-primary-foreground relative flex items-center justify-center rounded-full transition-all duration-150",
         "hover:bg-primary/90 focus-visible:ring-ring/50 outline-none hover:scale-105 focus-visible:ring-[3px] active:scale-95",
         size === "md" ? "size-14" : "size-12",
         className,
@@ -122,6 +128,10 @@ export function PlayAudioButton({
       type="button"
     >
       <Icon className={size === "md" ? "size-6" : "size-5"} />
+
+      {keyboardShortcut && (
+        <ShortcutKbd variant="badge">{keyboardShortcut.toUpperCase()}</ShortcutKbd>
+      )}
     </button>
   );
 }

--- a/packages/player/src/components/player-header.tsx
+++ b/packages/player/src/components/player-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { buttonVariants } from "@zoonk/ui/components/button";
+import { ShortcutKbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { XIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
@@ -25,10 +26,12 @@ export function PlayerCloseLink({ className, href }: { className?: string; href:
 
   return (
     <PlayerLink
-      className={cn(buttonVariants({ size: "icon", variant: "ghost" }), className)}
+      aria-keyshortcuts="Escape"
+      className={cn("relative", buttonVariants({ size: "icon", variant: "ghost" }), className)}
       href={href}
     >
       <XIcon />
+      <ShortcutKbd variant="badge">Esc</ShortcutKbd>
       <span className="sr-only">{t("Close")}</span>
     </PlayerLink>
   );

--- a/packages/player/src/components/result-kbd.tsx
+++ b/packages/player/src/components/result-kbd.tsx
@@ -1,12 +1,19 @@
 import { Kbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 
+/**
+ * Answer badges reuse keyboard styling for compact numbering and shortcut
+ * hints. Callers pass display classes because choice options intentionally show
+ * their numbers on every device, while shortcut-only hints are desktop-only.
+ */
 export function ResultKbd({
   children,
+  className,
   isSelected,
   resultState,
 }: {
   children: React.ReactNode;
+  className?: string;
   isSelected?: boolean;
   resultState?: "correct" | "incorrect";
 }) {
@@ -17,6 +24,7 @@ export function ResultKbd({
         isSelected && !resultState && "bg-primary text-primary-foreground",
         resultState === "correct" && "text-success",
         resultState === "incorrect" && "text-destructive",
+        className,
       )}
     >
       {children}

--- a/packages/player/src/components/select-image-step.tsx
+++ b/packages/player/src/components/select-image-step.tsx
@@ -12,6 +12,7 @@ import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { useOptionKeyboard } from "../use-option-keyboard";
 import { InlineFeedback } from "./inline-feedback";
 import { QuestionText } from "./question-text";
+import { ResultKbd } from "./result-kbd";
 import { InteractiveStepLayout } from "./step-layouts";
 
 function getSelectedOptionId(selectedAnswer?: SelectedAnswer): string | null {
@@ -111,6 +112,7 @@ function ImageWithFallback({ alt, url }: { alt: string; url?: string }) {
 
 function ImageOptionCard({
   disabled,
+  index,
   isDimmed,
   isSelected,
   onSelect,
@@ -120,6 +122,7 @@ function ImageOptionCard({
   url,
 }: {
   disabled: boolean;
+  index: number;
   isDimmed: boolean;
   isSelected: boolean;
   onSelect: () => void;
@@ -134,6 +137,7 @@ function ImageOptionCard({
     <button
       aria-label={prompt}
       aria-checked={isSelected}
+      aria-keyshortcuts={String(index + 1)}
       className={cn(
         "focus-visible:border-ring focus-visible:ring-ring/50 relative overflow-hidden rounded-xl border-2 transition-all duration-150 outline-none focus-visible:ring-[3px]",
         disabled && "pointer-events-none",
@@ -151,6 +155,12 @@ function ImageOptionCard({
     >
       <ImageWithFallback alt={prompt} url={url} />
 
+      <span className="absolute top-2 left-2 hidden lg:pointer-fine:block">
+        <ResultKbd isSelected={isSelected} resultState={resultState ?? undefined}>
+          {index + 1}
+        </ResultKbd>
+      </span>
+
       {!resultState && isSelected && (
         <span className="bg-info absolute top-2 right-2 flex size-7 items-center justify-center rounded-full text-white">
           <CircleCheck aria-hidden="true" className="size-4" />
@@ -160,7 +170,7 @@ function ImageOptionCard({
       {resultState && statusLabel && (
         <span
           className={cn(
-            "absolute top-2 left-2 flex items-center gap-1 rounded-full border bg-white/95 px-2.5 py-1 text-xs font-semibold shadow-sm backdrop-blur-sm",
+            "absolute top-2 right-2 flex items-center gap-1 rounded-full border bg-white/95 px-2.5 py-1 text-xs font-semibold shadow-sm backdrop-blur-sm",
             resultState === "correct" && "border-success/20 text-success",
             resultState === "incorrect" && "border-destructive/20 text-destructive",
           )}
@@ -239,6 +249,7 @@ export function SelectImageStep({
           return (
             <ImageOptionCard
               disabled={hasResult}
+              index={index}
               isDimmed={isDimmed}
               isSelected={isSelected}
               key={option.id}

--- a/packages/player/src/components/step-action-button.tsx
+++ b/packages/player/src/components/step-action-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@zoonk/ui/components/button";
+import { ShortcutKbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { usePlayerRuntime } from "../player-context";
@@ -40,11 +41,17 @@ export function StepActionButton({
 
   const buttonProps = {
     ...props,
+    "aria-keyshortcuts": "Enter",
     className: cn("w-full", className),
     disabled: model.disabled,
     onClick: actionByRun[model.run],
     size: "lg" as const,
   };
 
-  return <Button {...buttonProps}>{labelByButton[model.button]}</Button>;
+  return (
+    <Button {...buttonProps}>
+      {labelByButton[model.button]}
+      <ShortcutKbd tone="inverse">Enter</ShortcutKbd>
+    </Button>
+  );
 }

--- a/packages/player/src/components/swipe-navigable-step-layout.tsx
+++ b/packages/player/src/components/swipe-navigable-step-layout.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { Button } from "@zoonk/ui/components/button";
+import { ShortcutKbd } from "@zoonk/ui/components/kbd";
+import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { type TouchEvent, useEffect, useRef } from "react";
@@ -52,13 +54,14 @@ function DesktopNavigationButton({
     <Button
       aria-label={ariaLabel}
       aria-keyshortcuts={ariaKeyshortcuts}
-      className={DESKTOP_NAVIGATION_CONTROL_CLASS}
+      className={cn("relative", DESKTOP_NAVIGATION_CONTROL_CLASS)}
       onClick={onClick}
       size="icon-lg"
       type="button"
       variant="outline"
     >
       {children}
+      <ShortcutKbd variant="badge">{ariaKeyshortcuts === "ArrowLeft" ? "←" : "→"}</ShortcutKbd>
     </Button>
   );
 }

--- a/packages/player/src/components/word-bank-option-content.tsx
+++ b/packages/player/src/components/word-bank-option-content.tsx
@@ -1,0 +1,94 @@
+import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { cn } from "@zoonk/ui/lib/utils";
+import { useId } from "react";
+import { ResultKbd } from "./result-kbd";
+import { RomanizationText } from "./romanization-text";
+
+/**
+ * Word-bank buttons add shortcut badges and selection states around the word.
+ * Keeping the word, romanization, and pronunciation in one vertical stack
+ * prevents those surrounding controls from flattening pronunciation hints into
+ * the main text row.
+ */
+export function WordBankOptionContent({
+  descriptionId,
+  option,
+}: {
+  descriptionId?: string;
+  option: WordBankOption;
+}) {
+  const hasDescription = hasWordBankOptionDescription(option);
+
+  return (
+    <span className="flex min-w-0 flex-col items-start gap-0.5 text-left">
+      <span>{option.word}</span>
+
+      {hasDescription && (
+        <span className="flex flex-col items-start" id={descriptionId}>
+          <RomanizationText>{option.romanization}</RomanizationText>
+
+          {option.pronunciation && (
+            <span className="text-muted-foreground text-xs">{option.pronunciation}</span>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Parent buttons need to know whether a description id should be wired into
+ * aria-describedby, while this component owns the actual visual description.
+ */
+function hasWordBankOptionDescription(option: WordBankOption): boolean {
+  return Boolean(option.romanization || option.pronunciation);
+}
+
+/**
+ * Shared word-bank button chrome keeps fill-blank, reading, and listening tiles
+ * visually identical. The shortcut badge sits next to the text stack so
+ * pronunciation and romanization stay below the word instead of beside it.
+ */
+export function WordBankOptionButton({
+  disabled,
+  isUsed,
+  onToggle,
+  option,
+  shortcut,
+}: {
+  disabled: boolean;
+  isUsed: boolean;
+  onToggle: () => void;
+  option: WordBankOption;
+  shortcut: string | null;
+}) {
+  const descriptionId = useId();
+  const hasDescription = hasWordBankOptionDescription(option);
+
+  return (
+    <button
+      aria-describedby={hasDescription ? descriptionId : undefined}
+      aria-label={option.word}
+      aria-keyshortcuts={shortcut ?? undefined}
+      aria-pressed={isUsed}
+      className={cn(
+        "border-border flex min-h-11 min-w-16 items-center justify-start gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-all duration-150",
+        disabled
+          ? "opacity-50"
+          : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
+        isUsed && !disabled && "opacity-70",
+      )}
+      disabled={disabled}
+      onClick={onToggle}
+      type="button"
+    >
+      {shortcut && (
+        <ResultKbd className="hidden lg:pointer-fine:inline-flex" isSelected={isUsed}>
+          {shortcut}
+        </ResultKbd>
+      )}
+
+      <WordBankOptionContent descriptionId={descriptionId} option={option} />
+    </button>
+  );
+}

--- a/packages/player/src/player-audio-context.tsx
+++ b/packages/player/src/player-audio-context.tsx
@@ -2,9 +2,8 @@
 
 import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { PLAYER_AUDIO_KEYBOARD_SHORTCUT } from "./player-shortcuts";
 import { useWordAudio } from "./use-word-audio";
-
-export const PLAYER_AUDIO_KEYBOARD_SHORTCUT = "p";
 
 type PlayerAudioContextValue = {
   audioUrl: string | null;

--- a/packages/player/src/player-shortcuts.test.ts
+++ b/packages/player/src/player-shortcuts.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getNumberKeyShortcut } from "./player-shortcuts";
+
+describe(getNumberKeyShortcut, () => {
+  it("returns single-digit shortcuts for supported option indexes", () => {
+    expect(getNumberKeyShortcut(0)).toBe("1");
+    expect(getNumberKeyShortcut(8)).toBe("9");
+  });
+
+  it("does not create double-digit shortcuts", () => {
+    expect(getNumberKeyShortcut(9)).toBeNull();
+  });
+});

--- a/packages/player/src/player-shortcuts.ts
+++ b/packages/player/src/player-shortcuts.ts
@@ -1,0 +1,16 @@
+export const PLAYER_AUDIO_KEYBOARD_SHORTCUT = "p";
+
+export const MAX_NUMBER_KEY_SHORTCUT = 9;
+
+/**
+ * Player number shortcuts use the keys learners can press directly. Lists can
+ * contain more than 9 options, but double-digit shortcuts are not supported by
+ * the key handler and should not be shown in the UI.
+ */
+export function getNumberKeyShortcut(index: number): string | null {
+  if (index >= MAX_NUMBER_KEY_SHORTCUT) {
+    return null;
+  }
+
+  return String(index + 1);
+}

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -3,7 +3,7 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
 
 const buttonVariants = cva(
-  "group/button focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 relative inline-flex shrink-0 items-center justify-center rounded-4xl border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none before:absolute before:top-1/2 before:left-1/2 before:size-full before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 focus-visible:ring-[3px] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-[3px] [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 relative inline-flex shrink-0 items-center justify-center rounded-4xl border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none before:absolute before:top-1/2 before:left-1/2 before:size-full before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 focus-visible:ring-[3px] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-[3px] lg:pointer-fine:has-data-[slot=shortcut-kbd]:justify-between [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     defaultVariants: { size: "default", variant: "default" },
     variants: {

--- a/packages/ui/src/components/empty.tsx
+++ b/packages/ui/src/components/empty.tsx
@@ -14,10 +14,19 @@ function Empty({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+const emptyHeaderVariants = cva("flex max-w-sm flex-col gap-2", {
+  defaultVariants: { align: "center" },
+  variants: { align: { center: "items-center", start: "items-start text-left" } },
+});
+
+function EmptyHeader({
+  align,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyHeaderVariants>) {
   return (
     <div
-      className={cn("flex max-w-sm flex-col items-center gap-2", className)}
+      className={emptyHeaderVariants({ align, className })}
       data-slot="empty-header"
       {...props}
     />
@@ -75,13 +84,22 @@ function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
   );
 }
 
-function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+const emptyContentVariants = cva(
+  "flex w-full max-w-sm min-w-0 flex-col gap-4 text-sm text-balance",
+  {
+    defaultVariants: { align: "center" },
+    variants: { align: { center: "items-center", stretch: "items-stretch" } },
+  },
+);
+
+function EmptyContent({
+  align,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyContentVariants>) {
   return (
     <div
-      className={cn(
-        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
-        className,
-      )}
+      className={emptyContentVariants({ align, className })}
       data-slot="empty-content"
       {...props}
     />

--- a/packages/ui/src/components/input-otp.tsx
+++ b/packages/ui/src/components/input-otp.tsx
@@ -12,7 +12,7 @@ function InputOTP({ className, containerClassName, ...props }: InputOTPProps) {
     <OTPInput
       className={cn("disabled:cursor-not-allowed", className)}
       containerClassName={cn(
-        "cn-input-otp flex items-center has-disabled:opacity-50",
+        "cn-input-otp flex w-full items-center gap-2 has-disabled:opacity-50",
         containerClassName,
       )}
       data-slot="input-otp"
@@ -26,7 +26,7 @@ function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "has-aria-invalid:border-destructive has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 flex items-center rounded-4xl has-aria-invalid:ring-[3px]",
+        "has-aria-invalid:border-destructive has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 flex min-w-0 flex-1 items-center rounded-4xl has-aria-invalid:ring-[3px]",
         className,
       )}
       data-slot="input-otp-group"
@@ -46,7 +46,7 @@ function InputOTPSlot({
   return (
     <div
       className={cn(
-        "border-input bg-background aria-invalid:border-destructive data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 relative flex size-9 items-center justify-center border-y border-r text-sm transition-all outline-none first:rounded-l-4xl first:border-l last:rounded-r-4xl data-[active=true]:z-10 data-[active=true]:ring-[3px]",
+        "border-input bg-background aria-invalid:border-destructive data-[active=true]:border-ring data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40 relative flex h-12 w-auto flex-1 items-center justify-center border-y border-r text-base transition-all outline-none first:rounded-l-4xl first:border-l last:rounded-r-4xl data-[active=true]:z-10 data-[active=true]:ring-[3px]",
         className,
       )}
       data-active={isActive}
@@ -67,7 +67,7 @@ function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
   return (
     <div
       aria-hidden="true"
-      className="flex items-center [&_svg:not([class*='size-'])]:size-4"
+      className="flex shrink-0 items-center [&_svg:not([class*='size-'])]:size-4"
       data-slot="input-otp-separator"
       {...props}
     >

--- a/packages/ui/src/components/kbd.tsx
+++ b/packages/ui/src/components/kbd.tsx
@@ -1,4 +1,24 @@
 import { cn } from "@zoonk/ui/lib/utils";
+import { type VariantProps, cva } from "class-variance-authority";
+
+const shortcutKbdVariants = cva("", {
+  defaultVariants: { tone: "default", variant: "inline" },
+  variants: {
+    tone: { default: "", inverse: "bg-primary-foreground/15 text-primary-foreground" },
+    variant: {
+      badge:
+        "bg-background text-muted-foreground ring-border/60 absolute -top-1 -right-1 hidden h-4 min-w-4 rounded-full px-1 text-[9px] leading-none shadow-sm ring-1 lg:pointer-fine:inline-flex",
+      inline: "hidden opacity-70 lg:pointer-fine:inline-flex",
+    },
+  },
+});
+
+type ShortcutKbdProps = { children: React.ReactNode; className?: string } & VariantProps<
+  typeof shortcutKbdVariants
+>;
+
+type ShortcutKbdVariant = NonNullable<ShortcutKbdProps["variant"]>;
+type ShortcutKbdTone = NonNullable<ShortcutKbdProps["tone"]>;
 
 function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
@@ -13,6 +33,22 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
   );
 }
 
+/**
+ * Shows keyboard shortcut hints only when keyboard input is useful. The host
+ * control owns `aria-keyshortcuts`; this component is visual-only.
+ */
+function ShortcutKbd({ children, className, tone, variant }: ShortcutKbdProps) {
+  return (
+    <Kbd
+      aria-hidden="true"
+      className={shortcutKbdVariants({ className, tone, variant })}
+      data-slot={variant === "badge" ? "shortcut-kbd-badge" : "shortcut-kbd"}
+    >
+      {children}
+    </Kbd>
+  );
+}
+
 function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <kbd
@@ -23,4 +59,4 @@ function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-export { Kbd, KbdGroup };
+export { Kbd, KbdGroup, ShortcutKbd, type ShortcutKbdTone, type ShortcutKbdVariant };


### PR DESCRIPTION
## Summary

- Add visible desktop keyboard shortcut hints across player interactions and related empty/auth flows
- Share shortcut UI primitives through the UI package
- Cover shortcut behavior and mobile visibility regressions with browser/e2e tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds visible keyboard shortcut hints to the lesson player and related flows (OTP login and generation) to speed up desktop navigation and improve accessibility. Introduces `ShortcutKbd` and `GenerationShortcutLink`, wires `aria-keyshortcuts` across actions, and adds browser/e2e tests.

- **New Features**
  - Player: 1–9 to select options/tiles, Enter to check/continue, Esc to close, arrows to navigate, and "p" to play/pause audio; hints are desktop-only.
  - Auth & generation: Enter on Continue, Esc to go back (OTP “Change email”, generation exit); new `GenerationShortcutLink` shows badges and handles hotkeys.
  - Shared UI: `@zoonk/ui` `ShortcutKbd` (inline/badge, inverse tone) and `player-shortcuts` helpers; buttons/links use `aria-keyshortcuts` for a11y.

- **Tests**
  - Player browser tests cover number shortcuts, image options, word bank toggles, match pairs, and mobile-only controls; unit test for `getNumberKeyshortcut`.
  - E2E adds OTP shortcut checks and a retrying `pressShortcutAndWaitForUrl` helper; lesson/chapter flows verify link presence and shortcut navigation.

<sup>Written for commit 4a669aafcff36e97d733306aa303579fd4e1065c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

