### PR TITLE
feat(player): add completion progress milestones

### DIFF
--- a/apps/main/e2e/completion.ts
+++ b/apps/main/e2e/completion.ts
@@ -1,0 +1,54 @@
+import { type Locator } from "@playwright/test";
+import { type Page, expect } from "./fixtures";
+
+const MAX_COMPLETION_PROGRESS_MILESTONES = 10;
+
+/**
+ * Completion can show progress milestones before the ordinary summary with
+ * navigation links. App e2e specs usually care about the final lesson,
+ * chapter, or course action, so this helper advances through any milestone
+ * screens without tying the tests to a specific user-progress threshold.
+ */
+export async function advanceToCompletionSummary({
+  page,
+  steps = 0,
+}: {
+  page: Page;
+  steps?: number;
+}) {
+  const completionScreen = page.getByRole("status");
+
+  await expect(completionScreen).toBeVisible();
+
+  if (await getCompletionSummaryAction(completionScreen).isVisible()) {
+    return;
+  }
+
+  if (steps >= MAX_COMPLETION_PROGRESS_MILESTONES) {
+    await expect(getCompletionSummaryAction(completionScreen)).toBeVisible();
+    return;
+  }
+
+  const continueButton = completionScreen.getByRole("button", { name: /^continue$/iu });
+
+  if (await continueButton.isVisible()) {
+    await continueButton.click();
+    await advanceToCompletionSummary({ page, steps: steps + 1 });
+    return;
+  }
+
+  await expect(getCompletionSummaryAction(completionScreen)).toBeVisible();
+}
+
+/**
+ * The ordinary completion summary always exposes at least one navigation link.
+ * Progress milestone screens can expose "Learn about..." links too, so this
+ * sentinel intentionally matches only the summary actions.
+ */
+function getCompletionSummaryAction(completionScreen: Locator) {
+  return completionScreen
+    .getByRole("link", {
+      name: /^(?<summaryAction>exit|next|next chapter|review chapter|review course)$/iu,
+    })
+    .first();
+}

--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -7,6 +7,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
 import { userProgressFixture } from "@zoonk/testing/fixtures/progress";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { advanceToCompletionSummary } from "./completion";
 import { type Page, expect, test } from "./fixtures";
 
 async function createCourseWithThreeLessons() {
@@ -103,34 +104,6 @@ async function expectLessonCompleted({ lessonId, userId }: { lessonId: string; u
 }
 
 /**
- * Completion can show progress milestones before the final action links. The
- * revalidation tests need the stable chapter exit link, so they advance through
- * any intermediate milestone screens after the DB has confirmed completion.
- */
-async function expectCompletionActionsVisible({ page, steps = 0 }: { page: Page; steps?: number }) {
-  const exitLink = page.getByRole("link", { name: /exit/iu });
-
-  if (await exitLink.isVisible()) {
-    return;
-  }
-
-  if (steps >= 5) {
-    await expect(exitLink).toBeVisible();
-    return;
-  }
-
-  const continueButton = page.getByRole("button", { name: /continue/iu });
-
-  if (await continueButton.isVisible()) {
-    await continueButton.click();
-    await expectCompletionActionsVisible({ page, steps: steps + 1 });
-    return;
-  }
-
-  await expect(exitLink).toBeVisible();
-}
-
-/**
  * Static text lessons complete after one keyboard continue action. Waiting on
  * the server action response plus the DB row keeps the next navigation from
  * racing the background persistence work.
@@ -155,7 +128,7 @@ async function completeStaticLesson({
 
   await serverActionResponse;
   await expectLessonCompleted({ lessonId, userId });
-  await expectCompletionActionsVisible({ page });
+  await advanceToCompletionSummary({ page });
 }
 
 test.describe("Continue Learning Revalidation", () => {

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -8,6 +8,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
+import { advanceToCompletionSummary } from "./completion";
 import { expect, test } from "./fixtures";
 
 async function createUniqueUser(baseURL: string) {
@@ -55,16 +56,28 @@ async function createQuizLesson(lessonId: string, uniqueId: string) {
   });
 }
 
-async function completeQuiz(page: Page, uniqueId: string) {
+/**
+ * Quiz completion can pause on progress milestones before the normal summary.
+ * These specs verify the summary actions, so this helper completes the quiz
+ * and advances through any intermediate milestone screens first.
+ */
+async function completeQuizAndShowCompletionSummary({
+  page,
+  uniqueId,
+}: {
+  page: Page;
+  uniqueId: string;
+}) {
   await page.getByRole("radio", { name: new RegExp(`Right ${uniqueId}`, "u") }).click();
   await page.getByRole("button", { name: /check/iu }).click();
   await page.getByRole("button", { name: /continue/iu }).click();
+  await advanceToCompletionSummary({ page });
 }
 
 /**
- * Two lessons in one chapter. Completing the first lesson stays on the normal
- * scored completion screen because only chapter and course boundaries are
- * milestones.
+ * Two lessons in one chapter. Completing the first lesson eventually reaches
+ * the normal scored completion summary, even if progress milestones appear
+ * before that summary.
  */
 async function createLessonCompleteScenario(prefix: string) {
   const org = await getAiOrganization();
@@ -290,7 +303,7 @@ test.describe("Lesson Completion UX", () => {
     await page.goto(lessonUrl);
     await page.waitForLoadState("networkidle");
     await expect(page.getByText("Lesson 1 of 2")).toBeVisible();
-    await completeQuiz(page, uniqueId);
+    await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
     await expect(completionScreen.getByText("100%")).toBeVisible();
@@ -318,7 +331,7 @@ test.describe("Lesson Completion UX", () => {
 
     await page.goto(lessonUrl);
     await page.waitForLoadState("networkidle");
-    await completeQuiz(page, uniqueId);
+    await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
 
@@ -342,7 +355,7 @@ test.describe("Lesson Completion UX", () => {
 
     await page.goto(lessonUrl);
     await page.waitForLoadState("networkidle");
-    await completeQuiz(page, uniqueId);
+    await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
     await expect(completionScreen.getByText(/chapter complete/iu)).toBeVisible();
@@ -366,7 +379,7 @@ test.describe("Lesson Completion UX", () => {
 
     await page.goto(lessonUrl);
     await page.waitForLoadState("networkidle");
-    await completeQuiz(page, uniqueId);
+    await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
 
@@ -388,7 +401,7 @@ test.describe("Lesson Completion UX", () => {
 
     await page.goto(lessonUrl);
     await page.waitForLoadState("networkidle");
-    await completeQuiz(page, uniqueId);
+    await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
     await expect(completionScreen.getByText(/chapter complete/iu)).toBeVisible();
@@ -415,7 +428,7 @@ test.describe("Lesson Completion UX", () => {
 
     await page.goto(lessonUrl);
     await page.waitForLoadState("networkidle");
-    await completeQuiz(page, uniqueId);
+    await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
     await expect(completionScreen.getByText(/course complete/iu)).toBeVisible();
@@ -439,7 +452,7 @@ test.describe("Lesson Completion UX", () => {
 
     await page.goto(lessonUrl);
     await page.waitForLoadState("networkidle");
-    await completeQuiz(page, uniqueId);
+    await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
 
@@ -495,7 +508,7 @@ test.describe("Lesson Completion UX", () => {
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson1.slug}`);
     await page.waitForLoadState("networkidle");
-    await completeQuiz(page, uniqueId);
+    await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
     await expect(completionScreen.getByText("100%")).toBeVisible();

--- a/apps/main/e2e/review-step.test.ts
+++ b/apps/main/e2e/review-step.test.ts
@@ -7,6 +7,7 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { chapterSentenceFixture, sentenceFixture } from "@zoonk/testing/fixtures/sentences";
 import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { chapterWordFixture, wordFixture } from "@zoonk/testing/fixtures/words";
+import { advanceToCompletionSummary } from "./completion";
 import { expect, test } from "./fixtures";
 
 async function createReviewLesson(options: {
@@ -344,6 +345,8 @@ test.describe("Review Step", () => {
       sentenceWord2,
       translationToWord,
     });
+
+    await advanceToCompletionSummary({ page: userWithoutProgress });
 
     const completionScreen = userWithoutProgress.getByRole("status");
 

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
@@ -237,6 +237,7 @@ export function buildLessonPlayerModel({
       levelHref: "/level",
       loginHref: getLoginHref({ currentLessonHref }),
       nextLessonHref,
+      scoreHref: "/score",
     },
     onNextHref: nextLessonHref ?? nextChapterHref,
   };

--- a/apps/main/src/data/progress/get-player-progress-snapshot.test.ts
+++ b/apps/main/src/data/progress/get-player-progress-snapshot.test.ts
@@ -23,11 +23,16 @@ describe("authenticated users", () => {
     });
 
     expect(result).toStrictEqual({
+      bestDayScores: [],
       currentEnergy: 0,
       fullEnergyDays: 0,
       highestPreviousDailyBrainPower: 0,
+      learningDays: 0,
       todayBrainPower: 0,
+      todayCompletedLessons: 0,
       todayEnergyAtEnd: null,
+      todayInteractiveLessons: 0,
+      totalLearningSeconds: 0,
     });
   });
 
@@ -48,26 +53,35 @@ describe("authenticated users", () => {
         data: [
           {
             brainPowerEarned: 60,
+            correctAnswers: 18,
             date: new Date("2026-01-05T00:00:00Z"),
             dayOfWeek: 1,
             energyAtEnd: 100,
+            incorrectAnswers: 2,
             interactiveCompleted: 1,
+            timeSpentSeconds: 300,
             userId: user.id,
           },
           {
             brainPowerEarned: 80,
+            correctAnswers: 8,
             date: new Date("2026-01-09T00:00:00Z"),
             dayOfWeek: 5,
             energyAtEnd: 100,
+            incorrectAnswers: 2,
             interactiveCompleted: 1,
+            timeSpentSeconds: 600,
             userId: user.id,
           },
           {
             brainPowerEarned: 40,
+            correctAnswers: 4,
             date: new Date("2026-01-10T00:00:00Z"),
             dayOfWeek: 6,
             energyAtEnd: 99,
+            incorrectAnswers: 1,
             interactiveCompleted: 1,
+            timeSpentSeconds: 120,
             userId: user.id,
           },
         ],
@@ -80,11 +94,20 @@ describe("authenticated users", () => {
     });
 
     expect(result).toStrictEqual({
+      bestDayScores: [
+        { correctAnswers: 18, dayOfWeek: 1, incorrectAnswers: 2 },
+        { correctAnswers: 8, dayOfWeek: 5, incorrectAnswers: 2 },
+        { correctAnswers: 4, dayOfWeek: 6, incorrectAnswers: 1 },
+      ],
       currentEnergy: 49,
       fullEnergyDays: 2,
       highestPreviousDailyBrainPower: 80,
+      learningDays: 3,
       todayBrainPower: 40,
+      todayCompletedLessons: 1,
       todayEnergyAtEnd: 99,
+      todayInteractiveLessons: 1,
+      totalLearningSeconds: 1020,
     });
   });
 });

--- a/apps/main/src/data/progress/get-player-progress-snapshot.ts
+++ b/apps/main/src/data/progress/get-player-progress-snapshot.ts
@@ -2,16 +2,30 @@ import "server-only";
 import { hasUserLearningProgress } from "@zoonk/core/progress/user-progress";
 import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
+import { DEFAULT_PROGRESS_LOOKBACK_DAYS } from "@zoonk/utils/date-ranges";
 import { computeDecayedEnergy, toUTCMidnight } from "@zoonk/utils/energy";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
+import { getCompletedLessonDayWhere } from "./_utils/completed-lesson-day-where";
+
+type BestDayScore = { correctAnswers: number; dayOfWeek: number; incorrectAnswers: number };
+
+type BestDayScoreRow = {
+  _sum: { correctAnswers: number | null; incorrectAnswers: number | null };
+  dayOfWeek: number;
+};
 
 type PlayerProgressSnapshot = {
+  bestDayScores: BestDayScore[];
   currentEnergy: number;
   fullEnergyDays: number;
   highestPreviousDailyBrainPower: number;
+  learningDays: number;
   todayBrainPower: number;
+  todayCompletedLessons: number;
   todayEnergyAtEnd: number | null;
+  todayInteractiveLessons: number;
+  totalLearningSeconds: number;
 };
 
 /**
@@ -34,28 +48,68 @@ function getCurrentEnergy({
 }
 
 /**
+ * The score page uses a rolling 90-day default for best-day insights. The
+ * player receives the same window, based on the injected test clock, so a
+ * milestone and the page it links to agree on the learner's strongest weekday.
+ */
+function getBestDayStartDate(now: Date) {
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth(),
+      now.getUTCDate() - DEFAULT_PROGRESS_LOOKBACK_DAYS,
+    ),
+  );
+}
+
+/**
+ * Grouped progress rows return nullable sums. The player only needs simple
+ * numeric weekday totals, so this normalizes missing sums before the data
+ * crosses into the shared package.
+ */
+function getBestDayScores(rows: BestDayScoreRow[]): BestDayScore[] {
+  return rows.map((row) => ({
+    correctAnswers: row._sum.correctAnswers ?? 0,
+    dayOfWeek: row.dayOfWeek,
+    incorrectAnswers: row._sum.incorrectAnswers ?? 0,
+  }));
+}
+
+/**
  * Packages the few pre-completion facts needed to decide whether the next local
  * completion crosses an Energy, full-energy-day, or daily-BP milestone.
  */
 function buildPlayerProgressSnapshot({
+  bestDayScores,
   fullEnergyDays,
   highestPreviousDailyProgress,
+  learningDays,
   now,
   progress,
   todayProgress,
+  totalLearningSeconds,
 }: {
+  bestDayScores: BestDayScore[];
   fullEnergyDays: number;
   highestPreviousDailyProgress: Awaited<ReturnType<typeof prisma.dailyProgress.findFirst>>;
+  learningDays: number;
   now: Date;
   progress: Awaited<ReturnType<typeof prisma.userProgress.findUnique>>;
   todayProgress: Awaited<ReturnType<typeof prisma.dailyProgress.findUnique>>;
+  totalLearningSeconds: number;
 }): PlayerProgressSnapshot {
   return {
+    bestDayScores,
     currentEnergy: getCurrentEnergy({ now, progress }),
     fullEnergyDays,
     highestPreviousDailyBrainPower: highestPreviousDailyProgress?.brainPowerEarned ?? 0,
+    learningDays,
     todayBrainPower: todayProgress?.brainPowerEarned ?? 0,
+    todayCompletedLessons:
+      (todayProgress?.interactiveCompleted ?? 0) + (todayProgress?.staticCompleted ?? 0),
     todayEnergyAtEnd: todayProgress?.energyAtEnd ?? null,
+    todayInteractiveLessons: todayProgress?.interactiveCompleted ?? 0,
+    totalLearningSeconds,
   };
 }
 
@@ -69,6 +123,7 @@ const cachedGetPlayerProgressSnapshot = cache(
 
     const now = nowIso ? new Date(nowIso) : new Date();
     const today = toUTCMidnight(now);
+    const bestDayStartDate = getBestDayStartDate(now);
     const userId = session.user.id;
 
     const { data, error } = await safeAsync(() =>
@@ -80,6 +135,14 @@ const cachedGetPlayerProgressSnapshot = cache(
           where: { brainPowerEarned: { gt: 0 }, date: { lt: today }, userId },
         }),
         prisma.dailyProgress.count({ where: { energyAtEnd: { gte: 100 }, userId } }),
+        prisma.dailyProgress.count({ where: getCompletedLessonDayWhere({ userId }) }),
+        prisma.dailyProgress.aggregate({ _sum: { timeSpentSeconds: true }, where: { userId } }),
+        prisma.dailyProgress.groupBy({
+          _sum: { correctAnswers: true, incorrectAnswers: true },
+          by: ["dayOfWeek"],
+          orderBy: { dayOfWeek: "asc" },
+          where: { date: { gte: bestDayStartDate }, userId },
+        }),
       ]),
     );
 
@@ -87,14 +150,25 @@ const cachedGetPlayerProgressSnapshot = cache(
       return null;
     }
 
-    const [progress, todayProgress, highestPreviousDailyProgress, fullEnergyDays] = data;
+    const [
+      progress,
+      todayProgress,
+      highestPreviousDailyProgress,
+      fullEnergyDays,
+      learningDays,
+      totalLearningTime,
+      bestDayRows,
+    ] = data;
 
     return buildPlayerProgressSnapshot({
+      bestDayScores: getBestDayScores(bestDayRows),
       fullEnergyDays,
       highestPreviousDailyProgress,
+      learningDays,
       now,
       progress,
       todayProgress,
+      totalLearningSeconds: totalLearningTime._sum.timeSpentSeconds ?? 0,
     });
   },
 );

--- a/packages/i18n/.eloqnt/styleguide.pt.md
+++ b/packages/i18n/.eloqnt/styleguide.pt.md
@@ -20,11 +20,13 @@
 - "Brain Power": "Poder Mental"
 - "BP": "PM"
 - "Energy": "Energia"
-- "ajudar você": "te ajudar"
+- "helps you": "te ajuda"
 - "questions": "perguntas"
 - "practice questions": "perguntas práticas"
 - "options": "alternativas" (when used in the context of multiple choice questions)
 - "listening": "escuta"
+- "completed": "completou"
+- "we": "a gente"
 
 ## Special Cases
 
@@ -32,3 +34,4 @@
 - Use an article or possessive with "Poder Mental" only when the sentence sounds more natural with one. For example, "Você aumentou o Poder Mental".
 - When translating exam names, adapt them to Brazilian Portuguese. For example, SAT, AP, Bar, etc aren't relevant to Brazilian audiences. Instead, use concurso público, Enem, vestibular, etc. as appropriate. For example, instead of "SAT prep course", use "curso preparatório para o Enem" or "curso preparatório para concurso público", depending on the context.
 - For belt colors, use feminine forms. For example, "White Belt" = "Faixa Branca", "Yellow Belt" = "Faixa Amarela", etc. If it's color alone in the context of belts, use "Yellow" = "Amarela", "White" = "Branca", etc.
+- Don't use "{verb} você". Instead, use "te {verb}". For example, instead of "We help you learn", use "A gente te ajuda a aprender".

--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -99,6 +99,38 @@ msgstr "{days} Tage volle Energie"
 msgid "cIxpmv"
 msgstr "Wow, was für eine unglaubliche Ausdauer! Lern weiter jeden Tag, damit deine Energie bei 100% bleibt."
 
+#: src/components/completion-learning-days-milestone.tsx
+msgid "SIXtG5"
+msgstr "{days} Lerntage"
+
+#: src/components/completion-learning-days-milestone.tsx
+msgid "hjXoGI"
+msgstr "Du hast an {days} verschiedenen Tagen Lektionen abgeschlossen. Wenn du oft übst, kannst du dir das Gelernte besser merken."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "dZvEPp"
+msgstr "{minutes} Minuten lernen"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "kw1W3C"
+msgstr "1 voller Lerntag"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "BlVoPr"
+msgstr "{hours, plural, one {# Stunde gelernt} other {# Stunden gelernt}}"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "WcAhMT"
+msgstr "Du kannst viel lernen, wenn du täglich ein paar Minuten übst."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "LzEQnT"
+msgstr "Das ist ein ganzer Tag konzentriertes Üben."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "PpK3hX"
+msgstr "Das sind mehr als {days, plural, one {# voller Tag} other {# volle Tage}} konzentriertes Üben."
+
 #: src/components/completion-level-milestone.tsx
 msgid "155cHi"
 msgstr "Level erreicht"
@@ -132,6 +164,10 @@ msgid "iSioEh"
 msgstr "Mehr über Energie erfahren"
 
 #: src/components/completion-progress-milestone-screen.tsx
+msgid "DC0WoT"
+msgstr "Mehr über Score"
+
+#: src/components/completion-progress-milestone-screen.tsx
 msgid "Q0R3MU"
 msgstr "Mehr über Levels erfahren"
 
@@ -139,6 +175,14 @@ msgstr "Mehr über Levels erfahren"
 #: src/components/step-action-button.tsx
 msgid "acrOoz"
 msgstr "Fortfahren"
+
+#: src/components/completion-score-milestone.tsx
+msgid "e6_3Ke"
+msgstr "{day} ist dein bester Tag"
+
+#: src/components/completion-score-milestone.tsx
+msgid "PTQ0ah"
+msgstr "An {day} hast du normalerweise {percentage} der Antworten richtig – dein bester Durchschnitt in dieser Woche."
 
 #: src/components/completion-screen.tsx
 msgid "95stPq"

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -99,6 +99,38 @@ msgstr "{days} days of max Energy"
 msgid "cIxpmv"
 msgstr "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
 
+#: src/components/completion-learning-days-milestone.tsx
+msgid "SIXtG5"
+msgstr "{days} learning days"
+
+#: src/components/completion-learning-days-milestone.tsx
+msgid "hjXoGI"
+msgstr "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "dZvEPp"
+msgstr "{minutes} minutes of learning"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "kw1W3C"
+msgstr "1 full day of learning"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "BlVoPr"
+msgstr "{hours, plural, one {# hour of learning} other {# hours of learning}}"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "WcAhMT"
+msgstr "You can learn a lot by practicing for a few minutes a day."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "LzEQnT"
+msgstr "That's a full day of focused practice."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "PpK3hX"
+msgstr "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
+
 #: src/components/completion-level-milestone.tsx
 msgid "155cHi"
 msgstr "Level achieved"
@@ -132,6 +164,10 @@ msgid "iSioEh"
 msgstr "Learn about Energy"
 
 #: src/components/completion-progress-milestone-screen.tsx
+msgid "DC0WoT"
+msgstr "Learn about Score"
+
+#: src/components/completion-progress-milestone-screen.tsx
 msgid "Q0R3MU"
 msgstr "Learn about levels"
 
@@ -139,6 +175,14 @@ msgstr "Learn about levels"
 #: src/components/step-action-button.tsx
 msgid "acrOoz"
 msgstr "Continue"
+
+#: src/components/completion-score-milestone.tsx
+msgid "e6_3Ke"
+msgstr "{day} is your best day"
+
+#: src/components/completion-score-milestone.tsx
+msgid "PTQ0ah"
+msgstr "You usually get {percentage} of answers right on {day}, your highest average of the week."
 
 #: src/components/completion-screen.tsx
 msgid "95stPq"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -99,6 +99,38 @@ msgstr "{days} días con Energía máxima"
 msgid "cIxpmv"
 msgstr "¡Vaya, qué constancia increíble! Sigue estudiando todos los días para mantener tu Energía al 100%."
 
+#: src/components/completion-learning-days-milestone.tsx
+msgid "SIXtG5"
+msgstr "{days} días de estudio"
+
+#: src/components/completion-learning-days-milestone.tsx
+msgid "hjXoGI"
+msgstr "Has completado lecciones en {days} días distintos. Practicar a menudo te ayuda a recordar lo que aprendes."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "dZvEPp"
+msgstr "{minutes} minutos de estudio"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "kw1W3C"
+msgstr "1 día completo de estudio"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "BlVoPr"
+msgstr "{hours, plural, one {# hora de estudio} other {# horas de estudio}}"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "WcAhMT"
+msgstr "Puedes aprender mucho practicando unos minutos al día."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "LzEQnT"
+msgstr "Eso es un día completo de práctica concentrada."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "PpK3hX"
+msgstr "Eso es más de {days, plural, one {# día completo} other {# días completos}} de práctica concentrada."
+
 #: src/components/completion-level-milestone.tsx
 msgid "155cHi"
 msgstr "Nivel alcanzado"
@@ -132,6 +164,10 @@ msgid "iSioEh"
 msgstr "Aprende sobre la Energía"
 
 #: src/components/completion-progress-milestone-screen.tsx
+msgid "DC0WoT"
+msgstr "Aprende sobre Score"
+
+#: src/components/completion-progress-milestone-screen.tsx
 msgid "Q0R3MU"
 msgstr "Aprende sobre los niveles"
 
@@ -139,6 +175,14 @@ msgstr "Aprende sobre los niveles"
 #: src/components/step-action-button.tsx
 msgid "acrOoz"
 msgstr "Continuar"
+
+#: src/components/completion-score-milestone.tsx
+msgid "e6_3Ke"
+msgstr "{day} es tu mejor día"
+
+#: src/components/completion-score-milestone.tsx
+msgid "PTQ0ah"
+msgstr "Sueles acertar el {percentage} % de las respuestas en {day}, tu mejor promedio de la semana."
 
 #: src/components/completion-screen.tsx
 msgid "95stPq"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -182,7 +182,7 @@ msgstr "{day} es tu mejor día"
 
 #: src/components/completion-score-milestone.tsx
 msgid "PTQ0ah"
-msgstr "Sueles acertar el {percentage} % de las respuestas en {day}, tu mejor promedio de la semana."
+msgstr "Sueles acertar el {percentage} de las respuestas en {day}, tu mejor promedio de la semana."
 
 #: src/components/completion-screen.tsx
 msgid "95stPq"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -99,6 +99,38 @@ msgstr "{days} jours d’Énergie max"
 msgid "cIxpmv"
 msgstr "Wow, quelle régularité ! Continue d’étudier chaque jour pour garder ton Énergie à 100 %."
 
+#: src/components/completion-learning-days-milestone.tsx
+msgid "SIXtG5"
+msgstr "{days} jours d’apprentissage"
+
+#: src/components/completion-learning-days-milestone.tsx
+msgid "hjXoGI"
+msgstr "Tu as terminé des leçons sur {days} jours différents. S’entraîner souvent t’aide à retenir ce que tu apprends."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "dZvEPp"
+msgstr "{minutes} minutes d’apprentissage"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "kw1W3C"
+msgstr "1 journée entière d’apprentissage"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "BlVoPr"
+msgstr "{hours, plural, one {# heure d’apprentissage} other {# heures d’apprentissage}}"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "WcAhMT"
+msgstr "Tu peux apprendre beaucoup en t’entraînant quelques minutes par jour."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "LzEQnT"
+msgstr "Ça fait une journée entière de pratique concentrée."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "PpK3hX"
+msgstr "Ça fait plus de {days, plural, one {# journée entière} other {# journées entières}} de pratique concentrée."
+
 #: src/components/completion-level-milestone.tsx
 msgid "155cHi"
 msgstr "Niveau atteint"
@@ -132,6 +164,10 @@ msgid "iSioEh"
 msgstr "En savoir plus sur l’Énergie"
 
 #: src/components/completion-progress-milestone-screen.tsx
+msgid "DC0WoT"
+msgstr "En savoir plus sur Score"
+
+#: src/components/completion-progress-milestone-screen.tsx
 msgid "Q0R3MU"
 msgstr "En savoir plus sur les niveaux"
 
@@ -139,6 +175,14 @@ msgstr "En savoir plus sur les niveaux"
 #: src/components/step-action-button.tsx
 msgid "acrOoz"
 msgstr "Continuer"
+
+#: src/components/completion-score-milestone.tsx
+msgid "e6_3Ke"
+msgstr "Le {day} est ton meilleur jour"
+
+#: src/components/completion-score-milestone.tsx
+msgid "PTQ0ah"
+msgstr "Tu réponds juste à {percentage} des questions en général le {day}, ta meilleure moyenne de la semaine."
 
 #: src/components/completion-screen.tsx
 msgid "95stPq"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -99,6 +99,38 @@ msgstr "{days} dias com Energia máxima"
 msgid "cIxpmv"
 msgstr "Uau, que consistência incrível! Estude todo dia para manter sua Energia em 100%."
 
+#: src/components/completion-learning-days-milestone.tsx
+msgid "SIXtG5"
+msgstr "{days} dias de estudo"
+
+#: src/components/completion-learning-days-milestone.tsx
+msgid "hjXoGI"
+msgstr "Você completou aulas em {days} dias diferentes. Praticar com frequência te ajuda a lembrar do que você aprende."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "dZvEPp"
+msgstr "{minutes} minutos de estudo"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "kw1W3C"
+msgstr "1 dia inteiro de estudo"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "BlVoPr"
+msgstr "{hours, plural, one {# hora de estudo} other {# horas de estudo}}"
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "WcAhMT"
+msgstr "Você pode aprender muita coisa praticando alguns minutos por dia."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "LzEQnT"
+msgstr "Isso é um dia inteiro de prática focada."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgid "PpK3hX"
+msgstr "Isso é mais de {days, plural, one {# dia inteiro} other {# dias inteiros}} de prática focada."
+
 #: src/components/completion-level-milestone.tsx
 msgid "155cHi"
 msgstr "Nível conquistado"
@@ -132,6 +164,10 @@ msgid "iSioEh"
 msgstr "Saiba mais sobre Energia"
 
 #: src/components/completion-progress-milestone-screen.tsx
+msgid "DC0WoT"
+msgstr "Saiba mais sobre a pontuação"
+
+#: src/components/completion-progress-milestone-screen.tsx
 msgid "Q0R3MU"
 msgstr "Saiba mais sobre níveis"
 
@@ -139,6 +175,14 @@ msgstr "Saiba mais sobre níveis"
 #: src/components/step-action-button.tsx
 msgid "acrOoz"
 msgstr "Continuar"
+
+#: src/components/completion-score-milestone.tsx
+msgid "e6_3Ke"
+msgstr "{day} é o seu melhor dia"
+
+#: src/components/completion-score-milestone.tsx
+msgid "PTQ0ah"
+msgstr "Você costuma acertar {percentage} das respostas em {day}, sua maior média da semana."
 
 #: src/components/completion-screen.tsx
 msgid "95stPq"

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -3,6 +3,26 @@ import { page } from "vitest/browser";
 import { buildSerializedLesson, buildSerializedStep } from "../_test-utils/player-test-data";
 import { buildAuthenticatedViewer } from "../_test-utils/player-test-viewer";
 import { buildNavigation, renderPlayer } from "../_test-utils/render-player";
+import { type PlayerProgressSnapshot } from "../completion-milestones";
+import { getLocalDate } from "../player-date";
+
+function buildProgressSnapshot(
+  overrides: Partial<PlayerProgressSnapshot> = {},
+): PlayerProgressSnapshot {
+  return {
+    bestDayScores: [],
+    currentEnergy: 0,
+    fullEnergyDays: 0,
+    highestPreviousDailyBrainPower: 100,
+    learningDays: 0,
+    todayBrainPower: 0,
+    todayCompletedLessons: 0,
+    todayEnergyAtEnd: null,
+    todayInteractiveLessons: 0,
+    totalLearningSeconds: 0,
+    ...overrides,
+  };
+}
 
 /**
  * Completion browser tests all start from the same one-step quiz because it is
@@ -45,6 +65,17 @@ async function completeSingleChoiceLesson({
   await page.getByRole("radio", { name: optionName }).click();
   await page.getByRole("button", { name: /check/iu }).click();
   await page.getByRole("button", { name: /continue/iu }).click();
+}
+
+/**
+ * The milestone logic keys best day by local date, while DailyProgress stores
+ * weekday numbers on UTC-midnight date rows. Mirroring that conversion lets the
+ * browser test stay independent of the machine's current weekday.
+ */
+function getCurrentLocalDayOfWeek() {
+  const localDate = getLocalDate(new Date());
+
+  return new Date(`${localDate}T00:00:00Z`).getUTCDay();
 }
 
 describe("player browser integration: completion", () => {
@@ -180,13 +211,7 @@ describe("player browser integration: completion", () => {
   it("shows an Energy threshold milestone with an Energy page link", async () => {
     renderPlayer({
       lesson: buildCompletionQuizLesson(),
-      progressSnapshot: {
-        currentEnergy: 9.9,
-        fullEnergyDays: 0,
-        highestPreviousDailyBrainPower: 100,
-        todayBrainPower: 0,
-        todayEnergyAtEnd: null,
-      },
+      progressSnapshot: buildProgressSnapshot({ currentEnergy: 9.9 }),
       viewer: buildAuthenticatedViewer(),
     });
 
@@ -206,13 +231,11 @@ describe("player browser integration: completion", () => {
   it("shows full-energy day milestones after the Energy threshold screen", async () => {
     renderPlayer({
       lesson: buildCompletionQuizLesson(),
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 99.8,
         fullEnergyDays: 29,
-        highestPreviousDailyBrainPower: 100,
-        todayBrainPower: 0,
         todayEnergyAtEnd: 99.8,
-      },
+      }),
       viewer: buildAuthenticatedViewer(),
     });
 
@@ -238,13 +261,12 @@ describe("player browser integration: completion", () => {
   it("shows a daily Brain Power record milestone with a level page link", async () => {
     renderPlayer({
       lesson: buildCompletionQuizLesson(),
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 20,
-        fullEnergyDays: 0,
         highestPreviousDailyBrainPower: 40,
         todayBrainPower: 40,
         todayEnergyAtEnd: 20,
-      },
+      }),
       viewer: buildAuthenticatedViewer(),
     });
 
@@ -259,6 +281,60 @@ describe("player browser integration: completion", () => {
     await expect
       .element(milestoneScreen.getByRole("link", { name: /learn about levels/iu }))
       .toHaveAttribute("href", "/level");
+  });
+
+  it("shows a learning-days milestone with a level page link", async () => {
+    globalThis.sessionStorage.clear();
+
+    renderPlayer({
+      lesson: buildCompletionQuizLesson(),
+      progressSnapshot: buildProgressSnapshot({ learningDays: 4 }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await completeSingleChoiceLesson();
+
+    const milestoneScreen = page.getByRole("status");
+
+    await expect.element(milestoneScreen.getByText(/5 learning days/iu)).toBeInTheDocument();
+
+    await expect.element(milestoneScreen.getByText(/different days/iu)).toBeInTheDocument();
+
+    await expect
+      .element(milestoneScreen.getByRole("link", { name: /learn about levels/iu }))
+      .toHaveAttribute("href", "/level");
+  });
+
+  it("shows a best-day milestone with a Score page link", async () => {
+    globalThis.sessionStorage.clear();
+
+    const todayDayOfWeek = getCurrentLocalDayOfWeek();
+    const weakerDayOfWeek = (todayDayOfWeek + 1) % 7;
+
+    renderPlayer({
+      lesson: buildCompletionQuizLesson(),
+      progressSnapshot: buildProgressSnapshot({
+        bestDayScores: [
+          { correctAnswers: 18, dayOfWeek: todayDayOfWeek, incorrectAnswers: 2 },
+          { correctAnswers: 14, dayOfWeek: weakerDayOfWeek, incorrectAnswers: 6 },
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    await completeSingleChoiceLesson();
+
+    const milestoneScreen = page.getByRole("status");
+
+    await expect.element(milestoneScreen.getByText(/is your best day/iu)).toBeInTheDocument();
+
+    await expect
+      .element(milestoneScreen.getByText(/you usually get .* of answers right/iu))
+      .toBeInTheDocument();
+
+    await expect
+      .element(milestoneScreen.getByRole("link", { name: /learn about score/iu }))
+      .toHaveAttribute("href", "/score");
   });
 
   it("omits next lesson and level progress when optional lesson links are missing", async () => {

--- a/packages/player/src/_test-utils/render-player.tsx
+++ b/packages/player/src/_test-utils/render-player.tsx
@@ -128,6 +128,7 @@ export function buildNavigation(overrides: Partial<PlayerNavigation> = {}): Play
     levelHref: "/level",
     loginHref: "/login",
     nextLessonHref: "/lesson/play",
+    scoreHref: "/score",
     ...overrides,
   };
 }

--- a/packages/player/src/_utils/completion-brain-power-milestone.ts
+++ b/packages/player/src/_utils/completion-brain-power-milestone.ts
@@ -1,0 +1,39 @@
+import { type CompletionProgress, type PlayerProgressSnapshot } from "../completion-milestones";
+
+export type BrainPowerCompletionMilestone = {
+  brainPower: number;
+  kind: "brainPower";
+  status: "dailyRecord";
+};
+
+/**
+ * Daily Brain Power records should fire once per day: the first completion that
+ * beats every previous day's BP earns the milestone, but later lessons on the
+ * same already-record-setting day stay quiet.
+ */
+export function getDailyBrainPowerRecordMilestone({
+  completion,
+  progressSnapshot,
+}: {
+  completion: CompletionProgress;
+  progressSnapshot: PlayerProgressSnapshot | null;
+}): BrainPowerCompletionMilestone | null {
+  if (
+    !progressSnapshot ||
+    completion.brainPower <= 0 ||
+    progressSnapshot.highestPreviousDailyBrainPower <= 0
+  ) {
+    return null;
+  }
+
+  const newTodayBrainPower = progressSnapshot.todayBrainPower + completion.brainPower;
+
+  if (
+    progressSnapshot.todayBrainPower > progressSnapshot.highestPreviousDailyBrainPower ||
+    newTodayBrainPower <= progressSnapshot.highestPreviousDailyBrainPower
+  ) {
+    return null;
+  }
+
+  return { brainPower: newTodayBrainPower, kind: "brainPower", status: "dailyRecord" };
+}

--- a/packages/player/src/_utils/completion-energy-milestone.ts
+++ b/packages/player/src/_utils/completion-energy-milestone.ts
@@ -1,0 +1,86 @@
+import { clampEnergy } from "@zoonk/utils/energy";
+import { type CompletionProgress, type PlayerProgressSnapshot } from "../completion-milestones";
+import {
+  getReachedEnergyThreshold,
+  hasCompletedNewFullEnergyDay,
+  isFullEnergyDayMilestone,
+} from "./completion-milestone-thresholds";
+
+export type EnergyCompletionMilestone =
+  | { energy: number; kind: "energy"; status: "threshold" }
+  | { days: number; kind: "energy"; status: "fullDays" };
+
+/**
+ * Computes the post-completion Energy from the server snapshot and the same
+ * lesson score used by the completion summary. The server writes the same
+ * clamped value later, so the milestone preview matches persisted progress.
+ */
+function getNewEnergy({
+  completion,
+  progressSnapshot,
+}: {
+  completion: CompletionProgress;
+  progressSnapshot: PlayerProgressSnapshot;
+}) {
+  return clampEnergy(progressSnapshot.currentEnergy + completion.energyDelta);
+}
+
+/**
+ * Builds the 10-point Energy milestone when this completion moves the learner
+ * into a new visible Energy band.
+ */
+export function getEnergyThresholdMilestone({
+  completion,
+  progressSnapshot,
+}: {
+  completion: CompletionProgress;
+  progressSnapshot: PlayerProgressSnapshot | null;
+}): EnergyCompletionMilestone | null {
+  if (!progressSnapshot) {
+    return null;
+  }
+
+  const newEnergy = getNewEnergy({ completion, progressSnapshot });
+
+  const energy = getReachedEnergyThreshold({
+    newEnergy,
+    previousEnergy: progressSnapshot.currentEnergy,
+  });
+
+  if (energy === null) {
+    return null;
+  }
+
+  return { energy, kind: "energy", status: "threshold" };
+}
+
+/**
+ * Builds the full-energy-day milestone from the pre-completion count plus
+ * today's possible first 100% Energy finish.
+ */
+export function getFullEnergyDaysMilestone({
+  completion,
+  progressSnapshot,
+}: {
+  completion: CompletionProgress;
+  progressSnapshot: PlayerProgressSnapshot | null;
+}): EnergyCompletionMilestone | null {
+  if (!progressSnapshot) {
+    return null;
+  }
+
+  const newEnergy = getNewEnergy({ completion, progressSnapshot });
+
+  const completedFullEnergyDay = hasCompletedNewFullEnergyDay({
+    newEnergy,
+    todayEnergyAtEnd: progressSnapshot.todayEnergyAtEnd,
+  });
+
+  const newFullEnergyDays = progressSnapshot.fullEnergyDays + (completedFullEnergyDay ? 1 : 0);
+
+  if (!completedFullEnergyDay || !isFullEnergyDayMilestone(newFullEnergyDays)) {
+    return null;
+  }
+
+  return { days: newFullEnergyDays, kind: "energy", status: "fullDays" };
+}

--- a/packages/player/src/_utils/completion-learning-milestone.ts
+++ b/packages/player/src/_utils/completion-learning-milestone.ts
@@ -1,0 +1,61 @@
+import { type PlayerProgressSnapshot } from "../completion-milestones";
+import {
+  getReachedLearningTimeThreshold,
+  hasCompletedNewLearningDay,
+  isLearningDayMilestone,
+} from "./completion-milestone-thresholds";
+
+export type LearningDaysCompletionMilestone = { days: number; kind: "learningDays" };
+
+export type LearningTimeCompletionMilestone = { kind: "learningTime"; seconds: number };
+
+/**
+ * Builds the learning-day milestone when this completion is the first saved
+ * lesson today and that new day lands on one of the visible checkpoints.
+ */
+export function getLearningDaysMilestone({
+  progressSnapshot,
+}: {
+  progressSnapshot: PlayerProgressSnapshot | null;
+}): LearningDaysCompletionMilestone | null {
+  if (
+    !progressSnapshot ||
+    !hasCompletedNewLearningDay({ todayCompletedLessons: progressSnapshot.todayCompletedLessons })
+  ) {
+    return null;
+  }
+
+  const newLearningDays = (progressSnapshot.learningDays ?? 0) + 1;
+
+  if (!isLearningDayMilestone(newLearningDays)) {
+    return null;
+  }
+
+  return { days: newLearningDays, kind: "learningDays" };
+}
+
+/**
+ * Builds the total learning-time milestone from the lifetime server total plus
+ * the capped duration for this completed lesson.
+ */
+export function getLearningTimeMilestone({
+  lessonDurationSeconds,
+  progressSnapshot,
+}: {
+  lessonDurationSeconds: number;
+  progressSnapshot: PlayerProgressSnapshot | null;
+}): LearningTimeCompletionMilestone | null {
+  if (!progressSnapshot || lessonDurationSeconds <= 0) {
+    return null;
+  }
+
+  const previousTotalSeconds = progressSnapshot.totalLearningSeconds ?? 0;
+  const newTotalSeconds = previousTotalSeconds + lessonDurationSeconds;
+  const seconds = getReachedLearningTimeThreshold({ newTotalSeconds, previousTotalSeconds });
+
+  if (seconds === null) {
+    return null;
+  }
+
+  return { kind: "learningTime", seconds };
+}

--- a/packages/player/src/_utils/completion-level-milestone.ts
+++ b/packages/player/src/_utils/completion-level-milestone.ts
@@ -1,0 +1,120 @@
+import { type BeltLevelResult, calculateBeltLevel } from "@zoonk/utils/belt-level";
+import { type CompletionProgress } from "../completion-milestones";
+
+const LEVEL_HALFWAY_DIVISOR = 2;
+
+export type LevelCompletionMilestone =
+  | { belt: BeltLevelResult; kind: "level"; status: "achieved" }
+  | {
+      currentBelt: BeltLevelResult;
+      kind: "level";
+      remainingLessons: number;
+      status: "halfway";
+      targetBelt: BeltLevelResult;
+    };
+
+/**
+ * A belt milestone should only celebrate when the learner crosses into a new
+ * visible belt state. Comparing both color and level covers same-color level
+ * gains and color changes like White 10 to Yellow 1.
+ */
+function hasReachedNewBeltLevel({
+  currentBelt,
+  previousBelt,
+}: {
+  currentBelt: BeltLevelResult;
+  previousBelt: BeltLevelResult;
+}) {
+  return currentBelt.color !== previousBelt.color || currentBelt.level !== previousBelt.level;
+}
+
+/**
+ * Halfway milestones should fire once per level, exactly when the new total
+ * moves from the first half of the current level into the second half. This
+ * keeps the screen meaningful without showing it again on every later lesson.
+ */
+function hasReachedLevelHalfway({
+  currentBelt,
+  previousBelt,
+}: {
+  currentBelt: BeltLevelResult;
+  previousBelt: BeltLevelResult;
+}) {
+  const halfwayBp = currentBelt.bpPerLevel / LEVEL_HALFWAY_DIVISOR;
+
+  const stayedInSameLevel =
+    currentBelt.color === previousBelt.color && currentBelt.level === previousBelt.level;
+
+  return (
+    stayedInSameLevel &&
+    !currentBelt.isMaxLevel &&
+    previousBelt.progressInLevel < halfwayBp &&
+    currentBelt.progressInLevel >= halfwayBp
+  );
+}
+
+/**
+ * The halfway message names the next visible belt state, not the level the
+ * learner is currently inside. Adding the remaining BP to the current total
+ * asks the shared belt calculator for that next visible state directly.
+ */
+function getNextBeltLevel({
+  currentBelt,
+  totalBrainPower,
+}: {
+  currentBelt: BeltLevelResult;
+  totalBrainPower: number;
+}) {
+  return calculateBeltLevel(totalBrainPower + currentBelt.bpToNextLevel);
+}
+
+/**
+ * The milestone copy talks in lessons because that is the action learners can
+ * take next. Using the current lesson reward keeps the estimate aligned with
+ * the same scoring contract that produced the completion result.
+ */
+function getRemainingLessonCount({
+  brainPower,
+  currentBelt,
+}: {
+  brainPower: number;
+  currentBelt: BeltLevelResult;
+}) {
+  if (brainPower <= 0) {
+    return currentBelt.bpToNextLevel;
+  }
+
+  return Math.ceil(currentBelt.bpToNextLevel / brainPower);
+}
+
+/**
+ * Builds the level milestone for a completion. Achieved level changes outrank
+ * halfway nudges inside this family, so crossing a belt boundary never also
+ * shows the halfway message for the level that just ended.
+ */
+export function getLevelCompletionMilestone({
+  completion,
+  previousTotalBrainPower,
+}: {
+  completion: CompletionProgress;
+  previousTotalBrainPower: number;
+}): LevelCompletionMilestone | null {
+  const currentBelt = calculateBeltLevel(completion.newTotalBp);
+  const previousBelt = calculateBeltLevel(previousTotalBrainPower);
+
+  if (hasReachedNewBeltLevel({ currentBelt, previousBelt })) {
+    return { belt: currentBelt, kind: "level", status: "achieved" };
+  }
+
+  if (!hasReachedLevelHalfway({ currentBelt, previousBelt })) {
+    return null;
+  }
+
+  return {
+    currentBelt,
+    kind: "level",
+    remainingLessons: getRemainingLessonCount({ brainPower: completion.brainPower, currentBelt }),
+    status: "halfway",
+    targetBelt: getNextBeltLevel({ currentBelt, totalBrainPower: completion.newTotalBp }),
+  };
+}

--- a/packages/player/src/_utils/completion-milestone-thresholds.ts
+++ b/packages/player/src/_utils/completion-milestone-thresholds.ts
@@ -1,0 +1,215 @@
+import { type ScoredRow, findBestByScore } from "@zoonk/utils/aggregation";
+import { clampEnergy } from "@zoonk/utils/energy";
+
+export type BestDayScore = { correctAnswers: number; dayOfWeek: number; incorrectAnswers: number };
+
+const ENERGY_MILESTONE_STEP = 10;
+const FULL_ENERGY = 100;
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+const FULL_DAY_HOURS = 24;
+const RANGE_ITEM_COUNT_OFFSET = 1;
+const FULL_ENERGY_DAY_REPEAT_INTERVAL = 1000;
+
+type MilestoneRange = { every: number; from: number; to: number };
+
+/**
+ * Converts minute-based early checkpoints into seconds because the stored
+ * progress total is tracked in seconds, not display units.
+ */
+function minutesToSeconds(minutes: number) {
+  return minutes * SECONDS_PER_MINUTE;
+}
+
+/**
+ * Converts hour-based milestone rules into seconds at the threshold boundary
+ * so crossing detection can compare one unit consistently.
+ */
+function hoursToSeconds(hours: number) {
+  return hours * SECONDS_PER_HOUR;
+}
+
+/**
+ * Expands an inclusive threshold range so "100 to 1,000 every 100" produces
+ * every milestone inside the interval, not just the endpoints.
+ */
+function milestonesEvery({ every, from, to }: MilestoneRange) {
+  const itemCount = Math.floor((to - from) / every) + RANGE_ITEM_COUNT_OFFSET;
+
+  return Array.from({ length: itemCount }, (_, index) => from + index * every);
+}
+
+/**
+ * Overlapping ranges make the milestone progression easier to read because
+ * each interval can include its natural lower bound. Dedupe here keeps those
+ * overlaps from creating duplicate screens.
+ */
+function buildSortedUniqueThresholds(thresholds: number[]) {
+  return [...new Set(thresholds)].toSorted((first, second) => first - second);
+}
+
+/**
+ * Learning-time ranges are written in hours because the product rules are
+ * defined in hours after the first 10-minute and 30-minute checkpoints.
+ */
+function getLearningTimeRangeSeconds(ranges: readonly MilestoneRange[]) {
+  return ranges.flatMap((range) => milestonesEvery(range)).map((hours) => hoursToSeconds(hours));
+}
+
+/* eslint-disable no-magic-numbers -- These literals are the product milestone ladder. Naming each threshold individually makes the progression harder to audit. */
+const FULL_ENERGY_DAY_MILESTONES = new Set([
+  30,
+  FULL_ENERGY,
+  200,
+  300,
+  365,
+  500,
+  FULL_ENERGY_DAY_REPEAT_INTERVAL,
+]);
+
+const LEARNING_DAY_MILESTONES = new Set(
+  buildSortedUniqueThresholds([
+    5,
+    10,
+    30,
+    50,
+    365,
+    ...milestonesEvery({ every: 100, from: 100, to: 1000 }),
+    ...milestonesEvery({ every: 1000, from: 2000, to: 10_000 }),
+  ]),
+);
+
+const LEARNING_TIME_HOUR_RANGES: MilestoneRange[] = [
+  { every: 1, from: 1, to: 10 },
+  { every: 10, from: 10, to: 100 },
+  { every: 100, from: 100, to: 1000 },
+  { every: 1000, from: 1000, to: 10_000 },
+  { every: 10_000, from: 10_000, to: 100_000 },
+  { every: 100_000, from: 100_000, to: 1_000_000 },
+  { every: 1_000_000, from: 1_000_000, to: 10_000_000 },
+];
+
+const LEARNING_TIME_MILESTONE_SECONDS = buildSortedUniqueThresholds([
+  minutesToSeconds(10),
+  minutesToSeconds(30),
+  hoursToSeconds(FULL_DAY_HOURS),
+  ...getLearningTimeRangeSeconds(LEARNING_TIME_HOUR_RANGES),
+]);
+/* eslint-enable no-magic-numbers */
+
+/**
+ * Energy milestones are shown at visible 10-point boundaries, so decimal
+ * progress such as 9.9 -> 10.1 should produce the 10% milestone exactly once.
+ */
+function getEnergyMilestoneThreshold(energy: number) {
+  const clampedEnergy = clampEnergy(energy);
+
+  return Math.floor(clampedEnergy / ENERGY_MILESTONE_STEP) * ENERGY_MILESTONE_STEP;
+}
+
+/**
+ * The threshold screen should celebrate upward crossings only. If the learner
+ * was already inside the same 10-point band before this completion, showing the
+ * same threshold again would make ordinary follow-up lessons feel repetitive.
+ */
+export function getReachedEnergyThreshold({
+  newEnergy,
+  previousEnergy,
+}: {
+  newEnergy: number;
+  previousEnergy: number;
+}) {
+  const previousThreshold = getEnergyMilestoneThreshold(previousEnergy);
+  const newThreshold = getEnergyMilestoneThreshold(newEnergy);
+
+  if (newThreshold === 0 || newThreshold <= previousThreshold) {
+    return null;
+  }
+
+  return newThreshold;
+}
+
+/**
+ * Full-energy day milestones use a finite early ladder, then every 1,000 days
+ * after the first thousand. Keeping this rule in one predicate avoids repeating
+ * a long threshold list in both tests and milestone construction.
+ */
+export function isFullEnergyDayMilestone(dayCount: number) {
+  return (
+    FULL_ENERGY_DAY_MILESTONES.has(dayCount) ||
+    (dayCount > FULL_ENERGY_DAY_REPEAT_INTERVAL && dayCount % FULL_ENERGY_DAY_REPEAT_INTERVAL === 0)
+  );
+}
+
+/**
+ * A day should count as newly full only when today's stored daily row was not
+ * already capped. This prevents a second lesson at 100% Energy from retriggering
+ * the same full-day threshold.
+ */
+export function hasCompletedNewFullEnergyDay({
+  newEnergy,
+  todayEnergyAtEnd,
+}: {
+  newEnergy: number;
+  todayEnergyAtEnd: number | null;
+}) {
+  return (todayEnergyAtEnd ?? 0) < FULL_ENERGY && newEnergy >= FULL_ENERGY;
+}
+
+/**
+ * Learning-day milestones have a tighter early ladder, a 365-day marker, and
+ * then larger long-term checkpoints. Keeping the predicate here lets the
+ * milestone builder focus on whether today is a newly counted day.
+ */
+export function isLearningDayMilestone(dayCount: number) {
+  return LEARNING_DAY_MILESTONES.has(dayCount);
+}
+
+/**
+ * A lesson only creates a new learning day when the snapshot says today has no
+ * completed lessons yet. That keeps a second lesson on the same day from
+ * replaying a day-count milestone.
+ */
+export function hasCompletedNewLearningDay({
+  todayCompletedLessons = 0,
+}: {
+  todayCompletedLessons?: number;
+}) {
+  return todayCompletedLessons === 0;
+}
+
+/**
+ * Finds the largest learning-time checkpoint crossed by this completion. A
+ * single capped lesson can pass more than one early threshold, and showing the
+ * highest one keeps the pre-summary flow from stacking several time screens.
+ */
+export function getReachedLearningTimeThreshold({
+  newTotalSeconds,
+  previousTotalSeconds,
+}: {
+  newTotalSeconds: number;
+  previousTotalSeconds: number;
+}) {
+  return (
+    LEARNING_TIME_MILESTONE_SECONDS.findLast(
+      (seconds) => previousTotalSeconds < seconds && newTotalSeconds >= seconds,
+    ) ?? null
+  );
+}
+
+/**
+ * Converts the score-page weekday aggregate into the shared score-row shape so
+ * the player and score page rank best weekdays with the same utility.
+ */
+function getBestDayScoreRow(score: BestDayScore): ScoredRow {
+  return { correct: score.correctAnswers, incorrect: score.incorrectAnswers, key: score.dayOfWeek };
+}
+
+/**
+ * Ranks weekday scores with the same tie-breaking rules as the score page so
+ * the milestone never disagrees with the page linked from the screen.
+ */
+export function getBestDayScore(bestDayScores: BestDayScore[]) {
+  return findBestByScore(bestDayScores.map((score) => getBestDayScoreRow(score)));
+}

--- a/packages/player/src/_utils/completion-score-milestone.ts
+++ b/packages/player/src/_utils/completion-score-milestone.ts
@@ -57,23 +57,21 @@ function getTodayScore({
  * is saved, without mutating the server snapshot used by other milestones.
  */
 function getPostCompletionBestDayScores({
+  bestDayScores,
   completion,
-  progressSnapshot,
   todayDayOfWeek,
 }: {
+  bestDayScores: BestDayScore[];
   completion: CompletionProgress;
-  progressSnapshot: PlayerProgressSnapshot;
   todayDayOfWeek: number;
 }) {
-  const hasTodayScore = progressSnapshot.bestDayScores.some(
-    (score) => score.dayOfWeek === todayDayOfWeek,
-  );
+  const hasTodayScore = bestDayScores.some((score) => score.dayOfWeek === todayDayOfWeek);
 
   if (!hasTodayScore) {
-    return [...progressSnapshot.bestDayScores, getTodayScore({ completion, todayDayOfWeek })];
+    return [...bestDayScores, getTodayScore({ completion, todayDayOfWeek })];
   }
 
-  return progressSnapshot.bestDayScores.map((score) =>
+  return bestDayScores.map((score) =>
     getUpdatedBestDayScore({ completion, score, todayDayOfWeek }),
   );
 }
@@ -92,8 +90,11 @@ export function getBestDayMilestone({
   localDate: string;
   progressSnapshot: PlayerProgressSnapshot | null;
 }): ScoreCompletionMilestone | null {
+  const bestDayScores = progressSnapshot?.bestDayScores;
+
   if (
     !progressSnapshot ||
+    !bestDayScores ||
     !completion.completedInteractiveLesson ||
     (progressSnapshot.todayInteractiveLessons ?? 0) > 0
   ) {
@@ -103,7 +104,7 @@ export function getBestDayMilestone({
   const todayDayOfWeek = parseLocalDate(localDate).getUTCDay();
 
   const bestDay = getBestDayScore(
-    getPostCompletionBestDayScores({ completion, progressSnapshot, todayDayOfWeek }),
+    getPostCompletionBestDayScores({ bestDayScores, completion, todayDayOfWeek }),
   );
 
   if (!bestDay || bestDay.key !== todayDayOfWeek) {

--- a/packages/player/src/_utils/completion-score-milestone.ts
+++ b/packages/player/src/_utils/completion-score-milestone.ts
@@ -1,0 +1,114 @@
+import { parseLocalDate } from "@zoonk/utils/date";
+import { type CompletionProgress, type PlayerProgressSnapshot } from "../completion-milestones";
+import { type BestDayScore, getBestDayScore } from "./completion-milestone-thresholds";
+
+export type ScoreCompletionMilestone = {
+  dayOfWeek: number;
+  kind: "score";
+  score: number;
+  status: "bestDay";
+};
+
+/**
+ * Applies the just-finished lesson to the weekday totals before ranking them.
+ * The milestone appears before persistence finishes, but the linked score page
+ * will rank the saved totals, so the preview must include the current result.
+ */
+function getUpdatedBestDayScore({
+  completion,
+  score,
+  todayDayOfWeek,
+}: {
+  completion: CompletionProgress;
+  score: BestDayScore;
+  todayDayOfWeek: number;
+}): BestDayScore {
+  if (score.dayOfWeek !== todayDayOfWeek) {
+    return score;
+  }
+
+  return {
+    ...score,
+    correctAnswers: score.correctAnswers + (completion.correctCount ?? 0),
+    incorrectAnswers: score.incorrectAnswers + (completion.incorrectCount ?? 0),
+  };
+}
+
+/**
+ * Ensures today's weekday exists in the score rows even when this is the first
+ * interactive lesson on that weekday inside the rolling score window.
+ */
+function getTodayScore({
+  completion,
+  todayDayOfWeek,
+}: {
+  completion: CompletionProgress;
+  todayDayOfWeek: number;
+}): BestDayScore {
+  return {
+    correctAnswers: completion.correctCount ?? 0,
+    dayOfWeek: todayDayOfWeek,
+    incorrectAnswers: completion.incorrectCount ?? 0,
+  };
+}
+
+/**
+ * Builds the same weekday totals the score page will see after this completion
+ * is saved, without mutating the server snapshot used by other milestones.
+ */
+function getPostCompletionBestDayScores({
+  completion,
+  progressSnapshot,
+  todayDayOfWeek,
+}: {
+  completion: CompletionProgress;
+  progressSnapshot: PlayerProgressSnapshot;
+  todayDayOfWeek: number;
+}) {
+  const hasTodayScore = progressSnapshot.bestDayScores.some(
+    (score) => score.dayOfWeek === todayDayOfWeek,
+  );
+
+  if (!hasTodayScore) {
+    return [...progressSnapshot.bestDayScores, getTodayScore({ completion, todayDayOfWeek })];
+  }
+
+  return progressSnapshot.bestDayScores.map((score) =>
+    getUpdatedBestDayScore({ completion, score, todayDayOfWeek }),
+  );
+}
+
+/**
+ * Best-day milestones should appear once on the learner's strongest weekday.
+ * Requiring zero prior interactive lessons today makes the once-per-day rule
+ * durable after reloads, while session storage still protects prefetched pages.
+ */
+export function getBestDayMilestone({
+  completion,
+  localDate,
+  progressSnapshot,
+}: {
+  completion: CompletionProgress;
+  localDate: string;
+  progressSnapshot: PlayerProgressSnapshot | null;
+}): ScoreCompletionMilestone | null {
+  if (
+    !progressSnapshot ||
+    !completion.completedInteractiveLesson ||
+    (progressSnapshot.todayInteractiveLessons ?? 0) > 0
+  ) {
+    return null;
+  }
+
+  const todayDayOfWeek = parseLocalDate(localDate).getUTCDay();
+
+  const bestDay = getBestDayScore(
+    getPostCompletionBestDayScores({ completion, progressSnapshot, todayDayOfWeek }),
+  );
+
+  if (!bestDay || bestDay.key !== todayDayOfWeek) {
+    return null;
+  }
+
+  return { dayOfWeek: todayDayOfWeek, kind: "score", score: bestDay.score, status: "bestDay" };
+}

--- a/packages/player/src/completion-milestone-keys.ts
+++ b/packages/player/src/completion-milestone-keys.ts
@@ -26,6 +26,18 @@ export function getCompletionMilestoneKey({
     return `brain-power:daily-record:${localDate}`;
   }
 
+  if (milestone.kind === "learningDays") {
+    return `learning-days:${milestone.days}`;
+  }
+
+  if (milestone.kind === "learningTime") {
+    return `learning-time:${milestone.seconds}`;
+  }
+
+  if (milestone.kind === "score") {
+    return `score:best-day:${localDate}`;
+  }
+
   if (milestone.status === "achieved") {
     return `level:achieved:${milestone.belt.color}:${milestone.belt.level}`;
   }

--- a/packages/player/src/completion-milestone-storage.ts
+++ b/packages/player/src/completion-milestone-storage.ts
@@ -145,7 +145,7 @@ export function getEffectiveCompletionProgressSnapshot({
 
   if (!progressSnapshot) {
     return {
-      bestDayScores: [],
+      bestDayScores: null,
       currentEnergy: storedProgress.currentEnergy,
       fullEnergyDays: storedProgress.fullEnergyDays,
       highestPreviousDailyBrainPower: 0,
@@ -160,7 +160,7 @@ export function getEffectiveCompletionProgressSnapshot({
 
   return {
     ...progressSnapshot,
-    bestDayScores: progressSnapshot.bestDayScores ?? [],
+    bestDayScores: progressSnapshot.bestDayScores ?? null,
     currentEnergy: Math.max(progressSnapshot.currentEnergy, storedProgress.currentEnergy),
     fullEnergyDays: Math.max(progressSnapshot.fullEnergyDays, storedProgress.fullEnergyDays),
     learningDays: Math.max(progressSnapshot.learningDays ?? 0, storedProgress.learningDays),

--- a/packages/player/src/completion-milestone-storage.ts
+++ b/packages/player/src/completion-milestone-storage.ts
@@ -17,9 +17,13 @@ const FULL_ENERGY = 100;
 type StoredCompletionProgress = {
   currentEnergy: number;
   fullEnergyDays: number;
+  learningDays: number;
   localDate: string;
   todayBrainPower: number;
+  todayCompletedLessons: number;
   todayEnergyAtEnd: number | null;
+  todayInteractiveLessons: number;
+  totalLearningSeconds: number;
 };
 
 /**
@@ -67,6 +71,18 @@ function setSessionStorageItem(key: string, value: string) {
 }
 
 /**
+ * Stored progress can come from an older tab payload that predates newer
+ * milestone fields. Centralizing this fallback keeps backward-compatible
+ * parsing readable while still requiring core fields above to be valid.
+ */
+function getStoredNumber({ value }: { value: unknown }): number;
+function getStoredNumber({ fallback, value }: { fallback: null; value: unknown }): number | null;
+
+function getStoredNumber({ fallback = 0, value }: { fallback?: number | null; value: unknown }) {
+  return typeof value === "number" ? value : fallback;
+}
+
+/**
  * Parses the stored progress override conservatively so a corrupted value never
  * blocks milestone screens.
  */
@@ -96,10 +112,13 @@ function parseStoredCompletionProgress(rawValue: string | null): StoredCompletio
     return {
       currentEnergy: progress.currentEnergy,
       fullEnergyDays: progress.fullEnergyDays,
+      learningDays: getStoredNumber({ value: progress.learningDays }),
       localDate: progress.localDate,
       todayBrainPower: progress.todayBrainPower,
-      todayEnergyAtEnd:
-        typeof progress.todayEnergyAtEnd === "number" ? progress.todayEnergyAtEnd : null,
+      todayCompletedLessons: getStoredNumber({ value: progress.todayCompletedLessons }),
+      todayEnergyAtEnd: getStoredNumber({ fallback: null, value: progress.todayEnergyAtEnd }),
+      todayInteractiveLessons: getStoredNumber({ value: progress.todayInteractiveLessons }),
+      totalLearningSeconds: getStoredNumber({ value: progress.totalLearningSeconds }),
     };
   } catch {
     return null;
@@ -126,22 +145,41 @@ export function getEffectiveCompletionProgressSnapshot({
 
   if (!progressSnapshot) {
     return {
+      bestDayScores: [],
       currentEnergy: storedProgress.currentEnergy,
       fullEnergyDays: storedProgress.fullEnergyDays,
       highestPreviousDailyBrainPower: 0,
+      learningDays: storedProgress.learningDays,
       todayBrainPower: storedProgress.todayBrainPower,
+      todayCompletedLessons: storedProgress.todayCompletedLessons,
       todayEnergyAtEnd: storedProgress.todayEnergyAtEnd,
+      todayInteractiveLessons: storedProgress.todayInteractiveLessons,
+      totalLearningSeconds: storedProgress.totalLearningSeconds,
     };
   }
 
   return {
     ...progressSnapshot,
+    bestDayScores: progressSnapshot.bestDayScores ?? [],
     currentEnergy: Math.max(progressSnapshot.currentEnergy, storedProgress.currentEnergy),
     fullEnergyDays: Math.max(progressSnapshot.fullEnergyDays, storedProgress.fullEnergyDays),
+    learningDays: Math.max(progressSnapshot.learningDays ?? 0, storedProgress.learningDays),
     todayBrainPower: Math.max(progressSnapshot.todayBrainPower, storedProgress.todayBrainPower),
+    todayCompletedLessons: Math.max(
+      progressSnapshot.todayCompletedLessons ?? 0,
+      storedProgress.todayCompletedLessons,
+    ),
     todayEnergyAtEnd: Math.max(
       progressSnapshot.todayEnergyAtEnd ?? 0,
       storedProgress.todayEnergyAtEnd ?? 0,
+    ),
+    todayInteractiveLessons: Math.max(
+      progressSnapshot.todayInteractiveLessons ?? 0,
+      storedProgress.todayInteractiveLessons,
+    ),
+    totalLearningSeconds: Math.max(
+      progressSnapshot.totalLearningSeconds ?? 0,
+      storedProgress.totalLearningSeconds,
     ),
   };
 }
@@ -180,7 +218,10 @@ function getNextStoredCompletionProgress({
   localDate,
   progressSnapshot,
 }: {
-  completion: Pick<CompletionResult, "brainPower" | "energyDelta">;
+  completion: Pick<
+    CompletionResult,
+    "brainPower" | "correctCount" | "energyDelta" | "incorrectCount"
+  > & { completedInteractiveLesson?: boolean; lessonDurationSeconds?: number };
   localDate: string;
   progressSnapshot: PlayerProgressSnapshot | null;
 }): StoredCompletionProgress | null {
@@ -192,13 +233,22 @@ function getNextStoredCompletionProgress({
   const todayWasAlreadyFull = (progressSnapshot.todayEnergyAtEnd ?? 0) >= FULL_ENERGY;
   const todayIsNowFull = currentEnergy >= FULL_ENERGY;
 
+  const completedNewLearningDay = (progressSnapshot.todayCompletedLessons ?? 0) === 0;
+
   return {
     currentEnergy,
     fullEnergyDays:
       progressSnapshot.fullEnergyDays + (!todayWasAlreadyFull && todayIsNowFull ? 1 : 0),
+    learningDays: (progressSnapshot.learningDays ?? 0) + (completedNewLearningDay ? 1 : 0),
     localDate,
     todayBrainPower: progressSnapshot.todayBrainPower + completion.brainPower,
+    todayCompletedLessons: (progressSnapshot.todayCompletedLessons ?? 0) + 1,
     todayEnergyAtEnd: currentEnergy,
+    todayInteractiveLessons:
+      (progressSnapshot.todayInteractiveLessons ?? 0) +
+      (completion.completedInteractiveLesson ? 1 : 0),
+    totalLearningSeconds:
+      (progressSnapshot.totalLearningSeconds ?? 0) + (completion.lessonDurationSeconds ?? 0),
   };
 }
 
@@ -211,7 +261,10 @@ export function rememberCompletionProgress({
   localDate,
   progressSnapshot,
 }: {
-  completion: Pick<CompletionResult, "brainPower" | "energyDelta">;
+  completion: Pick<
+    CompletionResult,
+    "brainPower" | "correctCount" | "energyDelta" | "incorrectCount"
+  > & { completedInteractiveLesson?: boolean; lessonDurationSeconds?: number };
   localDate: string;
   progressSnapshot: PlayerProgressSnapshot | null;
 }) {

--- a/packages/player/src/completion-milestones.test.ts
+++ b/packages/player/src/completion-milestones.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { getCompletionMilestoneKey } from "./completion-milestone-keys";
-import { getCompletionMilestones } from "./completion-milestones";
+import { type PlayerProgressSnapshot, getCompletionMilestones } from "./completion-milestones";
+
+function buildProgressSnapshot(
+  overrides: Partial<PlayerProgressSnapshot> = {},
+): PlayerProgressSnapshot {
+  return {
+    bestDayScores: [],
+    currentEnergy: 0,
+    fullEnergyDays: 0,
+    highestPreviousDailyBrainPower: 0,
+    learningDays: 0,
+    todayBrainPower: 0,
+    todayCompletedLessons: 0,
+    todayEnergyAtEnd: null,
+    todayInteractiveLessons: 0,
+    totalLearningSeconds: 0,
+    ...overrides,
+  };
+}
 
 describe(getCompletionMilestones, () => {
   it("returns a level milestone when completion reaches a new belt level", () => {
@@ -72,20 +90,14 @@ describe(getCompletionMilestones, () => {
     });
 
     expect(milestones).toHaveLength(1);
-    expect(milestones[0]?.status).toBe("achieved");
+    expect(milestones[0]).toMatchObject({ kind: "level", status: "achieved" });
   });
 
   it("returns an energy milestone when completion reaches the next 10% threshold", () => {
     const milestones = getCompletionMilestones({
       completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
       previousTotalBrainPower: 0,
-      progressSnapshot: {
-        currentEnergy: 9.9,
-        fullEnergyDays: 0,
-        highestPreviousDailyBrainPower: 0,
-        todayBrainPower: 0,
-        todayEnergyAtEnd: null,
-      },
+      progressSnapshot: buildProgressSnapshot({ currentEnergy: 9.9 }),
     });
 
     expect(milestones).toContainEqual({ energy: 10, kind: "energy", status: "threshold" });
@@ -95,13 +107,7 @@ describe(getCompletionMilestones, () => {
     const milestones = getCompletionMilestones({
       completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
       previousTotalBrainPower: 0,
-      progressSnapshot: {
-        currentEnergy: 10,
-        fullEnergyDays: 0,
-        highestPreviousDailyBrainPower: 0,
-        todayBrainPower: 0,
-        todayEnergyAtEnd: null,
-      },
+      progressSnapshot: buildProgressSnapshot({ currentEnergy: 10 }),
     });
 
     expect(milestones).not.toContainEqual({ energy: 10, kind: "energy", status: "threshold" });
@@ -119,13 +125,10 @@ describe(getCompletionMilestones, () => {
       completion: { brainPower: 10, energyDelta: 0.1, newTotalBp: 20 },
       localDate: "2026-06-05",
       previousTotalBrainPower: 10,
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 9.9,
-        fullEnergyDays: 0,
         highestPreviousDailyBrainPower: 100,
-        todayBrainPower: 0,
-        todayEnergyAtEnd: null,
-      },
+      }),
       shownMilestoneKeys,
     });
 
@@ -136,13 +139,11 @@ describe(getCompletionMilestones, () => {
     const milestones = getCompletionMilestones({
       completion: { brainPower: 10, energyDelta: 1, newTotalBp: 10 },
       previousTotalBrainPower: 0,
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 99,
         fullEnergyDays: 29,
-        highestPreviousDailyBrainPower: 0,
-        todayBrainPower: 0,
         todayEnergyAtEnd: 99,
-      },
+      }),
     });
 
     expect(milestones).toContainEqual({ days: 30, kind: "energy", status: "fullDays" });
@@ -152,13 +153,11 @@ describe(getCompletionMilestones, () => {
     const milestones = getCompletionMilestones({
       completion: { brainPower: 10, energyDelta: 1, newTotalBp: 10 },
       previousTotalBrainPower: 0,
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 99,
         fullEnergyDays: 1999,
-        highestPreviousDailyBrainPower: 0,
-        todayBrainPower: 0,
         todayEnergyAtEnd: 99,
-      },
+      }),
     });
 
     expect(milestones).toContainEqual({ days: 2000, kind: "energy", status: "fullDays" });
@@ -168,13 +167,11 @@ describe(getCompletionMilestones, () => {
     const milestones = getCompletionMilestones({
       completion: { brainPower: 10, energyDelta: 1, newTotalBp: 10 },
       previousTotalBrainPower: 0,
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 100,
         fullEnergyDays: 30,
-        highestPreviousDailyBrainPower: 0,
-        todayBrainPower: 0,
         todayEnergyAtEnd: 100,
-      },
+      }),
     });
 
     expect(milestones).not.toContainEqual({ days: 30, kind: "energy", status: "fullDays" });
@@ -184,13 +181,12 @@ describe(getCompletionMilestones, () => {
     const milestones = getCompletionMilestones({
       completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 110 },
       previousTotalBrainPower: 100,
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 20,
-        fullEnergyDays: 0,
         highestPreviousDailyBrainPower: 40,
         todayBrainPower: 40,
         todayEnergyAtEnd: 20,
-      },
+      }),
     });
 
     expect(milestones).toContainEqual({
@@ -204,13 +200,7 @@ describe(getCompletionMilestones, () => {
     const milestones = getCompletionMilestones({
       completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
       previousTotalBrainPower: 0,
-      progressSnapshot: {
-        currentEnergy: 0,
-        fullEnergyDays: 0,
-        highestPreviousDailyBrainPower: 0,
-        todayBrainPower: 0,
-        todayEnergyAtEnd: null,
-      },
+      progressSnapshot: buildProgressSnapshot(),
     });
 
     expect(milestones).not.toContainEqual({
@@ -224,13 +214,12 @@ describe(getCompletionMilestones, () => {
     const milestones = getCompletionMilestones({
       completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 120 },
       previousTotalBrainPower: 110,
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 20,
-        fullEnergyDays: 0,
         highestPreviousDailyBrainPower: 40,
         todayBrainPower: 50,
         todayEnergyAtEnd: 20,
-      },
+      }),
     });
 
     expect(milestones).not.toContainEqual({
@@ -252,13 +241,12 @@ describe(getCompletionMilestones, () => {
       completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 120 },
       localDate: "2026-06-05",
       previousTotalBrainPower: 110,
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 20,
-        fullEnergyDays: 0,
         highestPreviousDailyBrainPower: 40,
         todayBrainPower: 40,
         todayEnergyAtEnd: 20,
-      },
+      }),
       shownMilestoneKeys,
     });
 
@@ -266,6 +254,240 @@ describe(getCompletionMilestones, () => {
       brainPower: 50,
       kind: "brainPower",
       status: "dailyRecord",
+    });
+  });
+
+  it("returns a learning-days milestone when completion starts a tracked new day", () => {
+    const milestones = getCompletionMilestones({
+      completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({ learningDays: 4 }),
+    });
+
+    expect(milestones).toContainEqual({ days: 5, kind: "learningDays" });
+  });
+
+  it("does not repeat a learning-days milestone when today already counted", () => {
+    const milestones = getCompletionMilestones({
+      completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({ learningDays: 4, todayCompletedLessons: 1 }),
+    });
+
+    expect(milestones).not.toContainEqual({ days: 5, kind: "learningDays" });
+  });
+
+  it("returns learning-days milestones for hundreds through 1,000 and thousands after that", () => {
+    const cases = [
+      { expectedDays: 100 },
+      { expectedDays: 400 },
+      { expectedDays: 700 },
+      { expectedDays: 900 },
+      { expectedDays: 1000 },
+      { expectedDays: 3000 },
+      { expectedDays: 9000 },
+      { expectedDays: 10_000 },
+    ];
+
+    for (const { expectedDays } of cases) {
+      const milestones = getCompletionMilestones({
+        completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
+        previousTotalBrainPower: 0,
+        progressSnapshot: buildProgressSnapshot({ learningDays: expectedDays - 1 }),
+      });
+
+      expect(milestones).toContainEqual({ days: expectedDays, kind: "learningDays" });
+    }
+  });
+
+  it("returns a learning-time milestone when completion reaches ten minutes", () => {
+    const milestones = getCompletionMilestones({
+      completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
+      lessonDurationSeconds: 20,
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({ totalLearningSeconds: 580 }),
+    });
+
+    expect(milestones).toContainEqual({ kind: "learningTime", seconds: 600 });
+  });
+
+  it("returns the special full-day learning-time milestone at 24 hours", () => {
+    const milestones = getCompletionMilestones({
+      completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
+      lessonDurationSeconds: 120,
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({ totalLearningSeconds: 86_280 }),
+    });
+
+    expect(milestones).toContainEqual({ kind: "learningTime", seconds: 86_400 });
+  });
+
+  it("returns large learning-time milestones on the expected hour steps", () => {
+    const milestones = getCompletionMilestones({
+      completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
+      lessonDurationSeconds: 120,
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({ totalLearningSeconds: 3_599_980 }),
+    });
+
+    expect(milestones).toContainEqual({ kind: "learningTime", seconds: 3_600_000 });
+  });
+
+  it("returns learning-time milestones throughout each stepped hour interval", () => {
+    const cases = [
+      { expectedHours: 100 },
+      { expectedHours: 300 },
+      { expectedHours: 700 },
+      { expectedHours: 900 },
+      { expectedHours: 4000 },
+      { expectedHours: 90_000 },
+      { expectedHours: 900_000 },
+      { expectedHours: 9_000_000 },
+    ];
+
+    for (const { expectedHours } of cases) {
+      const expectedSeconds = expectedHours * 60 * 60;
+
+      const milestones = getCompletionMilestones({
+        completion: { brainPower: 10, energyDelta: 0.2, newTotalBp: 10 },
+        lessonDurationSeconds: 1,
+        previousTotalBrainPower: 0,
+        progressSnapshot: buildProgressSnapshot({ totalLearningSeconds: expectedSeconds - 1 }),
+      });
+
+      expect(milestones).toContainEqual({ kind: "learningTime", seconds: expectedSeconds });
+    }
+  });
+
+  it("returns a best-day milestone on the first interactive completion of the best weekday", () => {
+    const milestones = getCompletionMilestones({
+      completion: {
+        brainPower: 10,
+        completedInteractiveLesson: true,
+        correctCount: 1,
+        energyDelta: 0.2,
+        incorrectCount: 0,
+        newTotalBp: 10,
+      },
+      localDate: "2026-06-08",
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({
+        bestDayScores: [
+          { correctAnswers: 17, dayOfWeek: 1, incorrectAnswers: 2 },
+          { correctAnswers: 14, dayOfWeek: 2, incorrectAnswers: 6 },
+        ],
+      }),
+    });
+
+    expect(milestones).toContainEqual({
+      dayOfWeek: 1,
+      kind: "score",
+      score: 90,
+      status: "bestDay",
+    });
+  });
+
+  it("returns a best-day milestone when the current lesson makes today the best weekday", () => {
+    const milestones = getCompletionMilestones({
+      completion: {
+        brainPower: 10,
+        completedInteractiveLesson: true,
+        correctCount: 10,
+        energyDelta: 0.2,
+        incorrectCount: 0,
+        newTotalBp: 10,
+      },
+      localDate: "2026-06-08",
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({
+        bestDayScores: [{ correctAnswers: 8, dayOfWeek: 2, incorrectAnswers: 2 }],
+      }),
+    });
+
+    expect(milestones).toContainEqual({
+      dayOfWeek: 1,
+      kind: "score",
+      score: 100,
+      status: "bestDay",
+    });
+  });
+
+  it("does not show best-day milestones when the current lesson makes another weekday best", () => {
+    const milestones = getCompletionMilestones({
+      completion: {
+        brainPower: 10,
+        completedInteractiveLesson: true,
+        correctCount: 0,
+        energyDelta: 0.2,
+        incorrectCount: 10,
+        newTotalBp: 10,
+      },
+      localDate: "2026-06-08",
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({
+        bestDayScores: [
+          { correctAnswers: 1, dayOfWeek: 1, incorrectAnswers: 0 },
+          { correctAnswers: 8, dayOfWeek: 2, incorrectAnswers: 2 },
+        ],
+      }),
+    });
+
+    expect(milestones).not.toContainEqual({
+      dayOfWeek: 1,
+      kind: "score",
+      score: 100,
+      status: "bestDay",
+    });
+  });
+
+  it("does not repeat the best-day milestone after an interactive lesson today", () => {
+    const milestones = getCompletionMilestones({
+      completion: {
+        brainPower: 10,
+        completedInteractiveLesson: true,
+        correctCount: 1,
+        energyDelta: 0.2,
+        incorrectCount: 0,
+        newTotalBp: 10,
+      },
+      localDate: "2026-06-08",
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({
+        bestDayScores: [{ correctAnswers: 18, dayOfWeek: 1, incorrectAnswers: 2 }],
+        todayInteractiveLessons: 1,
+      }),
+    });
+
+    expect(milestones).not.toContainEqual({
+      dayOfWeek: 1,
+      kind: "score",
+      score: 90,
+      status: "bestDay",
+    });
+  });
+
+  it("does not show the best-day milestone for static lesson completions", () => {
+    const milestones = getCompletionMilestones({
+      completion: {
+        brainPower: 10,
+        completedInteractiveLesson: false,
+        correctCount: 0,
+        energyDelta: 0.1,
+        incorrectCount: 0,
+        newTotalBp: 10,
+      },
+      localDate: "2026-06-08",
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({
+        bestDayScores: [{ correctAnswers: 18, dayOfWeek: 1, incorrectAnswers: 2 }],
+      }),
+    });
+
+    expect(milestones).not.toContainEqual({
+      dayOfWeek: 1,
+      kind: "score",
+      score: 90,
+      status: "bestDay",
     });
   });
 });

--- a/packages/player/src/completion-milestones.ts
+++ b/packages/player/src/completion-milestones.ts
@@ -1,64 +1,67 @@
 import { type CompletionResult } from "@zoonk/core/player/contracts/completion-input-schema";
-import { type BeltLevelResult, calculateBeltLevel } from "@zoonk/utils/belt-level";
-import { clampEnergy } from "@zoonk/utils/energy";
+import {
+  type BrainPowerCompletionMilestone,
+  getDailyBrainPowerRecordMilestone,
+} from "./_utils/completion-brain-power-milestone";
+import {
+  type EnergyCompletionMilestone,
+  getEnergyThresholdMilestone,
+  getFullEnergyDaysMilestone,
+} from "./_utils/completion-energy-milestone";
+import {
+  type LearningDaysCompletionMilestone,
+  type LearningTimeCompletionMilestone,
+  getLearningDaysMilestone,
+  getLearningTimeMilestone,
+} from "./_utils/completion-learning-milestone";
+import {
+  type LevelCompletionMilestone,
+  getLevelCompletionMilestone,
+} from "./_utils/completion-level-milestone";
+import { type BestDayScore } from "./_utils/completion-milestone-thresholds";
+import {
+  type ScoreCompletionMilestone,
+  getBestDayMilestone,
+} from "./_utils/completion-score-milestone";
 import {
   type PlayerCompletionMilestoneKey,
   getUnseenMilestones,
 } from "./completion-milestone-keys";
 
-type CompletionProgress = Pick<CompletionResult, "brainPower" | "energyDelta" | "newTotalBp">;
-
-type LevelCompletionMilestone =
-  | { belt: BeltLevelResult; kind: "level"; status: "achieved" }
-  | {
-      currentBelt: BeltLevelResult;
-      kind: "level";
-      remainingLessons: number;
-      status: "halfway";
-      targetBelt: BeltLevelResult;
-    };
-
-type EnergyCompletionMilestone =
-  | { energy: number; kind: "energy"; status: "threshold" }
-  | { days: number; kind: "energy"; status: "fullDays" };
-
-type BrainPowerCompletionMilestone = {
-  brainPower: number;
-  kind: "brainPower";
-  status: "dailyRecord";
+export type PlayerCompletionResult = CompletionResult & {
+  completedInteractiveLesson?: boolean;
+  lessonDurationSeconds?: number;
 };
 
+export type CompletionProgress = Pick<
+  CompletionResult,
+  "brainPower" | "energyDelta" | "newTotalBp"
+> &
+  Partial<Pick<CompletionResult, "correctCount" | "incorrectCount">> & {
+    completedInteractiveLesson?: boolean;
+    lessonDurationSeconds?: number;
+  };
+
 export type PlayerProgressSnapshot = {
+  bestDayScores: BestDayScore[];
   currentEnergy: number;
   fullEnergyDays: number;
   highestPreviousDailyBrainPower: number;
+  learningDays: number;
   todayBrainPower: number;
+  todayCompletedLessons: number;
   todayEnergyAtEnd: number | null;
+  todayInteractiveLessons: number;
+  totalLearningSeconds: number;
 };
 
 export type PlayerCompletionMilestone =
   | BrainPowerCompletionMilestone
   | EnergyCompletionMilestone
-  | LevelCompletionMilestone;
-
-const ENERGY_MILESTONE_STEP = 10;
-const FULL_ENERGY = 100;
-const THIRTY_FULL_ENERGY_DAYS = 30;
-const TWO_HUNDRED_FULL_ENERGY_DAYS = 200;
-const THREE_HUNDRED_FULL_ENERGY_DAYS = 300;
-const FULL_ENERGY_YEAR_DAYS = 365;
-const FIVE_HUNDRED_FULL_ENERGY_DAYS = 500;
-const THOUSAND_FULL_ENERGY_DAYS = 1000;
-
-const FULL_ENERGY_DAY_MILESTONES = new Set([
-  THIRTY_FULL_ENERGY_DAYS,
-  FULL_ENERGY,
-  TWO_HUNDRED_FULL_ENERGY_DAYS,
-  THREE_HUNDRED_FULL_ENERGY_DAYS,
-  FULL_ENERGY_YEAR_DAYS,
-  FIVE_HUNDRED_FULL_ENERGY_DAYS,
-  THOUSAND_FULL_ENERGY_DAYS,
-]);
+  | LearningDaysCompletionMilestone
+  | LearningTimeCompletionMilestone
+  | LevelCompletionMilestone
+  | ScoreCompletionMilestone;
 
 /**
  * Null milestones are a natural result of independent checks. This guard keeps
@@ -72,278 +75,6 @@ function isMilestone(
 }
 
 /**
- * Energy milestones are shown at visible 10-point boundaries, so decimal
- * progress such as 9.9 -> 10.1 should produce the 10% milestone exactly once.
- */
-function getEnergyMilestoneThreshold(energy: number) {
-  const clampedEnergy = clampEnergy(energy);
-
-  return Math.floor(clampedEnergy / ENERGY_MILESTONE_STEP) * ENERGY_MILESTONE_STEP;
-}
-
-/**
- * The threshold screen should celebrate upward crossings only. If the learner
- * was already inside the same 10-point band before this completion, showing the
- * same threshold again would make ordinary follow-up lessons feel repetitive.
- */
-function getReachedEnergyThreshold({
-  newEnergy,
-  previousEnergy,
-}: {
-  newEnergy: number;
-  previousEnergy: number;
-}) {
-  const previousThreshold = getEnergyMilestoneThreshold(previousEnergy);
-  const newThreshold = getEnergyMilestoneThreshold(newEnergy);
-
-  if (newThreshold === 0 || newThreshold <= previousThreshold) {
-    return null;
-  }
-
-  return newThreshold;
-}
-
-/**
- * Full-energy day milestones use a finite early ladder, then every 1,000 days
- * after the first thousand. Keeping this rule in one predicate avoids repeating
- * a long threshold list in both tests and milestone construction.
- */
-function isFullEnergyDayMilestone(dayCount: number) {
-  return (
-    FULL_ENERGY_DAY_MILESTONES.has(dayCount) ||
-    (dayCount > THOUSAND_FULL_ENERGY_DAYS && dayCount % THOUSAND_FULL_ENERGY_DAYS === 0)
-  );
-}
-
-/**
- * A day should count as newly full only when today's stored daily row was not
- * already capped. This prevents a second lesson at 100% Energy from retriggering
- * the same full-day threshold.
- */
-function hasCompletedNewFullEnergyDay({
-  newEnergy,
-  todayEnergyAtEnd,
-}: {
-  newEnergy: number;
-  todayEnergyAtEnd: number | null;
-}) {
-  return (todayEnergyAtEnd ?? 0) < FULL_ENERGY && newEnergy >= FULL_ENERGY;
-}
-
-/**
- * Computes the post-completion Energy from the server snapshot and the same
- * lesson score used by the completion summary. The server writes the same
- * clamped value later, so the milestone preview matches persisted progress.
- */
-function getNewEnergy({
-  completion,
-  progressSnapshot,
-}: {
-  completion: CompletionProgress;
-  progressSnapshot: PlayerProgressSnapshot;
-}) {
-  return clampEnergy(progressSnapshot.currentEnergy + completion.energyDelta);
-}
-
-/**
- * Builds the 10-point Energy milestone when this completion moves the learner
- * into a new visible Energy band.
- */
-function getEnergyThresholdMilestone({
-  completion,
-  progressSnapshot,
-}: {
-  completion: CompletionProgress;
-  progressSnapshot: PlayerProgressSnapshot | null;
-}): EnergyCompletionMilestone | null {
-  if (!progressSnapshot) {
-    return null;
-  }
-
-  const newEnergy = getNewEnergy({ completion, progressSnapshot });
-
-  const energy = getReachedEnergyThreshold({
-    newEnergy,
-    previousEnergy: progressSnapshot.currentEnergy,
-  });
-
-  if (energy === null) {
-    return null;
-  }
-
-  return { energy, kind: "energy", status: "threshold" };
-}
-
-/**
- * Builds the full-energy-day milestone from the pre-completion count plus
- * today's possible first 100% Energy finish.
- */
-function getFullEnergyDaysMilestone({
-  completion,
-  progressSnapshot,
-}: {
-  completion: CompletionProgress;
-  progressSnapshot: PlayerProgressSnapshot | null;
-}): EnergyCompletionMilestone | null {
-  if (!progressSnapshot) {
-    return null;
-  }
-
-  const newEnergy = getNewEnergy({ completion, progressSnapshot });
-
-  const completedFullEnergyDay = hasCompletedNewFullEnergyDay({
-    newEnergy,
-    todayEnergyAtEnd: progressSnapshot.todayEnergyAtEnd,
-  });
-
-  const newFullEnergyDays = progressSnapshot.fullEnergyDays + (completedFullEnergyDay ? 1 : 0);
-
-  if (!completedFullEnergyDay || !isFullEnergyDayMilestone(newFullEnergyDays)) {
-    return null;
-  }
-
-  return { days: newFullEnergyDays, kind: "energy", status: "fullDays" };
-}
-
-/**
- * Daily Brain Power records should fire once per day: the first completion that
- * beats every previous day's BP earns the milestone, but later lessons on the
- * same already-record-setting day stay quiet.
- */
-function getDailyBrainPowerRecordMilestone({
-  completion,
-  progressSnapshot,
-}: {
-  completion: CompletionProgress;
-  progressSnapshot: PlayerProgressSnapshot | null;
-}): BrainPowerCompletionMilestone | null {
-  if (
-    !progressSnapshot ||
-    completion.brainPower <= 0 ||
-    progressSnapshot.highestPreviousDailyBrainPower <= 0
-  ) {
-    return null;
-  }
-
-  const newTodayBrainPower = progressSnapshot.todayBrainPower + completion.brainPower;
-
-  if (
-    progressSnapshot.todayBrainPower > progressSnapshot.highestPreviousDailyBrainPower ||
-    newTodayBrainPower <= progressSnapshot.highestPreviousDailyBrainPower
-  ) {
-    return null;
-  }
-
-  return { brainPower: newTodayBrainPower, kind: "brainPower", status: "dailyRecord" };
-}
-
-/**
- * A belt milestone should only celebrate when the learner crosses into a new
- * visible belt state. Comparing both color and level covers same-color level
- * gains and color changes like White 10 to Yellow 1.
- */
-function hasReachedNewBeltLevel({
-  currentBelt,
-  previousBelt,
-}: {
-  currentBelt: BeltLevelResult;
-  previousBelt: BeltLevelResult;
-}) {
-  return currentBelt.color !== previousBelt.color || currentBelt.level !== previousBelt.level;
-}
-
-/**
- * Halfway milestones should fire once per level, exactly when the new total
- * moves from the first half of the current level into the second half. This
- * keeps the screen meaningful without showing it again on every later lesson.
- */
-function hasReachedLevelHalfway({
-  currentBelt,
-  previousBelt,
-}: {
-  currentBelt: BeltLevelResult;
-  previousBelt: BeltLevelResult;
-}) {
-  const halfwayBp = currentBelt.bpPerLevel / 2;
-
-  const stayedInSameLevel =
-    currentBelt.color === previousBelt.color && currentBelt.level === previousBelt.level;
-
-  return (
-    stayedInSameLevel &&
-    !currentBelt.isMaxLevel &&
-    previousBelt.progressInLevel < halfwayBp &&
-    currentBelt.progressInLevel >= halfwayBp
-  );
-}
-
-/**
- * The halfway message names the next visible belt state, not the level the
- * learner is currently inside. Adding the remaining BP to the current total
- * asks the shared belt calculator for that next visible state directly.
- */
-function getNextBeltLevel({
-  currentBelt,
-  totalBrainPower,
-}: {
-  currentBelt: BeltLevelResult;
-  totalBrainPower: number;
-}) {
-  return calculateBeltLevel(totalBrainPower + currentBelt.bpToNextLevel);
-}
-
-/**
- * The milestone copy talks in lessons because that is the action learners can
- * take next. Using the current lesson reward keeps the estimate aligned with
- * the same scoring contract that produced the completion result.
- */
-function getRemainingLessonCount({
-  brainPower,
-  currentBelt,
-}: {
-  brainPower: number;
-  currentBelt: BeltLevelResult;
-}) {
-  if (brainPower <= 0) {
-    return currentBelt.bpToNextLevel;
-  }
-
-  return Math.ceil(currentBelt.bpToNextLevel / brainPower);
-}
-
-/**
- * Builds the level milestone for a completion. Achieved level changes outrank
- * halfway nudges inside this family, so crossing a belt boundary never also
- * shows the halfway message for the level that just ended.
- */
-function getLevelCompletionMilestone({
-  completion,
-  previousTotalBrainPower,
-}: {
-  completion: CompletionProgress;
-  previousTotalBrainPower: number;
-}): LevelCompletionMilestone | null {
-  const currentBelt = calculateBeltLevel(completion.newTotalBp);
-  const previousBelt = calculateBeltLevel(previousTotalBrainPower);
-
-  if (hasReachedNewBeltLevel({ currentBelt, previousBelt })) {
-    return { belt: currentBelt, kind: "level", status: "achieved" };
-  }
-
-  if (!hasReachedLevelHalfway({ currentBelt, previousBelt })) {
-    return null;
-  }
-
-  return {
-    currentBelt,
-    kind: "level",
-    remainingLessons: getRemainingLessonCount({ brainPower: completion.brainPower, currentBelt }),
-    status: "halfway",
-    targetBelt: getNextBeltLevel({ currentBelt, totalBrainPower: completion.newTotalBp }),
-  };
-}
-
-/**
  * Derives the ordered milestone screens that should appear after a completion.
  *
  * Each milestone compares the post-lesson value with the page-load snapshot, so
@@ -352,12 +83,14 @@ function getLevelCompletionMilestone({
  */
 export function getCompletionMilestones({
   completion,
+  lessonDurationSeconds = completion.lessonDurationSeconds ?? 0,
   localDate = "",
   previousTotalBrainPower,
   progressSnapshot = null,
   shownMilestoneKeys = [],
 }: {
   completion: CompletionProgress;
+  lessonDurationSeconds?: number;
   localDate?: string;
   previousTotalBrainPower: number;
   progressSnapshot?: PlayerProgressSnapshot | null;
@@ -365,9 +98,12 @@ export function getCompletionMilestones({
 }): PlayerCompletionMilestone[] {
   const milestones = [
     getLevelCompletionMilestone({ completion, previousTotalBrainPower }),
+    getLearningDaysMilestone({ progressSnapshot }),
+    getLearningTimeMilestone({ lessonDurationSeconds, progressSnapshot }),
     getEnergyThresholdMilestone({ completion, progressSnapshot }),
     getFullEnergyDaysMilestone({ completion, progressSnapshot }),
     getDailyBrainPowerRecordMilestone({ completion, progressSnapshot }),
+    getBestDayMilestone({ completion, localDate, progressSnapshot }),
   ].filter((milestone) => isMilestone(milestone));
 
   return getUnseenMilestones({ localDate, milestones, shownMilestoneKeys });
@@ -380,12 +116,14 @@ export function getCompletionMilestones({
  */
 export function getInitialCompletionMilestoneIndex({
   completion,
+  lessonDurationSeconds = completion.lessonDurationSeconds ?? 0,
   localDate = "",
   previousTotalBrainPower,
   progressSnapshot = null,
   shownMilestoneKeys = [],
 }: {
   completion: CompletionProgress;
+  lessonDurationSeconds?: number;
   localDate?: string;
   previousTotalBrainPower: number;
   progressSnapshot?: PlayerProgressSnapshot | null;
@@ -393,6 +131,7 @@ export function getInitialCompletionMilestoneIndex({
 }): number | null {
   const milestones = getCompletionMilestones({
     completion,
+    lessonDurationSeconds,
     localDate,
     previousTotalBrainPower,
     progressSnapshot,

--- a/packages/player/src/completion-milestones.ts
+++ b/packages/player/src/completion-milestones.ts
@@ -43,7 +43,7 @@ export type CompletionProgress = Pick<
   };
 
 export type PlayerProgressSnapshot = {
-  bestDayScores: BestDayScore[];
+  bestDayScores: BestDayScore[] | null;
   currentEnergy: number;
   fullEnergyDays: number;
   highestPreviousDailyBrainPower: number;

--- a/packages/player/src/components/completion-learning-days-milestone.tsx
+++ b/packages/player/src/components/completion-learning-days-milestone.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { formatWholeNumber } from "@zoonk/utils/number";
+import { CalendarDaysIcon } from "lucide-react";
+import { useExtracted, useFormatter } from "next-intl";
+import { type PlayerCompletionMilestone } from "../completion-milestones";
+import { CompletionMilestoneMark, CompletionMilestoneTitle } from "./completion-milestone-shell";
+import { PlayerSupportingText } from "./player-supporting-text";
+
+type LearningDaysMilestone = Extract<PlayerCompletionMilestone, { kind: "learningDays" }>;
+
+/**
+ * Learning-day milestones use a calendar mark because the achievement is about
+ * returning on different days, not about one lesson's score.
+ */
+export function LearningDaysMilestoneIndicator() {
+  return (
+    <CompletionMilestoneMark>
+      <span className="bg-score/10 text-score flex size-10 items-center justify-center rounded-full">
+        <CalendarDaysIcon aria-hidden className="size-5" />
+      </span>
+    </CompletionMilestoneMark>
+  );
+}
+
+/**
+ * Explains the day-count checkpoint in plain habit-building language so the
+ * learner understands why different learning days matter.
+ */
+export function LearningDaysMilestoneCopy({ milestone }: { milestone: LearningDaysMilestone }) {
+  const t = useExtracted();
+  const format = useFormatter();
+  const formattedDays = formatWholeNumber({ format, value: milestone.days });
+
+  return (
+    <>
+      <CompletionMilestoneTitle>
+        {t("{days} learning days", { days: formattedDays })}
+      </CompletionMilestoneTitle>
+      <PlayerSupportingText>
+        {t(
+          "You've completed lessons on {days} different days. Practicing often helps you remember what you learn.",
+          { days: formattedDays },
+        )}
+      </PlayerSupportingText>
+    </>
+  );
+}

--- a/packages/player/src/components/completion-learning-time-milestone.tsx
+++ b/packages/player/src/components/completion-learning-time-milestone.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { formatWholeNumber } from "@zoonk/utils/number";
+import { ClockIcon } from "lucide-react";
+import { useExtracted, useFormatter } from "next-intl";
+import { type PlayerCompletionMilestone } from "../completion-milestones";
+import { CompletionMilestoneMark, CompletionMilestoneTitle } from "./completion-milestone-shell";
+import { PlayerSupportingText } from "./player-supporting-text";
+
+type LearningTimeMilestone = Extract<PlayerCompletionMilestone, { kind: "learningTime" }>;
+
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+
+/**
+ * Time milestones use a clock mark so they read as accumulated practice time
+ * instead of another accuracy or Energy celebration.
+ */
+export function LearningTimeMilestoneIndicator() {
+  return (
+    <CompletionMilestoneMark>
+      <span className="bg-score/10 text-score flex size-10 items-center justify-center rounded-full">
+        <ClockIcon aria-hidden className="size-5" />
+      </span>
+    </CompletionMilestoneMark>
+  );
+}
+
+/**
+ * Chooses the clearest title unit for the crossed threshold. Minutes are best
+ * below one hour, 24 hours gets the special full-day label, and larger
+ * thresholds stay in hours because that is the milestone ladder.
+ */
+function LearningTimeMilestoneTitle({ seconds }: { seconds: number }) {
+  const t = useExtracted();
+  const format = useFormatter();
+  const minutes = Math.round(seconds / SECONDS_PER_MINUTE);
+
+  if (minutes < MINUTES_PER_HOUR) {
+    const formattedMinutes = formatWholeNumber({ format, value: minutes });
+
+    return (
+      <CompletionMilestoneTitle>
+        {t("{minutes} minutes of learning", { minutes: formattedMinutes })}
+      </CompletionMilestoneTitle>
+    );
+  }
+
+  const hours = Math.round(minutes / MINUTES_PER_HOUR);
+
+  if (hours === HOURS_PER_DAY) {
+    return <CompletionMilestoneTitle>{t("1 full day of learning")}</CompletionMilestoneTitle>;
+  }
+
+  return (
+    <CompletionMilestoneTitle>
+      {t("{hours, plural, one {# hour of learning} other {# hours of learning}}", { hours })}
+    </CompletionMilestoneTitle>
+  );
+}
+
+/**
+ * Adds the day equivalent once the learner reaches 24 hours, matching the
+ * progress-page idea that long learning time is easier to feel in full days.
+ */
+function LearningTimeMilestoneDescription({ seconds }: { seconds: number }) {
+  const t = useExtracted();
+  const hours = Math.round(seconds / SECONDS_PER_MINUTE / MINUTES_PER_HOUR);
+
+  if (hours < HOURS_PER_DAY) {
+    return (
+      <PlayerSupportingText>
+        {t("You can learn a lot by practicing for a few minutes a day.")}
+      </PlayerSupportingText>
+    );
+  }
+
+  if (hours === HOURS_PER_DAY) {
+    return (
+      <PlayerSupportingText>{t("That's a full day of focused practice.")}</PlayerSupportingText>
+    );
+  }
+
+  const fullDays = Math.floor(hours / HOURS_PER_DAY);
+
+  return (
+    <PlayerSupportingText>
+      {t(
+        "That's more than {days, plural, one {# full day} other {# full days}} of focused practice.",
+        { days: fullDays },
+      )}
+    </PlayerSupportingText>
+  );
+}
+
+/**
+ * Keeps title and supporting copy together for the learning-time milestone
+ * while letting each part choose the most readable unit independently.
+ */
+export function LearningTimeMilestoneCopy({ milestone }: { milestone: LearningTimeMilestone }) {
+  return (
+    <>
+      <LearningTimeMilestoneTitle seconds={milestone.seconds} />
+      <LearningTimeMilestoneDescription seconds={milestone.seconds} />
+    </>
+  );
+}

--- a/packages/player/src/components/completion-progress-milestone-screen.tsx
+++ b/packages/player/src/components/completion-progress-milestone-screen.tsx
@@ -11,6 +11,14 @@ import {
   BrainPowerMilestoneIndicator,
 } from "./completion-brain-power-milestone";
 import { EnergyMilestoneCopy, EnergyMilestoneIndicator } from "./completion-energy-milestone";
+import {
+  LearningDaysMilestoneCopy,
+  LearningDaysMilestoneIndicator,
+} from "./completion-learning-days-milestone";
+import {
+  LearningTimeMilestoneCopy,
+  LearningTimeMilestoneIndicator,
+} from "./completion-learning-time-milestone";
 import { LevelMilestoneCopy, LevelMilestoneIndicator } from "./completion-level-milestone";
 import {
   CompletionMilestoneActions,
@@ -18,6 +26,7 @@ import {
   CompletionMilestoneCopy,
   CompletionMilestoneScreen,
 } from "./completion-milestone-shell";
+import { ScoreMilestoneCopy, ScoreMilestoneIndicator } from "./completion-score-milestone";
 
 /**
  * Routes each milestone kind to the copy that explains the specific progress
@@ -30,6 +39,18 @@ function CompletionMilestoneCopyContent({ milestone }: { milestone: PlayerComple
 
   if (milestone.kind === "energy") {
     return <EnergyMilestoneCopy milestone={milestone} />;
+  }
+
+  if (milestone.kind === "learningDays") {
+    return <LearningDaysMilestoneCopy milestone={milestone} />;
+  }
+
+  if (milestone.kind === "learningTime") {
+    return <LearningTimeMilestoneCopy milestone={milestone} />;
+  }
+
+  if (milestone.kind === "score") {
+    return <ScoreMilestoneCopy milestone={milestone} />;
   }
 
   return <BrainPowerMilestoneCopy milestone={milestone} />;
@@ -47,6 +68,18 @@ function CompletionMilestoneIndicator({ milestone }: { milestone: PlayerCompleti
     return <EnergyMilestoneIndicator />;
   }
 
+  if (milestone.kind === "learningDays") {
+    return <LearningDaysMilestoneIndicator />;
+  }
+
+  if (milestone.kind === "learningTime") {
+    return <LearningTimeMilestoneIndicator />;
+  }
+
+  if (milestone.kind === "score") {
+    return <ScoreMilestoneIndicator />;
+  }
+
   return <BrainPowerMilestoneIndicator />;
 }
 
@@ -58,13 +91,19 @@ function getMilestoneHref({
   energyHref,
   levelHref,
   milestone,
+  scoreHref,
 }: {
   energyHref?: PlayerRoute;
   levelHref?: PlayerRoute;
   milestone: PlayerCompletionMilestone;
+  scoreHref?: PlayerRoute;
 }) {
   if (milestone.kind === "energy") {
     return energyHref;
+  }
+
+  if (milestone.kind === "score") {
+    return scoreHref;
   }
 
   return levelHref;
@@ -73,27 +112,48 @@ function getMilestoneHref({
 /**
  * Labels the secondary link with the metric-specific page it opens.
  */
+function CompletionMilestoneLearnLinkLabel({
+  milestone,
+}: {
+  milestone: PlayerCompletionMilestone;
+}) {
+  const t = useExtracted();
+
+  if (milestone.kind === "energy") {
+    return <>{t("Learn about Energy")}</>;
+  }
+
+  if (milestone.kind === "score") {
+    return <>{t("Learn about Score")}</>;
+  }
+
+  return <>{t("Learn about levels")}</>;
+}
+
+/**
+ * Renders the optional secondary link without coupling the shared player
+ * package to concrete app routes.
+ */
 function CompletionMilestoneLearnLink({
   energyHref,
   levelHref,
   milestone,
+  scoreHref,
 }: {
   energyHref?: PlayerRoute;
   levelHref?: PlayerRoute;
   milestone: PlayerCompletionMilestone;
+  scoreHref?: PlayerRoute;
 }) {
-  const t = useExtracted();
-  const href = getMilestoneHref({ energyHref, levelHref, milestone });
+  const href = getMilestoneHref({ energyHref, levelHref, milestone, scoreHref });
 
   if (!href) {
     return null;
   }
 
-  const label = milestone.kind === "energy" ? t("Learn about Energy") : t("Learn about levels");
-
   return (
     <PlayerLink className={cn(buttonVariants({ variant: "outline" }), "w-full")} href={href}>
-      {label}
+      <CompletionMilestoneLearnLinkLabel milestone={milestone} />
     </PlayerLink>
   );
 }
@@ -107,11 +167,13 @@ export function CompletionProgressMilestoneScreen({
   levelHref,
   milestone,
   onContinue,
+  scoreHref,
 }: {
   energyHref?: PlayerRoute;
   levelHref?: PlayerRoute;
   milestone: PlayerCompletionMilestone;
   onContinue: () => void;
+  scoreHref?: PlayerRoute;
 }) {
   const t = useExtracted();
 
@@ -132,6 +194,7 @@ export function CompletionProgressMilestoneScreen({
           energyHref={energyHref}
           levelHref={levelHref}
           milestone={milestone}
+          scoreHref={scoreHref}
         />
       </CompletionMilestoneActions>
     </CompletionMilestoneScreen>

--- a/packages/player/src/components/completion-score-milestone.tsx
+++ b/packages/player/src/components/completion-score-milestone.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { EPOCH_YEAR, FIRST_SUNDAY_OFFSET } from "@zoonk/utils/date";
+import { formatMetricPercent } from "@zoonk/utils/number";
+import { TrophyIcon } from "lucide-react";
+import { useExtracted, useFormatter, useLocale } from "next-intl";
+import { type PlayerCompletionMilestone } from "../completion-milestones";
+import { CompletionMilestoneMark, CompletionMilestoneTitle } from "./completion-milestone-shell";
+import { PlayerSupportingText } from "./player-supporting-text";
+
+type ScoreMilestone = Extract<PlayerCompletionMilestone, { kind: "score" }>;
+
+/**
+ * Score milestones use a trophy mark because this screen highlights the
+ * learner's strongest weekday for answer accuracy.
+ */
+export function ScoreMilestoneIndicator() {
+  return (
+    <CompletionMilestoneMark>
+      <span className="bg-score/10 text-score flex size-10 items-center justify-center rounded-full">
+        <TrophyIcon aria-hidden className="size-5" />
+      </span>
+    </CompletionMilestoneMark>
+  );
+}
+
+/**
+ * Converts the stored 0-based weekday into a localized weekday name without
+ * relying on the current calendar week.
+ */
+function getWeekdayName({ dayOfWeek, locale }: { dayOfWeek: number; locale: string }) {
+  const referenceDate = new Date(EPOCH_YEAR, 0, FIRST_SUNDAY_OFFSET + dayOfWeek);
+
+  return new Intl.DateTimeFormat(locale, { weekday: "long" }).format(referenceDate);
+}
+
+/**
+ * Names the learner's best weekday and repeats the score-page percentage so
+ * the milestone feels connected to the page it links to.
+ */
+export function ScoreMilestoneCopy({ milestone }: { milestone: ScoreMilestone }) {
+  const t = useExtracted();
+  const format = useFormatter();
+  const locale = useLocale();
+  const dayName = getWeekdayName({ dayOfWeek: milestone.dayOfWeek, locale });
+  const formattedScore = formatMetricPercent({ format, value: milestone.score });
+
+  return (
+    <>
+      <CompletionMilestoneTitle>
+        {t("{day} is your best day", { day: dayName })}
+      </CompletionMilestoneTitle>
+      <PlayerSupportingText>
+        {t(
+          "You usually get {percentage} of answers right on {day}, your highest average of the week.",
+          { day: dayName, percentage: formattedScore },
+        )}
+      </PlayerSupportingText>
+    </>
+  );
+}

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -74,7 +74,10 @@ function hasEmbeddedDesktopAction({
 
 export function StageContent() {
   const { actions, screen, state } = usePlayerRuntime();
-  const { chapterHref, energyHref, levelHref, loginHref, nextLessonHref } = usePlayerNavigation();
+
+  const { chapterHref, energyHref, levelHref, loginHref, nextLessonHref, scoreHref } =
+    usePlayerNavigation();
+
   const { isAuthenticated } = usePlayerViewer();
 
   const activeCompletionMilestone = getActiveCompletionMilestone(state);
@@ -100,6 +103,7 @@ export function StageContent() {
           levelHref={levelHref}
           milestone={activeCompletionMilestone}
           onContinue={actions.continue}
+          scoreHref={scoreHref}
         />
       );
     }

--- a/packages/player/src/player-context.tsx
+++ b/packages/player/src/player-context.tsx
@@ -22,6 +22,7 @@ export type PlayerNavigation = {
   levelHref?: PlayerRoute;
   loginHref?: PlayerRoute;
   nextLessonHref: PlayerRoute | null;
+  scoreHref?: PlayerRoute;
 };
 
 export type PlayerLessonProgress = {

--- a/packages/player/src/player-reducer.test.ts
+++ b/packages/player/src/player-reducer.test.ts
@@ -3,6 +3,7 @@ import {
   type SerializedStep,
 } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type PlayerProgressSnapshot } from "./completion-milestones";
 import {
   type PlayerState,
   type SelectedAnswer,
@@ -78,6 +79,24 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
   };
 }
 
+function buildProgressSnapshot(
+  overrides: Partial<PlayerProgressSnapshot> = {},
+): PlayerProgressSnapshot {
+  return {
+    bestDayScores: [],
+    currentEnergy: 0,
+    fullEnergyDays: 0,
+    highestPreviousDailyBrainPower: 0,
+    learningDays: 0,
+    todayBrainPower: 0,
+    todayCompletedLessons: 0,
+    todayEnergyAtEnd: null,
+    todayInteractiveLessons: 0,
+    totalLearningSeconds: 0,
+    ...overrides,
+  };
+}
+
 const multipleChoiceAnswer: SelectedAnswer = {
   kind: "multipleChoice",
   selectedOptionId: "option-a",
@@ -136,13 +155,13 @@ describe(createInitialState, () => {
   });
 
   it("stores the progress snapshot from input", () => {
-    const progressSnapshot = {
+    const progressSnapshot = buildProgressSnapshot({
       currentEnergy: 20,
       fullEnergyDays: 30,
       highestPreviousDailyBrainPower: 40,
       todayBrainPower: 10,
       todayEnergyAtEnd: 20,
-    };
+    });
 
     const state = createInitialState({
       lesson: buildLesson(),
@@ -619,13 +638,10 @@ describe("local completion computation", () => {
       },
       completionMilestoneIndex: 0,
       phase: "completed",
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 9.9,
-        fullEnergyDays: 0,
         highestPreviousDailyBrainPower: 100,
-        todayBrainPower: 0,
-        todayEnergyAtEnd: null,
-      },
+      }),
       totalBrainPower: 240,
     });
 

--- a/packages/player/src/player-reducer.ts
+++ b/packages/player/src/player-reducer.ts
@@ -1,9 +1,10 @@
 import { type AnswerResult } from "@zoonk/core/player/contracts/check-answer";
-import { type CompletionResult } from "@zoonk/core/player/contracts/completion-input-schema";
+import { getCappedLessonDurationSeconds } from "@zoonk/core/player/contracts/completion-duration";
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { type LessonKind } from "@zoonk/core/steps/contract/content";
 import { type PlayerCompletionMilestoneKey } from "./completion-milestone-keys";
 import {
+  type PlayerCompletionResult,
   type PlayerProgressSnapshot,
   getCompletionMilestones,
   getInitialCompletionMilestoneIndex,
@@ -40,7 +41,7 @@ export type PlayerState = {
   completionMilestoneIndex: number | null;
   lessonId: string;
   lessonKind: LessonKind;
-  completion: CompletionResult | null;
+  completion: PlayerCompletionResult | null;
   currentStepIndex: number;
   localDate: string;
   phase: PlayerPhase;
@@ -123,6 +124,28 @@ function recordStepTiming(state: PlayerState, stepId: string): Record<string, St
   };
 }
 
+/**
+ * Only answer-producing completions should count as interactive progress.
+ * Static lessons can complete without checked answers, and score-based nudges
+ * would feel wrong there because no weekday score changed.
+ */
+function hasCompletedInteractiveLesson(state: Pick<PlayerState, "results">) {
+  return Object.keys(state.results).length > 0;
+}
+
+/**
+ * The milestone preview uses the same lesson-duration cap as persistence. The
+ * value is attached to the completion result so later milestone screens do not
+ * change if the learner pauses before pressing Continue.
+ */
+function getCompletionWithDuration(state: PlayerState): PlayerCompletionResult {
+  return {
+    ...computeLocalCompletion(state),
+    completedInteractiveLesson: hasCompletedInteractiveLesson(state),
+    lessonDurationSeconds: getCappedLessonDurationSeconds({ startedAt: state.startedAt }),
+  };
+}
+
 function handleCheckAnswer(
   state: PlayerState,
   action: Extract<PlayerAction, { type: "CHECK_ANSWER" }>,
@@ -157,13 +180,14 @@ function handleCheckAnswer(
 function completeWith(state: PlayerState): PlayerState {
   const localDate = getLocalDate(new Date());
   const completed: PlayerState = { ...state, localDate, phase: "completed" };
-  const completion = computeLocalCompletion(completed);
+  const completion = getCompletionWithDuration(completed);
 
   return {
     ...completed,
     completion,
     completionMilestoneIndex: getInitialCompletionMilestoneIndex({
       completion,
+      lessonDurationSeconds: completion.lessonDurationSeconds,
       localDate,
       previousTotalBrainPower: state.totalBrainPower,
       progressSnapshot: state.progressSnapshot,
@@ -186,6 +210,7 @@ function continueCompletionMilestone(state: PlayerState): PlayerState {
 
   const milestones = getCompletionMilestones({
     completion: state.completion,
+    lessonDurationSeconds: state.completion.lessonDurationSeconds,
     localDate: state.localDate,
     previousTotalBrainPower: state.totalBrainPower,
     progressSnapshot: state.progressSnapshot,

--- a/packages/player/src/player-selectors.ts
+++ b/packages/player/src/player-selectors.ts
@@ -33,6 +33,7 @@ export function getActiveCompletionMilestone(state: PlayerState) {
   return (
     getCompletionMilestones({
       completion: state.completion,
+      lessonDurationSeconds: state.completion.lessonDurationSeconds,
       localDate: state.localDate,
       previousTotalBrainPower: state.totalBrainPower,
       progressSnapshot: state.progressSnapshot,

--- a/packages/player/src/use-player-actions.test.tsx
+++ b/packages/player/src/use-player-actions.test.tsx
@@ -6,6 +6,7 @@ import {
   getEffectiveCompletionProgressSnapshot,
   getStoredCompletionMilestoneKeys,
 } from "./completion-milestone-storage";
+import { type PlayerProgressSnapshot } from "./completion-milestones";
 import { getLocalDate } from "./player-date";
 import { type PlayerState } from "./player-reducer";
 import { usePlayerActions } from "./use-player-actions";
@@ -51,6 +52,24 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
   };
 }
 
+function buildProgressSnapshot(
+  overrides: Partial<PlayerProgressSnapshot> = {},
+): PlayerProgressSnapshot {
+  return {
+    bestDayScores: [],
+    currentEnergy: 0,
+    fullEnergyDays: 0,
+    highestPreviousDailyBrainPower: 0,
+    learningDays: 0,
+    todayBrainPower: 0,
+    todayCompletedLessons: 0,
+    todayEnergyAtEnd: null,
+    todayInteractiveLessons: 0,
+    totalLearningSeconds: 0,
+    ...overrides,
+  };
+}
+
 describe(usePlayerActions, () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -74,13 +93,10 @@ describe(usePlayerActions, () => {
     const state = buildState({
       localDate,
       phase: "feedback",
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 9.9,
-        fullEnergyDays: 0,
         highestPreviousDailyBrainPower: 100,
-        todayBrainPower: 0,
-        todayEnergyAtEnd: null,
-      },
+      }),
       results: {
         "step-1": {
           result: { correctAnswer: null, feedback: "Done", isCorrect: true },
@@ -100,31 +116,33 @@ describe(usePlayerActions, () => {
     expect(
       getEffectiveCompletionProgressSnapshot({
         localDate,
-        progressSnapshot: {
+        progressSnapshot: buildProgressSnapshot({
           currentEnergy: 9.9,
-          fullEnergyDays: 0,
           highestPreviousDailyBrainPower: 100,
-          todayBrainPower: 0,
-          todayEnergyAtEnd: null,
-        },
+        }),
       }),
     ).toStrictEqual({
+      bestDayScores: [],
       currentEnergy: 10.1,
       fullEnergyDays: 0,
       highestPreviousDailyBrainPower: 100,
+      learningDays: 1,
       todayBrainPower: 10,
+      todayCompletedLessons: 1,
       todayEnergyAtEnd: 10.1,
+      todayInteractiveLessons: 1,
+      totalLearningSeconds: 1800,
     });
   });
 
   it("falls back to server progress when session storage reads fail", () => {
-    const progressSnapshot = {
+    const progressSnapshot = buildProgressSnapshot({
       currentEnergy: 9.9,
       fullEnergyDays: 0,
       highestPreviousDailyBrainPower: 100,
       todayBrainPower: 0,
       todayEnergyAtEnd: null,
-    };
+    });
 
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
       throw new DOMException("Blocked", "SecurityError");
@@ -172,13 +190,10 @@ describe(usePlayerActions, () => {
 
     const state = buildState({
       phase: "feedback",
-      progressSnapshot: {
+      progressSnapshot: buildProgressSnapshot({
         currentEnergy: 9.9,
-        fullEnergyDays: 0,
         highestPreviousDailyBrainPower: 100,
-        todayBrainPower: 0,
-        todayEnergyAtEnd: null,
-      },
+      }),
       results: {
         "step-1": {
           result: { correctAnswer: null, feedback: "Done", isCorrect: true },

--- a/packages/player/src/use-player-actions.test.tsx
+++ b/packages/player/src/use-player-actions.test.tsx
@@ -5,8 +5,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getEffectiveCompletionProgressSnapshot,
   getStoredCompletionMilestoneKeys,
+  rememberCompletionProgress,
 } from "./completion-milestone-storage";
-import { type PlayerProgressSnapshot } from "./completion-milestones";
+import { type PlayerProgressSnapshot, getCompletionMilestones } from "./completion-milestones";
 import { getLocalDate } from "./player-date";
 import { type PlayerState } from "./player-reducer";
 import { usePlayerActions } from "./use-player-actions";
@@ -153,6 +154,47 @@ describe(usePlayerActions, () => {
     expect(
       getEffectiveCompletionProgressSnapshot({ localDate: "2026-06-05", progressSnapshot }),
     ).toStrictEqual(progressSnapshot);
+  });
+
+  it("does not show score milestones when stored progress has no server best-day history", () => {
+    const localDate = "2026-06-08";
+
+    rememberCompletionProgress({
+      completion: {
+        brainPower: 10,
+        correctCount: 0,
+        energyDelta: 0.2,
+        incorrectCount: 0,
+        lessonDurationSeconds: 60,
+      },
+      localDate,
+      progressSnapshot: buildProgressSnapshot({
+        bestDayScores: [{ correctAnswers: 18, dayOfWeek: 2, incorrectAnswers: 2 }],
+      }),
+    });
+
+    const effectiveSnapshot = getEffectiveCompletionProgressSnapshot({
+      localDate,
+      progressSnapshot: null,
+    });
+
+    const milestones = getCompletionMilestones({
+      completion: {
+        brainPower: 10,
+        completedInteractiveLesson: true,
+        correctCount: 1,
+        energyDelta: 0.2,
+        incorrectCount: 0,
+        newTotalBp: 20,
+      },
+      localDate,
+      previousTotalBrainPower: 10,
+      progressSnapshot: effectiveSnapshot,
+    });
+
+    expect(milestones).not.toContainEqual(
+      expect.objectContaining({ kind: "score", status: "bestDay" }),
+    );
   });
 
   it("check still no-ops for unanswered interactive steps", () => {

--- a/packages/player/src/use-player-actions.ts
+++ b/packages/player/src/use-player-actions.ts
@@ -38,6 +38,7 @@ function rememberCompletedStateMilestones(state: PlayerState) {
 
   const milestones = getCompletionMilestones({
     completion: state.completion,
+    lessonDurationSeconds: state.completion.lessonDurationSeconds,
     localDate: state.localDate,
     previousTotalBrainPower: state.totalBrainPower,
     progressSnapshot: state.progressSnapshot,

--- a/turbo.json
+++ b/turbo.json
@@ -48,7 +48,7 @@
     "dev": { "cache": false, "dependsOn": ["db:generate", "^dev"], "persistent": true },
     "e2e": { "dependsOn": ["build:e2e"], "passThroughEnv": ["PLAYWRIGHT_*", "E2E_BASE_URL"] },
     "i18n:lint": {},
-    "i18n": {},
+    "i18n": { "cache": false },
     "start": { "cache": false, "dependsOn": ["^start"], "persistent": true },
     "test": { "dependsOn": ["db:generate", "^db:setup:test", "^test"] },
     "test:watch": {


### PR DESCRIPTION
## Summary

- Add completion milestones for learning days, learning time, and best day score progress
- Route milestone CTAs to the relevant level or score pages
- Update player and main e2e coverage for pre-summary milestone screens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add progress milestone screens to the lesson completion flow, celebrating learning days, learning time, best-day score, Energy thresholds/full days, daily Brain Power records, and belt levels. Milestones show before the summary and include CTAs to `/level` and `/score`.

- **New Features**
  - Learning streak milestones: learning days and total learning time (minutes, hours, full day).
  - Performance milestones: best-day score (weekday accuracy) with today’s result applied.
  - Energy milestones: 10-point thresholds and full Energy days.
  - Level milestones: achieved and “halfway to next belt.”
  - Milestone CTAs route to `/level` and `/score`; added `scoreHref` to player navigation.

- **Refactors**
  - Split milestone logic into focused utilities with shared threshold rules; time milestones use capped `lessonDurationSeconds` for accurate previews.
  - Expanded progress snapshot (server and client) with `bestDayScores`, `learningDays`, `totalLearningSeconds`, and today’s lesson/interactive counts; added short lookback for aggregations.
  - Backward-compatible parsing for stored progress; centralized e2e helper `advanceToCompletionSummary` and updated tests.
  - New i18n strings for EN/ES/FR/DE/PT; disabled `i18n` cache in `turbo.json` to ensure fresh extraction.

<sup>Written for commit 3dc07c4936ea202e322a7c5db35251aab87a4409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

