### PR TITLE
fix(main): improve command palette on ios

### DIFF
--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { type Locator } from "@playwright/test";
 import { setLocale } from "@zoonk/e2e/fixtures/locale";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
@@ -99,6 +100,48 @@ async function openCommandPalette(page: Page) {
     await searchButton.click();
     await expect(page.getByRole("dialog")).toBeVisible({ timeout: 1000 });
   }).toPass();
+}
+
+/**
+ * Base UI keeps listbox focus on the input and points assistive technology to
+ * the highlighted option with aria-activedescendant, so keyboard navigation
+ * assertions should follow that semantic relationship.
+ */
+async function expectActiveOption(page: Page, optionName: RegExp) {
+  const dialog = page.getByRole("dialog");
+  const input = dialog.getByPlaceholder(/search/iu);
+  const option = dialog.getByRole("option", { name: optionName });
+  const optionId = await option.getAttribute("id");
+
+  expect(optionId).toBeTruthy();
+  await expect(input).toHaveAttribute("aria-activedescendant", optionId!);
+}
+
+/**
+ * Long catalog titles and descriptions should truncate inside the palette; if
+ * they increase scrollWidth, touch users can accidentally pan sideways instead
+ * of only scrolling vertically through the result list.
+ */
+async function expectNoHorizontalScrollableOverflow(container: Locator) {
+  const overflowingElements = await container.evaluate((element: HTMLElement) =>
+    [element, ...element.querySelectorAll<HTMLElement>("*")]
+      .filter((node) => {
+        const { overflowX } = getComputedStyle(node);
+
+        return (
+          (overflowX === "auto" || overflowX === "scroll") &&
+          node.scrollWidth > node.clientWidth + 1
+        );
+      })
+      .map((node) => ({
+        clientWidth: node.clientWidth,
+        overflowX: getComputedStyle(node).overflowX,
+        scrollWidth: node.scrollWidth,
+        slot: node.dataset.slot,
+      })),
+  );
+
+  expect(overflowingElements).toEqual([]);
 }
 
 // Helper to get the correct modifier key for the platform
@@ -416,6 +459,53 @@ test.describe("Command Palette - Course Search", () => {
     await expect(page.getByRole("button", { name: new RegExp(chapterName, "u") })).toBeVisible();
   });
 
+  test("truncates long result content without horizontal overflow", async ({ page }) => {
+    const org = await getAiOrganization();
+    const uniqueId = randomUUID().slice(0, 8);
+    const searchTerm = `E2E Long Result ${uniqueId}`;
+    const courseName = `${searchTerm} Course`;
+    const chapterName = `${searchTerm} Chapter`;
+
+    const longDescription =
+      "This result has a deliberately long description that should stay inside the command palette and truncate instead of making the dialog pan sideways on touch devices.";
+
+    const course = await courseFixture({
+      description: longDescription,
+      isPublished: true,
+      normalizedTitle: normalizeString(courseName),
+      organizationId: org.id,
+      slug: `e2e-long-result-course-${uniqueId}`,
+      title: courseName,
+    });
+
+    await chapterFixture({
+      courseId: course.id,
+      description: longDescription,
+      isPublished: true,
+      normalizedTitle: normalizeString(chapterName),
+      organizationId: org.id,
+      position: 0,
+      slug: `e2e-long-result-chapter-${uniqueId}`,
+      title: chapterName,
+    });
+
+    await page.goto("/");
+    await openCommandPalette(page);
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByPlaceholder(/search/iu).fill(searchTerm);
+
+    await expect(
+      dialog.getByRole("option", { name: new RegExp(`^${courseName}`, "u") }),
+    ).toBeVisible();
+
+    await expect(
+      dialog.getByRole("option", { name: new RegExp(`^${chapterName}`, "u") }),
+    ).toBeVisible();
+
+    await expectNoHorizontalScrollableOverflow(dialog);
+  });
+
   test("suggests creating a course for non-matching query", async ({ page }) => {
     const uniqueId = randomUUID().slice(0, 8);
     const prompt = `E2E Empty Search ${uniqueId}`;
@@ -557,13 +647,14 @@ test.describe("Command Palette - Keyboard Navigation", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible();
 
-    // Ensure the search input is focused so cmdk receives keyboard events
+    // Ensure the search input is focused so Base UI receives keyboard events
     const input = dialog.getByPlaceholder(/search/iu);
     await expect(input).toBeFocused();
 
-    // Wait for cmdk to initialize - first item "Home page" should be selected
+    // Wait for Base UI to initialize - first item "Home page" should be active
     const homeOption = dialog.getByRole("option", { name: /home page/iu });
-    await expect(homeOption).toHaveAttribute("aria-selected", "true");
+    await expect(homeOption).toBeVisible();
+    await expectActiveOption(page, /home page/iu);
 
     // Also wait for the second option to be present before navigating
     const learnOption = dialog.getByRole("option", { name: /start a new course/iu });
@@ -571,11 +662,11 @@ test.describe("Command Palette - Keyboard Navigation", () => {
 
     // Press ArrowDown - "Start a new course" should now be selected
     await page.keyboard.press("ArrowDown");
-    await expect(learnOption).toHaveAttribute("aria-selected", "true");
+    await expectActiveOption(page, /start a new course/iu);
 
     // Press ArrowUp - "Home page" should be selected again
     await page.keyboard.press("ArrowUp");
-    await expect(homeOption).toHaveAttribute("aria-selected", "true");
+    await expectActiveOption(page, /home page/iu);
   });
 
   test("Enter to select shows start goals on the home page", async ({ page }) => {

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -7,6 +7,53 @@ msgstr ""
 "X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
+msgid "xmcVZ0"
+msgstr "Suche"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "PSiLeL"
+msgstr "Kurse, Kapitel oder Seiten durchsuchen..."
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/user-dropdown-menu.tsx
+msgid "I-38K2"
+msgstr "Meine Kurse"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "Oj9Phc"
+msgstr "Abo verwalten"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "OhXwmw"
+msgstr "Sprache ändern"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "O7ozeo"
+msgstr "Profil aktualisieren"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(settings)/_components/settings-navbar.tsx
+msgid "C81_uG"
+msgstr "Abmelden"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(progress)/_components/progress-empty-state.tsx
+#: src/app/(settings)/_components/protected-section.tsx
+msgid "AyGauy"
+msgstr "Anmelden"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/_components/settings-pills.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "y1Z3or"
+msgstr "Sprache"
+
+#: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
@@ -34,37 +81,12 @@ msgid "3wvH7G"
 msgstr "Prüfung bestehen"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(progress)/_components/progress-empty-state.tsx
-#: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
-msgstr "Anmelden"
+msgid "CxfKLC"
+msgstr "Seiten"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/_components/settings-pills.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
-msgstr "Sprache"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
-msgstr "Meine Kurse"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
-msgstr "Abo verwalten"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
-msgstr "Sprache ändern"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
-msgstr "Profil aktualisieren"
+msgid "dXSivY"
+msgstr "Mein Konto"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
@@ -78,28 +100,6 @@ msgstr "Blog"
 #: src/app/(settings)/support/support-content.tsx
 msgid "fFZ0Wd"
 msgstr "Feedback & Support"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
-msgstr "Suche"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
-msgstr "Kurse, Kapitel oder Seiten durchsuchen..."
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
-msgstr "Seiten"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
-msgstr "Mein Konto"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
-msgstr "Abmelden"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -7,6 +7,53 @@ msgstr ""
 "X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
+msgid "xmcVZ0"
+msgstr "Search"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "PSiLeL"
+msgstr "Search courses, chapters, or pages..."
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/user-dropdown-menu.tsx
+msgid "I-38K2"
+msgstr "My courses"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "Oj9Phc"
+msgstr "Manage subscription"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "OhXwmw"
+msgstr "Update language"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "O7ozeo"
+msgstr "Update profile"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(settings)/_components/settings-navbar.tsx
+msgid "C81_uG"
+msgstr "Logout"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(progress)/_components/progress-empty-state.tsx
+#: src/app/(settings)/_components/protected-section.tsx
+msgid "AyGauy"
+msgstr "Login"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/_components/settings-pills.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "y1Z3or"
+msgstr "Language"
+
+#: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
@@ -34,37 +81,12 @@ msgid "3wvH7G"
 msgstr "Pass an exam"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(progress)/_components/progress-empty-state.tsx
-#: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
-msgstr "Login"
+msgid "CxfKLC"
+msgstr "Pages"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/_components/settings-pills.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
-msgstr "Language"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
-msgstr "My courses"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
-msgstr "Manage subscription"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
-msgstr "Update language"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
-msgstr "Update profile"
+msgid "dXSivY"
+msgstr "My account"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
@@ -78,28 +100,6 @@ msgstr "Blog"
 #: src/app/(settings)/support/support-content.tsx
 msgid "fFZ0Wd"
 msgstr "Feedback & Support"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
-msgstr "Search"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
-msgstr "Search courses, chapters, or pages..."
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
-msgstr "Pages"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
-msgstr "My account"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
-msgstr "Logout"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -7,6 +7,53 @@ msgstr ""
 "X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
+msgid "xmcVZ0"
+msgstr "Buscar"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "PSiLeL"
+msgstr "Buscar cursos, capítulos o páginas..."
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/user-dropdown-menu.tsx
+msgid "I-38K2"
+msgstr "Mis cursos"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "Oj9Phc"
+msgstr "Gestionar suscripción"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "OhXwmw"
+msgstr "Actualizar idioma"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "O7ozeo"
+msgstr "Actualizar perfil"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(settings)/_components/settings-navbar.tsx
+msgid "C81_uG"
+msgstr "Cerrar sesión"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(progress)/_components/progress-empty-state.tsx
+#: src/app/(settings)/_components/protected-section.tsx
+msgid "AyGauy"
+msgstr "Iniciar sesión"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/_components/settings-pills.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "y1Z3or"
+msgstr "Idioma"
+
+#: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
@@ -34,37 +81,12 @@ msgid "3wvH7G"
 msgstr "Aprobar un examen"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(progress)/_components/progress-empty-state.tsx
-#: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
-msgstr "Iniciar sesión"
+msgid "CxfKLC"
+msgstr "Páginas"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/_components/settings-pills.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
-msgstr "Idioma"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
-msgstr "Mis cursos"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
-msgstr "Gestionar suscripción"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
-msgstr "Actualizar idioma"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
-msgstr "Actualizar perfil"
+msgid "dXSivY"
+msgstr "Mi cuenta"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
@@ -78,28 +100,6 @@ msgstr "Blog"
 #: src/app/(settings)/support/support-content.tsx
 msgid "fFZ0Wd"
 msgstr "Comentarios y soporte"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
-msgstr "Buscar"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
-msgstr "Buscar cursos, capítulos o páginas..."
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
-msgstr "Páginas"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
-msgstr "Mi cuenta"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
-msgstr "Cerrar sesión"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -7,6 +7,53 @@ msgstr ""
 "X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
+msgid "xmcVZ0"
+msgstr "Recherche"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "PSiLeL"
+msgstr "Rechercher des cours, chapitres ou pages..."
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/user-dropdown-menu.tsx
+msgid "I-38K2"
+msgstr "Mes cours"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "Oj9Phc"
+msgstr "Gérer l'abonnement"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "OhXwmw"
+msgstr "Changer la langue"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "O7ozeo"
+msgstr "Modifier le profil"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(settings)/_components/settings-navbar.tsx
+msgid "C81_uG"
+msgstr "Se déconnecter"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(progress)/_components/progress-empty-state.tsx
+#: src/app/(settings)/_components/protected-section.tsx
+msgid "AyGauy"
+msgstr "Se connecter"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/_components/settings-pills.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "y1Z3or"
+msgstr "Langue"
+
+#: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
@@ -34,37 +81,12 @@ msgid "3wvH7G"
 msgstr "Réussir un examen"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(progress)/_components/progress-empty-state.tsx
-#: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
-msgstr "Se connecter"
+msgid "CxfKLC"
+msgstr "Pages"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/_components/settings-pills.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
-msgstr "Langue"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
-msgstr "Mes cours"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
-msgstr "Gérer l'abonnement"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
-msgstr "Changer la langue"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
-msgstr "Modifier le profil"
+msgid "dXSivY"
+msgstr "Mon compte"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
@@ -78,28 +100,6 @@ msgstr "Blog"
 #: src/app/(settings)/support/support-content.tsx
 msgid "fFZ0Wd"
 msgstr "Retours et support"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
-msgstr "Recherche"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
-msgstr "Rechercher des cours, chapitres ou pages..."
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
-msgstr "Pages"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
-msgstr "Mon compte"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
-msgstr "Se déconnecter"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -7,6 +7,53 @@ msgstr ""
 "X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
+msgid "xmcVZ0"
+msgstr "Buscar"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "PSiLeL"
+msgstr "Buscar cursos, capítulos ou páginas..."
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/user-dropdown-menu.tsx
+msgid "I-38K2"
+msgstr "Meus cursos"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "Oj9Phc"
+msgstr "Gerenciar assinatura"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "OhXwmw"
+msgstr "Atualizar idioma"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+msgid "O7ozeo"
+msgstr "Atualizar perfil"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(settings)/_components/settings-navbar.tsx
+msgid "C81_uG"
+msgstr "Sair"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(catalog)/_components/logout-dropdown-item.tsx
+#: src/app/(progress)/_components/progress-empty-state.tsx
+#: src/app/(settings)/_components/protected-section.tsx
+msgid "AyGauy"
+msgstr "Entrar"
+
+#: src/app/(catalog)/_components/command-palette.tsx
+#: src/app/(settings)/_components/locale-switcher.tsx
+#: src/app/(settings)/_components/settings-pills.tsx
+#: src/app/(settings)/language/page.tsx
+msgid "y1Z3or"
+msgstr "Idioma"
+
+#: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
@@ -34,37 +81,12 @@ msgid "3wvH7G"
 msgstr "Passar em uma prova"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(progress)/_components/progress-empty-state.tsx
-#: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
-msgstr "Entrar"
+msgid "CxfKLC"
+msgstr "Páginas"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/_components/settings-pills.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
-msgstr "Idioma"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
-msgstr "Meus cursos"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
-msgstr "Gerenciar assinatura"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(settings)/_components/locale-switcher.tsx
-#: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
-msgstr "Atualizar idioma"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
-msgstr "Atualizar perfil"
+msgid "dXSivY"
+msgstr "Minha conta"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
@@ -78,28 +100,6 @@ msgstr "Blog"
 #: src/app/(settings)/support/support-content.tsx
 msgid "fFZ0Wd"
 msgstr "Sugestões e Suporte"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
-msgstr "Buscar"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
-msgstr "Buscar cursos, capítulos ou páginas..."
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
-msgstr "Páginas"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
-msgstr "Minha conta"
-
-#: src/app/(catalog)/_components/command-palette.tsx
-#: src/app/(catalog)/_components/logout-dropdown-item.tsx
-#: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
-msgstr "Sair"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"

--- a/apps/main/src/app/(catalog)/_components/command-palette-items.ts
+++ b/apps/main/src/app/(catalog)/_components/command-palette-items.ts
@@ -1,0 +1,163 @@
+import { removeAccents } from "@zoonk/utils/string";
+import { LogOutIcon, type LucideIcon } from "lucide-react";
+import { type Route } from "next";
+import { type ChapterSearchResult, type CourseSearchResult } from "./search-courses-action";
+
+type PaletteRoute = Route;
+
+export type NavigationPaletteItem = {
+  icon: LucideIcon;
+  id: string;
+  kind: "navigation";
+  label: string;
+  searchValue: string;
+  url: PaletteRoute;
+};
+
+export type LogoutPaletteItem = {
+  icon: LucideIcon;
+  id: string;
+  kind: "logout";
+  label: string;
+  searchValue: string;
+};
+
+export type CoursePaletteItem = {
+  course: CourseSearchResult;
+  id: string;
+  kind: "course";
+  label: string;
+  searchValue: string;
+};
+
+export type ChapterPaletteItem = {
+  chapter: ChapterSearchResult;
+  id: string;
+  kind: "chapter";
+  label: string;
+  searchValue: string;
+};
+
+export type PaletteItem =
+  | ChapterPaletteItem
+  | CoursePaletteItem
+  | LogoutPaletteItem
+  | NavigationPaletteItem;
+
+export type PaletteGroup = { id: string; items: PaletteItem[]; label: string };
+
+/**
+ * Navigation entries need both display text and a searchable value. Creating
+ * them in one place keeps the label shown to learners in sync with the text
+ * used by the palette filter.
+ */
+export function createNavigationPaletteItem({
+  id,
+  label,
+  menu,
+}: {
+  id: string;
+  label: string;
+  menu: { icon: LucideIcon; url: PaletteRoute };
+}): NavigationPaletteItem {
+  return { icon: menu.icon, id, kind: "navigation", label, searchValue: label, url: menu.url };
+}
+
+/**
+ * Logout behaves like the other account actions visually, but it must run the
+ * auth side effect instead of navigating to an application route.
+ */
+export function createLogoutPaletteItem({ label }: { label: string }): LogoutPaletteItem {
+  return { icon: LogOutIcon, id: "logout", kind: "logout", label, searchValue: label };
+}
+
+/**
+ * Course search can match on title or description, so both fields need to stay
+ * in the item's search value while the visible option keeps the compact title
+ * and description layout.
+ */
+export function createCoursePaletteItem(course: CourseSearchResult): CoursePaletteItem {
+  return {
+    course,
+    id: `course-${course.id}`,
+    kind: "course",
+    label: course.title,
+    searchValue: [course.title, course.description, course.id].filter(Boolean).join(" "),
+  };
+}
+
+/**
+ * Chapter titles are often reused across courses, so the search value includes
+ * the parent course context and description while the option still renders the
+ * fields as separate lines.
+ */
+export function createChapterPaletteItem(chapter: ChapterSearchResult): ChapterPaletteItem {
+  return {
+    chapter,
+    id: `chapter-${chapter.id}`,
+    kind: "chapter",
+    label: chapter.title,
+    searchValue: [chapter.title, chapter.courseTitle, chapter.description, chapter.id]
+      .filter(Boolean)
+      .join(" "),
+  };
+}
+
+/**
+ * Base UI's Autocomplete owns keyboard movement while this helper preserves the
+ * previous matching behavior: normalize accents, ignore case, and hide groups
+ * once none of their items match the query.
+ */
+export function getVisiblePaletteGroups({
+  groups,
+  query,
+}: {
+  groups: PaletteGroup[];
+  query: string;
+}) {
+  return groups
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item) => matchesPaletteItem({ item, query })),
+    }))
+    .filter((group) => group.items.length > 0);
+}
+
+/**
+ * Autocomplete uses this string for item matching and form values; keeping it
+ * separate from the visual label allows course and chapter descriptions to
+ * remain searchable without flattening the rendered option.
+ */
+export function getPaletteItemSearchValue(item: PaletteItem) {
+  return item.searchValue;
+}
+
+/**
+ * Detailed items use a larger row layout because they contain media and
+ * secondary text, while static actions should keep the compact item rhythm.
+ */
+export function isDetailedPaletteItem(item: PaletteItem) {
+  return item.kind === "chapter" || item.kind === "course";
+}
+
+/**
+ * Palette matching needs to be accent-insensitive because learners may search
+ * localized titles without entering the exact diacritics stored in the catalog.
+ */
+function matchesPaletteItem({ item, query }: { item: PaletteItem; query: string }) {
+  const normalizedQuery = normalizePaletteSearchText(query.trim());
+
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return normalizePaletteSearchText(item.searchValue).includes(normalizedQuery);
+}
+
+/**
+ * Search text is normalized in one helper so every palette item kind follows
+ * the same case and accent handling.
+ */
+function normalizePaletteSearchText(value: string) {
+  return removeAccents(value).toLocaleLowerCase();
+}

--- a/apps/main/src/app/(catalog)/_components/command-palette-options.tsx
+++ b/apps/main/src/app/(catalog)/_components/command-palette-options.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import {
+  CommandCollection,
+  CommandGroup,
+  CommandGroupLabel,
+  CommandItem,
+} from "@zoonk/ui/components/command";
+import { cn } from "@zoonk/ui/lib/utils";
+import { BookOpenIcon } from "lucide-react";
+import Image from "next/image";
+import {
+  type ChapterPaletteItem,
+  type CoursePaletteItem,
+  type LogoutPaletteItem,
+  type NavigationPaletteItem,
+  type PaletteGroup,
+  type PaletteItem,
+  isDetailedPaletteItem,
+} from "./command-palette-items";
+
+/**
+ * Groups are rendered with Base UI's collection primitive so the active option
+ * order used by keyboard navigation matches the visible grouped list.
+ */
+export function PaletteResultGroup({
+  group,
+  onSelectItem,
+}: {
+  group: PaletteGroup;
+  onSelectItem: (item: PaletteItem) => void;
+}) {
+  return (
+    <CommandGroup items={group.items}>
+      <CommandGroupLabel>{group.label}</CommandGroupLabel>
+      <CommandCollection>
+        {(item: PaletteItem) => (
+          <PaletteOption item={item} key={item.id} onSelectItem={onSelectItem} />
+        )}
+      </CommandCollection>
+    </CommandGroup>
+  );
+}
+
+/**
+ * Each option delegates selection to Autocomplete.Item so pointer clicks and
+ * Enter-key activation follow Base UI's combobox behavior on desktop and iOS.
+ */
+function PaletteOption({
+  item,
+  onSelectItem,
+}: {
+  item: PaletteItem;
+  onSelectItem: (item: PaletteItem) => void;
+}) {
+  return (
+    <CommandItem
+      className={cn(isDetailedPaletteItem(item) && "gap-3")}
+      onClick={() => onSelectItem(item)}
+      value={item}
+    >
+      <PaletteOptionContent item={item} />
+    </CommandItem>
+  );
+}
+
+/**
+ * Course and chapter results need richer media/text layouts, while static
+ * navigation actions should stay visually compact like regular command items.
+ */
+function PaletteOptionContent({ item }: { item: PaletteItem }) {
+  if (item.kind === "course") {
+    return <CourseOptionContent item={item} />;
+  }
+
+  if (item.kind === "chapter") {
+    return <ChapterOptionContent item={item} />;
+  }
+
+  return <SimpleOptionContent item={item} />;
+}
+
+/**
+ * Simple command items use the menu icon and label only, matching the compact
+ * page/account/help actions from the previous palette.
+ */
+function SimpleOptionContent({ item }: { item: LogoutPaletteItem | NavigationPaletteItem }) {
+  const Icon = item.icon;
+
+  return (
+    <>
+      <Icon aria-hidden="true" />
+      {item.label}
+    </>
+  );
+}
+
+/**
+ * Course results show the thumbnail when available so search results remain
+ * recognizable without requiring learners to inspect the destination URL.
+ */
+function CourseOptionContent({ item }: { item: CoursePaletteItem }) {
+  const { course } = item;
+
+  return (
+    <>
+      <PaletteResultImage imageUrl={course.imageUrl} title={course.title} />
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-medium">{course.title}</p>
+        {course.description && (
+          <p className="text-muted-foreground truncate text-xs">{course.description}</p>
+        )}
+      </div>
+    </>
+  );
+}
+
+/**
+ * Chapter results include the parent course because the same chapter title can
+ * appear in multiple courses.
+ */
+function ChapterOptionContent({ item }: { item: ChapterPaletteItem }) {
+  const { chapter } = item;
+
+  return (
+    <>
+      <PaletteResultImage imageUrl={chapter.imageUrl} title={chapter.title} />
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-medium">{chapter.title}</p>
+        <p className="text-muted-foreground truncate text-xs">{chapter.courseTitle}</p>
+        <p className="text-muted-foreground truncate text-xs">{chapter.description}</p>
+      </div>
+    </>
+  );
+}
+
+/**
+ * Catalog records do not always have thumbnails, so the fallback keeps result
+ * rows aligned while still communicating that the destination is course content.
+ */
+function PaletteResultImage({ imageUrl, title }: { imageUrl: string | null; title: string }) {
+  if (imageUrl) {
+    return (
+      <Image
+        alt={title}
+        className="size-8 shrink-0 rounded-md object-cover"
+        height={32}
+        src={imageUrl}
+        width={32}
+      />
+    );
+  }
+
+  return (
+    <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-md">
+      <BookOpenIcon aria-hidden="true" className="size-4" />
+    </div>
+  );
+}

--- a/apps/main/src/app/(catalog)/_components/command-palette.tsx
+++ b/apps/main/src/app/(catalog)/_components/command-palette.tsx
@@ -4,27 +4,31 @@ import { logout } from "@/lib/logout";
 import { getMenu } from "@/lib/menu";
 import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import {
+  Command,
   CommandDialog,
+  CommandDialogDescription,
+  CommandDialogTitle,
   CommandEmpty,
-  CommandGroup,
   CommandInput,
-  CommandItem,
   CommandList,
 } from "@zoonk/ui/components/command";
 import { useCommandPaletteSearch } from "@zoonk/ui/hooks/command-palette-search";
-import { BookOpenIcon, LogOut, PlusIcon, Search } from "lucide-react";
-import { type Route } from "next";
+import { PlusIcon, SearchIcon } from "lucide-react";
 import { useExtracted, useLocale } from "next-intl";
-import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 import {
-  type CatalogSearchResults,
-  type ChapterSearchResult,
-  type CourseSearchResult,
-  searchCatalogAction,
-} from "./search-courses-action";
+  type PaletteItem,
+  createChapterPaletteItem,
+  createCoursePaletteItem,
+  createLogoutPaletteItem,
+  createNavigationPaletteItem,
+  getPaletteItemSearchValue,
+  getVisiblePaletteGroups,
+} from "./command-palette-items";
+import { PaletteResultGroup } from "./command-palette-options";
+import { type CatalogSearchResults, searchCatalogAction } from "./search-courses-action";
 
 const EMPTY_SEARCH_RESULTS: CatalogSearchResults = { chapters: [], courses: [] };
 
@@ -55,38 +59,43 @@ export function CommandPalette({
       onSearch: handleSearch,
     });
 
-  function handleSelect<T extends string>(url: Route<T>) {
+  function handlePaletteItemSelect(item: PaletteItem) {
+    if (item.kind === "logout") {
+      closePalette();
+      logout();
+      return;
+    }
+
     onSelectItem();
-    router.push(url);
+
+    if (item.kind === "navigation") {
+      router.push(item.url);
+      return;
+    }
+
+    if (item.kind === "course") {
+      router.push(`/b/${item.course.brandSlug}/c/${item.course.slug}` as const);
+      return;
+    }
+
+    router.push(
+      `/b/${item.chapter.brandSlug}/c/${item.chapter.courseSlug}/ch/${item.chapter.slug}` as const,
+    );
   }
 
-  const getStarted = [
-    { key: t("Home page"), ...getMenu("home") },
-    { key: t("Start a new course"), ...getMenu("start") },
-    { key: t("Speak a language"), ...getMenu("startSpeak") },
-    { key: t("Learn something"), ...getMenu("startLearn") },
-    { key: t("Pass an exam"), ...getMenu("startExam") },
-  ];
+  const searchLabel = t("Search");
+  const searchPlaceholder = t("Search courses, chapters, or pages...");
+  const paletteGroups = usePaletteGroups({ isLoggedIn, query, results });
 
-  const accountPublic = [
-    { key: t("Login"), ...getMenu("login") },
-    { key: t("Language"), ...getMenu("language") },
-  ];
-
-  const accountPrivate = [
-    { key: t("My courses"), ...getMenu("myCourses") },
-    { key: t("Manage subscription"), ...getMenu("subscription") },
-    { key: t("Update language"), ...getMenu("language") },
-    { key: t("Update profile"), ...getMenu("profile") },
-  ];
-
-  const contactUs = [
-    { key: t("Blog"), ...getMenu("blog") },
-    { key: t("Feedback & Support"), ...getMenu("support") },
-  ];
-
-  const hasChapters = results.chapters.length > 0;
-  const hasCourses = results.courses.length > 0;
+  /**
+   * The dialog may close from Escape or an outside press. The search hook owns
+   * query/result reset, so close events should go through that single path.
+   */
+  function handleDialogOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      closePalette();
+    }
+  }
 
   return (
     <>
@@ -97,94 +106,144 @@ export function CommandPalette({
         size="icon"
         variant="outline"
       >
-        <Search aria-hidden="true" />
-        <span className="sr-only">{t("Search")}</span>
+        <SearchIcon aria-hidden="true" />
+        <span className="sr-only">{searchLabel}</span>
       </Button>
 
-      <CommandDialog
-        description={t("Search courses, chapters, or pages...")}
-        onOpenChange={closePalette}
-        open={isOpen}
-        title={t("Search")}
-      >
-        <CommandInput
+      <CommandDialog onOpenChange={handleDialogOpenChange} open={isOpen}>
+        <CommandDialogTitle>{searchLabel}</CommandDialogTitle>
+        <CommandDialogDescription>{searchPlaceholder}</CommandDialogDescription>
+        <Command
+          autoHighlight="always"
+          inline
+          itemToStringValue={getPaletteItemSearchValue}
+          items={paletteGroups}
+          keepHighlight
+          mode="none"
           onValueChange={setQuery}
-          placeholder={t("Search courses, chapters, or pages...")}
+          open
           value={query}
-        />
+        >
+          <CommandInput aria-label={searchLabel} placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>
+              <CreateCourseEmptyState onSelect={onSelectItem} query={query} />
+            </CommandEmpty>
 
-        <CommandList>
-          <CommandEmpty>
-            <CreateCourseEmptyState onSelect={onSelectItem} query={query} />
-          </CommandEmpty>
-
-          <CommandGroup heading={t("Pages")}>
-            {getStarted.map((item) => (
-              <CommandItem key={item.key} onSelect={() => handleSelect(item.url)}>
-                <item.icon aria-hidden="true" />
-                {item.key}
-              </CommandItem>
+            {paletteGroups.map((group) => (
+              <PaletteResultGroup
+                group={group}
+                key={group.id}
+                onSelectItem={handlePaletteItemSelect}
+              />
             ))}
-          </CommandGroup>
-
-          <CommandGroup heading={t("My account")}>
-            {!isLoggedIn &&
-              accountPublic.map((item) => (
-                <CommandItem key={item.key} onSelect={() => handleSelect(item.url)}>
-                  <item.icon aria-hidden="true" />
-                  {item.key}
-                </CommandItem>
-              ))}
-
-            {isLoggedIn &&
-              accountPrivate.map((item) => (
-                <CommandItem key={item.key} onSelect={() => handleSelect(item.url)}>
-                  <item.icon aria-hidden="true" />
-                  {item.key}
-                </CommandItem>
-              ))}
-
-            {isLoggedIn && (
-              <CommandItem
-                onSelect={() => {
-                  closePalette();
-                  logout();
-                }}
-              >
-                <LogOut aria-hidden="true" />
-                {t("Logout")}
-              </CommandItem>
-            )}
-          </CommandGroup>
-
-          <CommandGroup heading={t("Help")}>
-            {contactUs.map((item) => (
-              <CommandItem key={item.key} onSelect={() => handleSelect(item.url)}>
-                <item.icon aria-hidden="true" />
-                {item.key}
-              </CommandItem>
-            ))}
-          </CommandGroup>
-
-          {hasCourses && (
-            <CommandGroup heading={t("Courses")}>
-              {results.courses.map((course) => (
-                <CourseItem course={course} key={course.id} onSelect={handleSelect} />
-              ))}
-            </CommandGroup>
-          )}
-
-          {hasChapters && (
-            <CommandGroup heading={t("Chapters")}>
-              {results.chapters.map((chapter) => (
-                <ChapterItem chapter={chapter} key={chapter.id} onSelect={handleSelect} />
-              ))}
-            </CommandGroup>
-          )}
-        </CommandList>
+          </CommandList>
+        </Command>
       </CommandDialog>
     </>
   );
+}
+
+/**
+ * Palette groups are assembled in a hook because translated labels must be read
+ * with `t("literal")` at the render boundary, not passed through a translation
+ * helper or stored outside the component.
+ */
+function usePaletteGroups({
+  isLoggedIn,
+  query,
+  results,
+}: {
+  isLoggedIn: boolean;
+  query: string;
+  results: CatalogSearchResults;
+}) {
+  const t = useExtracted();
+
+  const accountItems = isLoggedIn
+    ? [
+        createNavigationPaletteItem({
+          id: "my-courses",
+          label: t("My courses"),
+          menu: getMenu("myCourses"),
+        }),
+        createNavigationPaletteItem({
+          id: "subscription",
+          label: t("Manage subscription"),
+          menu: getMenu("subscription"),
+        }),
+        createNavigationPaletteItem({
+          id: "update-language",
+          label: t("Update language"),
+          menu: getMenu("language"),
+        }),
+        createNavigationPaletteItem({
+          id: "profile",
+          label: t("Update profile"),
+          menu: getMenu("profile"),
+        }),
+        createLogoutPaletteItem({ label: t("Logout") }),
+      ]
+    : [
+        createNavigationPaletteItem({ id: "login", label: t("Login"), menu: getMenu("login") }),
+        createNavigationPaletteItem({
+          id: "language",
+          label: t("Language"),
+          menu: getMenu("language"),
+        }),
+      ];
+
+  return getVisiblePaletteGroups({
+    groups: [
+      {
+        id: "pages",
+        items: [
+          createNavigationPaletteItem({ id: "home", label: t("Home page"), menu: getMenu("home") }),
+          createNavigationPaletteItem({
+            id: "start",
+            label: t("Start a new course"),
+            menu: getMenu("start"),
+          }),
+          createNavigationPaletteItem({
+            id: "start-speak",
+            label: t("Speak a language"),
+            menu: getMenu("startSpeak"),
+          }),
+          createNavigationPaletteItem({
+            id: "start-learn",
+            label: t("Learn something"),
+            menu: getMenu("startLearn"),
+          }),
+          createNavigationPaletteItem({
+            id: "start-exam",
+            label: t("Pass an exam"),
+            menu: getMenu("startExam"),
+          }),
+        ],
+        label: t("Pages"),
+      },
+      { id: "account", items: accountItems, label: t("My account") },
+      {
+        id: "help",
+        items: [
+          createNavigationPaletteItem({ id: "blog", label: t("Blog"), menu: getMenu("blog") }),
+          createNavigationPaletteItem({
+            id: "support",
+            label: t("Feedback & Support"),
+            menu: getMenu("support"),
+          }),
+        ],
+        label: t("Help"),
+      },
+      { id: "courses", items: results.courses.map(createCoursePaletteItem), label: t("Courses") },
+      {
+        id: "chapters",
+        items: results.chapters.map(createChapterPaletteItem),
+        label: t("Chapters"),
+      },
+    ],
+    query,
+  });
 }
 
 /**
@@ -222,8 +281,8 @@ function CreateCourseEmptyState({ onSelect, query }: { onSelect: () => void; que
 }
 
 /**
- * The palette input may contain only whitespace while cmdk is still rendering
- * an empty result, and the Learn route should only receive a real subject.
+ * The palette input may contain only whitespace while the empty state is still
+ * rendering, and the Learn route should only receive a real subject.
  */
 function getCreateCoursePrompt(query: string) {
   const prompt = query.trim();
@@ -241,87 +300,4 @@ function getCreateCoursePrompt(query: string) {
  */
 function getLearnPromptHref(prompt: string) {
   return `/start/learn/${encodeURIComponent(prompt)}` as const;
-}
-
-function CourseItem({
-  course,
-  onSelect,
-}: {
-  course: CourseSearchResult;
-  onSelect: <T extends string>(url: Route<T>) => void;
-}) {
-  return (
-    <CommandItem
-      className="flex items-start gap-3"
-      onSelect={() => onSelect(`/b/${course.brandSlug}/c/${course.slug}`)}
-      value={`${course.title}-${course.id}`}
-    >
-      {course.imageUrl ? (
-        <Image
-          alt={course.title}
-          className="size-8 shrink-0 rounded-md object-cover"
-          height={32}
-          src={course.imageUrl}
-          width={32}
-        />
-      ) : (
-        <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-md">
-          <BookOpenIcon aria-hidden="true" className="size-4" />
-        </div>
-      )}
-
-      <div className="min-w-0 flex-1">
-        <p className="truncate font-medium">{course.title}</p>
-        {course.description && (
-          <p className="text-muted-foreground truncate text-xs">{course.description}</p>
-        )}
-      </div>
-    </CommandItem>
-  );
-}
-
-/**
- * Chapter results need to carry their parent course context because chapter
- * titles are often reused across courses. Including the course and description
- * in the command value also lets cmdk keep description-only server matches
- * visible after its local filtering runs.
- */
-function ChapterItem({
-  chapter,
-  onSelect,
-}: {
-  chapter: ChapterSearchResult;
-  onSelect: <T extends string>(url: Route<T>) => void;
-}) {
-  return (
-    <CommandItem
-      className="flex items-start gap-3"
-      onSelect={() =>
-        onSelect(`/b/${chapter.brandSlug}/c/${chapter.courseSlug}/ch/${chapter.slug}`)
-      }
-      value={[chapter.title, chapter.courseTitle, chapter.description, chapter.id]
-        .filter(Boolean)
-        .join(" ")}
-    >
-      {chapter.imageUrl ? (
-        <Image
-          alt={chapter.title}
-          className="size-8 shrink-0 rounded-md object-cover"
-          height={32}
-          src={chapter.imageUrl}
-          width={32}
-        />
-      ) : (
-        <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-md">
-          <BookOpenIcon aria-hidden="true" className="size-4" />
-        </div>
-      )}
-
-      <div className="min-w-0 flex-1">
-        <p className="truncate font-medium">{chapter.title}</p>
-        <p className="text-muted-foreground truncate text-xs">{chapter.courseTitle}</p>
-        <p className="text-muted-foreground truncate text-xs">{chapter.description}</p>
-      </div>
-    </CommandItem>
-  );
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,7 +32,6 @@
     "@zoonk/utils": "workspace:*",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
-    "cmdk": "1.1.1",
     "input-otp": "1.4.2",
     "next-themes": "0.4.6",
     "react-infinite-scroll-hook": "6.0.1",

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -1,175 +1,214 @@
 "use client";
 
 import {
+  Autocomplete,
+  type AutocompleteCollectionProps,
+  type AutocompleteEmptyProps,
+  type AutocompleteGroupLabelProps,
+  type AutocompleteGroupProps,
+  type AutocompleteInputProps,
+  type AutocompleteItemProps,
+  type AutocompleteListProps,
+} from "@base-ui/react/autocomplete";
+import {
   Dialog,
-  DialogContent,
   DialogDescription,
-  DialogHeader,
+  DialogOverlay,
+  DialogPopup,
+  DialogPortal,
   DialogTitle,
+  DialogViewport,
 } from "@zoonk/ui/components/dialog";
-import { InputGroup, InputGroupAddon } from "@zoonk/ui/components/input-group";
+import {
+  ScrollAreaContent,
+  ScrollAreaRoot,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+} from "@zoonk/ui/components/scroll-area";
 import { cn } from "@zoonk/ui/lib/utils";
-import { removeAccents } from "@zoonk/utils/string";
-import { Command as CommandPrimitive, defaultFilter } from "cmdk";
-import { CheckIcon, SearchIcon } from "lucide-react";
+import { SearchIcon } from "lucide-react";
 import type * as React from "react";
 
-function defaultNormalizedFilter(value: string, search: string, keywords?: string[]) {
-  return defaultFilter(removeAccents(value), removeAccents(search), keywords);
-}
+const Command = Autocomplete.Root;
 
-function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
-  return (
-    <CommandPrimitive
-      className={cn(
-        "bg-popover text-popover-foreground flex size-full flex-col overflow-hidden rounded-4xl p-1",
-        className,
-      )}
-      data-slot="command"
-      filter={defaultNormalizedFilter}
-      {...props}
-    />
-  );
-}
-
+/**
+ * CommandDialog provides the Base UI dialog structure used by command palettes:
+ * backdrop, visual viewport positioning, and a popup that keeps scrolling inside
+ * the palette on iOS.
+ */
 function CommandDialog({
-  title = "Command Palette",
-  description = "Search for a command to run...",
   children,
   className,
-  showCloseButton = false,
   ...props
-}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
-  title?: string;
-  description?: string;
-  className?: string;
-  showCloseButton?: boolean;
-  children: React.ReactNode;
-}) {
+}: React.ComponentProps<typeof Dialog> & { className?: string; children: React.ReactNode }) {
   return (
     <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
-      <DialogContent
-        className={cn(
-          "top-4 translate-y-0 overflow-hidden rounded-4xl! p-0 pointer-fine:top-1/2 pointer-fine:-translate-y-1/2",
-          className,
-        )}
-        showCloseButton={showCloseButton}
-      >
-        <Command>{children}</Command>
-      </DialogContent>
+      <DialogPortal>
+        <DialogOverlay className="bg-black/50" />
+        <DialogViewport className="flex items-start justify-center px-4 pt-[calc(1rem+env(safe-area-inset-top))] pb-[calc(1rem+env(safe-area-inset-bottom))] pointer-fine:pt-[20vh]">
+          <DialogPopup
+            className={cn(
+              "ring-foreground/5 bg-popover text-popover-foreground w-full max-w-xl overflow-hidden rounded-4xl p-1 shadow-lg ring-1 pointer-fine:max-h-[calc(100dvh-20vh-2rem)]",
+              className,
+            )}
+          >
+            {children}
+          </DialogPopup>
+        </DialogViewport>
+      </DialogPortal>
     </Dialog>
   );
 }
 
-function CommandInput({
+/**
+ * CommandDialogTitle keeps the accessible dialog title in the DOM without
+ * adding visible chrome above the command input.
+ */
+function CommandDialogTitle({ className, ...props }: React.ComponentProps<typeof DialogTitle>) {
+  return <DialogTitle className={cn("sr-only", className)} {...props} />;
+}
+
+/**
+ * CommandDialogDescription keeps the accessible dialog description in the DOM
+ * without adding visible text that duplicates the command input placeholder.
+ */
+function CommandDialogDescription({
   className,
   ...props
-}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+}: React.ComponentProps<typeof DialogDescription>) {
+  return <DialogDescription className={cn("sr-only", className)} {...props} />;
+}
+
+/**
+ * CommandInput matches the Base UI autocomplete demo: the input is focused when
+ * the dialog opens and keeps a 16px mobile font size to avoid iOS Safari zoom.
+ */
+function CommandInput({ className, ...props }: AutocompleteInputProps) {
   return (
     <div className="p-1 pb-0" data-slot="command-input-wrapper">
-      <InputGroup className="bg-input/30 h-9">
-        <CommandPrimitive.Input
+      <div className="bg-input/30 flex h-9 items-center gap-2 rounded-full px-3">
+        <SearchIcon aria-hidden="true" className="text-muted-foreground size-4" />
+        <Autocomplete.Input
+          autoFocus
           className={cn(
-            "w-full text-base outline-hidden disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm",
+            "placeholder:text-muted-foreground h-full min-w-0 flex-1 bg-transparent text-base outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm",
             className,
           )}
           data-slot="command-input"
           {...props}
         />
-        <InputGroupAddon>
-          <SearchIcon className="size-4 shrink-0 opacity-50" />
-        </InputGroupAddon>
-      </InputGroup>
+      </div>
     </div>
   );
 }
 
-function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+/**
+ * CommandList follows Base UI's ScrollArea structure while overriding the
+ * content's fit-content width because command results should only scroll
+ * vertically and truncate long labels horizontally.
+ */
+function CommandList({ children, className, ...props }: Omit<AutocompleteListProps, "render">) {
   return (
-    <CommandPrimitive.List
-      className={cn(
-        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
-        className,
-      )}
-      data-slot="command-list"
-      {...props}
-    />
+    <ScrollAreaRoot
+      className="h-[min(var(--total-height,18rem),18rem)] max-h-[calc(100dvh-8rem)]"
+      data-slot="command-scroll-area"
+    >
+      <ScrollAreaViewport>
+        <ScrollAreaContent style={{ minWidth: 0 }}>
+          <Autocomplete.List
+            className={cn("flex flex-col gap-1 p-1 outline-none", className)}
+            data-slot="command-list"
+            {...props}
+          >
+            {children}
+          </Autocomplete.List>
+        </ScrollAreaContent>
+      </ScrollAreaViewport>
+      <ScrollAreaScrollbar>
+        <ScrollAreaThumb />
+      </ScrollAreaScrollbar>
+    </ScrollAreaRoot>
   );
 }
 
-function CommandEmpty({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+/**
+ * CommandEmpty must stay mounted for Base UI's live-region announcements, so
+ * the default styles remove it from layout when Base UI renders no children.
+ */
+function CommandEmpty({ className, ...props }: AutocompleteEmptyProps) {
   return (
-    <CommandPrimitive.Empty
-      className={cn("py-6 text-center text-sm", className)}
+    <Autocomplete.Empty
+      className={cn("py-6 text-center text-sm empty:sr-only empty:p-0", className)}
       data-slot="command-empty"
       {...props}
     />
   );
 }
 
-function CommandGroup({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+/**
+ * CommandGroup scopes a set of related command items and passes the group's
+ * items to Base UI's collection renderer for keyboard navigation order.
+ */
+function CommandGroup({ className, ...props }: AutocompleteGroupProps) {
   return (
-    <CommandPrimitive.Group
-      className={cn(
-        "text-foreground **:[[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 **:[[cmdk-group-heading]]:px-3 **:[[cmdk-group-heading]]:py-2 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium",
-        className,
-      )}
+    <Autocomplete.Group
+      className={cn("text-foreground w-full max-w-full min-w-0 overflow-hidden p-1", className)}
       data-slot="command-group"
       {...props}
     />
   );
 }
 
-function CommandSeparator({
-  className,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+/**
+ * CommandGroupLabel provides the accessible and visual label for a command
+ * group without coupling group layout to a heading prop.
+ */
+function CommandGroupLabel({ className, ...props }: AutocompleteGroupLabelProps) {
   return (
-    <CommandPrimitive.Separator
-      className={cn("bg-border/50 my-1 h-px", className)}
-      data-slot="command-separator"
+    <Autocomplete.GroupLabel
+      className={cn("text-muted-foreground px-3 py-2 text-xs font-medium", className)}
+      data-slot="command-group-label"
       {...props}
     />
   );
 }
 
-function CommandItem({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+/**
+ * CommandCollection renders the filtered items from the nearest command group
+ * or root, letting consumers choose their own item contents.
+ */
+function CommandCollection({ ...props }: AutocompleteCollectionProps) {
+  return <Autocomplete.Collection {...props} />;
+}
+
+/**
+ * CommandItem delegates pointer and keyboard activation to Base UI while
+ * keeping the compact command-row styling shared across apps.
+ */
+function CommandItem({ className, ...props }: AutocompleteItemProps) {
   return (
-    <CommandPrimitive.Item
+    <Autocomplete.Item
       className={cn(
-        "group/command-item data-[selected=true]:bg-muted data-[selected=true]:text-foreground data-[selected=true]:*:[svg]:text-foreground relative flex cursor-default items-center gap-2 rounded-lg px-3 py-2 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-2xl data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group/command-item relative flex w-full max-w-full min-w-0 cursor-default items-center gap-2 overflow-hidden rounded-2xl px-3 py-2 text-sm outline-hidden select-none",
+        "data-highlighted:bg-muted data-highlighted:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       data-slot="command-item"
       {...props}
-    >
-      {children}
-      <CheckIcon className="ml-auto opacity-0 group-has-data-[slot=command-shortcut]/command-item:hidden group-data-[checked=true]/command-item:opacity-100" />
-    </CommandPrimitive.Item>
+    />
   );
 }
 
+/**
+ * CommandShortcut gives command rows a consistent trailing shortcut treatment
+ * when an app wants to show keyboard accelerators.
+ */
 function CommandShortcut({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
-      className={cn(
-        "text-muted-foreground group-data-[selected=true]/command-item:text-foreground ml-auto text-xs tracking-widest",
-        className,
-      )}
+      className={cn("text-muted-foreground ml-auto text-xs tracking-widest", className)}
       data-slot="command-shortcut"
       {...props}
     />
@@ -178,12 +217,15 @@ function CommandShortcut({ className, ...props }: React.ComponentProps<"span">) 
 
 export {
   Command,
+  CommandCollection,
   CommandDialog,
-  CommandInput,
-  CommandList,
+  CommandDialogDescription,
+  CommandDialogTitle,
   CommandEmpty,
   CommandGroup,
+  CommandGroupLabel,
+  CommandInput,
   CommandItem,
+  CommandList,
   CommandShortcut,
-  CommandSeparator,
 };

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -35,6 +35,21 @@ function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" ref={ref} {...props} />;
 }
 
+/**
+ * Some dialog layouts need Base UI's viewport between the backdrop and popup so
+ * the popup can be positioned and clipped like the upstream command palette
+ * demo instead of using the centered default DialogContent wrapper.
+ */
+function DialogViewport({ className, ...props }: DialogPrimitive.Viewport.Props) {
+  return (
+    <DialogPrimitive.Viewport
+      className={cn("fixed inset-0 z-50", className)}
+      data-slot="dialog-viewport"
+      {...props}
+    />
+  );
+}
+
 function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
@@ -81,6 +96,21 @@ function DialogContent({
         )}
       </DialogPrimitive.Popup>
     </DialogPortal>
+  );
+}
+
+/**
+ * DialogPopup exposes the raw Base UI popup for custom layouts that cannot use
+ * DialogContent because they need to supply their own portal, backdrop, or
+ * viewport structure.
+ */
+function DialogPopup({ className, ...props }: DialogPrimitive.Popup.Props) {
+  return (
+    <DialogPrimitive.Popup
+      className={cn("bg-background text-foreground outline-none", className)}
+      data-slot="dialog-content"
+      {...props}
+    />
   );
 }
 
@@ -141,7 +171,9 @@ export {
   DialogFooter,
   DialogHeader,
   DialogOverlay,
+  DialogPopup,
   DialogPortal,
   DialogTitle,
   DialogTrigger,
+  DialogViewport,
 };

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -3,25 +3,70 @@
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
 import { cn } from "@zoonk/ui/lib/utils";
 
-function ScrollArea({ className, children, ...props }: ScrollAreaPrimitive.Root.Props) {
+/**
+ * ScrollAreaRoot is exposed separately so composed primitives like Autocomplete
+ * can render their own content element inside Base UI's scroll viewport.
+ */
+function ScrollAreaRoot({ className, ...props }: ScrollAreaPrimitive.Root.Props) {
   return (
     <ScrollAreaPrimitive.Root
       className={cn("relative", className)}
       data-slot="scroll-area"
       {...props}
-    >
-      <ScrollAreaPrimitive.Viewport
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
-        data-slot="scroll-area-viewport"
-      >
-        {children}
-      </ScrollAreaPrimitive.Viewport>
-      <ScrollAreaPrimitive.Corner />
-    </ScrollAreaPrimitive.Root>
+    />
   );
 }
 
-function ScrollBar({
+/**
+ * ScrollAreaViewport owns the native scroll container while keeping focus
+ * styles consistent with the rest of the UI package.
+ */
+function ScrollAreaViewport({ className, ...props }: ScrollAreaPrimitive.Viewport.Props) {
+  return (
+    <ScrollAreaPrimitive.Viewport
+      className={cn(
+        "focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1",
+        className,
+      )}
+      data-slot="scroll-area-viewport"
+      {...props}
+    />
+  );
+}
+
+/**
+ * ScrollAreaContent lets list primitives render as the measured scroll content
+ * element that Base UI expects for stable scrolling and thumb sizing.
+ */
+function ScrollAreaContent({ className, ...props }: ScrollAreaPrimitive.Content.Props) {
+  return (
+    <ScrollAreaPrimitive.Content
+      className={cn("min-w-full", className)}
+      data-slot="scroll-area-content"
+      {...props}
+    />
+  );
+}
+
+/**
+ * ScrollAreaThumb is exported for layouts that need to place the scrollbar and
+ * thumb manually instead of using the bundled ScrollBar convenience component.
+ */
+function ScrollAreaThumb({ className, ...props }: ScrollAreaPrimitive.Thumb.Props) {
+  return (
+    <ScrollAreaPrimitive.Thumb
+      className={cn("bg-border relative flex-1 rounded-full", className)}
+      data-slot="scroll-area-thumb"
+      {...props}
+    />
+  );
+}
+
+/**
+ * ScrollAreaScrollbar wraps the native scrollbar primitive while preserving the
+ * shared orientation-aware sizing and touch behavior.
+ */
+function ScrollAreaScrollbar({
   className,
   orientation = "vertical",
   ...props
@@ -36,13 +81,50 @@ function ScrollBar({
       data-slot="scroll-area-scrollbar"
       orientation={orientation}
       {...props}
-    >
-      <ScrollAreaPrimitive.Thumb
-        className="bg-border relative flex-1 rounded-full"
-        data-slot="scroll-area-thumb"
-      />
-    </ScrollAreaPrimitive.Scrollbar>
+    />
   );
 }
 
-export { ScrollArea, ScrollBar };
+/**
+ * ScrollAreaCorner fills the gap created when both scrollbars are visible.
+ */
+function ScrollAreaCorner({ ...props }: ScrollAreaPrimitive.Corner.Props) {
+  return <ScrollAreaPrimitive.Corner data-slot="scroll-area-corner" {...props} />;
+}
+
+/**
+ * ScrollArea keeps the original convenience API for regular scroll regions and
+ * now uses the same explicit viewport/content structure as the composable parts.
+ */
+function ScrollArea({ children, ...props }: ScrollAreaPrimitive.Root.Props) {
+  return (
+    <ScrollAreaRoot {...props}>
+      <ScrollAreaViewport>
+        <ScrollAreaContent>{children}</ScrollAreaContent>
+      </ScrollAreaViewport>
+      <ScrollAreaCorner />
+    </ScrollAreaRoot>
+  );
+}
+
+/**
+ * ScrollBar remains the shorthand for a complete scrollbar with a thumb.
+ */
+function ScrollBar(props: ScrollAreaPrimitive.Scrollbar.Props) {
+  return (
+    <ScrollAreaScrollbar {...props}>
+      <ScrollAreaThumb />
+    </ScrollAreaScrollbar>
+  );
+}
+
+export {
+  ScrollArea,
+  ScrollAreaContent,
+  ScrollAreaCorner,
+  ScrollAreaRoot,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+  ScrollBar,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,9 +950,6 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      cmdk:
-        specifier: 1.1.1
-        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       input-otp:
         specifier: 1.4.2
         version: 1.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2849,9 +2846,6 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
-  '@radix-ui/primitive@1.1.4':
-    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
-
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -2861,122 +2855,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-compose-refs@1.1.3':
-    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-context@1.1.4':
-    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-dialog@1.1.16':
-    resolution: {integrity: sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-dismissable-layer@1.1.12':
-    resolution: {integrity: sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-focus-guards@1.1.4':
-    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-focus-scope@1.1.9':
-    resolution: {integrity: sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-id@1.1.2':
-    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-portal@1.1.11':
-    resolution: {integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-presence@1.1.6':
-    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-primitive@2.1.5':
-    resolution: {integrity: sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2997,15 +2877,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-slot@1.2.5':
-    resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-toggle@1.1.10':
     resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
     peerDependencies:
@@ -3019,26 +2890,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-use-callback-ref@1.1.2':
-    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-controllable-state@1.2.3':
-    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3055,35 +2908,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-use-effect-event@0.0.3':
-    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-escape-keydown@1.1.2':
-    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-layout-effect@1.1.2':
-    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4482,10 +4308,6 @@ packages:
   anynum@1.0.0:
     resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
 
-  aria-hidden@1.2.6:
-    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
-    engines: {node: '>=10'}
-
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -4813,12 +4635,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cmdk@1.1.1:
-    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
-    peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
-
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -5027,9 +4843,6 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  detect-node-es@1.1.0:
-    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
@@ -5408,10 +5221,6 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
-
-  get-nonce@1.0.1:
-    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
-    engines: {node: '>=6'}
 
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -6673,36 +6482,6 @@ packages:
       redux:
         optional: true
 
-  react-remove-scroll-bar@2.3.8:
-    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-remove-scroll@2.7.2:
-    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-style-singleton@2.2.3:
-    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
@@ -7390,30 +7169,10 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  use-callback-ref@1.3.3:
-    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   use-intl@4.13.0:
     resolution: {integrity: sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
-
-  use-sidecar@1.1.3:
-    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -9214,103 +8973,11 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/primitive@1.1.4': {}
-
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
-
-  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-context@1.1.4(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-dialog@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-dismissable-layer@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-focus-scope@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -9321,25 +8988,9 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-primitive@2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.5(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-slot@1.2.5(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
@@ -9355,24 +9006,10 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
@@ -9384,27 +9021,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:
@@ -10930,10 +10547,6 @@ snapshots:
 
   anynum@1.0.0: {}
 
-  aria-hidden@1.2.6:
-    dependencies:
-      tslib: 2.8.1
-
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -11215,18 +10828,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dialog': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -11380,8 +10981,6 @@ snapshots:
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
-
-  detect-node-es@1.1.0: {}
 
   devalue@5.8.1: {}
 
@@ -11840,8 +11439,6 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.4
       math-intrinsics: 1.1.0
-
-  get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
 
@@ -13309,33 +12906,6 @@ snapshots:
       '@types/react': 19.2.17
       redux: 5.0.1
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
-      tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
-      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      get-nonce: 1.0.1
-      react: 19.2.7
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   react@19.2.7: {}
 
   readdirp@4.1.2: {}
@@ -14091,13 +13661,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
-
   use-intl@4.13.0(react@19.2.7):
     dependencies:
       '@formatjs/fast-memoize': 3.1.6
@@ -14105,14 +13668,6 @@ snapshots:
       icu-minify: 4.13.0
       intl-messageformat: 11.2.8
       react: 19.2.7
-
-  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      detect-node-es: 1.1.0
-      react: 19.2.7
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
 
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:


### PR DESCRIPTION
## Summary
- replace the command palette with Base UI autocomplete primitives from the shared UI package
- keep palette scrolling vertical-only with truncated long results
- preserve iOS focus, dialog, and keyboard behavior coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the command palette on top of `@base-ui/react/autocomplete` to fix iOS focus/keyboard issues and stop horizontal panning. Results now truncate and the palette only scrolls vertically.

- **Bug Fixes**
  - Keeps input focused and uses aria-activedescendant for consistent Arrow/Enter behavior on iOS.
  - Truncates long titles/descriptions and prevents horizontal overflow/panning in the dialog.
  - Uses a dialog viewport/popup layout so scrolling stays inside the palette on touch devices; added E2E checks for active option and no horizontal overflow.

- **Refactors**
  - Replaced `cmdk` with Base UI primitives in `@zoonk/ui` (new `Command`, group/collection rendering, and input/list components).
  - Exposed `DialogViewport`/`DialogPopup` and composable `ScrollArea` parts to support the new layout.
  - Added palette item/group utilities and option renderers; removed `cmdk`; updated locale message keys.

<sup>Written for commit df341686848cb0dc73a8edc50705a4df6d305f4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

