### PR TITLE
feat(main): track chapter and subscription gates

### DIFF
--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/get-player-viewer.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/get-player-viewer.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { ContentFeedback } from "@/components/feedback/content-feedback";
+
+type LessonPlayerViewerInput = {
+  chapterSlug: string;
+  courseSlug: string;
+  isAuthenticated: boolean;
+  lessonSlug: string;
+  userEmail?: string;
+  userName: string | null;
+};
+
+/**
+ * Builds the player viewer config with the app-specific completion feedback
+ * footer while keeping the route component focused on player lifecycle events.
+ */
+export function getPlayerViewer({
+  chapterSlug,
+  courseSlug,
+  isAuthenticated,
+  lessonSlug,
+  userEmail,
+  userName,
+}: LessonPlayerViewerInput) {
+  return {
+    completionFooter: (
+      <ContentFeedback
+        className="pt-8"
+        defaultEmail={userEmail}
+        feedbackTarget={{ chapterSlug, courseSlug, kind: "lesson", lessonSlug }}
+        variant="minimal"
+      />
+    ),
+    isAuthenticated,
+    userName,
+  };
+}

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { ContentFeedback } from "@/components/feedback/content-feedback";
 import {
+  trackChapterCompleted,
   trackLessonCompleted,
   trackLessonSecondStep,
-  trackLessonStarted,
 } from "@/lib/track-events";
 import { type CompletionInput } from "@zoonk/core/player/contracts/completion-input-schema";
 import { type SerializedLesson } from "@zoonk/core/player/contracts/prepare-lesson-data";
@@ -16,9 +15,11 @@ import {
 import { PlayerShell } from "@zoonk/player/shell";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef } from "react";
+import { getPlayerViewer } from "./get-player-viewer";
 import { type LessonProgressMeta, buildLessonPlayerModel } from "./lesson-player-model";
 import { preloadNextLesson } from "./preload-next-lesson-action";
 import { submitCompletion } from "./submit-completion-action";
+import { useTrackLessonStarted } from "./use-track-lesson-started";
 
 type LessonPlayerClientProps = {
   lesson: SerializedLesson;
@@ -94,30 +95,8 @@ export function LessonPlayerClient({
     hasTrackedSecondStep.current = false;
   }, [lesson.id]);
 
-  useEffect(() => {
-    if (lesson.steps.length === 0) {
-      return;
-    }
+  useTrackLessonStarted({ chapterPosition, courseSlug, lesson, lessonPosition, lessonSlug });
 
-    trackLessonStarted({
-      chapterPosition,
-      courseSlug,
-      lessonKind: lesson.kind,
-      lessonPosition,
-      lessonSlug,
-      stepCount: lesson.steps.length,
-    });
-  }, [
-    chapterPosition,
-    courseSlug,
-    lesson.id,
-    lesson.kind,
-    lessonPosition,
-    lessonSlug,
-    lesson.steps.length,
-  ]);
-
-  /** Fire-and-forget: analytics runs for all learners; persistence requires auth. */
   const handleComplete = useCallback(
     (input: CompletionInput) => {
       trackLessonCompleted({
@@ -128,16 +107,28 @@ export function LessonPlayerClient({
         lessonSlug,
       });
 
+      if (model.milestone) {
+        trackChapterCompleted({ chapterPosition, chapterSlug, courseSlug });
+      }
+
       if (!isAuthenticated) {
         return;
       }
 
       void submitCompletion(input);
     },
-    [chapterPosition, courseSlug, isAuthenticated, lesson.kind, lessonPosition, lessonSlug],
+    [
+      chapterPosition,
+      chapterSlug,
+      courseSlug,
+      isAuthenticated,
+      lesson.kind,
+      lessonPosition,
+      lessonSlug,
+      model.milestone,
+    ],
   );
 
-  /** Fire once after the first forward step change; completion handles short lessons. */
   const handleStepChange = useCallback(
     (event: PlayerStepChangeEvent) => {
       if (isSecondStepForwardEvent(event) && !hasTrackedSecondStep.current) {
@@ -192,18 +183,14 @@ export function LessonPlayerClient({
       onStepChange={handleStepChange}
       progressSnapshot={progressSnapshot}
       totalBrainPower={totalBrainPower}
-      viewer={{
-        completionFooter: (
-          <ContentFeedback
-            className="pt-8"
-            defaultEmail={userEmail}
-            feedbackTarget={{ chapterSlug, courseSlug, kind: "lesson", lessonSlug }}
-            variant="minimal"
-          />
-        ),
+      viewer={getPlayerViewer({
+        chapterSlug,
+        courseSlug,
         isAuthenticated,
+        lessonSlug,
+        userEmail,
         userName,
-      }}
+      })}
     >
       <PlayerShell />
     </PlayerProvider>

--- a/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/use-track-lesson-started.ts
+++ b/apps/main/src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/use-track-lesson-started.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { trackLessonStarted } from "@/lib/track-events";
+import { type SerializedLesson } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { useEffect } from "react";
+
+type LessonStartedTrackingInput = {
+  chapterPosition: number;
+  courseSlug: string;
+  lesson: SerializedLesson;
+  lessonPosition: number;
+  lessonSlug: string;
+};
+
+/**
+ * Counts the lesson-start funnel event when a playable lesson mounts. The
+ * effect synchronizes the mounted player screen with external analytics.
+ */
+export function useTrackLessonStarted({
+  chapterPosition,
+  courseSlug,
+  lesson,
+  lessonPosition,
+  lessonSlug,
+}: LessonStartedTrackingInput) {
+  useEffect(() => {
+    if (lesson.steps.length === 0) {
+      return;
+    }
+
+    trackLessonStarted({
+      chapterPosition,
+      courseSlug,
+      lessonKind: lesson.kind,
+      lessonPosition,
+      lessonSlug,
+      stepCount: lesson.steps.length,
+    });
+  }, [
+    chapterPosition,
+    courseSlug,
+    lesson.id,
+    lesson.kind,
+    lessonPosition,
+    lessonSlug,
+    lesson.steps.length,
+  ]);
+}

--- a/apps/main/src/components/subscription/subscription-gate-tracker.tsx
+++ b/apps/main/src/components/subscription/subscription-gate-tracker.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { trackSubscriptionGateShown } from "@/lib/track-events";
+import { useEffect } from "react";
+
+/**
+ * Records the moment the upgrade CTA is visible. The app only renders this CTA
+ * for blocked subscription states, so the effect represents a real paywall
+ * impression rather than a subscribed visit.
+ */
+export function SubscriptionGateTracker() {
+  useEffect(() => {
+    trackSubscriptionGateShown();
+  }, []);
+
+  return null;
+}

--- a/apps/main/src/components/subscription/upgrade-cta.tsx
+++ b/apps/main/src/components/subscription/upgrade-cta.tsx
@@ -10,6 +10,7 @@ import {
 import { SparklesIcon } from "lucide-react";
 import { type Route } from "next";
 import { getExtracted } from "next-intl/server";
+import { SubscriptionGateTracker } from "./subscription-gate-tracker";
 
 export async function UpgradeCTA<Href extends string>({
   backHref,
@@ -26,6 +27,8 @@ export async function UpgradeCTA<Href extends string>({
 
   return (
     <Empty className="border-0">
+      <SubscriptionGateTracker />
+
       <EmptyHeader align="start">
         <EmptyMedia variant="icon">
           <SparklesIcon />

--- a/apps/main/src/lib/track-events.ts
+++ b/apps/main/src/lib/track-events.ts
@@ -14,6 +14,12 @@ type LessonProgressEventInput = {
 
 type LessonCompletionEventInput = Omit<LessonProgressEventInput, "stepCount">;
 
+type ChapterCompletionEventInput = {
+  chapterPosition: number;
+  chapterSlug: string;
+  courseSlug: string;
+};
+
 type SubscriptionBillingPeriod = "monthly" | "yearly";
 
 export type FeedbackValue = "upvote" | "downvote";
@@ -78,6 +84,15 @@ export function trackLessonCompleted(input: LessonCompletionEventInput) {
 }
 
 /**
+ * Counts learners who reach the structural end of a chapter, including the
+ * final chapter of a course where the visible milestone is the course
+ * completion screen.
+ */
+export function trackChapterCompleted(input: ChapterCompletionEventInput) {
+  trackEvent({ name: "Chapter Completed", properties: getChapterCompletionEventData(input) });
+}
+
+/**
  * Counts when the course goal form is visible, regardless of whether the
  * learner reached it from `/start/learn`, `/`, or another reusable placement.
  */
@@ -119,6 +134,15 @@ export function trackSubscriptionCheckoutStarted({
   plan: string;
 }) {
   trackEvent({ name: "Subscription Checkout Started", properties: { billingPeriod, plan } });
+}
+
+/**
+ * Counts learners who hit the reusable generation paywall instead of inferring
+ * the subscription funnel from pageviews that look the same for subscribed and
+ * gated learners.
+ */
+export function trackSubscriptionGateShown() {
+  trackEvent({ name: "Subscription Gate Shown" });
 }
 
 /**
@@ -193,6 +217,18 @@ function getLessonEventData({
   lessonSlug,
 }: LessonCompletionEventInput): AnalyticsEventProperties {
   return { chapterPosition, courseSlug, lessonKind, lessonPosition, lessonSlug };
+}
+
+/**
+ * Keeps chapter completion filters focused on the completed chapter instead of
+ * the lesson that happened to trigger the structural milestone.
+ */
+function getChapterCompletionEventData({
+  chapterPosition,
+  chapterSlug,
+  courseSlug,
+}: ChapterCompletionEventInput): AnalyticsEventProperties {
+  return { chapterPosition, chapterSlug, courseSlug };
 }
 
 /**


### PR DESCRIPTION
## Summary
- add chapter completion analytics from the player completion flow
- track upgrade CTA impressions for subscription gates
- split player viewer and lesson-start tracking helpers out of the route client

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds analytics for chapter completion and subscription paywall impressions to improve funnel tracking. Also extracts viewer config and lesson-start tracking into small, reusable helpers.

- **New Features**
  - Emit "Chapter Completed" when a lesson completion hits a chapter milestone.
  - Emit "Subscription Gate Shown" when the upgrade CTA renders via `SubscriptionGateTracker`.
  - Keep "Lesson Started" tracking in a new `useTrackLessonStarted` hook.

- **Refactors**
  - Moved viewer config into `getPlayerViewer` to separate UI from lifecycle events.
  - Simplified `lesson-player-client` by removing inline effects and using helpers.

<sup>Written for commit 6bf2322c531338c8c1889abe319eb413a8b04b70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

