### PR TITLE
fix(player): remove arrange word shortcuts

### DIFF
--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -141,7 +141,7 @@ describe("player browser integration: word bank steps", () => {
       .toBeInTheDocument();
   });
 
-  it("keeps fill-blank number shortcuts while hiding selected options", async () => {
+  it("hides selected fill-blank options without number shortcuts", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         steps: [
@@ -166,10 +166,17 @@ describe("player browser integration: word bank steps", () => {
     const wordBank = page.getByRole("group", { name: /word bank/iu });
     const catOption = wordBank.getByRole("button", { exact: true, name: "cat" });
 
-    await expect.element(catOption.getByText(/^2$/u)).toBeInTheDocument();
-    await expect.element(catOption).toHaveAttribute("aria-keyshortcuts", "2");
+    await expect.element(catOption).not.toHaveAttribute("aria-keyshortcuts");
 
     fireEvent.keyDown(globalThis.window, { key: "2" });
+
+    await expect
+      .element(page.getByRole("button", { name: /tap to remove/iu }))
+      .not.toBeInTheDocument();
+
+    await expect.element(catOption).toBeInTheDocument();
+
+    await catOption.click();
 
     const selectedBlank = page.getByRole("button", { name: /tap to remove/iu });
 

--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -85,7 +85,7 @@ describe("player browser integration: word bank steps", () => {
     await expect.element(page.getByText("100%")).toBeInTheDocument();
   });
 
-  it("toggles reading word-bank options from number shortcuts", async () => {
+  it("hides selected arrange-word options without number shortcuts", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         kind: "reading",
@@ -110,39 +110,38 @@ describe("player browser integration: word bank steps", () => {
 
     const wordBank = page.getByRole("group", { name: /word bank/iu });
     const mundoOption = wordBank.getByRole("button", { exact: true, name: "mundo" });
+    const answerArea = page.getByRole("group", { name: /your answer/iu });
 
-    await expect.element(mundoOption.getByText(/^2$/u)).toBeInTheDocument();
-    await expect.element(mundoOption).toHaveAttribute("aria-keyshortcuts", "2");
-
-    fireEvent.keyDown(globalThis.window, { key: "2" });
-
-    const answerTile = page
-      .getByRole("group", { name: /your answer/iu })
-      .getByRole("button", { name: /mundo/iu });
-
-    await expect.element(answerTile).toBeInTheDocument();
-
-    await expect.element(answerTile.getByText(/^2$/u)).toBeInTheDocument();
-    await expect.element(answerTile).toHaveAttribute("aria-keyshortcuts", "2");
-    await expect.element(mundoOption).toHaveAttribute("aria-pressed", "true");
+    await expect.element(mundoOption).not.toHaveAttribute("aria-keyshortcuts");
 
     fireEvent.keyDown(globalThis.window, { key: "2" });
 
     await expect
-      .element(
-        page.getByRole("group", { name: /your answer/iu }).getByRole("button", { name: /mundo/iu }),
-      )
+      .element(answerArea.getByRole("button", { name: /mundo/iu }))
       .not.toBeInTheDocument();
 
-    await expect.element(mundoOption).toHaveAttribute("aria-pressed", "false");
+    await expect.element(mundoOption).toBeInTheDocument();
 
-    fireEvent.keyDown(globalThis.window, { key: "1" });
-    fireEvent.keyDown(globalThis.window, { key: "2" });
+    await mundoOption.click();
 
-    await expect.element(page.getByRole("button", { name: /check/iu })).toBeEnabled();
+    await expect.element(answerArea.getByRole("button", { name: /mundo/iu })).toBeInTheDocument();
+
+    await expect
+      .element(wordBank.getByRole("button", { exact: true, name: "mundo" }))
+      .not.toBeInTheDocument();
+
+    await expect
+      .element(wordBank.getByRole("button", { exact: true, name: "Hola" }))
+      .toBeInTheDocument();
+
+    await answerArea.getByRole("button", { name: /mundo/iu }).click();
+
+    await expect
+      .element(wordBank.getByRole("button", { exact: true, name: "mundo" }))
+      .toBeInTheDocument();
   });
 
-  it("toggles fill-blank word-bank options from number shortcuts", async () => {
+  it("keeps fill-blank number shortcuts while hiding selected options", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         steps: [
@@ -172,14 +171,20 @@ describe("player browser integration: word bank steps", () => {
 
     fireEvent.keyDown(globalThis.window, { key: "2" });
 
-    await expect.element(page.getByRole("button", { name: /tap to remove/iu })).toBeInTheDocument();
+    const selectedBlank = page.getByRole("button", { name: /tap to remove/iu });
+
+    await expect.element(selectedBlank).toBeInTheDocument();
     await expect.element(page.getByRole("button", { name: /check/iu })).toBeEnabled();
 
-    fireEvent.keyDown(globalThis.window, { key: "2" });
+    await expect
+      .element(wordBank.getByRole("button", { exact: true, name: "cat" }))
+      .not.toBeInTheDocument();
+
+    await selectedBlank.click();
 
     await expect
-      .element(page.getByRole("button", { name: /tap to remove/iu }))
-      .not.toBeInTheDocument();
+      .element(wordBank.getByRole("button", { exact: true, name: "cat" }))
+      .toBeInTheDocument();
 
     await expect.element(page.getByRole("button", { name: /check/iu })).toBeDisabled();
   });

--- a/packages/player/src/components/_utils/fill-blank-state.ts
+++ b/packages/player/src/components/_utils/fill-blank-state.ts
@@ -1,22 +1,10 @@
-import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
-
-type BlankValue = { sourceIndex: number | null; word: string };
-export type BlankState = (BlankValue | null)[];
-export type WordPlacement = { option: WordBankOption; sourceIndex: number };
-
-/**
- * Fill-blank answer state tracks source tile indexes only for interaction.
- * The selected-answer contract remains the original string array.
- */
-export function getBlankWords(blanks: BlankState): (string | null)[] {
-  return blanks.map((blank) => blank?.word ?? null);
-}
+export type BlankState = (string | null)[];
 
 /**
  * Complete blanks can be serialized into the public answer shape. Incomplete
  * blanks return null so callers do not accidentally submit partial answers.
  */
-function isComplete(blanks: BlankState): blanks is BlankValue[] {
+function isComplete(blanks: BlankState): blanks is string[] {
   return blanks.every((blank) => blank !== null);
 }
 
@@ -29,5 +17,5 @@ export function getCompletedUserAnswers(blanks: BlankState): string[] | null {
     return null;
   }
 
-  return blanks.map((blank) => blank.word);
+  return blanks;
 }

--- a/packages/player/src/components/arrange-words-answer-area.tsx
+++ b/packages/player/src/components/arrange-words-answer-area.tsx
@@ -18,11 +18,9 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useCallback, useId, useMemo, useState } from "react";
 import { type StepResult } from "../player-reducer";
-import { getNumberKeyShortcut } from "../player-shortcuts";
-import { ResultKbd } from "./result-kbd";
-import { WordBankOptionContent } from "./word-bank-option-content";
+import { RomanizationText } from "./romanization-text";
 
-export type PlacedWord = WordBankOption & { id: string; sourceIndex?: number };
+export type PlacedWord = WordBankOption & { id: string };
 
 function getWordResultState(
   word: string,
@@ -41,15 +39,12 @@ function PlacedWordTile({
 }: {
   id: string;
   onClick: () => void;
-  option: PlacedWord;
+  option: WordBankOption;
   position: number;
   resultState?: "correct" | "incorrect";
 }) {
   const t = useExtracted();
   const hasResult = Boolean(resultState);
-
-  const shortcut =
-    typeof option.sourceIndex === "number" ? getNumberKeyShortcut(option.sourceIndex) : null;
 
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
     disabled: hasResult,
@@ -73,9 +68,8 @@ function PlacedWordTile({
       {...attributes}
       {...listeners}
       aria-label={ariaLabel}
-      aria-keyshortcuts={shortcut ?? undefined}
       className={cn(
-        "border-border flex min-h-11 min-w-16 items-center justify-start gap-2.5 rounded-lg border px-3 py-2.5 text-left text-base transition-all duration-150",
+        "border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 text-base transition-all duration-150",
         hasResult && "pointer-events-none",
         !hasResult &&
           "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
@@ -91,13 +85,9 @@ function PlacedWordTile({
       style={{ transform: CSS.Transform.toString(transform), transition }}
       type="button"
     >
-      {shortcut && (
-        <ResultKbd className="hidden lg:pointer-fine:inline-flex" isSelected>
-          {shortcut}
-        </ResultKbd>
-      )}
+      <span>{option.word}</span>
 
-      <WordBankOptionContent option={option} />
+      <RomanizationText>{option.romanization}</RomanizationText>
     </button>
   );
 }
@@ -105,7 +95,8 @@ function PlacedWordTile({
 function DragOverlayWord({ option }: { option: WordBankOption }) {
   return (
     <div className="bg-background border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 text-base shadow-md">
-      <WordBankOptionContent option={option} />
+      <span>{option.word}</span>
+      <RomanizationText>{option.romanization}</RomanizationText>
     </div>
   );
 }

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -3,84 +3,20 @@
 import { type DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
-import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
-import { MAX_NUMBER_KEY_SHORTCUT, getNumberKeyShortcut } from "../player-shortcuts";
-import { useOptionKeyboard } from "../use-option-keyboard";
 import { useWordAudio } from "../use-word-audio";
 import { ArrangeWordsAnswerArea, type PlacedWord } from "./arrange-words-answer-area";
+import { RomanizationText } from "./romanization-text";
 import { InteractiveStepLayout } from "./step-layouts";
-import { WordBankOptionButton } from "./word-bank-option-content";
 
-type WordBankTile = {
-  index: number;
-  isUsed: boolean;
-  key: string;
-  option: WordBankOption;
-  occurrenceNumber: number;
-  shortcut: string | null;
-};
-
-type WordBankPlacement = { option: WordBankOption; sourceIndex: number };
+type WordBankTile = { isUsed: boolean; key: string; option: WordBankOption };
 
 /**
- * Source indexes are added when a learner chooses a tile in this session. They
- * let duplicate words behave like distinct toggles instead of guessing from the
- * visible word text alone.
- */
-function hasPlacedWordSourceIndex(placedWord: PlacedWord): boolean {
-  return typeof placedWord.sourceIndex === "number";
-}
-
-/**
- * Old saved/result answers only contain words. The occurrence number keeps that
- * legacy shape usable by matching the first tile to the first placed copy, the
- * second tile to the second placed copy, and so on.
- */
-function getPlacedWordOccurrenceNumber({
-  index,
-  option,
-  words,
-}: {
-  index: number;
-  option: WordBankOption;
-  words: WordBankOption[];
-}): number {
-  return words.slice(0, index + 1).filter((item) => item.word === option.word).length;
-}
-
-/**
- * Tile usage prefers exact source indexes when available and falls back to
- * occurrence counting for restored answers that predate source-index tracking.
- */
-function isWordBankTileUsed({
-  index,
-  occurrenceNumber,
-  option,
-  placedWords,
-}: {
-  index: number;
-  occurrenceNumber: number;
-  option: WordBankOption;
-  placedWords: PlacedWord[];
-}): boolean {
-  const hasSourceIndexes = placedWords.some((placedWord) => hasPlacedWordSourceIndex(placedWord));
-
-  if (hasSourceIndexes) {
-    return placedWords.some((placedWord) => placedWord.sourceIndex === index);
-  }
-
-  const usedCount = placedWords.filter((placed) => placed.word === option.word).length;
-  return usedCount >= occurrenceNumber;
-}
-
-/**
- * Duplicate words are valid in generated word banks. Counting earlier
- * occurrences lets each duplicate tile become unavailable only after the
- * learner has placed that many copies of the same word.
+ * Duplicate words are valid, so a tile is considered used only when the learner
+ * has already placed this exact occurrence of that word.
  */
 function getWordBankTile({
   index,
@@ -93,125 +29,90 @@ function getWordBankTile({
   placedWords: PlacedWord[];
   words: WordBankOption[];
 }): WordBankTile {
-  const occurrenceNumber = getPlacedWordOccurrenceNumber({ index, option, words });
+  const usedCount = placedWords.filter((placed) => placed.word === option.word).length;
 
-  return {
-    index,
-    isUsed: isWordBankTileUsed({ index, occurrenceNumber, option, placedWords }),
-    key: `bank-${option.word}-${index}`,
-    occurrenceNumber,
-    option,
-    shortcut: getNumberKeyShortcut(index),
-  };
+  const occurrenceCount = words
+    .slice(0, index + 1)
+    .filter((item) => item.word === option.word).length;
+
+  return { isUsed: usedCount >= occurrenceCount, key: `bank-${option.word}-${index}`, option };
 }
 
 /**
- * Builds the render and keyboard model for the word bank once so pointer and
- * number-key selection cannot disagree about which duplicate tile is still
- * available.
+ * The word bank should only show words the learner can still choose. Selected
+ * words remain removable from the answer area, then reappear here.
  */
-function getWordBankTiles({
+function getVisibleWordBankTiles({
   placedWords,
   words,
 }: {
   placedWords: PlacedWord[];
   words: WordBankOption[];
 }): WordBankTile[] {
-  return words.map((option, index) => getWordBankTile({ index, option, placedWords, words }));
+  return words
+    .map((option, index) => getWordBankTile({ index, option, placedWords, words }))
+    .filter((tile) => !tile.isUsed);
 }
 
-/**
- * Finds the selected answer word controlled by a bank tile. Exact source-index
- * matches handle normal play, while occurrence matching keeps restored answers
- * removable even though they only know the selected word text.
- */
-function getPlacedWordIndexForTile({
-  placedWords,
-  tile,
+function BankTileContent({
+  descriptionId,
+  option,
 }: {
-  placedWords: PlacedWord[];
-  tile: WordBankTile;
-}): number | null {
-  const sourceIndexMatch = placedWords.findIndex(
-    (placedWord) => placedWord.sourceIndex === tile.index,
+  descriptionId?: string;
+  option: WordBankOption;
+}) {
+  const hasDescription = Boolean(option.romanization || option.pronunciation);
+
+  return (
+    <>
+      <span>{option.word}</span>
+
+      {hasDescription && (
+        <span className="flex flex-col items-center" id={descriptionId}>
+          <RomanizationText>{option.romanization}</RomanizationText>
+
+          {option.pronunciation && (
+            <span className="text-muted-foreground text-xs">{option.pronunciation}</span>
+          )}
+        </span>
+      )}
+    </>
   );
+}
 
-  if (sourceIndexMatch !== -1) {
-    return sourceIndexMatch;
-  }
+function BankTile({ onPlace, option }: { onPlace: () => void; option: WordBankOption }) {
+  const descriptionId = useId();
+  const hasDescription = Boolean(option.romanization || option.pronunciation);
 
-  if (placedWords.some((placedWord) => hasPlacedWordSourceIndex(placedWord))) {
-    return null;
-  }
-
-  const matchingIndexes = placedWords.flatMap((placedWord, index) =>
-    placedWord.word === tile.option.word ? [index] : [],
+  return (
+    <button
+      aria-describedby={hasDescription ? descriptionId : undefined}
+      aria-label={option.word}
+      className="border-border hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 transition-all duration-150 outline-none focus-visible:ring-[3px]"
+      onClick={onPlace}
+      type="button"
+    >
+      <BankTileContent descriptionId={descriptionId} option={option} />
+    </button>
   );
-
-  return matchingIndexes[tile.occurrenceNumber - 1] ?? null;
 }
 
 function WordBank({
-  disabled,
   onPlace,
-  onRemove,
   placedWords,
   words,
 }: {
-  disabled: boolean;
-  onPlace: (placement: WordBankPlacement) => void;
-  onRemove: (index: number) => void;
+  onPlace: (option: WordBankOption) => void;
   placedWords: PlacedWord[];
   words: WordBankOption[];
 }) {
   const t = useExtracted();
-  const tiles = getWordBankTiles({ placedWords, words });
-
-  const handleToggleTile = useCallback(
-    (tile: WordBankTile) => {
-      if (!tile.isUsed) {
-        onPlace({ option: tile.option, sourceIndex: tile.index });
-        return;
-      }
-
-      const placedWordIndex = getPlacedWordIndexForTile({ placedWords, tile });
-
-      if (placedWordIndex !== null) {
-        onRemove(placedWordIndex);
-      }
-    },
-    [onPlace, onRemove, placedWords],
-  );
-
-  useOptionKeyboard({
-    enabled: !disabled,
-    onSelect: (index) => {
-      const tile = tiles[index];
-
-      if (!tile) {
-        return;
-      }
-
-      handleToggleTile(tile);
-    },
-    optionCount: Math.min(words.length, MAX_NUMBER_KEY_SHORTCUT),
-  });
+  const tiles = getVisibleWordBankTiles({ placedWords, words });
 
   return (
-    <div
-      aria-label={t("Word bank")}
-      className={cn("flex flex-wrap gap-2.5", disabled && "pointer-events-none opacity-50")}
-      role="group"
-    >
+    <div aria-label={t("Word bank")} className="flex flex-wrap gap-2.5" role="group">
       {tiles.map((tile) => (
-        <WordBankOptionButton
-          disabled={disabled}
-          isUsed={tile.isUsed}
-          key={tile.key}
-          onToggle={() => handleToggleTile(tile)}
-          option={tile.option}
-          shortcut={tile.shortcut}
-        />
+        <BankTile key={tile.key} onPlace={() => onPlace(tile.option)} option={tile.option} />
       ))}
     </div>
   );
@@ -282,13 +183,13 @@ export function ArrangeWordsInteraction({
   );
 
   const handlePlace = useCallback(
-    ({ option, sourceIndex }: WordBankPlacement) => {
+    (option: WordBankOption) => {
       if (placedWords.length >= maxAnswerLength) {
         return;
       }
 
       void play(option.audioUrl);
-      const placed: PlacedWord = { ...option, id: String(idCounter.current), sourceIndex };
+      const placed: PlacedWord = { ...option, id: String(idCounter.current) };
       idCounter.current += 1;
       const next = [...placedWords, placed];
       setPlacedWords(next);
@@ -347,13 +248,7 @@ export function ArrangeWordsInteraction({
         result={result}
       />
 
-      <WordBank
-        disabled={result !== undefined}
-        onPlace={handlePlace}
-        onRemove={handleRemove}
-        placedWords={placedWords}
-        words={wordBankOptions}
-      />
+      <WordBank onPlace={handlePlace} placedWords={placedWords} words={wordBankOptions} />
     </InteractiveStepLayout>
   );
 }

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -3,14 +3,15 @@
 import { type DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
-import { useCallback, useId, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useWebHaptics } from "web-haptics/react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
 import { useWordAudio } from "../use-word-audio";
 import { ArrangeWordsAnswerArea, type PlacedWord } from "./arrange-words-answer-area";
-import { RomanizationText } from "./romanization-text";
 import { InteractiveStepLayout } from "./step-layouts";
+import { WordBankOptionButton } from "./word-bank-option-content";
 
 type WordBankTile = { isUsed: boolean; key: string; option: WordBankOption };
 
@@ -54,54 +55,13 @@ function getVisibleWordBankTiles({
     .filter((tile) => !tile.isUsed);
 }
 
-function BankTileContent({
-  descriptionId,
-  option,
-}: {
-  descriptionId?: string;
-  option: WordBankOption;
-}) {
-  const hasDescription = Boolean(option.romanization || option.pronunciation);
-
-  return (
-    <>
-      <span>{option.word}</span>
-
-      {hasDescription && (
-        <span className="flex flex-col items-center" id={descriptionId}>
-          <RomanizationText>{option.romanization}</RomanizationText>
-
-          {option.pronunciation && (
-            <span className="text-muted-foreground text-xs">{option.pronunciation}</span>
-          )}
-        </span>
-      )}
-    </>
-  );
-}
-
-function BankTile({ onPlace, option }: { onPlace: () => void; option: WordBankOption }) {
-  const descriptionId = useId();
-  const hasDescription = Boolean(option.romanization || option.pronunciation);
-
-  return (
-    <button
-      aria-describedby={hasDescription ? descriptionId : undefined}
-      aria-label={option.word}
-      className="border-border hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 transition-all duration-150 outline-none focus-visible:ring-[3px]"
-      onClick={onPlace}
-      type="button"
-    >
-      <BankTileContent descriptionId={descriptionId} option={option} />
-    </button>
-  );
-}
-
 function WordBank({
+  disabled,
   onPlace,
   placedWords,
   words,
 }: {
+  disabled: boolean;
   onPlace: (option: WordBankOption) => void;
   placedWords: PlacedWord[];
   words: WordBankOption[];
@@ -110,9 +70,18 @@ function WordBank({
   const tiles = getVisibleWordBankTiles({ placedWords, words });
 
   return (
-    <div aria-label={t("Word bank")} className="flex flex-wrap gap-2.5" role="group">
+    <div
+      aria-label={t("Word bank")}
+      className={cn("flex flex-wrap gap-2.5", disabled && "pointer-events-none opacity-50")}
+      role="group"
+    >
       {tiles.map((tile) => (
-        <BankTile key={tile.key} onPlace={() => onPlace(tile.option)} option={tile.option} />
+        <WordBankOptionButton
+          disabled={disabled}
+          key={tile.key}
+          onToggle={() => onPlace(tile.option)}
+          option={tile.option}
+        />
       ))}
     </div>
   );
@@ -184,7 +153,7 @@ export function ArrangeWordsInteraction({
 
   const handlePlace = useCallback(
     (option: WordBankOption) => {
-      if (placedWords.length >= maxAnswerLength) {
+      if (result || placedWords.length >= maxAnswerLength) {
         return;
       }
 
@@ -196,7 +165,7 @@ export function ArrangeWordsInteraction({
 
       syncSelectedAnswer(next);
     },
-    [maxAnswerLength, placedWords, play, syncSelectedAnswer],
+    [maxAnswerLength, placedWords, play, result, syncSelectedAnswer],
   );
 
   const handleRemove = useCallback(
@@ -248,7 +217,12 @@ export function ArrangeWordsInteraction({
         result={result}
       />
 
-      <WordBank onPlace={handlePlace} placedWords={placedWords} words={wordBankOptions} />
+      <WordBank
+        disabled={result !== undefined}
+        onPlace={handlePlace}
+        placedWords={placedWords}
+        words={wordBankOptions}
+      />
     </InteractiveStepLayout>
   );
 }

--- a/packages/player/src/components/fill-blank-step.tsx
+++ b/packages/player/src/components/fill-blank-step.tsx
@@ -6,12 +6,7 @@ import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { useCallback, useMemo, useState } from "react";
 import { type SelectedAnswer, type StepResult } from "../player-reducer";
-import {
-  type BlankState,
-  type WordPlacement,
-  getBlankWords,
-  getCompletedUserAnswers,
-} from "./_utils/fill-blank-state";
+import { type BlankState, getCompletedUserAnswers } from "./_utils/fill-blank-state";
 import { getTemplateRomanization } from "./_utils/template-romanization";
 import { FillBlankWordBank } from "./fill-blank-word-bank";
 import { InlineFeedback } from "./inline-feedback";
@@ -152,14 +147,14 @@ export function FillBlankStep({
 
   const [blanks, setBlanks] = useState<BlankState>(() => {
     if (result?.answer?.kind === "fillBlank") {
-      return result.answer.userAnswers.map((word) => ({ sourceIndex: null, word }));
+      return result.answer.userAnswers;
     }
 
     return Array.from({ length: blankCount }, () => null);
   });
 
   const handlePlaceWord = useCallback(
-    ({ option, sourceIndex }: WordPlacement) => {
+    (word: string) => {
       const firstEmptyIndex = blanks.indexOf(null);
 
       if (firstEmptyIndex === -1) {
@@ -167,7 +162,7 @@ export function FillBlankStep({
       }
 
       const next = [...blanks];
-      next[firstEmptyIndex] = { sourceIndex, word: option.word };
+      next[firstEmptyIndex] = word;
       setBlanks(next);
 
       const userAnswers = getCompletedUserAnswers(next);
@@ -202,7 +197,7 @@ export function FillBlankStep({
 
       <TemplateText
         answers={content.answers}
-        blanks={getBlankWords(blanks)}
+        blanks={blanks}
         hasResult={hasResult}
         onRemoveWord={handleRemoveWord}
         template={content.template}
@@ -214,7 +209,6 @@ export function FillBlankStep({
         blanks={blanks}
         disabled={hasResult}
         onPlaceWord={handlePlaceWord}
-        onRemoveWord={handleRemoveWord}
         options={step.fillBlankOptions}
       />
 

--- a/packages/player/src/components/fill-blank-word-bank.tsx
+++ b/packages/player/src/components/fill-blank-word-bank.tsx
@@ -3,24 +3,14 @@
 import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
-import { useCallback } from "react";
-import { MAX_NUMBER_KEY_SHORTCUT, getNumberKeyShortcut } from "../player-shortcuts";
-import { useOptionKeyboard } from "../use-option-keyboard";
-import { type BlankState, type WordPlacement } from "./_utils/fill-blank-state";
+import { type BlankState } from "./_utils/fill-blank-state";
 import { WordBankOptionButton } from "./word-bank-option-content";
 
-type WordTileData = {
-  index: number;
-  isUsed: boolean;
-  key: string;
-  occurrenceNumber: number;
-  option: WordBankOption;
-  shortcut: string | null;
-};
+type WordTileData = { isUsed: boolean; key: string; option: WordBankOption };
 
 /**
- * Restored results do not have source indexes, so duplicates fall back to the
- * same occurrence counting used before shortcuts were introduced.
+ * Duplicate options need occurrence counting so selecting one copy of a word
+ * hides only one matching tile and leaves any additional copies available.
  */
 function getWordOccurrenceNumber({
   index,
@@ -35,34 +25,25 @@ function getWordOccurrenceNumber({
 }
 
 /**
- * Source-index matches make each numbered tile reversible. Occurrence fallback
- * keeps server-provided answer strings readable when the component is restored
- * from a checked result.
+ * Duplicate words are valid, so a tile is used only after that many copies of
+ * the same word are already placed in blanks.
  */
 function isWordTileUsed({
   blanks,
-  index,
   occurrenceNumber,
   option,
 }: {
   blanks: BlankState;
-  index: number;
   occurrenceNumber: number;
   option: WordBankOption;
 }): boolean {
-  const hasSourceIndexes = blanks.some((blank) => typeof blank?.sourceIndex === "number");
-
-  if (hasSourceIndexes) {
-    return blanks.some((blank) => blank?.sourceIndex === index);
-  }
-
-  const usedCount = blanks.filter((blank) => blank?.word === option.word).length;
+  const usedCount = blanks.filter((blank) => blank === option.word).length;
   return usedCount >= occurrenceNumber;
 }
 
 /**
- * Builds one model for rendering and keyboard selection so click and number
- * shortcuts stay aligned even when generated word banks contain duplicates.
+ * Builds the render model in one place so click selection and duplicate
+ * visibility use the same occurrence-counting rule.
  */
 function getWordTileData({
   blanks,
@@ -78,92 +59,29 @@ function getWordTileData({
   const occurrenceNumber = getWordOccurrenceNumber({ index, option, options });
 
   return {
-    index,
-    isUsed: isWordTileUsed({ blanks, index, occurrenceNumber, option }),
+    isUsed: isWordTileUsed({ blanks, occurrenceNumber, option }),
     key: `${option.word}-${index}`,
-    occurrenceNumber,
     option,
-    shortcut: getNumberKeyShortcut(index),
   };
 }
 
 /**
- * Finds the blank controlled by a used bank tile. Exact source indexes are the
- * normal path, with occurrence matching for restored string-only answers.
- */
-function getBlankIndexForTile({
-  blanks,
-  tile,
-}: {
-  blanks: BlankState;
-  tile: WordTileData;
-}): number | null {
-  const sourceIndexMatch = blanks.findIndex((blank) => blank?.sourceIndex === tile.index);
-
-  if (sourceIndexMatch !== -1) {
-    return sourceIndexMatch;
-  }
-
-  if (blanks.some((blank) => typeof blank?.sourceIndex === "number")) {
-    return null;
-  }
-
-  const matchingIndexes = blanks.flatMap((blank, index) =>
-    blank?.word === tile.option.word ? [index] : [],
-  );
-
-  return matchingIndexes[tile.occurrenceNumber - 1] ?? null;
-}
-
-/**
- * Renders the fill-blank word bank and owns its number-key toggle behavior so
- * FillBlankStep can stay focused on the template and answer contract.
+ * Renders only the fill-blank words learners can still choose. Selected words
+ * are removed from the bank and become removable from their blank slot instead.
  */
 export function FillBlankWordBank({
   blanks,
   disabled,
   onPlaceWord,
-  onRemoveWord,
   options,
 }: {
   blanks: BlankState;
   disabled: boolean;
-  onPlaceWord: (placement: WordPlacement) => void;
-  onRemoveWord: (blankIndex: number) => void;
+  onPlaceWord: (word: string) => void;
   options: WordBankOption[];
 }) {
   const t = useExtracted();
   const tiles = options.map((option, index) => getWordTileData({ blanks, index, option, options }));
-
-  const handleToggleTile = useCallback(
-    (tile: WordTileData) => {
-      if (!tile.isUsed) {
-        onPlaceWord({ option: tile.option, sourceIndex: tile.index });
-        return;
-      }
-
-      const blankIndex = getBlankIndexForTile({ blanks, tile });
-
-      if (blankIndex !== null) {
-        onRemoveWord(blankIndex);
-      }
-    },
-    [blanks, onPlaceWord, onRemoveWord],
-  );
-
-  useOptionKeyboard({
-    enabled: !disabled,
-    onSelect: (index) => {
-      const tile = tiles[index];
-
-      if (!tile) {
-        return;
-      }
-
-      handleToggleTile(tile);
-    },
-    optionCount: Math.min(options.length, MAX_NUMBER_KEY_SHORTCUT),
-  });
 
   return (
     <div
@@ -176,11 +94,9 @@ export function FillBlankWordBank({
         .map((tile) => (
           <WordBankOptionButton
             disabled={disabled}
-            isUsed={tile.isUsed}
             key={tile.key}
-            onToggle={() => handleToggleTile(tile)}
+            onToggle={() => onPlaceWord(tile.option.word)}
             option={tile.option}
-            shortcut={tile.shortcut}
           />
         ))}
     </div>

--- a/packages/player/src/components/fill-blank-word-bank.tsx
+++ b/packages/player/src/components/fill-blank-word-bank.tsx
@@ -171,16 +171,18 @@ export function FillBlankWordBank({
       className={cn("flex flex-wrap gap-2.5", disabled && "pointer-events-none opacity-50")}
       role="group"
     >
-      {tiles.map((tile) => (
-        <WordBankOptionButton
-          disabled={disabled}
-          isUsed={tile.isUsed}
-          key={tile.key}
-          onToggle={() => handleToggleTile(tile)}
-          option={tile.option}
-          shortcut={tile.shortcut}
-        />
-      ))}
+      {tiles
+        .filter((tile) => !tile.isUsed)
+        .map((tile) => (
+          <WordBankOptionButton
+            disabled={disabled}
+            isUsed={tile.isUsed}
+            key={tile.key}
+            onToggle={() => handleToggleTile(tile)}
+            option={tile.option}
+            shortcut={tile.shortcut}
+          />
+        ))}
     </div>
   );
 }

--- a/packages/player/src/components/word-bank-option-content.tsx
+++ b/packages/player/src/components/word-bank-option-content.tsx
@@ -1,37 +1,25 @@
 import { type WordBankOption } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { cn } from "@zoonk/ui/lib/utils";
-import { useId } from "react";
-import { ResultKbd } from "./result-kbd";
+import { type ReactNode, useId } from "react";
 import { RomanizationText } from "./romanization-text";
 
 /**
- * Word-bank buttons add shortcut badges and selection states around the word.
- * Keeping the word, romanization, and pronunciation in one vertical stack
- * prevents those surrounding controls from flattening pronunciation hints into
- * the main text row.
+ * Word-bank buttons keep the word, romanization, and pronunciation in one
+ * vertical stack so metadata reads as a hint for the word instead of a separate
+ * option.
  */
-function WordBankOptionContent({
-  descriptionId,
-  option,
-}: {
-  descriptionId?: string;
-  option: WordBankOption;
-}) {
-  const hasDescription = hasWordBankOptionDescription(option);
+function WordBankOptionContent({ children }: { children: ReactNode }) {
+  return <span className="flex min-w-0 flex-col items-center gap-0.5 text-center">{children}</span>;
+}
 
+/**
+ * Description metadata has its own slot so layout stays coordinated without
+ * callers passing styling props into the shared button.
+ */
+function WordBankOptionDescription({ children, id }: { children: ReactNode; id: string }) {
   return (
-    <span className="flex min-w-0 flex-col items-start gap-0.5 text-left">
-      <span>{option.word}</span>
-
-      {hasDescription && (
-        <span className="flex flex-col items-start" id={descriptionId}>
-          <RomanizationText>{option.romanization}</RomanizationText>
-
-          {option.pronunciation && (
-            <span className="text-muted-foreground text-xs">{option.pronunciation}</span>
-          )}
-        </span>
-      )}
+    <span className="flex flex-col items-center" id={id}>
+      {children}
     </span>
   );
 }
@@ -46,21 +34,17 @@ function hasWordBankOptionDescription(option: WordBankOption): boolean {
 
 /**
  * Shared word-bank button chrome keeps fill-blank, reading, and listening tiles
- * visually identical. The shortcut badge sits next to the text stack so
- * pronunciation and romanization stay below the word instead of beside it.
+ * visually identical. The compact centered layout lets short words size to
+ * their text plus padding instead of reserving space for unavailable controls.
  */
 export function WordBankOptionButton({
   disabled,
-  isUsed,
   onToggle,
   option,
-  shortcut,
 }: {
   disabled: boolean;
-  isUsed: boolean;
   onToggle: () => void;
   option: WordBankOption;
-  shortcut: string | null;
 }) {
   const descriptionId = useId();
   const hasDescription = hasWordBankOptionDescription(option);
@@ -69,26 +53,29 @@ export function WordBankOptionButton({
     <button
       aria-describedby={hasDescription ? descriptionId : undefined}
       aria-label={option.word}
-      aria-keyshortcuts={shortcut ?? undefined}
-      aria-pressed={isUsed}
       className={cn(
-        "border-border flex min-h-11 min-w-16 items-center justify-start gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-all duration-150",
+        "border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 text-center transition-all duration-150 outline-none",
         disabled
           ? "opacity-50"
-          : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 outline-none focus-visible:ring-[3px]",
-        isUsed && !disabled && "opacity-70",
+          : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
       )}
       disabled={disabled}
       onClick={onToggle}
       type="button"
     >
-      {shortcut && (
-        <ResultKbd className="hidden lg:pointer-fine:inline-flex" isSelected={isUsed}>
-          {shortcut}
-        </ResultKbd>
-      )}
+      <WordBankOptionContent>
+        <span>{option.word}</span>
 
-      <WordBankOptionContent descriptionId={descriptionId} option={option} />
+        {hasDescription && (
+          <WordBankOptionDescription id={descriptionId}>
+            <RomanizationText>{option.romanization}</RomanizationText>
+
+            {option.pronunciation && (
+              <span className="text-muted-foreground text-xs">{option.pronunciation}</span>
+            )}
+          </WordBankOptionDescription>
+        )}
+      </WordBankOptionContent>
     </button>
   );
 }

--- a/packages/player/src/components/word-bank-option-content.tsx
+++ b/packages/player/src/components/word-bank-option-content.tsx
@@ -10,7 +10,7 @@ import { RomanizationText } from "./romanization-text";
  * prevents those surrounding controls from flattening pronunciation hints into
  * the main text row.
  */
-export function WordBankOptionContent({
+function WordBankOptionContent({
   descriptionId,
   option,
 }: {


### PR DESCRIPTION
## Summary

- remove number-key shortcuts from arrange-word steps
- restore compact arrange-word tile rendering
- hide selected word-bank options for arrange words and fill blanks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed number-key shortcuts from arrange-word and fill-blank steps. Restored compact, centered word-bank tiles and made selected options hide after placement; they reappear when removed.

- **Refactors**
  - Simplified fill-blank state to `(string | null)[]`; removed source index tracking and `getBlankWords`.
  - Removed shortcut logic and UI (no `aria-keyshortcuts`/badges) for a consistent word bank across steps.
  - Word bank now renders only unused options; placement plays audio and respects result/length limits.

<sup>Written for commit f50b6ea9671a0c2ca0e655cfc5c5fea97429c6d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

