### PR TITLE
fix(player): require learning days for best-day milestone

### DIFF
--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -318,6 +318,7 @@ describe("player browser integration: completion", () => {
           { correctAnswers: 18, dayOfWeek: todayDayOfWeek, incorrectAnswers: 2 },
           { correctAnswers: 14, dayOfWeek: weakerDayOfWeek, incorrectAnswers: 6 },
         ],
+        learningDays: 6,
       }),
       viewer: buildAuthenticatedViewer(),
     });

--- a/packages/player/src/_utils/completion-score-milestone.ts
+++ b/packages/player/src/_utils/completion-score-milestone.ts
@@ -1,6 +1,10 @@
 import { parseLocalDate } from "@zoonk/utils/date";
 import { type CompletionProgress, type PlayerProgressSnapshot } from "../completion-milestones";
-import { type BestDayScore, getBestDayScore } from "./completion-milestone-thresholds";
+import {
+  type BestDayScore,
+  getBestDayScore,
+  hasCompletedNewLearningDay,
+} from "./completion-milestone-thresholds";
 
 export type ScoreCompletionMilestone = {
   dayOfWeek: number;
@@ -8,6 +12,37 @@ export type ScoreCompletionMilestone = {
   score: number;
   status: "bestDay";
 };
+
+const MIN_BEST_DAY_LEARNING_DAYS = 5;
+
+/**
+ * The best-day insight needs enough calendar history to be useful. Counting the
+ * just-finished lesson keeps the milestone aligned with the post-save progress
+ * the learner will see on the score page.
+ */
+function getPostCompletionLearningDays({
+  progressSnapshot,
+}: {
+  progressSnapshot: PlayerProgressSnapshot;
+}) {
+  const completedNewLearningDay = hasCompletedNewLearningDay({
+    todayCompletedLessons: progressSnapshot.todayCompletedLessons,
+  });
+
+  return (progressSnapshot.learningDays ?? 0) + (completedNewLearningDay ? 1 : 0);
+}
+
+/**
+ * A weekday ranking is noisy before the learner has completed lessons across
+ * several different days, so the milestone waits until the data is more stable.
+ */
+function hasEnoughLearningDaysForBestDayMilestone({
+  progressSnapshot,
+}: {
+  progressSnapshot: PlayerProgressSnapshot;
+}) {
+  return getPostCompletionLearningDays({ progressSnapshot }) > MIN_BEST_DAY_LEARNING_DAYS;
+}
 
 /**
  * Applies the just-finished lesson to the weekday totals before ranking them.
@@ -96,6 +131,7 @@ export function getBestDayMilestone({
     !progressSnapshot ||
     !bestDayScores ||
     !completion.completedInteractiveLesson ||
+    !hasEnoughLearningDaysForBestDayMilestone({ progressSnapshot }) ||
     (progressSnapshot.todayInteractiveLessons ?? 0) > 0
   ) {
     return null;

--- a/packages/player/src/completion-milestones.test.ts
+++ b/packages/player/src/completion-milestones.test.ts
@@ -376,6 +376,7 @@ describe(getCompletionMilestones, () => {
           { correctAnswers: 17, dayOfWeek: 1, incorrectAnswers: 2 },
           { correctAnswers: 14, dayOfWeek: 2, incorrectAnswers: 6 },
         ],
+        learningDays: 6,
       }),
     });
 
@@ -401,6 +402,7 @@ describe(getCompletionMilestones, () => {
       previousTotalBrainPower: 0,
       progressSnapshot: buildProgressSnapshot({
         bestDayScores: [{ correctAnswers: 8, dayOfWeek: 2, incorrectAnswers: 2 }],
+        learningDays: 6,
       }),
     });
 
@@ -429,6 +431,7 @@ describe(getCompletionMilestones, () => {
           { correctAnswers: 1, dayOfWeek: 1, incorrectAnswers: 0 },
           { correctAnswers: 8, dayOfWeek: 2, incorrectAnswers: 2 },
         ],
+        learningDays: 6,
       }),
     });
 
@@ -454,6 +457,7 @@ describe(getCompletionMilestones, () => {
       previousTotalBrainPower: 0,
       progressSnapshot: buildProgressSnapshot({
         bestDayScores: [{ correctAnswers: 18, dayOfWeek: 1, incorrectAnswers: 2 }],
+        learningDays: 6,
         todayInteractiveLessons: 1,
       }),
     });
@@ -480,10 +484,63 @@ describe(getCompletionMilestones, () => {
       previousTotalBrainPower: 0,
       progressSnapshot: buildProgressSnapshot({
         bestDayScores: [{ correctAnswers: 18, dayOfWeek: 1, incorrectAnswers: 2 }],
+        learningDays: 6,
       }),
     });
 
     expect(milestones).not.toContainEqual({
+      dayOfWeek: 1,
+      kind: "score",
+      score: 90,
+      status: "bestDay",
+    });
+  });
+
+  it("does not show best-day milestones before the learner has more than five learning days", () => {
+    const milestones = getCompletionMilestones({
+      completion: {
+        brainPower: 10,
+        completedInteractiveLesson: true,
+        correctCount: 1,
+        energyDelta: 0.2,
+        incorrectCount: 0,
+        newTotalBp: 10,
+      },
+      localDate: "2026-06-08",
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({
+        bestDayScores: [{ correctAnswers: 17, dayOfWeek: 1, incorrectAnswers: 2 }],
+        learningDays: 4,
+      }),
+    });
+
+    expect(milestones).not.toContainEqual({
+      dayOfWeek: 1,
+      kind: "score",
+      score: 90,
+      status: "bestDay",
+    });
+  });
+
+  it("returns a best-day milestone when this completion pushes learning days above five", () => {
+    const milestones = getCompletionMilestones({
+      completion: {
+        brainPower: 10,
+        completedInteractiveLesson: true,
+        correctCount: 1,
+        energyDelta: 0.2,
+        incorrectCount: 0,
+        newTotalBp: 10,
+      },
+      localDate: "2026-06-08",
+      previousTotalBrainPower: 0,
+      progressSnapshot: buildProgressSnapshot({
+        bestDayScores: [{ correctAnswers: 17, dayOfWeek: 1, incorrectAnswers: 2 }],
+        learningDays: 5,
+      }),
+    });
+
+    expect(milestones).toContainEqual({
       dayOfWeek: 1,
       kind: "score",
       score: 90,


### PR DESCRIPTION
## Summary

- gate the best-day milestone behind more than five post-completion learning days
- keep existing best-day tests and browser fixture aligned with the new threshold

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the best-day milestone behind more than five post-completion learning days to reduce noisy weekday rankings. Counts today’s newly completed lesson toward the threshold and updates tests/fixtures in `packages/player`.

- **Bug Fixes**
  - Require >5 post-completion learning days in `getBestDayMilestone`.
  - Compute post-completion days using `hasCompletedNewLearningDay`.
  - Update unit/browser tests to include `learningDays`; add cases for 4 days (no milestone) and 5→6 (milestone shown).

<sup>Written for commit bce12e5232a02d168701aced933a09a107762fcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

