### PR TITLE
fix(main): clarify free lesson copy

### DIFF
--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -563,7 +563,7 @@ test.describe("Lesson Player Page", () => {
     await expect(authenticatedPage.getByText(/unlock the rest of this course/iu)).toBeVisible();
 
     await expect(
-      authenticatedPage.getByText(/free accounts include the first 10 lessons/iu),
+      authenticatedPage.getByText(/the first 10 lessons in every course are free/iu),
     ).toBeVisible();
 
     await expect(authenticatedPage.getByRole("heading", { name: lessonTitle })).not.toBeVisible();
@@ -615,7 +615,7 @@ test.describe("Lesson Player Page", () => {
     await expect(authenticatedPage.getByText(/unlock the rest of this course/iu)).toBeVisible();
 
     await expect(
-      authenticatedPage.getByText(/free accounts include the first 10 lessons/iu),
+      authenticatedPage.getByText(/the first 10 lessons in every course are free/iu),
     ).toBeVisible();
   });
 

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -1206,8 +1206,8 @@ msgid "_N8rYN"
 msgstr "Zurück zum Kapitel"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "rPcS-X"
-msgstr "Kostenlose Konten enthalten die ersten 10 Lektionen in jedem Kurs. Upgrade für unbegrenzten Zugriff auf jede Lektion in jedem Kurs."
+msgid "FHCzlw"
+msgstr "Die ersten 10 Lektionen in jedem Kurs sind kostenlos. Mit einem Upgrade bekommst du unbegrenzten Zugriff auf alle Lektionen in allen Kursen."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgid "ZnMcrz"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1206,8 +1206,8 @@ msgid "_N8rYN"
 msgstr "Back to chapter"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "rPcS-X"
-msgstr "Free accounts include the first 10 lessons in each course. Upgrade for unlimited access to every lesson in every course."
+msgid "FHCzlw"
+msgstr "The first 10 lessons in every course are free. Upgrade for unlimited access to every lesson in every course."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgid "ZnMcrz"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1206,8 +1206,8 @@ msgid "_N8rYN"
 msgstr "Volver al capítulo"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "rPcS-X"
-msgstr "Las cuentas gratis incluyen las primeras 10 lecciones de cada curso. Actualiza para tener acceso ilimitado a todas las lecciones de todos los cursos."
+msgid "FHCzlw"
+msgstr "Las primeras 10 lecciones de cada curso son gratis. Hazte premium para tener acceso ilimitado a todas las lecciones de todos los cursos."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgid "ZnMcrz"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -1206,8 +1206,8 @@ msgid "_N8rYN"
 msgstr "Retour au chapitre"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "rPcS-X"
-msgstr "Les comptes gratuits incluent les 10 premières leçons de chaque cours. Passe à la version supérieure pour un accès illimité à toutes les leçons de tous les cours."
+msgid "FHCzlw"
+msgstr "Les 10 premières leçons de chaque cours sont gratuites. Passe à l’offre supérieure pour un accès illimité à toutes les leçons de tous les cours."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgid "ZnMcrz"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1206,8 +1206,8 @@ msgid "_N8rYN"
 msgstr "Voltar ao capítulo"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "rPcS-X"
-msgstr "Contas grátis incluem as 10 primeiras aulas de cada curso. Faça upgrade para ter acesso ilimitado a todas as aulas de todos os cursos."
+msgid "FHCzlw"
+msgstr "As 10 primeiras aulas de cada curso são grátis. Faça upgrade para ter acesso ilimitado a todas as aulas de todos os cursos."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgid "ZnMcrz"

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -95,7 +95,7 @@ async function getLessonAccessGate({
           backHref={backHref}
           backLabel={t("Back to chapter")}
           description={t(
-            "Free accounts include the first 10 lessons in each course. Upgrade for unlimited access to every lesson in every course.",
+            "The first 10 lessons in every course are free. Upgrade for unlimited access to every lesson in every course.",
           )}
           title={t("Unlock the rest of this course")}
         />


### PR DESCRIPTION
Updates the lesson upgrade CTA to avoid referring to free accounts and keeps the e2e expectations and generated translations aligned.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the lesson upgrade CTA to say “The first 10 lessons in every course are free,” removing references to “free accounts.” Updated translations and e2e tests to match.

<sup>Written for commit 4a52496dc64b8a6fe71a004321065c3d002610b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

