### PR TITLE
feat(i18n): use custom model

### DIFF
--- a/apps/api/messages/es.po
+++ b/apps/api/messages/es.po
@@ -8,7 +8,7 @@ msgstr ""
 
 #: src/app/auth/layout.tsx
 msgid "dVItHD"
-msgstr "Iniciar sesión en Zoonk"
+msgstr "Inicia sesión en Zoonk"
 
 #: src/app/auth/login/email-login-form.tsx
 msgid "sy-pv5"
@@ -20,12 +20,12 @@ msgstr "yo@gmail.com"
 
 #: src/app/auth/login/email-login-form.tsx
 msgid "YRe93Y"
-msgstr "Introduce una dirección de correo válida"
+msgstr "Ingresa un correo electrónico válido"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/login/social-login.tsx
 msgid "pN2p0t"
-msgstr "Hubo un error al iniciar sesión. Inténtalo de nuevo o contacta a contacto@zoonk.com"
+msgstr "Hubo un error al iniciar sesión. Inténtalo de nuevo o escribe a contacto@zoonk.com"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/otp/otp-form.tsx
@@ -43,7 +43,7 @@ msgstr "O"
 
 #: src/app/auth/login/page.tsx
 msgid "Ju9oB-"
-msgstr "Al hacer clic en Continuar, aceptas nuestros <terms>Términos de servicio</terms> y la <privacy>Política de privacidad</privacy>."
+msgstr "Al hacer clic en Continuar, aceptas nuestros <terms>Términos del Servicio</terms> y nuestra <privacy>Política de Privacidad</privacy>."
 
 #: src/app/auth/login/social-login.tsx
 msgid "FJ6r9E"
@@ -55,7 +55,7 @@ msgstr "Continuar con Apple"
 
 #: src/app/auth/otp/otp-form.tsx
 msgid "HkHvQv"
-msgstr "El código que ingresaste es incorrecto. Inténtalo de nuevo o contacta a contacto@zoonk.com"
+msgstr "El código que ingresaste es incorrecto. Inténtalo de nuevo o escribe a contacto@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
 msgid "ChATeO"
@@ -67,7 +67,7 @@ msgstr "Revisa tu correo"
 
 #: src/app/auth/otp/page.tsx
 msgid "LZHcmZ"
-msgstr "Introduce el código que enviamos a {email}:"
+msgstr "Ingresa el código que enviamos a {email}:"
 
 #: src/app/auth/setup/page.tsx
 msgid "CYqIel"
@@ -79,7 +79,7 @@ msgstr "Elige un nombre y un nombre de usuario antes de continuar."
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "1SvspN"
-msgstr "Comprobando..."
+msgstr "Comprobando…"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "9N4_rz"
@@ -91,7 +91,7 @@ msgstr "{username} ya está en uso"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "vLl7z0"
-msgstr "3-30 caracteres. Solo letras, números y guiones bajos."
+msgstr "De 3 a 30 caracteres. Solo letras, números y guiones bajos."
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "HAlOn1"
@@ -107,7 +107,7 @@ msgstr "tu-nombre-de-usuario"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "yCCLud"
-msgstr "No se pudo configurar tu perfil. Inténtalo de nuevo o contacta a contacto@zoonk.com"
+msgstr "No pudimos configurar tu perfil. Inténtalo de nuevo o escribe a contacto@zoonk.com"
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "1vqX2W"
@@ -115,7 +115,7 @@ msgstr "No se puede redirigir"
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "83K2kN"
-msgstr "La URL de destino no está reconocida como una aplicación de Zoonk confiable."
+msgstr "La URL de destino no se reconoce como una aplicación de Zoonk confiable."
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "wkO19y"

--- a/apps/api/messages/fr.po
+++ b/apps/api/messages/fr.po
@@ -12,20 +12,20 @@ msgstr "Connecte-toi à Zoonk"
 
 #: src/app/auth/login/email-login-form.tsx
 msgid "sy-pv5"
-msgstr "Email"
+msgstr "E-mail"
 
 #: src/app/auth/login/email-login-form.tsx
 msgid "apQW0E"
-msgstr "moi@gmail.com"
+msgstr "me@gmail.com"
 
 #: src/app/auth/login/email-login-form.tsx
 msgid "YRe93Y"
-msgstr "Saisis une adresse email valide"
+msgstr "Saisis une adresse e-mail valide"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/login/social-login.tsx
 msgid "pN2p0t"
-msgstr "Une erreur est survenue lors de ta connexion. Réessaie ou contacte hello@zoonk.com"
+msgstr "Impossible de te connecter. Réessaie ou contacte hello@zoonk.com"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/otp/otp-form.tsx
@@ -43,7 +43,7 @@ msgstr "Ou"
 
 #: src/app/auth/login/page.tsx
 msgid "Ju9oB-"
-msgstr "En cliquant sur Continuer, tu acceptes nos <terms>Conditions d'utilisation</terms> et <privacy>Politique de confidentialité</privacy>."
+msgstr "En cliquant sur Continuer, tu acceptes nos <terms>Conditions d’utilisation</terms> et notre <privacy>Politique de confidentialité</privacy>."
 
 #: src/app/auth/login/social-login.tsx
 msgid "FJ6r9E"
@@ -59,15 +59,15 @@ msgstr "Le code saisi est incorrect. Réessaie ou contacte hello@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
 msgid "ChATeO"
-msgstr "Changer d'email"
+msgstr "Changer d’e-mail"
 
 #: src/app/auth/otp/page.tsx
 msgid "zx7CKB"
-msgstr "Vérifie ton email"
+msgstr "Consulte tes e-mails"
 
 #: src/app/auth/otp/page.tsx
 msgid "LZHcmZ"
-msgstr "Saisis le code que nous avons envoyé à {email} :"
+msgstr "Saisis le code envoyé à {email} :"
 
 #: src/app/auth/setup/page.tsx
 msgid "CYqIel"
@@ -75,11 +75,11 @@ msgstr "Complète ton profil"
 
 #: src/app/auth/setup/page.tsx
 msgid "7463XU"
-msgstr "Choisis un nom et un nom d'utilisateur avant de continuer."
+msgstr "Choisis un nom et un nom d’utilisateur avant de continuer."
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "1SvspN"
-msgstr "Vérification..."
+msgstr "Vérification…"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "9N4_rz"
@@ -91,7 +91,7 @@ msgstr "{username} est déjà pris"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "vLl7z0"
-msgstr "3 à 30 caractères. Lettres, chiffres et tirets bas seulement."
+msgstr "3 à 30 caractères. Lettres, chiffres et tirets bas uniquement."
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "HAlOn1"
@@ -99,11 +99,11 @@ msgstr "Nom"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "JCIgkj"
-msgstr "Nom d'utilisateur"
+msgstr "Nom d’utilisateur"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "XLl_pd"
-msgstr "ton-nomdutilisateur"
+msgstr "ton-nom-utilisateur"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "yCCLud"
@@ -111,11 +111,11 @@ msgstr "Impossible de configurer ton profil. Réessaie ou contacte hello@zoonk.c
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "1vqX2W"
-msgstr "Impossible de rediriger"
+msgstr "Redirection impossible"
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "83K2kN"
-msgstr "L'URL de destination n'est pas reconnue comme une application Zoonk de confiance."
+msgstr "L’URL de destination n’est pas reconnue comme une application Zoonk de confiance."
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "wkO19y"

--- a/apps/api/messages/pt.po
+++ b/apps/api/messages/pt.po
@@ -20,12 +20,12 @@ msgstr "meu@email.com"
 
 #: src/app/auth/login/email-login-form.tsx
 msgid "YRe93Y"
-msgstr "Digite um endereço de email válido"
+msgstr "Digite um email válido"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/login/social-login.tsx
 msgid "pN2p0t"
-msgstr "Ocorreu um erro ao fazer login. Tente novamente ou contate contato@zoonk.com"
+msgstr "Houve um erro ao entrar. Tente de novo ou fale com contato@zoonk.com"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/otp/otp-form.tsx
@@ -35,7 +35,7 @@ msgstr "Continuar"
 
 #: src/app/auth/login/page.tsx
 msgid "eN8MTJ"
-msgstr "Entrar ou criar uma conta"
+msgstr "Entre ou crie uma conta"
 
 #: src/app/auth/login/page.tsx
 msgid "4wpUNc"
@@ -55,19 +55,19 @@ msgstr "Continuar com Apple"
 
 #: src/app/auth/otp/otp-form.tsx
 msgid "HkHvQv"
-msgstr "O código que você inseriu está incorreto. Tente novamente ou contate contato@zoonk.com"
+msgstr "O código que você digitou está incorreto. Tente de novo ou fale com contato@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
 msgid "ChATeO"
-msgstr "Alterar email"
+msgstr "Trocar email"
 
 #: src/app/auth/otp/page.tsx
 msgid "zx7CKB"
-msgstr "Verifique seu email"
+msgstr "Confira seu email"
 
 #: src/app/auth/otp/page.tsx
 msgid "LZHcmZ"
-msgstr "Digite o código que enviamos para {email}:"
+msgstr "Digite o código que a gente enviou para {email}:"
 
 #: src/app/auth/setup/page.tsx
 msgid "CYqIel"
@@ -79,7 +79,7 @@ msgstr "Escolha um nome e nome de usuário antes de continuar."
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "1SvspN"
-msgstr "Verificando..."
+msgstr "Verificando…"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "9N4_rz"
@@ -91,7 +91,7 @@ msgstr "{username} já está em uso"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "vLl7z0"
-msgstr "3–30 caracteres. Apenas letras, números e sublinhados."
+msgstr "3 a 30 caracteres. Use apenas letras, números e sublinhados."
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "HAlOn1"
@@ -103,11 +103,11 @@ msgstr "Nome de usuário"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "XLl_pd"
-msgstr "seu-usuario"
+msgstr "seu-nome-de-usuario"
 
 #: src/app/auth/setup/setup-form.tsx
 msgid "yCCLud"
-msgstr "Falha ao configurar seu perfil. Tente novamente ou contate contato@zoonk.com"
+msgstr "Não foi possível configurar seu perfil. Tente de novo ou fale com contato@zoonk.com"
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "1vqX2W"
@@ -115,7 +115,7 @@ msgstr "Não foi possível redirecionar"
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "83K2kN"
-msgstr "A URL de destino não é reconhecida como um aplicativo Zoonk confiável."
+msgstr "A URL de destino não é reconhecida como um aplicativo confiável do Zoonk."
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "wkO19y"
@@ -123,8 +123,8 @@ msgstr "Aviso de segurança"
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "585u5Z"
-msgstr "Para sua segurança, não podemos redirecionar você para um destino não reconhecido."
+msgstr "Para sua segurança, a gente não pode te redirecionar para um destino não reconhecido."
 
 #: src/app/auth/untrusted-origin/page.tsx
 msgid "-e4BVR"
-msgstr "Continuar no Zoonk"
+msgstr "Continuar para o Zoonk"

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -611,7 +611,7 @@ test.describe("Command Palette - Course Search", () => {
     await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
-    await dialog.getByPlaceholder(SEARCH_CONTROL_NAME).fill(uniqueId);
+    await dialog.getByRole("combobox", { name: SEARCH_CONTROL_NAME }).fill(uniqueId);
 
     await expect(
       dialog.getByRole("option", { name: new RegExp(`^${ptCourseTitle}`, "u") }),

--- a/apps/main/e2e/language.test.ts
+++ b/apps/main/e2e/language.test.ts
@@ -40,7 +40,7 @@ test.describe("Language settings page", () => {
     await expect(
       page.getByRole("heading", {
         level: 2,
-        name: /escolha o idioma do app que você prefere para este dispositivo/iu,
+        name: /escolha o idioma do app que você prefere neste dispositivo/iu,
       }),
     ).toBeVisible();
   });

--- a/apps/main/e2e/locale.test.ts
+++ b/apps/main/e2e/locale.test.ts
@@ -55,7 +55,7 @@ test.describe("Locale Behavior - Portuguese", () => {
     await expect(nav.getByRole("link", { exact: true, name: "Novo curso" })).toBeVisible();
 
     await expect(page).toHaveURL(/\/$/u);
-    await expect(page.getByRole("heading", { name: /qual é o seu objetivo/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /qual é seu objetivo/iu })).toBeVisible();
   });
 });
 
@@ -102,6 +102,6 @@ test.describe("Locale Navigation", () => {
       .click();
 
     await expect(page).toHaveURL(/\/start$/u);
-    await expect(page.getByRole("heading", { name: /qual é o seu objetivo/iu })).toBeVisible();
+    await expect(page.getByRole("heading", { name: /qual é seu objetivo/iu })).toBeVisible();
   });
 });

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -12,7 +12,7 @@ msgstr "Buscar"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "PSiLeL"
-msgstr "Buscar cursos, capítulos o páginas..."
+msgstr "Busca cursos, capítulos o páginas…"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
@@ -27,7 +27,7 @@ msgstr "Gestionar suscripción"
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/language/page.tsx
 msgid "OhXwmw"
-msgstr "Actualizar idioma"
+msgstr "Cambiar idioma"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "O7ozeo"
@@ -58,11 +58,11 @@ msgstr "Idioma"
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
 msgid "U3l-Q9"
-msgstr "Inicio"
+msgstr "Página de inicio"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "jboh4c"
-msgstr "Comenzar un nuevo curso"
+msgstr "Empezar un curso nuevo"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
@@ -99,7 +99,7 @@ msgstr "Blog"
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
 msgid "fFZ0Wd"
-msgstr "Comentarios y soporte"
+msgstr "Comentarios y ayuda"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"
@@ -119,7 +119,7 @@ msgstr "No se encontraron resultados"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "OXAZiT"
-msgstr "Crear curso sobre {term}"
+msgstr "Crear un curso sobre {term}"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
 msgid "onRJrc"
@@ -127,7 +127,7 @@ msgstr "Página del curso"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
 msgid "m826WB"
-msgstr "Nuevo curso"
+msgstr "Curso nuevo"
 
 #: src/app/(catalog)/_components/user-avatar-menu.tsx
 msgid "6b2CRH"
@@ -165,7 +165,7 @@ msgstr "Últimos 3 meses"
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
 msgid "00_IyC"
-msgstr "Madrugada"
+msgstr "Noche"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
@@ -180,12 +180,12 @@ msgstr "Tarde"
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
 msgid "mPEpnN"
-msgstr "Noche"
+msgstr "Atardecer"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
 msgid "dFW9lU"
-msgstr "Mejor hora"
+msgstr "Mejor momento"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
@@ -203,15 +203,15 @@ msgstr "Continuar"
 
 #: src/app/(catalog)/(home)/continue-learning.tsx
 msgid "0X-xfW"
-msgstr "Sigue estudiando"
+msgstr "Seguir estudiando"
 
 #: src/app/(catalog)/(home)/energy.tsx
 msgid "soDmlG"
-msgstr "Sigue estudiando para aumentarlo"
+msgstr "Sigue estudiando para aumentarla"
 
 #: src/app/(catalog)/(home)/energy.tsx
 msgid "WgeB0r"
-msgstr "Sigue estudiando para mantenerlo"
+msgstr "Sigue estudiando para mantenerla"
 
 #: src/app/(catalog)/(home)/energy.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
@@ -234,7 +234,7 @@ msgstr "Al menos una lección completada"
 
 #: src/app/(catalog)/(home)/learning-time.tsx
 msgid "F6B8A3"
-msgstr "Tiempo en lecciones"
+msgstr "Tiempo dedicado a las lecciones"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
@@ -259,7 +259,7 @@ msgstr "{belt} - Nivel {level}"
 
 #: src/app/(catalog)/(home)/page.tsx
 msgid "a50ZRn"
-msgstr "Zoonk es una plataforma de aprendizaje con IA y una app para crear cursos sobre cualquier tema usando IA. Estudia para tus exámenes o aprende nuevas habilidades."
+msgstr "Zoonk es una plataforma de estudio con IA para crear cursos sobre cualquier tema. Estudia para tus exámenes o aprende habilidades nuevas."
 
 #: src/app/(catalog)/(home)/page.tsx
 msgid "leBFvu"
@@ -288,7 +288,7 @@ msgstr "Crear este capítulo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 msgid "YQGe0H"
-msgstr "Este capítulo forma parte del curso, pero todavía no se ha creado. Créalo para ver todas sus lecciones."
+msgstr "Este capítulo forma parte del curso, pero aún no se ha creado. Créalo para ver todas sus lecciones."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 msgid "3IOFp2"
@@ -325,7 +325,7 @@ msgstr "Lección actual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
-msgstr "Buscar lecciones..."
+msgstr "Buscar lecciones…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "FuT9vz"
@@ -347,7 +347,7 @@ msgstr "Capítulo actual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "3SOcGR"
-msgstr "Buscar capítulos..."
+msgstr "Buscar capítulos…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "8udPa-"
@@ -359,7 +359,7 @@ msgstr "{completed, number}/{total, number} completadas"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-curriculum-pending-notice.tsx
 msgid "Pf4uqS"
-msgstr "El capítulo introductorio ya está listo. Todavía estamos creando el programa completo, así que pronto aparecerán más capítulos aquí."
+msgstr "El capítulo de introducción está listo. Aún estamos creando el plan completo, así que pronto aparecerán más capítulos aquí."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-actions.tsx
 #: src/app/(catalog)/courses/page.tsx
@@ -368,11 +368,11 @@ msgstr "Explorar cursos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-actions.tsx
 msgid "Y9LULP"
-msgstr "Prueba un capítulo gratis"
+msgstr "Probar capítulo gratis"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "8A99N6"
-msgstr "Las ideas abstractas se vuelven una situación real"
+msgstr "Las ideas abstractas se vuelven situaciones reales"
 
 #. Short imperative verb label for the first tab in a learning flow: understand, practice, then test. Translate as an action the learner takes, not as a noun.
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
@@ -381,15 +381,15 @@ msgstr "Entiende"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "LcPoK0"
-msgstr "La gravedad es la fuerza que atrae los objetos con masa entre sí."
+msgstr "La gravedad es la fuerza que atrae entre sí a los objetos con masa."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "wC-aSO"
-msgstr "vídeo de 2 h 47 min"
+msgstr "Video de 2 h 47 min"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "7C2tU3"
-msgstr "Por eso tu café se cae cuando tiras la taza."
+msgstr "Por eso tu café cae cuando tiras la taza."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "B3Il8E"
@@ -422,7 +422,7 @@ msgstr "Hoja de ejercicios"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "k3LaSh"
-msgstr "Un concierto tiene 300 asientos y 1.200 personas esperando. ¿Qué pasa con los precios de las entradas si no se añaden más asientos?"
+msgstr "Un concierto tiene 300 asientos y 1.200 personas esperando. ¿Qué pasa con los precios de las entradas si no se agregan más asientos?"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "VlR_2v"
@@ -431,7 +431,7 @@ msgstr "Resuelve un problema"
 #. Short imperative verb label for the third tab in a learning flow: understand, practice, then test. Translate as an action the learner takes, not as a noun.
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "courseLandingComparisonTestTab"
-msgstr "Prueba"
+msgstr "Ponte a prueba"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "8Nkyqo"
@@ -451,11 +451,11 @@ msgstr "¿Qué es la inercia?"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "vKGhx1"
-msgstr "Quiz de repaso"
+msgstr "Quiz de memoria"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "cZ39v4"
-msgstr "Cuando un coche frena de golpe, todos se inclinan hacia delante. ¿Qué provoca eso?"
+msgstr "Cuando un coche frena de golpe, todos se inclinan hacia delante. ¿Qué hace que pase eso?"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "PTjjt2"
@@ -475,7 +475,7 @@ msgstr "Introducción"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-curriculum.tsx
 msgid "itC9lG"
-msgstr "Fundamentos"
+msgstr "Lo básico"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-curriculum.tsx
 msgid "o5_DJA"
@@ -495,7 +495,7 @@ msgstr "{count, plural, one {# capítulo} other {# capítulos}}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-curriculum.tsx
 msgid "3nOnkT"
-msgstr "Empieza con lo básico y luego avanza hacia temas más avanzados. Abre una sección para ver los capítulos."
+msgstr "Empieza por lo básico y luego avanza hacia temas más avanzados. Abre una sección para revisar los capítulos."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "hmZz9H"
@@ -507,7 +507,7 @@ msgstr "Contenido"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "o8KenS"
-msgstr "Para quién"
+msgstr "Quién"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "y9RWqI"
@@ -519,7 +519,7 @@ msgstr "Dónde"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "9RUPaY"
-msgstr "Preguntas sobre el curso"
+msgstr "Preguntas del curso"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-hero.tsx
 msgid "HgZhb7"
@@ -539,11 +539,11 @@ msgstr "Aprende a tu ritmo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "kvjzxh"
-msgstr "Lo que aprenderás"
+msgstr "Qué aprenderás"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "k9VAoq"
-msgstr "Principiantes curiosos que quieren ver si el tema les engancha"
+msgstr "Principiantes curiosos que quieren ver si el tema les gusta"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "6d4U8p"
@@ -555,7 +555,7 @@ msgstr "Dónde lo usarás"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "qieSfO"
-msgstr "Aprende palabras útiles y luego practícalas hasta que te salgan naturales."
+msgstr "Aprende palabras útiles y practícalas hasta que te salgan de forma natural."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -564,7 +564,7 @@ msgstr "Vocabulario"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "ZHyORV"
-msgstr "Lee textos cortos y cotidianos que muestran cómo se usa de verdad el idioma."
+msgstr "Lee textos cortos del día a día que muestran cómo se usa el idioma de verdad."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -573,7 +573,7 @@ msgstr "Lectura"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "Tt4yPU"
-msgstr "Escucha situaciones de la vida real y entrena el oído para entender de forma natural."
+msgstr "Escucha situaciones reales y entrena el oído para entender con naturalidad."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -582,7 +582,7 @@ msgstr "Escucha"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "_BizQu"
-msgstr "Entiende las reglas de gramática con explicaciones sencillas."
+msgstr "Entiende las reglas de gramática con explicaciones simples."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -591,7 +591,7 @@ msgstr "Gramática"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "BuBt5e"
-msgstr "Aprende la pronunciación comparando los sonidos con los de tu idioma (p. ej. Hi → Jái)"
+msgstr "Aprende pronunciación comparando sonidos con tu propio idioma (por ejemplo, Hola → OH-lah)"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "vuwclE"
@@ -599,7 +599,7 @@ msgstr "Pronunciación"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "FkGq7Y"
-msgstr "Ideas complejas explicadas en un lenguaje sencillo."
+msgstr "Ideas complejas explicadas con palabras simples."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "-ccXf6"
@@ -607,15 +607,15 @@ msgstr "Lenguaje cotidiano"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "SUbq96"
-msgstr "Mira cómo aparece cada concepto en situaciones cotidianas."
+msgstr "Ve cómo aparece cada concepto en situaciones cotidianas."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "PWMkDF"
-msgstr "Ejemplos de la vida real"
+msgstr "Ejemplos reales"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "9HRhoP"
-msgstr "Aplica lo que aprendes a situaciones reales, no solo a definiciones."
+msgstr "Aplica lo que aprendes a situaciones realistas, no solo a definiciones."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "5gsjXY"
@@ -623,12 +623,12 @@ msgstr "Practica con problemas reales"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "NLqVU5"
-msgstr "Practica lo que aprendiste con unas cuantas preguntas rápidas."
+msgstr "Practica lo que aprendiste con unas preguntas rápidas."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
 msgid "OuR_Ij"
-msgstr "Cuestionario"
+msgstr "Quiz"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "KWp1o4"
@@ -640,11 +640,11 @@ msgstr "Un curso, no una credencial"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "jt8_3X"
-msgstr "El objetivo de este curso es ayudarte a entender el tema y desarrollar habilidades útiles. No otorga un título universitario, una licencia profesional ni otra acreditación reconocida oficialmente."
+msgstr "El objetivo de este curso es ayudarte a entender el tema y desarrollar habilidades útiles. No otorga un título universitario, una licencia profesional ni otra cualificación reconocida oficialmente."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
 msgid "_allXG"
-msgstr "Aprende {course} online con ejemplos prácticos y lenguaje sencillo. {description}"
+msgstr "Aprende {course} en línea con ejemplos prácticos y lenguaje cotidiano. {description}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
 msgid "gyGolN"
@@ -657,15 +657,15 @@ msgstr "Categorías de cursos"
 #: src/app/(catalog)/courses/category-pills.tsx
 #: src/app/(progress)/_components/period-tabs.tsx
 msgid "zQvVDJ"
-msgstr "Todos"
+msgstr "Todo"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 msgid "Wc7aau"
-msgstr "Aún no hay cursos disponibles."
+msgstr "Todavía no hay cursos disponibles."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 msgid "zJxO2f"
-msgstr "Sin cursos"
+msgstr "No hay cursos"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 msgid "T0mfNV"
@@ -679,11 +679,11 @@ msgstr "Algo salió mal. Inténtalo de nuevo."
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
 msgid "FazwRl"
-msgstr "Intentar de nuevo"
+msgstr "Inténtalo de nuevo"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "WgPMAP"
-msgstr "Explora todos los cursos de Zoonk para aprender cualquier cosa usando IA. Encuentra lecciones interactivas para estudiar temas como ciencia, matemáticas, tecnología y más."
+msgstr "Explora todos los cursos de Zoonk para aprender cualquier cosa con IA. Encuentra lecciones interactivas para aprender temas como ciencia, matemáticas, tecnología y más."
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
@@ -695,7 +695,7 @@ msgstr "Empieza a aprender algo nuevo hoy"
 
 #: src/app/(catalog)/my/page.tsx
 msgid "riE3I5"
-msgstr "Ve todos los cursos que empezaste en Zoonk. Continúa donde lo dejaste y sigue tu progreso en las lecciones interactivas."
+msgstr "Ve todos los cursos que empezaste en Zoonk. Continúa donde lo dejaste y sigue tu progreso en lecciones interactivas."
 
 #: src/app/(catalog)/my/page.tsx
 msgid "eeNr_Y"
@@ -715,18 +715,18 @@ msgstr "Empieza a aprender algo nuevo hoy."
 
 #: src/app/(catalog)/my/user-course-list.tsx
 msgid "9m9h0p"
-msgstr "Comenzar un curso"
+msgstr "Empezar un curso"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 #: src/app/(catalog)/start/start-content.tsx
 msgid "e61Jf3"
-msgstr "Próximamente"
+msgstr "Muy pronto"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 msgid "dtRj3N"
-msgstr "Los cursos personalizados llegarán pronto."
+msgstr "Los cursos personalizados estarán disponibles muy pronto."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
@@ -738,11 +738,11 @@ msgstr "Correo electrónico"
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
 msgid "OiSL94"
-msgstr "miemail@gmail.com"
+msgstr "micorreo@gmail.com"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "45yKj9"
-msgstr "Usaremos este correo para avisarte cuando la preparación para el examen esté lista."
+msgstr "Usaremos este correo para avisarte cuando la preparación para exámenes esté lista."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "Xy7a7A"
@@ -750,20 +750,20 @@ msgstr "Examen"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "cDZwI_"
-msgstr "TOEFL, SAT, CFA, CPA..."
+msgstr "TOEFL, SAT, CFA, CPA…"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "E_0Y4u"
-msgstr "Dinos el examen, la certificación o la prueba escolar que te interesa."
+msgstr "Cuéntanos qué prueba, certificación o examen escolar te interesa."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 msgid "6eV4UR"
-msgstr "No pudimos añadirte a la lista de espera. Inténtalo de nuevo."
+msgstr "No pudimos agregarte a la lista de espera. Inténtalo de nuevo."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "W78DIe"
-msgstr "Estás en la lista. Te avisaremos cuando la preparación para el examen esté lista."
+msgstr "Ya estás en la lista. Te avisaremos cuando la preparación para exámenes esté lista."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
@@ -772,27 +772,27 @@ msgstr "Avísame"
 
 #: src/app/(catalog)/start/exam/page.tsx
 msgid "gs2Dwu"
-msgstr "Preparación de exámenes con IA en línea para certificaciones y pruebas. Explicaciones prácticas y preguntas de práctica para ayudarte a aprobar."
+msgstr "Preparación en línea con IA para certificaciones y exámenes. Explicaciones prácticas y preguntas de práctica para ayudarte a aprobar."
 
 #: src/app/(catalog)/start/exam/page.tsx
 msgid "z8OyvL"
-msgstr "Preparación de exámenes con IA en línea"
+msgstr "Preparación para exámenes en línea con IA"
 
 #: src/app/(catalog)/start/exam/page.tsx
 msgid "CzV5fE"
-msgstr "La preparación para exámenes aún no está disponible. Dinos para qué te estás preparando y te avisaremos cuando se lance."
+msgstr "La preparación para exámenes aún no está disponible. Cuéntanos para qué te estás preparando y te avisaremos cuando se lance."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 msgid "hCixWc"
-msgstr "Estás en la lista. Te enviaremos un correo cuando esté disponible."
+msgstr "Ya estás en la lista. Te enviaremos un correo cuando esté disponible."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 msgid "UdDpuW"
-msgstr "Buscando la mejor forma de ayudar"
+msgstr "Buscando la mejor forma de ayudarte"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 msgid "1A36NM"
-msgstr "Estamos revisando tu objetivo de aprendizaje. Esto puede tardar unos segundos."
+msgstr "Estamos revisando tu objetivo de estudio. Esto puede tardar unos segundos."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 #: src/app/(settings)/subscription/plan-list.tsx
@@ -817,15 +817,15 @@ msgstr "No podemos crear este curso"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "m6ju4Q"
-msgstr "Zoonk no puede ayudar con solicitudes que impliquen actividades inseguras, ilegales o dañinas. Intenta con otro tema."
+msgstr "Zoonk no puede ayudar con solicitudes que impliquen actividades inseguras, ilegales o dañinas. Prueba con otro tema."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "PDFZz6"
-msgstr "Prueba otro objetivo"
+msgstr "Probar otro objetivo"
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
 msgid "CaU_nf"
-msgstr "Descubre cursos personalizados y recursos para aprender {prompt}. Zoonk usa IA para crear lecciones interactivas adaptadas a ti."
+msgstr "Descubre cursos y recursos personalizados para aprender {prompt}. Zoonk usa IA para crear lecciones interactivas hechas para ti."
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
 msgid "X2b6pH"
@@ -833,7 +833,7 @@ msgstr "Aprende {prompt} con IA"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "l450Bl"
-msgstr "Informática"
+msgstr "Ciencias de la computación"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "ElyVN0"
@@ -911,7 +911,7 @@ msgstr "Química orgánica"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "1axOcX"
-msgstr "OVNIs"
+msgstr "Ovnis"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "e7q85h"
@@ -939,7 +939,7 @@ msgstr "Agujeros negros"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "eQHeGX"
-msgstr "Cómo funciona Internet"
+msgstr "Cómo funciona internet"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "QOSGzc"
@@ -947,7 +947,7 @@ msgstr "Imperio romano"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "gyEihl"
-msgstr "Criaturas de las profundidades"
+msgstr "Criaturas de las profundidades marinas"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "0MqSJ1"
@@ -967,11 +967,11 @@ msgstr "Temas sugeridos"
 
 #: src/app/(catalog)/start/learn/learn-form.tsx
 msgid "uCb1nG"
-msgstr "Introduce un tema"
+msgstr "Escribe un tema"
 
 #: src/app/(catalog)/start/learn/page.tsx
 msgid "JlJVf1"
-msgstr "Dile a Zoonk qué quieres aprender y crea un curso con IA. Comienza cualquier materia con lecciones interactivas."
+msgstr "Dile a Zoonk qué quieres aprender y obtén un curso creado con IA. Empieza a estudiar cualquier tema con lecciones interactivas."
 
 #: src/app/(catalog)/start/learn/page.tsx
 msgid "Zs1QEq"
@@ -979,15 +979,15 @@ msgstr "Aprende cualquier cosa con IA"
 
 #: src/app/(catalog)/start/page.tsx
 msgid "UFOGo9"
-msgstr "Empieza cursos en línea para aprender idiomas y más en Zoonk. Practica idiomas, aprende inglés o español y crea cursos con IA sobre cualquier tema."
+msgstr "Empieza cursos en línea para aprender idiomas y mucho más en Zoonk. Practica idiomas, aprende inglés o español y crea cursos con IA sobre cualquier tema."
 
 #: src/app/(catalog)/start/page.tsx
 msgid "rqpQgj"
-msgstr "Cursos en línea para aprender idiomas y más"
+msgstr "Cursos en línea para aprender idiomas y mucho más"
 
 #: src/app/(catalog)/start/speak/page.tsx
 msgid "K4jMHW"
-msgstr "Cursos de idiomas en línea con IA. Aprende con consejos de pronunciación, vocabulario, lectura y práctica auditiva."
+msgstr "Cursos de idiomas en línea con IA. Aprende un idioma con consejos de pronunciación, vocabulario, lectura y práctica de escucha."
 
 #: src/app/(catalog)/start/speak/page.tsx
 msgid "Ht6aMH"
@@ -1007,15 +1007,15 @@ msgstr "Buscar idiomas"
 
 #: src/app/(catalog)/start/start-content.tsx
 msgid "ah2CR6"
-msgstr "Aprende un idioma con consejos de pronunciación, vocabulario, lectura y práctica auditiva."
+msgstr "Aprende un idioma con consejos de pronunciación, vocabulario, lectura y práctica de escucha."
 
 #: src/app/(catalog)/start/start-content.tsx
 msgid "_E8OKF"
-msgstr "Convierte cualquier tema en un curso claro que puedas seguir paso a paso, con ejemplos prácticos y sin relleno."
+msgstr "Convierte cualquier tema en un curso claro que puedas seguir paso a paso, con ejemplos prácticos y sin vueltas."
 
 #: src/app/(catalog)/start/start-content.tsx
 msgid "IF6NT-"
-msgstr "Prepararemos una ruta de estudio para ayudarte a aprobar un examen de ingreso, una certificación o una prueba escolar."
+msgstr "Prepararemos un plan de estudio para ayudarte a aprobar un examen de ingreso, una certificación o una prueba escolar."
 
 #: src/app/(catalog)/start/start-content.tsx
 msgid "AaFZIp"
@@ -1023,11 +1023,11 @@ msgstr "¿Cuál es tu objetivo?"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "pev_fB"
-msgstr "vs mes anterior"
+msgstr "vs. el mes pasado"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "R9qHBU"
-msgstr "vs últimos 6 meses"
+msgstr "vs. los últimos 6 meses"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 #: src/app/(progress)/_components/progress-insight-period-label.ts
@@ -1036,7 +1036,7 @@ msgstr "Todo el tiempo"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "YFV6dH"
-msgstr "vs año pasado"
+msgstr "vs. el año pasado"
 
 #: src/app/(progress)/_components/period-navigation.tsx
 msgid "hCCWuZ"
@@ -1044,7 +1044,7 @@ msgstr "Periodo anterior"
 
 #: src/app/(progress)/_components/period-navigation.tsx
 msgid "I2z5s_"
-msgstr "Siguiente periodo"
+msgstr "Periodo siguiente"
 
 #: src/app/(progress)/_components/period-tabs.tsx
 msgid "PIaUh-"
@@ -1068,7 +1068,7 @@ msgstr "No hay datos disponibles para este periodo"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "FVh2Tr"
-msgstr "Empieza a aprender para seguir tu progreso"
+msgstr "Empieza a estudiar para seguir tu progreso"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "Y1zzQt"
@@ -1093,7 +1093,7 @@ msgstr "Gráfico de Energía"
 #: src/app/(progress)/energy/energy-chart-client.tsx
 #: src/app/(progress)/score/score-chart-client.tsx
 msgid "rGSqvt"
-msgstr "Prom"
+msgstr "Promedio"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "TLPAMC"
@@ -1101,15 +1101,15 @@ msgstr "¿Qué es la Energía?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "OvOWOR"
-msgstr "La Energía es una puntuación de 0% a 100% sobre tu consistencia y precisión recientes al aprender."
+msgstr "La Energía es una puntuación del 0 % al 100 % que mide tu constancia y acierto recientes en el estudio."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "K3jN6p"
-msgstr "¿Cómo mejoro la Energía?"
+msgstr "¿Cómo mejoro mi Energía?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "pssms6"
-msgstr "Responde correctamente y mantén el hábito de estudiar. Las respuestas correctas suben la Energía; las incorrectas y los días sin estudiar la bajan."
+msgstr "Responde bien las preguntas y estudia con regularidad. Las respuestas correctas suben la Energía; las incorrectas y los días sin estudiar la bajan."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "-8Qx8X"
@@ -1117,11 +1117,11 @@ msgstr "¿Por qué es importante la Energía?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "UfEfhq"
-msgstr "Energía es como la frecuencia cardíaca en una app de salud: muestra tu ritmo de estudio actual. Saltarte un día no reinicia tu progreso; te recuperas en cuanto vuelves a estudiar."
+msgstr "La Energía es como el ritmo cardíaco en una app de salud: muestra tu ritmo de estudio actual. Perder un día no reinicia tu progreso; te recuperas en cuanto vuelves a estudiar."
 
 #: src/app/(progress)/energy/energy-insights.tsx
 msgid "XxS-he"
-msgstr "Día de mayor Energía"
+msgstr "Día con más Energía"
 
 #: src/app/(progress)/energy/energy-insights.tsx
 msgid "aaiQkv"
@@ -1133,15 +1133,15 @@ msgstr "Energía actual"
 
 #: src/app/(progress)/energy/energy-stats.tsx
 msgid "e9DcQa"
-msgstr "{percentage} de media"
+msgstr "{percentage} de promedio"
 
 #: src/app/(progress)/energy/page.tsx
 msgid "AZMpf3"
-msgstr "La Energía es una puntuación de 0% a 100% basada en la actividad y precisión recientes."
+msgstr "La Energía es una puntuación del 0 % al 100 % basada en tu actividad y acierto recientes."
 
 #: src/app/(progress)/energy/page.tsx
 msgid "rsIaGW"
-msgstr "Una puntuación de 0% a 100% por actividad y precisión recientes"
+msgstr "Una puntuación del 0 % al 100 % por actividad y acierto recientes"
 
 #: src/app/(progress)/level/level-chart-client.tsx
 msgid "GA8RuL"
@@ -1161,27 +1161,27 @@ msgstr "¿Qué es Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "MIjvOA"
-msgstr "Poder Mental (PM) es el crédito total de estudio que has acumulado. Cada lección completada suma {brainPower} PM."
+msgstr "Poder Mental (PM) es el crédito total de estudio que has ganado. Cada lección completada suma {brainPower} PM."
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "jzKXJS"
-msgstr "¿Cómo aumento mi Poder Mental?"
+msgstr "¿Cómo aumento Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "Gzq1tT"
-msgstr "Completa lecciones. El Poder Mental nunca disminuye, incluso cuando tu Energía baja o haces una pausa."
+msgstr "Completa lecciones. Poder Mental nunca baja, incluso cuando tu Energía baja o te tomas un descanso."
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "JGLOtn"
-msgstr "¿Por qué es importante el Poder Mental?"
+msgstr "¿Por qué es importante Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "tC6vNz"
-msgstr "Es como los pasos en una app de salud: un registro de cuánto has aprendido. También funciona como las artes marciales para tu mente: aumenta tu Poder Mental para avanzar de cinturón blanco a cinturón negro."
+msgstr "Es como los pasos en una app de salud: un registro de cuánto has aprendido. También funciona como artes marciales para tu mente: aumenta Poder Mental para avanzar de cinturón blanco a cinturón negro."
 
 #: src/app/(progress)/level/level-insights.tsx
 msgid "elq-tg"
-msgstr "Máximo PM"
+msgstr "Mayor PM"
 
 #: src/app/(progress)/level/level-insights.tsx
 msgid "BW4bMl"
@@ -1193,11 +1193,11 @@ msgstr "{belt}, nivel {level} de 10. Nivel máximo alcanzado."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "2Y-P4e"
-msgstr "{belt}, nivel {level} de 10. {bp} de Poder Mental para el siguiente nivel."
+msgstr "{belt}, nivel {level} de 10. Faltan {bp} de Poder Mental para el siguiente nivel."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "n_mgOm"
-msgstr "Progresión de cinturón"
+msgstr "Progreso de cinturón"
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "ZKbTsS"
@@ -1205,7 +1205,7 @@ msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "-Sn2yd"
-msgstr "{belt}: Nivel {current} de 10"
+msgstr "{belt}: nivel {current} de 10"
 
 #: src/app/(progress)/level/level-stats.tsx
 msgid "v5yNm3"
@@ -1217,11 +1217,11 @@ msgstr "PM"
 
 #: src/app/(progress)/level/level-stats.tsx
 msgid "u_oEJA"
-msgstr "{value} PM obtenidos"
+msgstr "{value} PM ganados"
 
 #: src/app/(progress)/level/page.tsx
 msgid "4-USpX"
-msgstr "Sigue tu progreso de nivel y ve cómo avanzas."
+msgstr "Sigue tu progreso de nivel y mira cómo avanzas."
 
 #: src/app/(progress)/level/page.tsx
 msgid "L9hqMH"
@@ -1229,11 +1229,11 @@ msgstr "Sigue tu progreso de nivel"
 
 #: src/app/(progress)/score/page.tsx
 msgid "qHWZBu"
-msgstr "Sigue tu puntuación a lo largo del tiempo y descubre tus mejores días y horas."
+msgstr "Sigue tu puntuación con el tiempo y mira tus mejores días y horas."
 
 #: src/app/(progress)/score/page.tsx
 msgid "GWkswX"
-msgstr "Sigue tu puntuación y las tendencias de progreso"
+msgstr "Sigue tu puntuación y tendencias de progreso"
 
 #: src/app/(progress)/score/score-chart-client.tsx
 msgid "J-05ol"
@@ -1245,15 +1245,15 @@ msgstr "¿Qué es la puntuación?"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "JA-N5Z"
-msgstr "La puntuación es el porcentaje de preguntas que respondiste correctamente durante este periodo."
+msgstr "La puntuación es el porcentaje de preguntas que respondiste correctamente durante este período."
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "z9kvhA"
-msgstr "¿Cómo mejoro la puntuación?"
+msgstr "¿Cómo mejoro mi puntuación?"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "7_C9do"
-msgstr "Revisa los errores y repite lecciones. A medida que respondas más preguntas correctamente, tu puntuación sube."
+msgstr "Repasa tus errores y vuelve a intentar las lecciones. A medida que respondas más preguntas correctamente, tu puntuación subirá."
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "WqH8eP"
@@ -1261,31 +1261,31 @@ msgstr "¿Por qué es importante la puntuación?"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "E0saoA"
-msgstr "La puntuación muestra precisión, no actividad. El mejor día y la mejor hora te ayudan a encontrar cuándo aprendes con más eficacia."
+msgstr "La puntuación muestra acierto, no actividad. Tu mejor día y tu mejor hora te ayudan a descubrir cuándo aprendes mejor."
 
 #: src/app/(settings)/_components/protected-section.tsx
 msgid "yOFm9C"
-msgstr "Necesitas iniciar sesión para acceder a esta página."
+msgstr "Debes iniciar sesión para acceder a esta página."
 
 #: src/app/(settings)/language/page.tsx
 msgid "2WHx14"
-msgstr "Actualiza el idioma de la app para aprender en inglés, portugués, español, francés u otros idiomas compatibles."
+msgstr "Actualiza el idioma de la app para estudiar en inglés, portugués, español, francés u otros idiomas compatibles."
 
 #: src/app/(settings)/language/page.tsx
 msgid "aNLa1G"
-msgstr "Elige el idioma de la app que prefieras para este dispositivo."
+msgstr "Elige el idioma de la app que prefieres para este dispositivo."
 
 #: src/app/(settings)/profile/page.tsx
 msgid "dSVD13"
-msgstr "Actualiza tu nombre y tu nombre de usuario en Zoonk."
+msgstr "Actualiza tu nombre y nombre de usuario en Zoonk."
 
 #: src/app/(settings)/profile/page.tsx
 msgid "wjIStY"
-msgstr "Tu nombre y nombre de usuario tal como aparecen a otros."
+msgstr "Tu nombre y nombre de usuario tal como los ven los demás."
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "1SvspN"
-msgstr "Comprobando..."
+msgstr "Comprobando…"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "9N4_rz"
@@ -1297,7 +1297,7 @@ msgstr "{username} ya está en uso"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "vLl7z0"
-msgstr "3-30 caracteres. Solo letras, números y guiones bajos."
+msgstr "De 3 a 30 caracteres. Solo letras, números y guiones bajos."
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "HAlOn1"
@@ -1305,7 +1305,7 @@ msgstr "Nombre"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "yNHZ-a"
-msgstr "¡Tu perfil se ha actualizado con éxito!"
+msgstr "¡Tu perfil se actualizó correctamente!"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "VT-G_7"
@@ -1313,7 +1313,7 @@ msgstr "Este nombre será visible para otros usuarios."
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "wYCHCR"
-msgstr "No se pudo actualizar tu perfil. Intenta de nuevo o contacta a contacto@zoonk.com"
+msgstr "No se pudo actualizar tu perfil. Inténtalo de nuevo o escribe a contacto@zoonk.com"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "JCIgkj"
@@ -1333,11 +1333,11 @@ msgstr "Gestionar en Google Play"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "Tp4wJB"
-msgstr "Esta suscripción se gestiona a través de App Store. Para cambiarla o cancelarla, usa los ajustes de suscripción de Apple."
+msgstr "Esta suscripción se gestiona desde App Store. Para cambiarla o cancelarla, usa los ajustes de suscripciones de Apple."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "unNUPf"
-msgstr "Esta suscripción se gestiona a través de Google Play. Para cambiarla o cancelarla, usa Google Play."
+msgstr "Esta suscripción se gestiona desde Google Play. Para cambiarla o cancelarla, usa Google Play."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "P0ZHma"
@@ -1349,7 +1349,7 @@ msgstr "Contactar con soporte"
 
 #: src/app/(settings)/subscription/page.tsx
 msgid "TKk9oj"
-msgstr "Compara planes y gestiona tu suscripción de Zoonk. Consulta precios, cambia de plan o actualiza la facturación."
+msgstr "Compara planes y gestiona tu suscripción a Zoonk. Consulta precios, cambia de plan o actualiza la facturación."
 
 #: src/app/(settings)/subscription/page.tsx
 msgid "NBEnVd"
@@ -1369,7 +1369,7 @@ msgstr "Gestionar"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "_gko4g"
-msgstr "Suscribirse a {plan}"
+msgstr "Mejorar a {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "wYsv4Z"
@@ -1381,7 +1381,7 @@ msgstr "Anual"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "s1ZXI0"
-msgstr "No se pudo actualizar tu suscripción. Contacta con contacto@zoonk.com"
+msgstr "No se pudo actualizar tu suscripción. Escríbenos a contacto@zoonk.com"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "2EsPdm"
@@ -1443,7 +1443,7 @@ msgstr "Lecciones personalizadas, IA rápida"
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
 msgid "B5MLC7"
-msgstr "Envía comentarios, haz preguntas o recibe ayuda con tu cuenta y cursos."
+msgstr "Comparte tu opinión, haz preguntas o recibe ayuda con tu cuenta y tus cursos."
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "cDAb4a"
@@ -1451,11 +1451,11 @@ msgstr "GitHub Discussions"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "7h49qt"
-msgstr "Conéctate con la comunidad y obtén respuestas"
+msgstr "Conecta con la comunidad y recibe respuestas"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "YdQxfw"
-msgstr "Contacta al soporte"
+msgstr "Contactar con soporte"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "dQIo6c"
@@ -1471,7 +1471,7 @@ msgstr "Crear esta lección"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 msgid "AtnLyn"
-msgstr "Esta lección forma parte del curso, pero todavía no se ha creado. Créala para empezar a estudiar."
+msgstr "Esta lección forma parte del curso, pero aún no se ha creado. Créala para empezar a estudiar."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
@@ -1494,11 +1494,11 @@ msgstr "Crea lecciones antes de revisar"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "Qy4EsI"
-msgstr "Nada para repasar todavía"
+msgstr "Aún no hay nada para repasar"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "4w9Y_P"
-msgstr "La revisión se desbloquea después de que se hayan creado las lecciones anteriores de este capítulo."
+msgstr "El repaso se desbloquea cuando se hayan creado las lecciones anteriores de este capítulo."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"
@@ -1510,11 +1510,11 @@ msgstr "Creando el capítulo {title}"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "kiZUDf"
-msgstr "Esto suele tardar alrededor de un minuto"
+msgstr "Suele tardar cerca de un minuto"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "5c2xtK"
-msgstr "Llevándote a tu capítulo..."
+msgstr "Te llevamos a tu capítulo…"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "45uo73"
@@ -1528,11 +1528,11 @@ msgstr "Eligiendo tipos de lección"
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "EKtClK"
-msgstr "Comenzando"
+msgstr "Empezando"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "SF9AtA"
-msgstr "Preparando las lecciones"
+msgstr "Preparando lecciones"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "L7nQzn"
@@ -1540,48 +1540,48 @@ msgstr "Guardando tus lecciones"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "Sbsm52"
-msgstr "Verificando cómo debe enseñarse cada lección..."
+msgstr "Revisando cómo enseñar cada lección…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "0xCLwv"
-msgstr "Eligiendo el tipo para la lección {number}..."
+msgstr "Eligiendo el tipo de la lección {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "Vbn5Wz"
-msgstr "Revisando la mezcla de lecciones..."
+msgstr "Revisando la combinación de lecciones…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "5342HA"
-msgstr "Comenzando..."
+msgstr "Empezando…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "nwGJ65"
-msgstr "Explorando tu tema..."
+msgstr "Explorando tu tema…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "VKFa_t"
-msgstr "Trazando la ruta de aprendizaje..."
+msgstr "Trazando la ruta de estudio…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "zQWv1_"
-msgstr "Escribiendo la lección {number}..."
+msgstr "Escribiendo la lección {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "HWSnYS"
-msgstr "Revisando el flujo hasta ahora..."
+msgstr "Revisando cómo va todo…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "txvxwS"
-msgstr "Guardando tu progreso..."
+msgstr "Guardando tu progreso…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JUr8Er"
-msgstr "Terminando..."
+msgstr "Terminando…"
 
 #: src/app/generate/course/[id]/generate-course-start-request-content.tsx
 msgid "rPgekg"
@@ -1598,12 +1598,12 @@ msgstr "Tu lección está lista"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 msgid "0o41MR"
-msgstr "Te estamos llevando a tu curso…"
+msgstr "Te llevamos a tu curso…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
 msgid "T2TGxR"
-msgstr "Llevándote a tu lección..."
+msgstr "Te llevamos a tu lección…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 msgid "u6ROZF"
@@ -1615,7 +1615,7 @@ msgstr "Suele tardar unos 2 minutos"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "i3JgLB"
-msgstr "Clasificando tu curso"
+msgstr "Categorizando tu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "WOe-OA"
@@ -1651,7 +1651,7 @@ msgstr "Preparando la introducción"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "HbhIvm"
-msgstr "Escribiendo la descripción del curso"
+msgstr "Escribiendo la descripción de tu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Y4F0xn"
@@ -1663,67 +1663,67 @@ msgstr "Escribiendo la página de tu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "aev_pt"
-msgstr "Averiguando las categorías correctas..."
+msgstr "Buscando las categorías adecuadas…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "EKAN6s"
-msgstr "Etiquetando tu curso..."
+msgstr "Etiquetando tu curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "JJrUOR"
-msgstr "Comparando cursos parecidos..."
+msgstr "Comparando cursos parecidos…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "uw23V-"
-msgstr "Comprobando si este curso ya existe..."
+msgstr "Comprobando si este curso ya existe…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "qFmZfG"
-msgstr "Evitando cursos duplicados..."
+msgstr "Evitando cursos duplicados…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "lxBtcx"
-msgstr "Diseñando la portada..."
+msgstr "Diseñando la portada…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "W8n2i3"
-msgstr "Eligiendo el estilo adecuado..."
+msgstr "Eligiendo el aspecto adecuado…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "At4rk1"
-msgstr "Añadiendo los toques finales..."
+msgstr "Dando los últimos retoques…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "NgONb4"
-msgstr "Buscando temas coincidentes..."
+msgstr "Buscando temas relacionados…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Auz1tl"
-msgstr "Buscando nombres alternativos..."
+msgstr "Buscando nombres alternativos…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Gt_VNO"
-msgstr "Ampliando la búsqueda de cursos..."
+msgstr "Ampliando la búsqueda del curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "AEG3Ol"
-msgstr "Planificando la estructura del curso..."
+msgstr "Planeando la estructura del curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "OW9vMd"
-msgstr "Escribiendo el capítulo {number}..."
+msgstr "Escribiendo el capítulo {number}…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "tXkuD8"
-msgstr "Revisando el flujo general..."
+msgstr "Revisando cómo fluye todo…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "8-bhNP"
-msgstr "Buscando el mejor gancho inicial…"
+msgstr "Buscando la mejor forma de empezar…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "xrFhkn"
-msgstr "Escribiendo una guía amigable del tema…"
+msgstr "Escribiendo una guía clara sobre el tema…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "c_e4hk"
@@ -1731,15 +1731,15 @@ msgstr "Haciendo que el primer capítulo sea fácil de empezar…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "4LsE_n"
-msgstr "Creando la estructura del curso..."
+msgstr "Creando la base del curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "3hEaI4"
-msgstr "Preparando el espacio de trabajo..."
+msgstr "Preparando el espacio de trabajo…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "7Pw3r5"
-msgstr "Guardando el capítulo introductorio…"
+msgstr "Guardando el capítulo de introducción…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "cc6_Yn"
@@ -1747,11 +1747,11 @@ msgstr "Preparando las primeras lecciones…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "a7FJJd"
-msgstr "Resumiendo lo que aprenderás..."
+msgstr "Resumiendo lo que vas a aprender…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "9r_4zz"
-msgstr "Escribiendo el resumen..."
+msgstr "Escribiendo el resumen…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "QqKzYM"
@@ -1759,15 +1759,15 @@ msgstr "Escribiendo la primera lección…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "XxRMuO"
-msgstr "Añadiendo ejemplos y elementos visuales…"
+msgstr "Agregando ejemplos e imágenes…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "kmuvIN"
-msgstr "Preparando la primera lección…"
+msgstr "Dejando lista la primera lección…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "chqN-J"
-msgstr "Aterrizando por qué este curso te sirve…"
+msgstr "Explicando por qué este curso es útil…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "twf4n2"
@@ -1783,315 +1783,315 @@ msgstr "Creando la lección {title}"
 
 #: src/app/generate/l/[id]/generation-client.tsx
 msgid "3vY0Zu"
-msgstr "Suele tardar 1-2 minutos"
+msgstr "Esto suele tardar 1-2 minutos"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "cVoRCh"
-msgstr "Preparando opciones..."
+msgstr "Preparando opciones…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "BBwnPG"
-msgstr "Añadiendo más opciones..."
+msgstr "Agregando más opciones…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "4wkMNX"
-msgstr "Preparando las opciones de respuesta..."
+msgstr "Preparando las opciones de respuesta…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "WsjFV2"
-msgstr "Preparando el banco de palabras..."
+msgstr "Preparando el banco de palabras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "6xEJTk"
-msgstr "Diseñando ejercicios de práctica..."
+msgstr "Diseñando ejercicios de práctica…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "6hjA6_"
-msgstr "Creando ejemplos para probar..."
+msgstr "Creando ejemplos para probar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "KddvJw"
-msgstr "Escribiendo ejercicios de completar..."
+msgstr "Escribiendo ejercicios para completar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "C05-tM"
-msgstr "Creando tareas interactivas..."
+msgstr "Creando actividades interactivas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JGNN92"
-msgstr "Dibujando una ilustración..."
+msgstr "Dibujando una ilustración…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "a08k7g"
-msgstr "Generando las imágenes..."
+msgstr "Generando las imágenes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "bJVUNz"
-msgstr "Añadiendo color..."
+msgstr "Agregando algo de color…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "Yoev2R"
-msgstr "Refinando los detalles..."
+msgstr "Afinando los detalles…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "xBaVAH"
-msgstr "Terminando la ilustración..."
+msgstr "Terminando la ilustración…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "W2b0tx"
-msgstr "Diseñando la miniatura de la lección..."
+msgstr "Diseñando la miniatura de la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "fRAHqN"
-msgstr "Creando la miniatura de la lección..."
+msgstr "Creando la miniatura de la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "elwtxf"
-msgstr "Refinando la miniatura de la lección..."
+msgstr "Afinando la miniatura de la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "uDzgwu"
-msgstr "Escribiendo frases de ejemplo..."
+msgstr "Escribiendo frases de ejemplo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "SHIHyL"
-msgstr "Creando textos de lectura..."
+msgstr "Creando textos de lectura…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "0Zum4g"
-msgstr "Poniendo las palabras en contexto..."
+msgstr "Poniendo las palabras en contexto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "jixTNM"
-msgstr "Formando oraciones naturales..."
+msgstr "Creando frases naturales…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "txIcop"
-msgstr "Cargando datos de la lección..."
+msgstr "Cargando los datos de la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "l486Kx"
-msgstr "Comprobando lo que necesitamos..."
+msgstr "Revisando qué necesitamos…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "EAqAX_"
-msgstr "Pensando qué ilustrar..."
+msgstr "Pensando en qué ilustrar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "2Tovpk"
-msgstr "Planificando cada imagen..."
+msgstr "Planeando cada imagen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "sQsQbH"
-msgstr "Eligiendo las escenas adecuadas..."
+msgstr "Eligiendo las escenas adecuadas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "iUUJom"
-msgstr "Planificando las ilustraciones..."
+msgstr "Planeando las ilustraciones…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "BszFlm"
-msgstr "Guardando tu lección..."
+msgstr "Guardando tu lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "bC9979"
-msgstr "Casi listo..."
+msgstr "Ya casi está…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "5Jyenk"
-msgstr "Preparando el siguiente paso..."
+msgstr "Preparando el siguiente paso…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "r8xznK"
-msgstr "Investigando el tema..."
+msgstr "Investigando el tema…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "K_JznZ"
-msgstr "Escribiendo la explicación..."
+msgstr "Escribiendo la explicación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "19fPwV"
-msgstr "Aclarándolo..."
+msgstr "Dejándolo claro…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "65JXIy"
-msgstr "Armando la lección..."
+msgstr "Armando la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "nwi1Ym"
-msgstr "Creando el contenido..."
+msgstr "Creando el contenido…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "-QrqeN"
-msgstr "Escribiendo la explicación primero..."
+msgstr "Escribiendo primero la explicación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "epxxAx"
-msgstr "Construyendo la base..."
+msgstr "Creando la base…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "GyThaR"
-msgstr "Preparando el contexto..."
+msgstr "Preparando el contexto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "0AWsLH"
-msgstr "Explicando el tema..."
+msgstr "Explicando el tema…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "KL34l5"
-msgstr "Añadiendo romanización para la gramática..."
+msgstr "Añadiendo romanización a la gramática…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "GILb0l"
-msgstr "Convirtiendo el texto gramatical a alfabeto latino..."
+msgstr "Convirtiendo el texto de gramática al alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "OFH7dE"
-msgstr "Haciendo el contenido gramatical más fácil de leer..."
+msgstr "Haciendo que la gramática sea más fácil de leer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "VADOBa"
-msgstr "Consultando cómo suena cada palabra..."
+msgstr "Buscando cómo suena cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "WnqJeL"
-msgstr "Mapeando la pronunciación..."
+msgstr "Organizando la pronunciación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "HDNFHk"
-msgstr "Comprobando cómo se pronuncia cada palabra..."
+msgstr "Revisando cómo se dice cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "_Fl7bm"
-msgstr "Encontrando los sonidos correctos..."
+msgstr "Buscando los sonidos correctos…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "DLZ9fl"
-msgstr "Convirtiendo a alfabeto latino..."
+msgstr "Convirtiendo al alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "boocfl"
-msgstr "Añadiendo ayudas de lectura..."
+msgstr "Añadiendo ayudas para leer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "AQMVYX"
-msgstr "Facilitando la lectura..."
+msgstr "Haciendo que sea más fácil de leer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "ud2yWh"
-msgstr "Transcribiendo los sonidos..."
+msgstr "Escribiendo cómo suena…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "kxBeWt"
-msgstr "Añadiendo romanización para el vocabulario..."
+msgstr "Añadiendo romanización al vocabulario…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "Ch9BcP"
-msgstr "Convirtiendo el vocabulario al alfabeto latino..."
+msgstr "Convirtiendo el vocabulario al alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "1aPaHZ"
-msgstr "Haciendo el vocabulario más fácil de leer..."
+msgstr "Haciendo que el vocabulario sea más fácil de leer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "zYx0UG"
-msgstr "Añadiendo pronunciación para cada palabra..."
+msgstr "Añadiendo la pronunciación de cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "VQ3-C2"
-msgstr "Anotando cómo suena cada palabra..."
+msgstr "Anotando cómo suena cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "YWB-K_"
-msgstr "Detallando los sonidos de las palabras..."
+msgstr "Detallando los sonidos de las palabras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "L6f1Zq"
-msgstr "Registrando información de pronunciación..."
+msgstr "Guardando la información de pronunciación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "i-rNdh"
-msgstr "Eligiendo el vocabulario clave..."
+msgstr "Eligiendo el vocabulario clave…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "IdWf9_"
-msgstr "Seleccionando palabras para practicar..."
+msgstr "Eligiendo palabras para practicar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "UFDKHM"
-msgstr "Buscando las palabras más útiles..."
+msgstr "Buscando las palabras más útiles…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "YgG70c"
-msgstr "Seleccionando términos importantes..."
+msgstr "Seleccionando términos importantes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "6BQo6o"
-msgstr "Traduciendo palabras individuales..."
+msgstr "Traduciendo palabras una por una…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "k0Q_Ph"
-msgstr "Consultando cada término..."
+msgstr "Buscando cada término…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "hZLCkp"
-msgstr "Buscando significados de palabras..."
+msgstr "Buscando significados de palabras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "SC0o7J"
-msgstr "Creando la guía de vocabulario..."
+msgstr "Creando la guía de vocabulario…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "5InW8H"
-msgstr "Grabando el audio..."
+msgstr "Grabando el audio…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "4xvh9e"
-msgstr "Afinando la pronunciación..."
+msgstr "Afinando la pronunciación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "oB01Wc"
-msgstr "Preparando la voz..."
+msgstr "Preparando la voz…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "ScA7Xm"
-msgstr "Haciendo que suene natural..."
+msgstr "Haciendo que suene natural…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "1vO-bV"
-msgstr "Grabando audio del vocabulario..."
+msgstr "Grabando el audio del vocabulario…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "jV2zI1"
-msgstr "Obteniendo el sonido de cada palabra..."
+msgstr "Preparando el sonido de cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "FahI7K"
-msgstr "Preparando audio del vocabulario..."
+msgstr "Preparando el audio del vocabulario…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "JfNFGM"
-msgstr "Haciendo las palabras fáciles de escuchar..."
+msgstr "Dejando las palabras listas para escuchar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "muXaEm"
-msgstr "Grabando la pronunciación de cada palabra..."
+msgstr "Grabando la pronunciación de cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "QDv0wS"
-msgstr "Obteniendo el audio de cada término..."
+msgstr "Preparando el audio de cada término…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "OJkDgV"
-msgstr "Preparando audio palabra por palabra..."
+msgstr "Preparando audio palabra por palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "C2ELVi"
-msgstr "Haciendo cada palabra fácil de escuchar..."
+msgstr "Dejando cada palabra lista para escuchar…"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "58heST"
-msgstr "Añadiendo romanización de la gramática"
+msgstr "Añadiendo romanización de gramática"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "TlrPFF"
@@ -2111,7 +2111,7 @@ msgstr "Añadiendo pronunciación de palabras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "RXfSEl"
-msgstr "Creando lista de palabras"
+msgstr "Creando la lista de palabras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "viluaR"
@@ -2127,11 +2127,11 @@ msgstr "Creando imágenes"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "WI2yui"
-msgstr "Creando miniatura de la lección"
+msgstr "Creando la miniatura de la lección"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "mIpv67"
-msgstr "Creando oraciones"
+msgstr "Creando frases"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "0zeST_"
@@ -2234,7 +2234,7 @@ msgstr "{percent}% completado"
 
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"
-msgstr "Comenzar"
+msgstr "Empezar"
 
 #: src/components/catalog/continue-lesson-link.tsx
 #: src/lib/lessons.ts
@@ -2251,19 +2251,19 @@ msgstr "Mensaje"
 
 #: src/components/feedback/contact-form.tsx
 msgid "M6PcEI"
-msgstr "¿En qué podemos ayudarte?"
+msgstr "¿Cómo podemos ayudarte?"
 
 #: src/components/feedback/contact-form.tsx
 msgid "vD72E5"
-msgstr "¡Mensaje enviado con éxito! Te responderemos pronto."
+msgstr "¡Mensaje enviado correctamente! Te responderemos pronto."
 
 #: src/components/feedback/contact-form.tsx
 msgid "-5vOOu"
-msgstr "Proporciona la mayor cantidad de detalles posible."
+msgstr "Cuéntanos todos los detalles que puedas."
 
 #: src/components/feedback/contact-form.tsx
 msgid "1WHPmV"
-msgstr "Error al enviar el mensaje. Inténtalo de nuevo o escríbenos directamente a contacto@zoonk.com"
+msgstr "No se pudo enviar el mensaje. Inténtalo de nuevo o escríbenos directamente a contacto@zoonk.com"
 
 #: src/components/feedback/contact-form.tsx
 msgid "Xx0WZV"
@@ -2279,15 +2279,15 @@ msgstr "Comentarios"
 
 #: src/components/feedback/feedback-dialog.tsx
 msgid "eUzs3M"
-msgstr "Envíanos comentarios, preguntas o sugerencias. Completa el formulario más abajo o escríbenos directamente a contacto@zoonk.com."
+msgstr "Envíanos comentarios, preguntas o sugerencias. Completa el formulario de abajo o escríbenos directamente a contacto@zoonk.com."
 
 #: src/components/generation/workflow-generation-error.tsx
 msgid "ctqXbT"
-msgstr "Se perdió la conexión de progreso. Es posible que tu contenido aún se esté generando."
+msgstr "Se perdió la conexión de progreso. Es posible que tu contenido se siga generando."
 
 #: src/components/generation/workflow-generation-error.tsx
 msgid "1A8Z_l"
-msgstr "Comprobar de nuevo"
+msgstr "Revisar de nuevo"
 
 #: src/components/generation/workflow-generation-error.tsx
 msgid "yHqv96"
@@ -2307,7 +2307,7 @@ msgstr "0 min"
 
 #: src/components/progress/progress-learning-time-label.ts
 msgid "yMhrnF"
-msgstr "{seconds, plural, one {# seg} other {# seg}}"
+msgstr "{seconds, plural, one {# s} other {# s}}"
 
 #: src/components/progress/progress-learning-time-label.ts
 msgid "a-oHjQ"
@@ -2327,23 +2327,23 @@ msgstr "Tiempo de estudio"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "IS_YjO"
-msgstr "Suscríbete para crear"
+msgstr "Mejora tu plan para crear"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "ZMU6iN"
-msgstr "Has llegado al límite de tus lecciones gratis. Actualiza para tener lecciones ilimitadas"
+msgstr "Llegaste al límite de lecciones gratis. Mejora tu plan para tener lecciones ilimitadas"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "0h_lPM"
-msgstr "Suscribirse"
+msgstr "Mejorar plan"
 
 #: src/lib/belt-colors.ts
 msgid "znY9eW"
-msgstr "{color, select, white {Cinturón Blanco} yellow {Cinturón Amarillo} orange {Cinturón Naranja} green {Cinturón Verde} blue {Cinturón Azul} purple {Cinturón Morado} brown {Cinturón Marrón} red {Cinturón Rojo} gray {Cinturón Gris} black {Cinturón Negro} other {Cinturón}}"
+msgstr "{color, select, white {Cinturón blanco} yellow {Cinturón amarillo} orange {Cinturón naranja} green {Cinturón verde} blue {Cinturón azul} purple {Cinturón morado} brown {Cinturón marrón} red {Cinturón rojo} gray {Cinturón gris} black {Cinturón negro} other {Cinturón}}"
 
 #: src/lib/categories/category.ts
 msgid "fFt3il"
-msgstr "Artes"
+msgstr "Arte"
 
 #: src/lib/categories/category.ts
 msgid "w1Fanr"
@@ -2383,7 +2383,7 @@ msgstr "Matemáticas"
 
 #: src/lib/categories/category.ts
 msgid "qydxOd"
-msgstr "Ciencias"
+msgstr "Ciencia"
 
 #: src/lib/categories/category.ts
 msgid "OV_2-4"
@@ -2395,7 +2395,7 @@ msgstr "Tecnología"
 
 #: src/lib/categories/category.ts
 msgid "XL8IWT"
-msgstr "Cursos de {category}. Los mejores cursos en línea de {category}, lecciones interactivas para aprender."
+msgstr "Cursos de {category}. Los mejores cursos en línea de {category}, con lecciones interactivas para aprender."
 
 #: src/lib/categories/category.ts
 msgid "4HKnmB"
@@ -2439,11 +2439,11 @@ msgstr "Aprende cómo funcionan las letras y los sonidos en este sistema de escr
 
 #: src/lib/lessons.ts
 msgid "LZC7R9"
-msgstr "Realiza una lección creada para tu objetivo."
+msgstr "Avanza en una lección creada para tu objetivo."
 
 #: src/lib/lessons.ts
 msgid "fOfLbt"
-msgstr "Entiende las ideas clave con un lenguaje cotidiano y ejemplos prácticos."
+msgstr "Entiende las ideas clave con palabras sencillas y ejemplos prácticos."
 
 #: src/lib/lessons.ts
 msgid "dHmgw1"
@@ -2451,27 +2451,27 @@ msgstr "Practica patrones gramaticales con ejemplos y ejercicios."
 
 #: src/lib/lessons.ts
 msgid "AetsPy"
-msgstr "Escucha oraciones con palabras que aprendiste recientemente."
+msgstr "Escucha oraciones con palabras que aprendiste hace poco."
 
 #: src/lib/lessons.ts
 msgid "6oNgY9"
-msgstr "Usa lo aprendido en la lección anterior para resolver problemas del mundo real."
+msgstr "Usa lo que aprendiste en la lección anterior para resolver problemas reales."
 
 #: src/lib/lessons.ts
 msgid "vO6aLm"
-msgstr "Comprueba lo que entendiste con un breve cuestionario."
+msgstr "Comprueba lo que entendiste con un quiz corto."
 
 #: src/lib/lessons.ts
 msgid "OIim7M"
-msgstr "Lee oraciones con palabras que aprendiste recientemente."
+msgstr "Lee oraciones con palabras que aprendiste hace poco."
 
 #: src/lib/lessons.ts
 msgid "pwrprO"
-msgstr "Repasa este capítulo con ejercicios basados en tus errores."
+msgstr "Repasa este capítulo con práctica basada en tus errores."
 
 #: src/lib/lessons.ts
 msgid "IQOJhk"
-msgstr "Traduce palabras de tu lección de vocabulario anterior."
+msgstr "Traduce palabras de tu lección anterior de vocabulario."
 
 #: src/lib/lessons.ts
 msgid "9XByXq"
@@ -2479,7 +2479,7 @@ msgstr "Sigue un tutorial guiado paso a paso."
 
 #: src/lib/lessons.ts
 msgid "IHSVS5"
-msgstr "Aprende palabras nuevas y practica usarlas."
+msgstr "Aprende palabras nuevas y practica cómo usarlas."
 
 #: src/lib/lessons.ts
 msgid "OjyuQ-"
@@ -2487,15 +2487,15 @@ msgstr "Aprende el sistema de escritura de {topic} con práctica enfocada."
 
 #: src/lib/lessons.ts
 msgid "pSQZ7W"
-msgstr "Aprende sobre {topic} mediante una lección interactiva."
+msgstr "Aprende sobre {topic} con una lección interactiva."
 
 #: src/lib/lessons.ts
 msgid "THPcKi"
-msgstr "Entiende qué es {topic} — conceptos y definiciones clave explicados con metáforas y analogías claras."
+msgstr "Entiende qué es {topic}: conceptos clave y definiciones explicados con metáforas y analogías claras."
 
 #: src/lib/lessons.ts
 msgid "tlgfSZ"
-msgstr "Practica las reglas gramaticales de {topic} con ejercicios diseñados para ayudarte a recordarlas y aplicarlas."
+msgstr "Practica las reglas gramaticales de {topic} con ejercicios pensados para ayudarte a recordarlas y usarlas."
 
 #: src/lib/lessons.ts
 msgid "xCvEE1"
@@ -2503,15 +2503,15 @@ msgstr "Practica la escucha en {topic} traduciendo oraciones de audio."
 
 #: src/lib/lessons.ts
 msgid "wHBT6R"
-msgstr "Aplica {topic} mediante un problema visual del mundo real con decisiones breves."
+msgstr "Aplica {topic} con un problema visual de la vida real y decisiones cortas."
 
 #: src/lib/lessons.ts
 msgid "h2acN8"
-msgstr "Pon a prueba tu comprensión de {topic} con preguntas pensadas para evaluar la comprensión real, no solo la memorización."
+msgstr "Pon a prueba cuánto entiendes de {topic} con preguntas que comprueban si de verdad entendiste, no solo si memorizaste."
 
 #: src/lib/lessons.ts
 msgid "XzxpBZ"
-msgstr "Mejora tu comprensión lectora de {topic} traduciendo oraciones y textos."
+msgstr "Mejora tu comprensión lectora de {topic} traduciendo oraciones y fragmentos."
 
 #: src/lib/lessons.ts
 msgid "bzFQEy"
@@ -2519,7 +2519,7 @@ msgstr "Repasa todo lo que aprendiste sobre {topic} con un cuestionario completo
 
 #: src/lib/lessons.ts
 msgid "X8Gqiq"
-msgstr "Practica vocabulario en {topic} traduciendo palabras que aprendiste."
+msgstr "Practica el vocabulario de {topic} traduciendo palabras que ya aprendiste."
 
 #: src/lib/lessons.ts
 msgid "3bJDQa"
@@ -2527,7 +2527,7 @@ msgstr "Aprende {topic} con un tutorial guiado paso a paso."
 
 #: src/lib/lessons.ts
 msgid "77SLH5"
-msgstr "Aprende palabras nuevas en {topic} con tarjetas — ve cada palabra, su traducción y pronunciación."
+msgstr "Aprende palabras nuevas de {topic} con tarjetas: ve cada palabra, su traducción y su pronunciación."
 
 #: src/lib/lessons.ts
 msgid "oCxmX9"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -8,11 +8,11 @@ msgstr ""
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "xmcVZ0"
-msgstr "Recherche"
+msgstr "Rechercher"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "PSiLeL"
-msgstr "Rechercher des cours, chapitres ou pages..."
+msgstr "Rechercher des cours, chapitres ou pages…"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
@@ -21,7 +21,7 @@ msgstr "Mes cours"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "Oj9Phc"
-msgstr "Gérer l'abonnement"
+msgstr "Gérer l’abonnement"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
@@ -58,7 +58,7 @@ msgstr "Langue"
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
 msgid "U3l-Q9"
-msgstr "Accueil"
+msgstr "Page d’accueil"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "jboh4c"
@@ -99,7 +99,7 @@ msgstr "Blog"
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
 msgid "fFZ0Wd"
-msgstr "Retours et support"
+msgstr "Avis et aide"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "SENRqu"
@@ -148,7 +148,7 @@ msgstr "Abonnement"
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/score/score-insights.tsx
 msgid "HHFpcy"
-msgstr "Meilleure journée"
+msgstr "Meilleur jour"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/energy/energy-insights.tsx
@@ -194,7 +194,7 @@ msgstr "{period} avec {percentage}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
 msgid "NubPSk"
-msgstr "Suivant : {lesson}"
+msgstr "Ensuite : {lesson}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
 #: src/components/catalog/continue-lesson-link.tsx
@@ -207,11 +207,11 @@ msgstr "Continuer à apprendre"
 
 #: src/app/(catalog)/(home)/energy.tsx
 msgid "soDmlG"
-msgstr "Continue d'apprendre pour l'augmenter"
+msgstr "Continue à apprendre pour l’augmenter"
 
 #: src/app/(catalog)/(home)/energy.tsx
 msgid "WgeB0r"
-msgstr "Continue d'apprendre pour la maintenir"
+msgstr "Continue à apprendre pour la maintenir"
 
 #: src/app/(catalog)/(home)/energy.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
@@ -221,12 +221,12 @@ msgstr "Énergie"
 
 #: src/app/(catalog)/(home)/energy.tsx
 msgid "AV5XNu"
-msgstr "Ton énergie est {percentage}"
+msgstr "Ton énergie est à {percentage}"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
 msgid "8F6teD"
-msgstr "Jours d'apprentissage"
+msgstr "Jours d’apprentissage"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 msgid "QbNcMh"
@@ -234,17 +234,17 @@ msgstr "Au moins une leçon terminée"
 
 #: src/app/(catalog)/(home)/learning-time.tsx
 msgid "F6B8A3"
-msgstr "Temps passé dans les leçons"
+msgstr "Temps passé en leçon"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
 msgid "pgt3eW"
-msgstr "Niveau max atteint"
+msgstr "Niveau maximal atteint"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
 msgid "8N9BRu"
-msgstr "{value} PM avant le niveau suivant"
+msgstr "{value} PM jusqu’au prochain niveau"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
@@ -259,11 +259,11 @@ msgstr "{belt} - Niveau {level}"
 
 #: src/app/(catalog)/(home)/page.tsx
 msgid "a50ZRn"
-msgstr "Zoonk est une plateforme d'apprentissage alimentée par l'IA et une application d'étude qui permet de créer des cours sur n'importe quel sujet grâce à l'IA. Prépare tes examens ou apprends de nouvelles compétences."
+msgstr "Zoonk est une plateforme d’apprentissage et une appli d’étude avec IA pour créer des cours sur n’importe quel sujet. Révise pour tes examens ou apprends de nouvelles compétences."
 
 #: src/app/(catalog)/(home)/page.tsx
 msgid "leBFvu"
-msgstr "Zoonk : application d'étude avec IA"
+msgstr "Zoonk : appli d’étude avec IA"
 
 #: src/app/(catalog)/(home)/progress.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx
@@ -280,7 +280,7 @@ msgstr "Score"
 
 #: src/app/(catalog)/(home)/score.tsx
 msgid "_lCW0j"
-msgstr "{percentage} réponses correctes"
+msgstr "{percentage} de bonnes réponses"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 msgid "QhvU1f"
@@ -301,7 +301,7 @@ msgstr "Retour au cours"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
 msgid "Ap-oRa"
-msgstr "Impossible d'appliquer les filtres de leçons. Réessaie."
+msgstr "Impossible d’appliquer les filtres des leçons. Réessaie."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
 msgid "d6tcJn"
@@ -321,11 +321,11 @@ msgstr "Effacer le filtre"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "orGV_i"
-msgstr "Leçon en cours"
+msgstr "Leçon actuelle"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
-msgstr "Rechercher des leçons..."
+msgstr "Rechercher des leçons…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "FuT9vz"
@@ -343,11 +343,11 @@ msgstr "Pas commencé"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "iRubpl"
-msgstr "Chapitre en cours"
+msgstr "Chapitre actuel"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "3SOcGR"
-msgstr "Rechercher des chapitres..."
+msgstr "Rechercher des chapitres…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "8udPa-"
@@ -359,20 +359,20 @@ msgstr "{completed, number}/{total, number} terminés"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-curriculum-pending-notice.tsx
 msgid "Pf4uqS"
-msgstr "Le chapitre d’intro est prêt. On crée encore le programme complet, donc d’autres chapitres vont bientôt apparaître ici."
+msgstr "Le chapitre d’introduction est prêt. Nous créons encore le programme complet, donc d’autres chapitres apparaîtront bientôt ici."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-actions.tsx
 #: src/app/(catalog)/courses/page.tsx
 msgid "s-Ncqj"
-msgstr "Découvrir les cours"
+msgstr "Explorer les cours"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-actions.tsx
 msgid "Y9LULP"
-msgstr "Essaye le chapitre gratuit"
+msgstr "Essayer le chapitre gratuit"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "8A99N6"
-msgstr "Les idées abstraites prennent une situation concrète"
+msgstr "Les idées abstraites deviennent concrètes"
 
 #. Short imperative verb label for the first tab in a learning flow: understand, practice, then test. Translate as an action the learner takes, not as a noun.
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
@@ -385,7 +385,7 @@ msgstr "La gravité est la force qui attire les objets ayant une masse les uns v
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "wC-aSO"
-msgstr "Vidéo de 2 h 47"
+msgstr "2 h 47 min de vidéo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "7C2tU3"
@@ -393,16 +393,16 @@ msgstr "C’est pour ça que ton café tombe quand tu renverses la tasse."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "B3Il8E"
-msgstr "Des leçons courtes et pratiques"
+msgstr "Leçons courtes et pratiques"
 
 #. Short imperative verb label for the second tab in a learning flow: understand, practice, then test. Translate as an action the learner takes, not as a noun.
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "courseLandingComparisonPracticeTab"
-msgstr "Pratiquer"
+msgstr "S’entraîner"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "F_F8WX"
-msgstr "Les prix augmentent"
+msgstr "Les prix montent"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "-EEAVi"
@@ -414,7 +414,7 @@ msgstr "La demande disparaît"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "361ky2"
-msgstr "L’offre et la demande fixent les prix. Définis l’offre, puis la demande."
+msgstr "L’offre et la demande déterminent les prix. Définis l’offre, puis définis la demande."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "2hewNe"
@@ -422,7 +422,7 @@ msgstr "Fiche d’exercices"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "k3LaSh"
-msgstr "Un concert a 300 places et 1 200 personnes en attente. Que se passe-t-il pour les prix des billets si aucune place n’est ajoutée ?"
+msgstr "Un concert a 300 places et 1 200 personnes en attente. Que se passe-t-il pour le prix des billets si aucune place n’est ajoutée ?"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "VlR_2v"
@@ -443,7 +443,7 @@ msgstr "Gravité"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "HC8xUj"
-msgstr "Frottement"
+msgstr "Friction"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "clPnhd"
@@ -455,11 +455,11 @@ msgstr "Quiz de rappel"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "cZ39v4"
-msgstr "Quand une voiture freine brusquement, tout le monde penche vers l’avant. Qu’est-ce qui provoque ça ?"
+msgstr "Quand une voiture freine brusquement, tout le monde se penche vers l’avant. Qu’est-ce qui provoque ça ?"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "PTjjt2"
-msgstr "Exemple concret"
+msgstr "Exemple pratique"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "ne7a4s"
@@ -495,7 +495,7 @@ msgstr "{count, plural, one {# chapitre} other {# chapitres}}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-curriculum.tsx
 msgid "3nOnkT"
-msgstr "Commence par les bases, puis avance vers des sujets plus poussés. Ouvre une section pour parcourir les chapitres."
+msgstr "Commence par les bases, puis passe à des sujets plus avancés. Ouvre une section pour parcourir les chapitres."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "hmZz9H"
@@ -507,7 +507,7 @@ msgstr "Contenu"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "o8KenS"
-msgstr "Qui"
+msgstr "Pour qui"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "y9RWqI"
@@ -531,7 +531,7 @@ msgstr "Premier chapitre gratuit"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-hero.tsx
 msgid "D6Uiky"
-msgstr "Du débutant à l’avancé"
+msgstr "Du niveau débutant au niveau avancé"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-hero.tsx
 msgid "L9JGVa"
@@ -551,11 +551,11 @@ msgstr "À qui s'adresse ce cours"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "hsgfxV"
-msgstr "Où tu vas l'utiliser"
+msgstr "Où tu l'utiliseras"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "qieSfO"
-msgstr "Apprends des mots utiles, puis entraîne-toi jusqu’à ce qu’ils deviennent naturels."
+msgstr "Apprends des mots utiles, puis entraîne-toi jusqu'à ce qu'ils deviennent naturels."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -564,7 +564,7 @@ msgstr "Vocabulaire"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "ZHyORV"
-msgstr "Lis des textes courts du quotidien qui montrent comment la langue est vraiment utilisée."
+msgstr "Lis de courts textes du quotidien qui montrent comment la langue est vraiment utilisée."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -573,7 +573,7 @@ msgstr "Lecture"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "Tt4yPU"
-msgstr "Écoute des situations de la vie réelle et entraîne ton oreille à comprendre naturellement."
+msgstr "Écoute des situations réelles et entraîne ton oreille à comprendre naturellement."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -591,7 +591,7 @@ msgstr "Grammaire"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "BuBt5e"
-msgstr "Apprends la prononciation en comparant les sons à ceux de ta langue (par ex. Hi → Haï)"
+msgstr "Apprends la prononciation en comparant les sons à ta propre langue (p. ex. Hola → OH-lah)"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "vuwclE"
@@ -599,7 +599,7 @@ msgstr "Prononciation"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "FkGq7Y"
-msgstr "Des idées complexes expliquées simplement."
+msgstr "Des idées complexes expliquées avec des mots simples."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "-ccXf6"
@@ -615,15 +615,15 @@ msgstr "Exemples concrets"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "9HRhoP"
-msgstr "Applique ce que tu apprends à des situations concrètes, pas seulement à des définitions."
+msgstr "Applique ce que tu apprends à des situations réalistes, pas seulement à des définitions."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "5gsjXY"
-msgstr "S’entraîner avec des problèmes concrets"
+msgstr "Entraîne-toi avec de vrais problèmes"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "NLqVU5"
-msgstr "Entraîne-toi avec quelques questions rapides sur ce que tu as appris."
+msgstr "Révise ce que tu as appris avec quelques questions rapides."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -636,15 +636,15 @@ msgstr "Comment fonctionnent nos leçons"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "eO0KtN"
-msgstr "Un cours, pas une certification"
+msgstr "Un cours, pas un diplôme"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "jt8_3X"
-msgstr "Le but de ce cours est de t’aider à comprendre le sujet et à développer des compétences utiles. Il ne donne pas de diplôme universitaire, de licence professionnelle ni d’autre qualification officiellement reconnue."
+msgstr "Le but de ce cours est de t'aider à comprendre le sujet et à développer des compétences utiles. Il ne donne pas de diplôme universitaire, de licence professionnelle ni d'autre qualification officiellement reconnue."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
 msgid "_allXG"
-msgstr "Apprends {course} en ligne avec des exemples pratiques et un langage simple. {description}"
+msgstr "Apprends {course} en ligne avec des exemples pratiques et un langage du quotidien. {description}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
 msgid "gyGolN"
@@ -657,7 +657,7 @@ msgstr "Catégories de cours"
 #: src/app/(catalog)/courses/category-pills.tsx
 #: src/app/(progress)/_components/period-tabs.tsx
 msgid "zQvVDJ"
-msgstr "Tous"
+msgstr "Tout"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 msgid "Wc7aau"
@@ -683,11 +683,11 @@ msgstr "Réessayer"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "WgPMAP"
-msgstr "Découvre tous les cours Zoonk pour apprendre n'importe quoi avec l'IA. Trouve des leçons interactives pour des sujets comme les sciences, les maths, la technologie, et plus encore."
+msgstr "Explore tous les cours Zoonk pour tout apprendre avec l'IA. Trouve des leçons interactives pour apprendre les sciences, les maths, la technologie et plus encore."
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
-msgstr "Cours en ligne avec IA"
+msgstr "Cours en ligne avec l'IA"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"
@@ -695,7 +695,7 @@ msgstr "Commence à apprendre quelque chose de nouveau aujourd'hui"
 
 #: src/app/(catalog)/my/page.tsx
 msgid "riE3I5"
-msgstr "Consulte tous les cours que tu as commencés sur Zoonk. Reprends là où tu t'étais arrêté et suis ta progression dans les leçons interactives."
+msgstr "Vois tous les cours que tu as commencés sur Zoonk. Reprends là où tu t'es arrêté et suis ta progression dans les leçons interactives."
 
 #: src/app/(catalog)/my/page.tsx
 msgid "eeNr_Y"
@@ -703,11 +703,11 @@ msgstr "Mes cours"
 
 #: src/app/(catalog)/my/page.tsx
 msgid "Dr13kE"
-msgstr "Continue où tu t'es arrêté"
+msgstr "Reprends là où tu t'es arrêté"
 
 #: src/app/(catalog)/my/user-course-list.tsx
 msgid "BDHWkf"
-msgstr "Pas encore de cours"
+msgstr "Aucun cours pour l'instant"
 
 #: src/app/(catalog)/my/user-course-list.tsx
 msgid "azX41u"
@@ -742,7 +742,7 @@ msgstr "myemail@gmail.com"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "45yKj9"
-msgstr "Nous utiliserons cet e-mail pour te prévenir lorsque la préparation à l'examen sera prête."
+msgstr "Nous utiliserons cet e-mail pour te prévenir quand la préparation aux examens sera prête."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "Xy7a7A"
@@ -750,49 +750,49 @@ msgstr "Examen"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "cDZwI_"
-msgstr "TOEFL, SAT, CFA, CPA..."
+msgstr "TOEFL, SAT, CFA, CPA…"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "E_0Y4u"
-msgstr "Dis-nous pour quel test, quelle certification ou quel examen scolaire tu veux te préparer."
+msgstr "Dis-nous le test, la certification ou l'examen scolaire qui t'intéresse."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 msgid "6eV4UR"
-msgstr "On n'a pas pu t'ajouter à la liste d'attente. Réessaie."
+msgstr "Nous n'avons pas pu t'ajouter à la liste d'attente. Réessaie."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "W78DIe"
-msgstr "Tu es sur la liste. On te préviendra quand la préparation à l'examen sera prête."
+msgstr "Tu es sur la liste. Nous te préviendrons quand la préparation aux examens sera prête."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 msgid "ipGe-B"
-msgstr "Préviens-moi"
+msgstr "Me prévenir"
 
 #: src/app/(catalog)/start/exam/page.tsx
 msgid "gs2Dwu"
-msgstr "Préparation aux examens en ligne avec IA pour certifications et tests. Explications pratiques et questions d'entraînement pour t'aider à réussir ton examen."
+msgstr "Préparation aux examens en ligne avec l'IA pour les certifications et les tests. Des explications pratiques et des questions d'entraînement pour t'aider à réussir ton examen."
 
 #: src/app/(catalog)/start/exam/page.tsx
 msgid "z8OyvL"
-msgstr "Prépa examens IA en ligne"
+msgstr "Préparation aux examens en ligne avec l'IA"
 
 #: src/app/(catalog)/start/exam/page.tsx
 msgid "CzV5fE"
-msgstr "La préparation aux examens n'est pas encore disponible. Dis-nous pour quoi tu te prépares et on te préviendra au lancement."
+msgstr "La préparation aux examens n'est pas encore disponible. Dis-nous ce que tu prépares et nous te préviendrons au lancement."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 msgid "hCixWc"
-msgstr "Tu es sur la liste. On t'enverra un e‑mail quand ce sera disponible."
+msgstr "Tu es sur la liste. Nous t'enverrons un e-mail quand ce sera disponible."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 msgid "UdDpuW"
-msgstr "On cherche la meilleure façon de t'aider"
+msgstr "Nous cherchons la meilleure façon de t'aider"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 msgid "1A36NM"
-msgstr "On vérifie ton objectif d'apprentissage. Ça peut prendre quelques secondes."
+msgstr "Nous vérifions ton objectif d'apprentissage. Cela peut prendre quelques secondes."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 #: src/app/(settings)/subscription/plan-list.tsx
@@ -805,27 +805,27 @@ msgstr "Cette option n'est pas encore disponible"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "TV5hlz"
-msgstr "Inscris-toi sur la liste d'attente et on te préviendra quand tu pourras apprendre <strong>{title}</strong> avec Zoonk."
+msgstr "Rejoins la liste d'attente et nous te préviendrons quand tu pourras apprendre <strong>{title}</strong> avec Zoonk."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "cPhKTw"
-msgstr "Indisponible"
+msgstr "Non disponible"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "5DZYgN"
-msgstr "On ne peut pas créer ce cours"
+msgstr "Nous ne pouvons pas créer ce cours"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "m6ju4Q"
-msgstr "Zoonk ne peut pas aider pour des demandes qui impliquent des activités dangereuses, illégales ou nuisibles. Essaie un autre sujet."
+msgstr "Zoonk ne peut pas aider avec les demandes liées à une activité dangereuse, illégale ou nuisible. Essaie plutôt un autre sujet."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "PDFZz6"
-msgstr "Essaie un autre objectif"
+msgstr "Essayer un autre objectif"
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
 msgid "CaU_nf"
-msgstr "Découvre des cours et ressources personnalisés pour apprendre {prompt}. Zoonk utilise l'IA pour créer des leçons interactives adaptées à toi."
+msgstr "Découvre des cours personnalisés et des ressources pour apprendre {prompt}. Zoonk utilise l'IA pour créer des leçons interactives adaptées à toi."
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
 msgid "X2b6pH"
@@ -866,7 +866,7 @@ msgstr "Biologie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "oiUZCZ"
-msgstr "Graphisme"
+msgstr "Design graphique"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
@@ -879,7 +879,7 @@ msgstr "Marketing"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "9zLpJ_"
-msgstr "Que veux-tu apprendre ?"
+msgstr "Qu'est-ce que tu veux apprendre ?"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "zfDq-e"
@@ -911,7 +911,7 @@ msgstr "Chimie organique"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "1axOcX"
-msgstr "OVNIs"
+msgstr "Ovnis"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "e7q85h"
@@ -947,7 +947,7 @@ msgstr "Empire romain"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "gyEihl"
-msgstr "Créatures des abysses"
+msgstr "Créatures des grands fonds"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "0MqSJ1"
@@ -971,31 +971,31 @@ msgstr "Saisis un sujet"
 
 #: src/app/(catalog)/start/learn/page.tsx
 msgid "JlJVf1"
-msgstr "Dis à Zoonk ce que tu veux apprendre et obtiens un cours créé par l'IA. Commence n'importe quel sujet avec des leçons interactives."
+msgstr "Dis à Zoonk ce que tu veux apprendre et obtiens un cours créé avec l’IA. Commence à apprendre n’importe quel sujet avec des leçons interactives."
 
 #: src/app/(catalog)/start/learn/page.tsx
 msgid "Zs1QEq"
-msgstr "Apprends n'importe quoi avec l'IA"
+msgstr "Apprends tout avec l’IA"
 
 #: src/app/(catalog)/start/page.tsx
 msgid "UFOGo9"
-msgstr "Commence des cours en ligne pour apprendre des langues et plus encore sur Zoonk. Pratique les langues, apprends l'anglais ou l'espagnol, et crée des cours alimentés par l'IA pour n'importe quel sujet."
+msgstr "Commence des cours en ligne pour apprendre des langues et plus encore sur Zoonk. Pratique une langue, apprends l’anglais ou l’espagnol, et crée des cours avec l’IA sur n’importe quel sujet."
 
 #: src/app/(catalog)/start/page.tsx
 msgid "rqpQgj"
-msgstr "Cours en ligne pour apprendre des langues et plus"
+msgstr "Cours en ligne pour apprendre des langues et plus encore"
 
 #: src/app/(catalog)/start/speak/page.tsx
 msgid "K4jMHW"
-msgstr "Cours de langues en ligne avec l'IA. Apprends une langue avec conseils de prononciation, vocabulaire, lecture et exercices d'écoute."
+msgstr "Cours de langue en ligne avec l’IA. Apprends une langue avec des conseils de prononciation, du vocabulaire, de la lecture et de l’écoute."
 
 #: src/app/(catalog)/start/speak/page.tsx
 msgid "Ht6aMH"
-msgstr "Apprends une langue en ligne avec l'IA"
+msgstr "Apprends une langue en ligne avec l’IA"
 
 #: src/app/(catalog)/start/speak/page.tsx
 msgid "lSAK6U"
-msgstr "Quelle langue veux-tu apprendre ?"
+msgstr "Quelle langue veux-tu apprendre ?"
 
 #: src/app/(catalog)/start/speak/page.tsx
 msgid "ptPPVk"
@@ -1007,27 +1007,27 @@ msgstr "Rechercher des langues"
 
 #: src/app/(catalog)/start/start-content.tsx
 msgid "ah2CR6"
-msgstr "Apprends une langue avec conseils de prononciation, vocabulaire, lecture et exercices d'écoute."
+msgstr "Apprends une langue avec des conseils de prononciation, du vocabulaire, de la lecture et de l’écoute."
 
 #: src/app/(catalog)/start/start-content.tsx
 msgid "_E8OKF"
-msgstr "Transforme n'importe quel sujet en un cours clair à suivre pas à pas, avec des exemples pratiques et sans blabla."
+msgstr "Transforme n’importe quel sujet en cours clair, à suivre étape par étape, avec des exemples pratiques et sans blabla."
 
 #: src/app/(catalog)/start/start-content.tsx
 msgid "IF6NT-"
-msgstr "Nous préparerons un parcours d'étude pour t'aider à réussir un concours d'entrée, une certification ou un contrôle scolaire."
+msgstr "Nous préparerons un parcours d’étude pour t’aider à réussir un concours d’entrée, une certification ou un examen scolaire."
 
 #: src/app/(catalog)/start/start-content.tsx
 msgid "AaFZIp"
-msgstr "Quel est ton objectif ?"
+msgstr "Quel est ton objectif ?"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "pev_fB"
-msgstr "vs le mois dernier"
+msgstr "par rapport au mois dernier"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "R9qHBU"
-msgstr "vs les 6 derniers mois"
+msgstr "par rapport aux 6 derniers mois"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 #: src/app/(progress)/_components/progress-insight-period-label.ts
@@ -1036,7 +1036,7 @@ msgstr "Depuis le début"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "YFV6dH"
-msgstr "vs l'année dernière"
+msgstr "par rapport à l’année dernière"
 
 #: src/app/(progress)/_components/period-navigation.tsx
 msgid "hCCWuZ"
@@ -1048,7 +1048,7 @@ msgstr "Période suivante"
 
 #: src/app/(progress)/_components/period-tabs.tsx
 msgid "PIaUh-"
-msgstr "Sélection de période"
+msgstr "Choix de la période"
 
 #: src/app/(progress)/_components/period-tabs.tsx
 msgid "TBovrx"
@@ -1068,11 +1068,11 @@ msgstr "Aucune donnée disponible pour cette période"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "FVh2Tr"
-msgstr "Commence à apprendre pour suivre tes progrès"
+msgstr "Commence à apprendre pour suivre ta progression"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "Y1zzQt"
-msgstr "Connecte-toi pour suivre tes progrès"
+msgstr "Connecte-toi pour suivre ta progression"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
 msgid "J3fNDZ"
@@ -1093,7 +1093,7 @@ msgstr "Graphique d'Énergie"
 #: src/app/(progress)/energy/energy-chart-client.tsx
 #: src/app/(progress)/score/score-chart-client.tsx
 msgid "rGSqvt"
-msgstr "Moy"
+msgstr "Moy."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "TLPAMC"
@@ -1101,15 +1101,15 @@ msgstr "Qu'est-ce que l'Énergie ?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "OvOWOR"
-msgstr "L'Énergie est un score de 0% à 100% pour ta régularité et ta précision récentes."
+msgstr "L'Énergie est un score de 0 % à 100 % qui reflète ta régularité et ta précision récentes dans l'apprentissage."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "K3jN6p"
-msgstr "Comment augmenter ton Énergie ?"
+msgstr "Comment améliorer mon Énergie ?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "pssms6"
-msgstr "Réponds correctement aux questions et apprends régulièrement. Les bonnes réponses augmentent l'Énergie ; les mauvaises réponses et les jours sans étude la font baisser."
+msgstr "Réponds correctement aux questions et continue d'apprendre régulièrement. Les bonnes réponses augmentent l'Énergie ; les mauvaises réponses et les jours sans étudier la font baisser."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "-8Qx8X"
@@ -1117,15 +1117,15 @@ msgstr "Pourquoi l'Énergie est-elle importante ?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "UfEfhq"
-msgstr "L'Énergie, c'est comme la fréquence cardiaque dans une appli de santé : elle montre ton rythme d'apprentissage actuel. Sauter un jour ne réinitialise pas ta progression ; tu la retrouves dès que tu recommences à apprendre."
+msgstr "L'Énergie, c'est comme le rythme cardiaque dans une appli santé : elle montre ton rythme d'apprentissage actuel. Rater une journée ne remet pas tes progrès à zéro ; tu récupères dès que tu recommences à apprendre."
 
 #: src/app/(progress)/energy/energy-insights.tsx
 msgid "XxS-he"
-msgstr "Jour d'Énergie le plus élevé"
+msgstr "Jour avec le plus d'énergie"
 
 #: src/app/(progress)/energy/energy-insights.tsx
 msgid "aaiQkv"
-msgstr "Énergie maximale"
+msgstr "Énergie au maximum"
 
 #: src/app/(progress)/energy/energy-stats.tsx
 msgid "zLCmVM"
@@ -1133,19 +1133,19 @@ msgstr "Énergie actuelle"
 
 #: src/app/(progress)/energy/energy-stats.tsx
 msgid "e9DcQa"
-msgstr "{percentage} en moyenne"
+msgstr "{percentage} de moyenne"
 
 #: src/app/(progress)/energy/page.tsx
 msgid "AZMpf3"
-msgstr "L'Énergie est un score de 0% à 100% basé sur l'activité et la précision récentes."
+msgstr "L'Énergie est un score de 0 % à 100 % basé sur ton activité récente et ta précision."
 
 #: src/app/(progress)/energy/page.tsx
 msgid "rsIaGW"
-msgstr "Un score de 0% à 100% pour l'activité et la précision récentes"
+msgstr "Un score de 0 % à 100 % pour l'activité récente et la précision"
 
 #: src/app/(progress)/level/level-chart-client.tsx
 msgid "GA8RuL"
-msgstr "Graphique Puissance Mentale"
+msgstr "Graphique de Puissance Mentale"
 
 #: src/app/(progress)/level/level-chart-client.tsx
 msgid "XdkaHc"
@@ -1157,27 +1157,27 @@ msgstr "Puissance Mentale totale gagnée : {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "EMy5Vs"
-msgstr "Qu'est‑ce que Puissance Mentale ?"
+msgstr "Qu'est-ce que Puissance Mentale ?"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "MIjvOA"
-msgstr "La Puissance Mentale (PM) correspond au total des crédits d'apprentissage que tu as accumulés. Chaque leçon terminée ajoute {brainPower} PM."
+msgstr "Puissance Mentale (PM) est le total de crédits d'apprentissage que tu as gagnés. Chaque leçon terminée ajoute {brainPower} PM."
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "jzKXJS"
-msgstr "Comment augmenter ta Puissance Mentale ?"
+msgstr "Comment augmenter Puissance Mentale ?"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "Gzq1tT"
-msgstr "Complète les leçons. La Puissance Mentale ne diminue jamais, même si ton Énergie baisse ou si tu fais une pause."
+msgstr "Termine des leçons. Puissance Mentale ne baisse jamais, même quand ton Énergie diminue ou que tu fais une pause."
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "JGLOtn"
-msgstr "Pourquoi la Puissance Mentale est importante ?"
+msgstr "Pourquoi Puissance Mentale est-elle importante ?"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "tC6vNz"
-msgstr "C'est comme le nombre de pas dans une appli de santé : un enregistrement de tout ce que tu as appris. Ça fonctionne aussi comme les arts martiaux pour ton esprit : augmente ta Puissance Mentale pour passer de Ceinture Blanche à Ceinture Noire."
+msgstr "C'est comme les pas dans une appli santé : un suivi de tout ce que tu as appris. Ça marche aussi comme les arts martiaux pour ton esprit : développe ta Puissance Mentale pour passer de la ceinture blanche à la ceinture noire."
 
 #: src/app/(progress)/level/level-insights.tsx
 msgid "elq-tg"
@@ -1193,7 +1193,7 @@ msgstr "{belt}, niveau {level} sur 10. Niveau maximum atteint."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "2Y-P4e"
-msgstr "{belt}, niveau {level} sur 10. Il te faut {bp} Puissance Mentale pour passer au niveau suivant."
+msgstr "{belt}, niveau {level} sur 10. {bp} de Puissance Mentale avant le niveau suivant."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "n_mgOm"
@@ -1205,7 +1205,7 @@ msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "-Sn2yd"
-msgstr "{belt} : Niveau {current} sur 10"
+msgstr "{belt} : niveau {current} sur 10"
 
 #: src/app/(progress)/level/level-stats.tsx
 msgid "v5yNm3"
@@ -1229,11 +1229,11 @@ msgstr "Suis ta progression de niveau"
 
 #: src/app/(progress)/score/page.tsx
 msgid "qHWZBu"
-msgstr "Suis ton score dans le temps et découvre tes meilleurs jours et moments."
+msgstr "Suis ton score au fil du temps et découvre tes meilleurs jours et moments."
 
 #: src/app/(progress)/score/page.tsx
 msgid "GWkswX"
-msgstr "Suis ton score et les tendances de ta progression"
+msgstr "Suis ton score et tes tendances de progression"
 
 #: src/app/(progress)/score/score-chart-client.tsx
 msgid "J-05ol"
@@ -1241,7 +1241,7 @@ msgstr "Graphique du score"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "bIZaXJ"
-msgstr "Qu'est-ce que le Score ?"
+msgstr "Qu'est-ce que le score ?"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "JA-N5Z"
@@ -1253,7 +1253,7 @@ msgstr "Comment améliorer mon score ?"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "7_C9do"
-msgstr "Revois tes erreurs et refais les leçons. Dès que tu réponds correctement à plus de questions, ton score augmente."
+msgstr "Revois tes erreurs et réessaie les leçons. Plus tu réponds correctement aux questions, plus ton score augmente."
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "WqH8eP"
@@ -1261,31 +1261,31 @@ msgstr "Pourquoi le score est-il important ?"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "E0saoA"
-msgstr "Le score montre la précision, pas l'activité. Le meilleur jour et le meilleur moment t'aident à repérer quand tu apprends le plus efficacement."
+msgstr "Le score montre ta précision, pas ton activité. Le meilleur jour et le meilleur moment t'aident à savoir quand tu apprends le plus efficacement."
 
 #: src/app/(settings)/_components/protected-section.tsx
 msgid "yOFm9C"
-msgstr "Tu dois être connecté·e pour accéder à cette page."
+msgstr "Tu dois être connecté pour accéder à cette page."
 
 #: src/app/(settings)/language/page.tsx
 msgid "2WHx14"
-msgstr "Mets à jour la langue de l'app pour apprendre en anglais, portugais, espagnol, français ou dans d'autres langues prises en charge."
+msgstr "Mets à jour la langue de l'appli pour apprendre en anglais, portugais, espagnol, français ou dans une autre langue prise en charge."
 
 #: src/app/(settings)/language/page.tsx
 msgid "aNLa1G"
-msgstr "Choisis la langue de l'app que tu préfères pour cet appareil."
+msgstr "Choisis la langue de l'appli que tu préfères pour cet appareil."
 
 #: src/app/(settings)/profile/page.tsx
 msgid "dSVD13"
-msgstr "Modifie ton nom et ton identifiant sur Zoonk."
+msgstr "Mets à jour ton nom et ton nom d'utilisateur sur Zoonk."
 
 #: src/app/(settings)/profile/page.tsx
 msgid "wjIStY"
-msgstr "Ton nom et ton identifiant tels qu'ils apparaissent aux autres."
+msgstr "Ton nom et ton nom d'utilisateur tels qu'ils apparaissent aux autres."
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "1SvspN"
-msgstr "Vérification..."
+msgstr "Vérification…"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "9N4_rz"
@@ -1297,7 +1297,7 @@ msgstr "{username} est déjà pris"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "vLl7z0"
-msgstr "3 à 30 caractères. Lettres, chiffres et tirets bas uniquement."
+msgstr "3 à 30 caractères. Lettres, chiffres et traits de soulignement uniquement."
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "HAlOn1"
@@ -1305,7 +1305,7 @@ msgstr "Nom"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "yNHZ-a"
-msgstr "Ton profil a été mis à jour avec succès !"
+msgstr "Ton profil a bien été mis à jour !"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "VT-G_7"
@@ -1313,19 +1313,19 @@ msgstr "Ce nom sera visible par les autres utilisateurs."
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "wYCHCR"
-msgstr "Échec de la mise à jour de ton profil. Essaie à nouveau ou contacte hello@zoonk.com"
+msgstr "Impossible de mettre ton profil à jour. Réessaie ou contacte hello@zoonk.com"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "JCIgkj"
-msgstr "Identifiant"
+msgstr "Nom d’utilisateur"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "X0ha1a"
-msgstr "Enregistrer les modifications"
+msgstr "Enregistrer les changements"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "3iCRcP"
-msgstr "Gérer dans l'App Store"
+msgstr "Gérer dans l’App Store"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "tiFovn"
@@ -1333,23 +1333,23 @@ msgstr "Gérer dans Google Play"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "Tp4wJB"
-msgstr "Cet abonnement est géré via l'App Store. Pour le modifier ou l'annuler, utilise les réglages d'abonnement d'Apple."
+msgstr "Cet abonnement est géré dans l’App Store. Pour le modifier ou l’annuler, utilise les réglages d’abonnement Apple."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "unNUPf"
-msgstr "Cet abonnement est géré via Google Play. Pour le modifier ou l'annuler, utilise Google Play."
+msgstr "Cet abonnement est géré dans Google Play. Pour le modifier ou l’annuler, utilise Google Play."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "P0ZHma"
-msgstr "Cet abonnement est géré par Zoonk. Contacte le support si tu as besoin d'aide pour le modifier ou l'annuler."
+msgstr "Cet abonnement est géré par Zoonk. Contacte l’assistance si tu as besoin d’aide pour le modifier ou l’annuler."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "5CI3KH"
-msgstr "Contacter le support"
+msgstr "Contacter l’assistance"
 
 #: src/app/(settings)/subscription/page.tsx
 msgid "TKk9oj"
-msgstr "Compare les offres et gère ton abonnement Zoonk. Consulte les tarifs, change d'offre ou mets à jour la facturation."
+msgstr "Compare les offres et gère ton abonnement Zoonk. Consulte les prix, change d’offre ou mets à jour la facturation."
 
 #: src/app/(settings)/subscription/page.tsx
 msgid "NBEnVd"
@@ -1357,11 +1357,11 @@ msgstr "Compare les offres et gère ton abonnement."
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "PJfdJl"
-msgstr "Économise jusqu'à {amount}"
+msgstr "Économise jusqu’à {amount}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "KAb0Yr"
-msgstr "Passe à {plan}"
+msgstr "Passer à {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "0Azlrb"
@@ -1369,7 +1369,7 @@ msgstr "Gérer"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "_gko4g"
-msgstr "Passe à {plan}"
+msgstr "Passer à {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "wYsv4Z"
@@ -1381,7 +1381,7 @@ msgstr "Annuel"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "s1ZXI0"
-msgstr "Impossible de mettre à jour ton abonnement. Contacte-nous à hello@zoonk.com"
+msgstr "Impossible de mettre ton abonnement à jour. Contacte-nous à hello@zoonk.com"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "2EsPdm"
@@ -1398,11 +1398,11 @@ msgstr "Gratuit"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "ZBALng"
-msgstr "Forfait en cours"
+msgstr "Offre actuelle"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "fF376U"
-msgstr "En cours"
+msgstr "Actuel"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "kkjl2v"
@@ -1418,7 +1418,7 @@ msgstr "Pro"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "9o8O4m"
-msgstr "Ton abonnement se terminera le {date}."
+msgstr "Ton abonnement prendra fin le {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "vaN1qz"
@@ -1430,7 +1430,7 @@ msgstr "Premier chapitre inclus"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "mqHNd6"
-msgstr "Leçons personnalisées, IA la plus intelligente"
+msgstr "Leçons personnalisées, IA la plus avancée"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "SC0MFR"
@@ -1443,19 +1443,19 @@ msgstr "Leçons personnalisées, IA rapide"
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
 msgid "B5MLC7"
-msgstr "Partage tes retours, pose des questions ou obtiens de l'aide pour ton compte et tes cours."
+msgstr "Partage tes retours, pose tes questions ou obtiens de l’aide pour ton compte et tes cours."
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "cDAb4a"
-msgstr "GitHub Discussions"
+msgstr "Discussions GitHub"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "7h49qt"
-msgstr "Connecte‑toi avec la communauté et trouve des réponses"
+msgstr "Échange avec la communauté et obtiens des réponses"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "YdQxfw"
-msgstr "Contacte le support"
+msgstr "Contacter l’assistance"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "dQIo6c"
@@ -1463,7 +1463,7 @@ msgstr "Écris-nous à hello@zoonk.com"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "l1XTI5"
-msgstr "Suis‑nous"
+msgstr "Suis-nous"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 msgid "rCpmYD"
@@ -1486,23 +1486,23 @@ msgstr "Retour au chapitre"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgid "ZnMcrz"
-msgstr "Débloque le reste de ce cours"
+msgstr "Déverrouiller le reste de ce cours"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "A_uNk-"
-msgstr "Crée des leçons avant de réviser"
+msgstr "Crée les leçons avant de les réviser"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "Qy4EsI"
-msgstr "Rien à réviser pour l'instant"
+msgstr "Rien à réviser pour l’instant"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "4w9Y_P"
-msgstr "La révision se débloque après la création des leçons précédentes de ce chapitre."
+msgstr "La révision se débloque une fois que les leçons précédentes de ce chapitre ont été créées."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"
-msgstr "Aucune question d'entraînement à réviser pour l'instant."
+msgstr "Il n’y a pas encore de questions d’entraînement à réviser."
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "txNTbP"
@@ -1510,11 +1510,11 @@ msgstr "Création du chapitre {title}"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "kiZUDf"
-msgstr "Généralement, cela prend environ une minute"
+msgstr "Ça prend généralement environ une minute"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "5c2xtK"
-msgstr "Redirection vers ton chapitre..."
+msgstr "On t’emmène vers ton chapitre…"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "45uo73"
@@ -1522,13 +1522,13 @@ msgstr "Tes leçons sont prêtes"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "gnxL73"
-msgstr "Choix des types de leçon"
+msgstr "Choix des types de leçons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "EKtClK"
-msgstr "Premiers pas"
+msgstr "Démarrage"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "SF9AtA"
@@ -1540,52 +1540,52 @@ msgstr "Enregistrement de tes leçons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "Sbsm52"
-msgstr "Vérification de la façon d'enseigner chaque leçon..."
+msgstr "On vérifie comment enseigner chaque leçon…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "0xCLwv"
-msgstr "Choix du type pour la leçon {number}..."
+msgstr "Choix du type de la leçon {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "Vbn5Wz"
-msgstr "Vérification du mix de leçons..."
+msgstr "Vérification de l’ensemble des leçons…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "5342HA"
-msgstr "On commence..."
+msgstr "Démarrage…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "nwGJ65"
-msgstr "Exploration de ton sujet..."
+msgstr "Exploration de ton sujet…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "VKFa_t"
-msgstr "Élaboration du parcours d'apprentissage..."
+msgstr "Préparation du parcours d’apprentissage…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "zQWv1_"
-msgstr "Rédaction de la leçon {number}..."
+msgstr "Rédaction de la leçon {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "HWSnYS"
-msgstr "Révision du déroulé jusqu'ici..."
+msgstr "Vérification du parcours jusqu’ici…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "txvxwS"
-msgstr "Sauvegarde de ta progression..."
+msgstr "Enregistrement de ta progression…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JUr8Er"
-msgstr "Finalisation..."
+msgstr "Dernières finitions…"
 
 #: src/app/generate/course/[id]/generate-course-start-request-content.tsx
 msgid "rPgekg"
-msgstr "Retour à l'accueil"
+msgstr "Retour à l’accueil"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 msgid "15FsdE"
@@ -1603,7 +1603,7 @@ msgstr "On t’emmène vers ton cours…"
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
 msgid "T2TGxR"
-msgstr "On t'emmène vers ta leçon..."
+msgstr "On t’emmène vers ta leçon…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 msgid "u6ROZF"
@@ -1611,39 +1611,39 @@ msgstr "Création du cours {title}"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 msgid "GJKrUK"
-msgstr "Cela prend environ 2 minutes"
+msgstr "Ça prend généralement environ 2 minutes"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "i3JgLB"
-msgstr "Catégorisation de ton cours..."
+msgstr "Classement de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "WOe-OA"
-msgstr "Recherche de doublons..."
+msgstr "Recherche de doublons"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Gjutu-"
-msgstr "Création de l'image de couverture..."
+msgstr "Création de l’image de couverture"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "SQFyKH"
-msgstr "Recherche de cours similaires..."
+msgstr "Recherche de cours similaires"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "WZpB8D"
-msgstr "Rédaction des chapitres..."
+msgstr "Rédaction des chapitres"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "vEOpTk"
-msgstr "Planification de l’introduction"
+msgstr "Préparation de l’introduction"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "d2xrsv"
-msgstr "Préparation de ton cours..."
+msgstr "Préparation de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "CFWOGF"
-msgstr "Sauvegarde de ton cours..."
+msgstr "Enregistrement de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "XPla-v"
@@ -1651,107 +1651,107 @@ msgstr "Préparation de l’introduction"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "HbhIvm"
-msgstr "Rédaction de la description de ton cours..."
+msgstr "Rédaction de la description de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Y4F0xn"
-msgstr "On écrit la première leçon"
+msgstr "Rédaction de la première leçon"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "e1myvm"
-msgstr "Rédaction de ta page de cours"
+msgstr "Rédaction de la page de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "aev_pt"
-msgstr "Détermination des bonnes catégories..."
+msgstr "Recherche des bonnes catégories…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "EKAN6s"
-msgstr "Ajout d'étiquettes à ton cours..."
+msgstr "Ajout de tags à ton cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "JJrUOR"
-msgstr "Comparaison des cours proches..."
+msgstr "Comparaison avec des cours proches…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "uw23V-"
-msgstr "Vérification si ce cours existe déjà..."
+msgstr "Vérification de l’existence de ce cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "qFmZfG"
-msgstr "Éviter les cours en double..."
+msgstr "Évitement des cours en double…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "lxBtcx"
-msgstr "Conception de la couverture..."
+msgstr "Création de la couverture…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "W8n2i3"
-msgstr "Choix du bon style..."
+msgstr "Choix du bon style…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "At4rk1"
-msgstr "Ajout des touches finales..."
+msgstr "Ajout des dernières touches…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "NgONb4"
-msgstr "Recherche de sujets correspondants..."
+msgstr "Recherche de sujets correspondants…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Auz1tl"
-msgstr "Recherche de noms alternatifs..."
+msgstr "Recherche d’autres noms…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Gt_VNO"
-msgstr "Extension de la recherche de cours..."
+msgstr "On élargit la recherche de cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "AEG3Ol"
-msgstr "Planification de la structure du cours..."
+msgstr "On prépare la structure du cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "OW9vMd"
-msgstr "Rédaction du chapitre {number}..."
+msgstr "On écrit le chapitre {number}…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "tXkuD8"
-msgstr "Révision du déroulé général..."
+msgstr "On vérifie l’enchaînement global…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "8-bhNP"
-msgstr "Recherche du meilleur point d’accroche pour commencer…"
+msgstr "On cherche la meilleure accroche pour commencer…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "xrFhkn"
-msgstr "Rédaction d’un guide sympa sur le sujet…"
+msgstr "On écrit un guide simple pour découvrir le sujet…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "c_e4hk"
-msgstr "Rendre le premier chapitre facile à démarrer…"
+msgstr "On rend le premier chapitre facile à commencer…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "4LsE_n"
-msgstr "Création de la structure du cours..."
+msgstr "On crée la structure de base du cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "3hEaI4"
-msgstr "Préparation de l'espace de travail..."
+msgstr "On prépare l’espace de travail…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "7Pw3r5"
-msgstr "Enregistrement du chapitre d’intro…"
+msgstr "On enregistre le chapitre d’introduction…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "cc6_Yn"
-msgstr "Préparation des premières leçons…"
+msgstr "On prépare les premières leçons…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "a7FJJd"
-msgstr "Résumé de ce que tu vas apprendre..."
+msgstr "On résume ce que tu vas apprendre…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "9r_4zz"
-msgstr "Rédaction de l'aperçu..."
+msgstr "On écrit l’aperçu…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "QqKzYM"
@@ -1759,7 +1759,7 @@ msgstr "On écrit la première leçon…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "XxRMuO"
-msgstr "On ajoute des exemples et des visuels…"
+msgstr "On ajoute des exemples et des images…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "kmuvIN"
@@ -1767,15 +1767,15 @@ msgstr "On prépare la première leçon…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "chqN-J"
-msgstr "Expliquer pourquoi ce cours est utile…"
+msgstr "On explique pourquoi ce cours est utile…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "twf4n2"
-msgstr "Rédaction de la page de cours…"
+msgstr "On écrit la page du cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "k15wFf"
-msgstr "Définir le point de départ…"
+msgstr "On prépare le point de départ…"
 
 #: src/app/generate/l/[id]/generation-client.tsx
 msgid "WihX6L"
@@ -1787,307 +1787,307 @@ msgstr "Cela prend généralement 1 à 2 minutes"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "cVoRCh"
-msgstr "Préparation des options..."
+msgstr "On prépare les options…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "BBwnPG"
-msgstr "Ajout d'autres options..."
+msgstr "On ajoute plus d’options…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "4wkMNX"
-msgstr "Préparation des options de réponse..."
+msgstr "On prépare les choix de réponse…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "WsjFV2"
-msgstr "Préparation de la banque de mots..."
+msgstr "On prépare la banque de mots…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "6xEJTk"
-msgstr "Conception des exercices pratiques..."
+msgstr "On crée des exercices d’entraînement…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "6hjA6_"
-msgstr "Création d'exemples à essayer..."
+msgstr "On crée des exemples à essayer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "KddvJw"
-msgstr "Rédaction des textes à trous..."
+msgstr "On écrit des textes à trous…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "C05-tM"
-msgstr "Création de tâches interactives..."
+msgstr "On crée des activités interactives…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JGNN92"
-msgstr "Création d'une illustration..."
+msgstr "On dessine une illustration…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "a08k7g"
-msgstr "Génération des images..."
+msgstr "On génère les images…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "bJVUNz"
-msgstr "Ajout de couleur..."
+msgstr "On ajoute un peu de couleur…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "Yoev2R"
-msgstr "Affinement des détails..."
+msgstr "On affine les détails…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "xBaVAH"
-msgstr "Finalisation de l'œuvre..."
+msgstr "On termine l’illustration…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "W2b0tx"
-msgstr "Conception de la vignette de la leçon..."
+msgstr "On conçoit la vignette de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "fRAHqN"
-msgstr "Création de la vignette de la leçon..."
+msgstr "On crée la vignette de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "elwtxf"
-msgstr "Affinement de la vignette de la leçon..."
+msgstr "On affine la vignette de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "uDzgwu"
-msgstr "Rédaction d'exemples de phrases..."
+msgstr "On écrit des phrases d’exemple…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "SHIHyL"
-msgstr "Création de textes de lecture..."
+msgstr "On crée des textes à lire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "0Zum4g"
-msgstr "Mise des mots en contexte..."
+msgstr "On met les mots en contexte…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "jixTNM"
-msgstr "Construction de phrases naturelles..."
+msgstr "On construit des phrases naturelles…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "txIcop"
-msgstr "Chargement des données de la leçon..."
+msgstr "On charge les données de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "l486Kx"
-msgstr "Vérification des éléments nécessaires..."
+msgstr "On vérifie ce dont on a besoin…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "EAqAX_"
-msgstr "Réflexion sur ce qu'il faut illustrer..."
+msgstr "On réfléchit à ce qu’il faut illustrer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "2Tovpk"
-msgstr "Planification de chaque image..."
+msgstr "On prépare chaque image…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "sQsQbH"
-msgstr "Choix des scènes appropriées..."
+msgstr "On choisit les bonnes scènes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "iUUJom"
-msgstr "Planification des illustrations..."
+msgstr "On prépare les illustrations…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "BszFlm"
-msgstr "Enregistrement de ta leçon..."
+msgstr "On enregistre ta leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "bC9979"
-msgstr "Presque terminé..."
+msgstr "C’est presque fini…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "5Jyenk"
-msgstr "Préparation pour l'étape suivante..."
+msgstr "On se prépare pour la prochaine étape…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "r8xznK"
-msgstr "Recherche sur le sujet..."
+msgstr "Recherche sur le sujet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "K_JznZ"
-msgstr "Rédaction de l'explication..."
+msgstr "Rédaction de l’explication…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "19fPwV"
-msgstr "Clarification du contenu..."
+msgstr "Clarification en cours…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "65JXIy"
-msgstr "Assemblage de la leçon..."
+msgstr "Préparation de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "nwi1Ym"
-msgstr "Conception du contenu..."
+msgstr "Création du contenu…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "-QrqeN"
-msgstr "Rédaction de l'explication en premier..."
+msgstr "Rédaction de l’explication d’abord…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "epxxAx"
-msgstr "Construction des bases..."
+msgstr "Mise en place des bases…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "GyThaR"
-msgstr "Préparation du contexte..."
+msgstr "Préparation du contexte…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "0AWsLH"
-msgstr "Explication du sujet..."
+msgstr "Explication du sujet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "KL34l5"
-msgstr "Ajout de la romanisation pour la grammaire..."
+msgstr "Ajout de la romanisation pour la grammaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "GILb0l"
-msgstr "Conversion du texte grammatical en alphabet latin..."
+msgstr "Conversion du texte de grammaire en alphabet latin…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "OFH7dE"
-msgstr "Faciliter la lecture du contenu grammatical..."
+msgstr "Simplification de la lecture de la grammaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "VADOBa"
-msgstr "Vérification de la prononciation de chaque mot..."
+msgstr "Recherche du son de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "WnqJeL"
-msgstr "Cartographie de la prononciation..."
+msgstr "Préparation de la prononciation…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "HDNFHk"
-msgstr "Vérification de la façon de prononcer chaque mot..."
+msgstr "Vérification de la prononciation de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "_Fl7bm"
-msgstr "Recherche des sons appropriés..."
+msgstr "Recherche des bons sons…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "DLZ9fl"
-msgstr "Conversion en alphabet latin..."
+msgstr "Conversion en alphabet latin…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "boocfl"
-msgstr "Ajout d'aides à la lecture..."
+msgstr "Ajout d’aides à la lecture…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "AQMVYX"
-msgstr "Faciliter la lecture..."
+msgstr "Simplification de la lecture…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "ud2yWh"
-msgstr "Transcription des sons..."
+msgstr "Transcription des sons…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "kxBeWt"
-msgstr "Ajout de la romanisation pour le vocabulaire..."
+msgstr "Ajout de la romanisation pour le vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "Ch9BcP"
-msgstr "Conversion du vocabulaire en alphabet latin..."
+msgstr "Conversion du vocabulaire en alphabet latin…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "1aPaHZ"
-msgstr "Faciliter la lecture du vocabulaire..."
+msgstr "Simplification de la lecture du vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "zYx0UG"
-msgstr "Ajout de la prononciation pour chaque mot..."
+msgstr "Ajout de la prononciation pour chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "VQ3-C2"
-msgstr "Notation de la prononciation de chaque mot..."
+msgstr "Notation du son de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "YWB-K_"
-msgstr "Détails sur la prononciation des mots..."
+msgstr "Détail des sons des mots…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "L6f1Zq"
-msgstr "Enregistrement des informations de prononciation..."
+msgstr "Enregistrement des infos de prononciation…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "i-rNdh"
-msgstr "Sélection du vocabulaire clé..."
+msgstr "Choix du vocabulaire clé…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "IdWf9_"
-msgstr "Choix des mots à pratiquer..."
+msgstr "Choix des mots à pratiquer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "UFDKHM"
-msgstr "Recherche des mots les plus utiles..."
+msgstr "Recherche des mots les plus utiles…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "YgG70c"
-msgstr "Sélection des termes importants..."
+msgstr "Sélection des termes importants…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "6BQo6o"
-msgstr "Traduction des mots individuels..."
+msgstr "Traduction des mots un par un…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "k0Q_Ph"
-msgstr "Recherche de chaque terme..."
+msgstr "Recherche de chaque terme…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "hZLCkp"
-msgstr "Recherche des sens des mots..."
+msgstr "Recherche du sens des mots…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "SC0o7J"
-msgstr "Construction du guide de vocabulaire..."
+msgstr "Création du guide de vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "5InW8H"
-msgstr "Enregistrement de l'audio..."
+msgstr "Enregistrement de l’audio…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "4xvh9e"
-msgstr "Trouver la bonne prononciation..."
+msgstr "Ajustement de la prononciation…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "oB01Wc"
-msgstr "Préparation de la voix..."
+msgstr "Préparation de la voix…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "ScA7Xm"
-msgstr "Rendre le son naturel..."
+msgstr "Création d’un son naturel…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "1vO-bV"
-msgstr "Enregistrement de l'audio du vocabulaire..."
+msgstr "Enregistrement de l’audio du vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "jV2zI1"
-msgstr "Obtenir le son de chaque mot..."
+msgstr "Préparation du son de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "FahI7K"
-msgstr "Préparation de l'audio du vocabulaire..."
+msgstr "Préparation de l’audio du vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "JfNFGM"
-msgstr "Rendre les mots écoutables..."
+msgstr "Préparation des mots à écouter…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "muXaEm"
-msgstr "Enregistrement de la prononciation de chaque mot..."
+msgstr "Enregistrement de la prononciation de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "QDv0wS"
-msgstr "Récupération de l'audio pour chaque terme..."
+msgstr "Préparation de l’audio de chaque terme…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "OJkDgV"
-msgstr "Préparation de l'audio mot par mot..."
+msgstr "Préparation de l’audio mot par mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "C2ELVi"
-msgstr "Rendre chaque mot écoutable..."
+msgstr "Préparation de chaque mot à écouter…"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "58heST"
@@ -2111,7 +2111,7 @@ msgstr "Ajout de la prononciation des mots"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "RXfSEl"
-msgstr "Construction de la liste de mots"
+msgstr "Création de la liste de mots"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "viluaR"
@@ -2119,23 +2119,23 @@ msgstr "Préparation des options"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "c7xJGQ"
-msgstr "Création d'exercices"
+msgstr "Création des exercices"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "aKNA_b"
-msgstr "Création d'images"
+msgstr "Création des images"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "WI2yui"
-msgstr "Création de la miniature de la leçon"
+msgstr "Création de la vignette de la leçon"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "mIpv67"
-msgstr "Création de phrases"
+msgstr "Création des phrases"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "0zeST_"
-msgstr "Recherche des mots"
+msgstr "Recherche de mots"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "v7HGj3"
@@ -2143,15 +2143,15 @@ msgstr "Planification des images"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "T00GEW"
-msgstr "Enregistrement audio"
+msgstr "Enregistrement de l’audio"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "v2DAdY"
-msgstr "Enregistrement de l'audio du vocabulaire"
+msgstr "Enregistrement de l’audio du vocabulaire"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "j-pO55"
-msgstr "Enregistrement de l'audio des mots"
+msgstr "Enregistrement de l’audio du mot"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "2ZPUqg"
@@ -2163,11 +2163,11 @@ msgstr "Rédaction du contenu"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "ZA0_P-"
-msgstr "Rédaction de l'explication"
+msgstr "Rédaction de l’explication"
 
 #: src/app/generate/layout.tsx
 msgid "_tq5fR"
-msgstr "Création de contenu"
+msgstr "Création du contenu"
 
 #: src/app/privacy/page.tsx
 msgid "afKQHy"
@@ -2179,38 +2179,38 @@ msgstr "Politique de confidentialité"
 
 #: src/app/terms/page.tsx
 msgid "DaGtoz"
-msgstr "Lis les conditions d'utilisation de Zoonk pour comprendre les règles et conditions d'utilisation de notre plateforme et de nos services"
+msgstr "Lis les conditions d’utilisation de Zoonk pour comprendre les règles et conditions liées à l’utilisation de notre plateforme et de nos services"
 
 #: src/app/terms/page.tsx
 msgid "UhkSyx"
-msgstr "Conditions d'utilisation"
+msgstr "Conditions d’utilisation"
 
 #: src/components/catalog/ai-warning.tsx
 msgid "FYZlTZ"
-msgstr "Créé avec l'IA"
+msgstr "Créé avec l’IA"
 
 #: src/components/catalog/catalog-actions.tsx
 msgid "F0tnKc"
-msgstr "Merci pour ton retour"
+msgstr "Merci pour ton avis"
 
 #: src/components/catalog/catalog-actions.tsx
 msgid "IzCVhG"
-msgstr "Plus d'options"
+msgstr "Plus d’options"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
 msgid "rTFrsw"
-msgstr "Je l'ai aimé"
+msgstr "J’ai aimé"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
 msgid "Hqn5Uo"
-msgstr "Je n'ai pas aimé"
+msgstr "Je n’ai pas aimé"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
 msgid "G5YSJR"
-msgstr "Envoyer un retour"
+msgstr "Envoyer un avis"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
 msgid "PAKDzS"
@@ -2230,7 +2230,7 @@ msgstr "Retour en haut"
 
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "AvySqa"
-msgstr "{percent}% terminé"
+msgstr "{percent} % terminé"
 
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"
@@ -2243,7 +2243,7 @@ msgstr "Réviser"
 
 #: src/components/feedback/contact-form.tsx
 msgid "WzCvaN"
-msgstr "Nous utiliserons cet e‑mail pour te contacter."
+msgstr "Nous utiliserons cet e-mail pour te contacter."
 
 #: src/components/feedback/contact-form.tsx
 msgid "T7Ry38"
@@ -2251,11 +2251,11 @@ msgstr "Message"
 
 #: src/components/feedback/contact-form.tsx
 msgid "M6PcEI"
-msgstr "En quoi pouvons-nous t'aider ?"
+msgstr "Comment pouvons-nous t’aider ?"
 
 #: src/components/feedback/contact-form.tsx
 msgid "vD72E5"
-msgstr "Message envoyé avec succès ! Nous te répondrons bientôt."
+msgstr "Message envoyé ! Nous te répondrons bientôt."
 
 #: src/components/feedback/contact-form.tsx
 msgid "-5vOOu"
@@ -2263,27 +2263,27 @@ msgstr "Donne autant de détails que possible."
 
 #: src/components/feedback/contact-form.tsx
 msgid "1WHPmV"
-msgstr "Échec de l'envoi du message. Essaie de nouveau ou écris-nous à hello@zoonk.com"
+msgstr "Impossible d’envoyer le message. Réessaie ou écris-nous directement à hello@zoonk.com"
 
 #: src/components/feedback/contact-form.tsx
 msgid "Xx0WZV"
-msgstr "Envoyer"
+msgstr "Envoyer le message"
 
 #: src/components/feedback/content-feedback.tsx
 msgid "BlI1_9"
-msgstr "Ce contenu t'a plu ?"
+msgstr "As-tu aimé ce contenu ?"
 
 #: src/components/feedback/feedback-dialog.tsx
 msgid "Ejhdi4"
-msgstr "Commentaires"
+msgstr "Avis"
 
 #: src/components/feedback/feedback-dialog.tsx
 msgid "eUzs3M"
-msgstr "Envoie-nous tes retours, questions ou suggestions. Remplis le formulaire ci‑dessous ou écris-nous à hello@zoonk.com."
+msgstr "Envoie-nous tes avis, questions ou suggestions. Remplis le formulaire ci-dessous ou écris-nous directement à hello@zoonk.com."
 
 #: src/components/generation/workflow-generation-error.tsx
 msgid "ctqXbT"
-msgstr "Connexion de progression perdue. Ton contenu est peut‑être toujours en cours de génération."
+msgstr "La connexion au suivi de progression a été perdue. Ton contenu est peut-être encore en cours de création."
 
 #: src/components/generation/workflow-generation-error.tsx
 msgid "1A8Z_l"
@@ -2299,7 +2299,7 @@ msgstr "Un problème est survenu"
 
 #: src/components/progress/progress-day-count-label.ts
 msgid "r9koty"
-msgstr "{count, plural, =0 {# jours} one {# jour} other {# jours}}"
+msgstr "{count, plural, =0 {# jour} one {# jour} other {# jours}}"
 
 #: src/components/progress/progress-learning-time-label.ts
 msgid "tRA46q"
@@ -2323,19 +2323,19 @@ msgstr "{hours, plural, one {# h} other {# h}} {minutes, plural, one {# min} oth
 
 #: src/components/progress/total-learning-time-card.tsx
 msgid "-V74AY"
-msgstr "Temps d'apprentissage"
+msgstr "Temps d’apprentissage"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "IS_YjO"
-msgstr "Abonne‑toi pour créer"
+msgstr "Passe à l’offre supérieure pour créer"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "ZMU6iN"
-msgstr "Tu as atteint la limite de leçons gratuites. Passe à la version payante pour des leçons illimitées"
+msgstr "Tu as atteint ta limite de leçons gratuites. Passe à l’offre supérieure pour des leçons illimitées"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "0h_lPM"
-msgstr "S'abonner"
+msgstr "Passer à l’offre supérieure"
 
 #: src/lib/belt-colors.ts
 msgid "znY9eW"
@@ -2347,7 +2347,7 @@ msgstr "Arts"
 
 #: src/lib/categories/category.ts
 msgid "w1Fanr"
-msgstr "Entreprise"
+msgstr "Business"
 
 #: src/lib/categories/category.ts
 msgid "n5D_Ku"
@@ -2395,7 +2395,7 @@ msgstr "Technologie"
 
 #: src/lib/categories/category.ts
 msgid "XL8IWT"
-msgstr "{category} courses. Les meilleurs cours en ligne de {category}, leçons interactives pour apprendre."
+msgstr "Cours de {category}. Les meilleurs cours en ligne de {category}, avec des leçons interactives pour apprendre."
 
 #: src/lib/categories/category.ts
 msgid "4HKnmB"
@@ -2407,7 +2407,7 @@ msgstr "Explorer tous les cours de {category}"
 
 #: src/lib/categories/category.ts
 msgid "Rz9oL-"
-msgstr "cours de {category}"
+msgstr "Cours de {category}"
 
 #: src/lib/lessons.ts
 msgid "w0J_gv"
@@ -2423,7 +2423,7 @@ msgstr "Explication"
 
 #: src/lib/lessons.ts
 msgid "KV-O0y"
-msgstr "Pratique"
+msgstr "Entraînement"
 
 #: src/lib/lessons.ts
 msgid "_vCXIP"
@@ -2435,7 +2435,7 @@ msgstr "Tutoriel"
 
 #: src/lib/lessons.ts
 msgid "22k1CY"
-msgstr "Apprends comment les lettres et les sons fonctionnent dans ce système d’écriture."
+msgstr "Découvre comment les lettres et les sons fonctionnent dans ce système d’écriture."
 
 #: src/lib/lessons.ts
 msgid "LZC7R9"
@@ -2443,15 +2443,15 @@ msgstr "Suis une leçon créée pour ton objectif."
 
 #: src/lib/lessons.ts
 msgid "fOfLbt"
-msgstr "Comprends les idées clés avec un langage courant et des exemples concrets."
+msgstr "Comprends les idées clés avec des mots simples et des exemples pratiques."
 
 #: src/lib/lessons.ts
 msgid "dHmgw1"
-msgstr "Exerce-toi aux structures grammaticales avec des exemples et des exercices."
+msgstr "Entraîne-toi aux structures grammaticales avec des exemples et des exercices."
 
 #: src/lib/lessons.ts
 msgid "AetsPy"
-msgstr "Écoute des phrases utilisant des mots que tu as récemment appris."
+msgstr "Écoute des phrases avec des mots que tu as appris récemment."
 
 #: src/lib/lessons.ts
 msgid "6oNgY9"
@@ -2459,71 +2459,71 @@ msgstr "Utilise ce que tu as appris dans la leçon précédente pour résoudre d
 
 #: src/lib/lessons.ts
 msgid "vO6aLm"
-msgstr "Vérifie ta compréhension avec un petit quiz."
+msgstr "Vérifie ce que tu as compris avec un petit quiz."
 
 #: src/lib/lessons.ts
 msgid "OIim7M"
-msgstr "Lis des phrases utilisant des mots que tu as récemment appris."
+msgstr "Lis des phrases avec des mots que tu as appris récemment."
 
 #: src/lib/lessons.ts
 msgid "pwrprO"
-msgstr "Revois ce chapitre avec des exercices basés sur tes erreurs."
+msgstr "Révise ce chapitre avec des exercices basés sur tes erreurs."
 
 #: src/lib/lessons.ts
 msgid "IQOJhk"
-msgstr "Traduis des mots de ta précédente leçon de vocabulaire."
+msgstr "Traduis les mots de ta leçon de vocabulaire précédente."
 
 #: src/lib/lessons.ts
 msgid "9XByXq"
-msgstr "Suis un tutoriel guidé pas à pas."
+msgstr "Suis un tutoriel guidé étape par étape."
 
 #: src/lib/lessons.ts
 msgid "IHSVS5"
-msgstr "Apprends de nouveaux mots et exerce-toi à les utiliser."
+msgstr "Apprends de nouveaux mots et entraîne-toi à les utiliser."
 
 #: src/lib/lessons.ts
 msgid "OjyuQ-"
-msgstr "Apprends le système d’écriture pour {topic} avec des exercices ciblés."
+msgstr "Apprends le système d’écriture de {topic} avec un entraînement ciblé."
 
 #: src/lib/lessons.ts
 msgid "pSQZ7W"
-msgstr "Découvre {topic} via une leçon interactive."
+msgstr "Découvre {topic} avec une leçon interactive."
 
 #: src/lib/lessons.ts
 msgid "THPcKi"
-msgstr "Comprends ce qu’est {topic} — concepts clés et définitions expliqués avec des métaphores claires."
+msgstr "Comprends ce qu’est {topic} : les concepts clés et les définitions sont expliqués avec des métaphores et des analogies claires."
 
 #: src/lib/lessons.ts
 msgid "tlgfSZ"
-msgstr "Exerce-toi aux règles de grammaire de {topic} avec des exercices conçus pour t’aider à les retenir et à les appliquer."
+msgstr "Entraîne-toi aux règles de grammaire de {topic} avec des exercices conçus pour t’aider à les retenir et à les appliquer."
 
 #: src/lib/lessons.ts
 msgid "xCvEE1"
-msgstr "Exerce ton écoute en {topic} en traduisant des phrases audio."
+msgstr "Entraîne ton écoute en {topic} en traduisant des phrases audio."
 
 #: src/lib/lessons.ts
 msgid "wHBT6R"
-msgstr "Applique {topic} via un problème visuel réel avec de courtes décisions."
+msgstr "Mets {topic} en pratique avec un problème visuel concret et de courtes décisions."
 
 #: src/lib/lessons.ts
 msgid "h2acN8"
-msgstr "Teste ta compréhension de {topic} avec des questions qui vérifient la vraie compréhension, pas seulement la mémorisation."
+msgstr "Teste ta compréhension de {topic} avec des questions faites pour vérifier si tu as vraiment compris, pas juste mémorisé."
 
 #: src/lib/lessons.ts
 msgid "XzxpBZ"
-msgstr "Améliore ta compréhension écrite de {topic} en traduisant des phrases et des textes."
+msgstr "Améliore ta compréhension écrite de {topic} en traduisant des phrases et des passages."
 
 #: src/lib/lessons.ts
 msgid "bzFQEy"
-msgstr "Revois tout ce que tu as appris sur {topic} grâce à un quiz complet."
+msgstr "Révise tout ce que tu as appris sur {topic} avec un quiz complet."
 
 #: src/lib/lessons.ts
 msgid "X8Gqiq"
-msgstr "Exerce ton vocabulaire en {topic} en traduisant les mots que tu as appris."
+msgstr "Entraîne-toi au vocabulaire de {topic} en traduisant les mots que tu as appris."
 
 #: src/lib/lessons.ts
 msgid "3bJDQa"
-msgstr "Apprends {topic} avec un tutoriel guidé pas à pas."
+msgstr "Apprends {topic} avec un tutoriel guidé, étape par étape."
 
 #: src/lib/lessons.ts
 msgid "77SLH5"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -8,11 +8,11 @@ msgstr ""
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "xmcVZ0"
-msgstr "Buscar"
+msgstr "Pesquisar"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "PSiLeL"
-msgstr "Buscar cursos, capítulos ou páginas..."
+msgstr "Busque cursos, capítulos ou páginas…"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
@@ -27,7 +27,7 @@ msgstr "Gerenciar assinatura"
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/language/page.tsx
 msgid "OhXwmw"
-msgstr "Atualizar idioma"
+msgstr "Alterar idioma"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "O7ozeo"
@@ -119,7 +119,7 @@ msgstr "Nenhum resultado encontrado"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 msgid "OXAZiT"
-msgstr "Criar curso de {term}"
+msgstr "Criar curso sobre {term}"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
 msgid "onRJrc"
@@ -230,7 +230,7 @@ msgstr "Dias de estudo"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 msgid "QbNcMh"
-msgstr "Pelo menos uma aula concluída"
+msgstr "Pelo menos uma aula completa"
 
 #: src/app/(catalog)/(home)/learning-time.tsx
 msgid "F6B8A3"
@@ -244,7 +244,7 @@ msgstr "Nível máximo alcançado"
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
 msgid "8N9BRu"
-msgstr "{value} PM para o próximo nível"
+msgstr "Faltam {value} PM para o próximo nível"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
@@ -280,7 +280,7 @@ msgstr "Pontuação"
 
 #: src/app/(catalog)/(home)/score.tsx
 msgid "_lCW0j"
-msgstr "{percentage} de respostas corretas"
+msgstr "{percentage} de acertos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 msgid "QhvU1f"
@@ -297,11 +297,11 @@ msgstr "Criar capítulo"
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/generate/ch/[id]/generate-chapter-content.tsx
 msgid "qrEiLa"
-msgstr "Voltar ao curso"
+msgstr "Voltar para o curso"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
 msgid "Ap-oRa"
-msgstr "Não foi possível aplicar os filtros de aulas. Tente novamente."
+msgstr "Não foi possível aplicar os filtros de aulas. Tente de novo."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
 msgid "d6tcJn"
@@ -325,7 +325,7 @@ msgstr "Aula atual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "ssvp3R"
-msgstr "Buscar aulas..."
+msgstr "Buscar aulas…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 msgid "FuT9vz"
@@ -334,12 +334,12 @@ msgstr "Nenhuma aula encontrada"
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "95stPq"
-msgstr "Concluído"
+msgstr "Completou"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "xTTP0x"
-msgstr "Não iniciado"
+msgstr "Não começou"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "iRubpl"
@@ -347,7 +347,7 @@ msgstr "Capítulo atual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "3SOcGR"
-msgstr "Buscar capítulos..."
+msgstr "Buscar capítulos…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgid "8udPa-"
@@ -359,7 +359,7 @@ msgstr "{completed, number}/{total, number} concluídos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-curriculum-pending-notice.tsx
 msgid "Pf4uqS"
-msgstr "O capítulo de introdução está pronto. Ainda estamos criando todo o currículo, então mais capítulos vão aparecer aqui em breve."
+msgstr "O capítulo de introdução está pronto. A gente ainda está criando o currículo completo, então mais capítulos vão aparecer aqui em breve."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-actions.tsx
 #: src/app/(catalog)/courses/page.tsx
@@ -372,7 +372,7 @@ msgstr "Experimente um capítulo grátis"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "8A99N6"
-msgstr "Ideias abstratas ganham uma situação real"
+msgstr "Ideias abstratas viram situações reais"
 
 #. Short imperative verb label for the first tab in a learning flow: understand, practice, then test. Translate as an action the learner takes, not as a noun.
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
@@ -381,7 +381,7 @@ msgstr "Entenda"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "LcPoK0"
-msgstr "Gravidade é a força que atrai objetos com massa uns para os outros."
+msgstr "A gravidade é a força que atrai objetos com massa uns para os outros."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "wC-aSO"
@@ -414,15 +414,15 @@ msgstr "A demanda desaparece"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "361ky2"
-msgstr "Oferta e demanda definem os preços. Defina oferta, depois defina demanda."
+msgstr "Oferta e demanda determinam os preços. Defina oferta e depois demanda."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "2hewNe"
-msgstr "Folha de exercícios"
+msgstr "Atividade"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "k3LaSh"
-msgstr "Um show tem 300 lugares e 1.200 pessoas esperando. O que acontece com o preço dos ingressos se não abrirem mais lugares?"
+msgstr "Um show tem 300 lugares e 1.200 pessoas na fila. O que acontece com o preço dos ingressos se nenhum lugar novo for adicionado?"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "VlR_2v"
@@ -455,7 +455,7 @@ msgstr "Quiz de revisão"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "cZ39v4"
-msgstr "Quando um carro freia de repente, todo mundo vai pra frente. O que faz isso acontecer?"
+msgstr "Quando um carro freia de repente, todo mundo se inclina para a frente. O que faz isso acontecer?"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-comparison.tsx
 msgid "PTjjt2"
@@ -475,7 +475,7 @@ msgstr "Introdução"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-curriculum.tsx
 msgid "itC9lG"
-msgstr "Noções básicas"
+msgstr "Básico"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-curriculum.tsx
 msgid "o5_DJA"
@@ -495,7 +495,7 @@ msgstr "{count, plural, one {# capítulo} other {# capítulos}}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-curriculum.tsx
 msgid "3nOnkT"
-msgstr "Comece com o básico e depois avance para temas mais difíceis. Abra uma seção para ver os capítulos."
+msgstr "Comece pelo básico e avance para temas mais avançados. Abra uma seção para ver os capítulos."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "hmZz9H"
@@ -511,7 +511,7 @@ msgstr "Para quem"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "y9RWqI"
-msgstr "O que"
+msgstr "O quê"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-decision-tabs.tsx
 msgid "ujaB7H"
@@ -535,7 +535,7 @@ msgstr "Do básico ao avançado"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-hero.tsx
 msgid "L9JGVa"
-msgstr "Aprenda no seu próprio ritmo"
+msgstr "Estude no seu ritmo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "kvjzxh"
@@ -555,7 +555,7 @@ msgstr "Onde você vai usar isso"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "qieSfO"
-msgstr "Aprenda palavras úteis e depois pratique até elas ficarem naturais."
+msgstr "Aprenda palavras úteis e pratique até elas ficarem naturais."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -573,7 +573,7 @@ msgstr "Leitura"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "Tt4yPU"
-msgstr "Ouça situações reais e treine seu ouvido para entender de forma natural."
+msgstr "Escute situações da vida real e treine seu ouvido para entender com naturalidade."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 #: src/lib/lessons.ts
@@ -591,7 +591,7 @@ msgstr "Gramática"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "BuBt5e"
-msgstr "Aprenda a pronúncia comparando os sons com os do seu idioma (ex. Hi → Rai)"
+msgstr "Aprenda a pronúncia comparando sons com o seu próprio idioma (ex.: Hi → Rai)"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "vuwclE"
@@ -599,7 +599,7 @@ msgstr "Pronúncia"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "FkGq7Y"
-msgstr "Conceitos complexos explicados em linguagem simples."
+msgstr "Ideias complexas explicadas em linguagem simples."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "-ccXf6"
@@ -615,7 +615,7 @@ msgstr "Exemplos da vida real"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "9HRhoP"
-msgstr "Aplique o que você aprende em situações reais, não só em definições."
+msgstr "Use o que você aprende em situações realistas, não só em definições."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "5gsjXY"
@@ -640,11 +640,11 @@ msgstr "Um curso, não uma credencial"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-landing-page-sections.tsx
 msgid "jt8_3X"
-msgstr "O objetivo deste curso é te ajudar a entender o assunto e desenvolver habilidades úteis. Ele não dá diploma de faculdade, licença profissional nem outra qualificação reconhecida oficialmente."
+msgstr "O objetivo deste curso é te ajudar a entender o assunto e desenvolver habilidades úteis. Ele não concede diploma universitário, licença profissional nem outra qualificação reconhecida oficialmente."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
 msgid "_allXG"
-msgstr "Aprenda {course} online com exemplos práticos e linguagem simples. {description}"
+msgstr "Aprenda {course} online com exemplos práticos e linguagem do dia a dia. {description}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
 msgid "gyGolN"
@@ -652,7 +652,7 @@ msgstr "Aprenda {course}"
 
 #: src/app/(catalog)/courses/category-pills.tsx
 msgid "tuZsq-"
-msgstr "Categorias de curso"
+msgstr "Categorias de cursos"
 
 #: src/app/(catalog)/courses/category-pills.tsx
 #: src/app/(progress)/_components/period-tabs.tsx
@@ -665,7 +665,7 @@ msgstr "Ainda não há cursos disponíveis."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 msgid "zJxO2f"
-msgstr "Sem cursos"
+msgstr "Nenhum curso"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 msgid "T0mfNV"
@@ -674,20 +674,20 @@ msgstr "Carregando mais cursos…"
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
 msgid "W_5hwr"
-msgstr "Algo deu errado. Por favor, tente novamente."
+msgstr "Algo deu errado. Tente de novo."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
 msgid "FazwRl"
-msgstr "Tentar novamente"
+msgstr "Tentar de novo"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "WgPMAP"
-msgstr "Explore todos os cursos do Zoonk para aprender qualquer coisa usando IA. Encontre aulas interativas para aprender assuntos como ciência, matemática, tecnologia e mais."
+msgstr "Explore todos os cursos do Zoonk para aprender qualquer coisa com IA. Encontre aulas interativas para aprender temas como ciências, matemática, tecnologia e muito mais."
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "P5jxUC"
-msgstr "Cursos online usando IA"
+msgstr "Cursos online com IA"
 
 #: src/app/(catalog)/courses/page.tsx
 msgid "hUF3bo"
@@ -695,11 +695,11 @@ msgstr "Comece a aprender algo novo hoje"
 
 #: src/app/(catalog)/my/page.tsx
 msgid "riE3I5"
-msgstr "Veja todos os cursos que você começou no Zoonk. Continue de onde parou e acompanhe seu progresso ao longo das aulas interativas."
+msgstr "Veja todos os cursos que você começou no Zoonk. Continue de onde parou e acompanhe seu progresso nas aulas interativas."
 
 #: src/app/(catalog)/my/page.tsx
 msgid "eeNr_Y"
-msgstr "Meus Cursos"
+msgstr "Meus cursos"
 
 #: src/app/(catalog)/my/page.tsx
 msgid "Dr13kE"
@@ -707,7 +707,7 @@ msgstr "Continue de onde parou"
 
 #: src/app/(catalog)/my/user-course-list.tsx
 msgid "BDHWkf"
-msgstr "Ainda sem cursos"
+msgstr "Nenhum curso ainda"
 
 #: src/app/(catalog)/my/user-course-list.tsx
 msgid "azX41u"
@@ -715,7 +715,7 @@ msgstr "Comece a aprender algo novo hoje."
 
 #: src/app/(catalog)/my/user-course-list.tsx
 msgid "9m9h0p"
-msgstr "Iniciar um curso"
+msgstr "Começar um curso"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 #: src/app/(catalog)/start/exam/page.tsx
@@ -726,13 +726,13 @@ msgstr "Em breve"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 msgid "dtRj3N"
-msgstr "Cursos personalizados em breve."
+msgstr "Cursos personalizados chegam em breve."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
 msgid "hJZwTS"
-msgstr "Endereço de e-mail"
+msgstr "Email"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
@@ -742,7 +742,7 @@ msgstr "meuemail@gmail.com"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "45yKj9"
-msgstr "Vamos usar este email para avisar quando a preparação para provas estiver pronta."
+msgstr "A gente vai usar este email para te avisar quando a preparação para provas estiver pronta."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "Xy7a7A"
@@ -754,21 +754,21 @@ msgstr "TOEFL, ENEM, OAB, concurso..."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "E_0Y4u"
-msgstr "Conte para a gente qual teste, certificação ou prova escolar é importante para você."
+msgstr "Conte qual prova, certificação ou exame escolar importa para você."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 msgid "6eV4UR"
-msgstr "Não conseguimos adicionar você à lista de espera. Por favor, tente novamente."
+msgstr "Não conseguimos te colocar na lista de espera. Tente de novo."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 msgid "W78DIe"
-msgstr "Você está na lista. Avisaremos quando o preparatório para provas estiver pronto."
+msgstr "Você entrou na lista. A gente te avisa quando a preparação para provas estiver pronta."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 msgid "ipGe-B"
-msgstr "Me avisar"
+msgstr "Me avise"
 
 #: src/app/(catalog)/start/exam/page.tsx
 msgid "gs2Dwu"
@@ -780,19 +780,19 @@ msgstr "Estudar para concursos e provas com IA"
 
 #: src/app/(catalog)/start/exam/page.tsx
 msgid "CzV5fE"
-msgstr "O preparatório ainda não está disponível. Diga para qual prova você está se preparando e nós avisaremos quando for lançado."
+msgstr "A preparação para provas ainda não está disponível. Conte para qual prova está estudando e a gente te avisa quando for lançada."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-mode-waitlist-form.tsx
 msgid "hCixWc"
-msgstr "Você está na lista. Enviaremos um e-mail quando estiver disponível."
+msgstr "Você entrou na lista. A gente te envia um email quando estiver disponível."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 msgid "UdDpuW"
-msgstr "Procurando a melhor forma de ajudar"
+msgstr "Buscando a melhor forma de ajudar"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 msgid "1A36NM"
-msgstr "Estamos verificando seu objetivo de estudo. Isso pode levar alguns segundos."
+msgstr "A gente está analisando sua meta de estudo. Isso pode levar alguns segundos."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 #: src/app/(settings)/subscription/plan-list.tsx
@@ -805,7 +805,7 @@ msgstr "Esta opção ainda não está disponível"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "TV5hlz"
-msgstr "Entre na lista de espera e avisaremos quando você puder aprender <strong>{title}</strong> com o Zoonk."
+msgstr "Entre na lista de espera e a gente te avisa quando você puder aprender <strong>{title}</strong> com o Zoonk."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "cPhKTw"
@@ -813,15 +813,15 @@ msgstr "Indisponível"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "5DZYgN"
-msgstr "Não conseguimos criar este curso"
+msgstr "Não podemos criar este curso"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "m6ju4Q"
-msgstr "O Zoonk não pode ajudar com pedidos que envolvam atividades inseguras, ilegais ou prejudiciais. Tente outro assunto."
+msgstr "O Zoonk não pode ajudar com pedidos que envolvem atividades inseguras, ilegais ou prejudiciais. Tente outro assunto."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-result.tsx
 msgid "PDFZz6"
-msgstr "Tente outro objetivo"
+msgstr "Tentar outra meta"
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
 msgid "CaU_nf"
@@ -919,7 +919,7 @@ msgstr "Extinção dos dinossauros"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "MO2lwh"
-msgstr "Como funcionam os vulcões"
+msgstr "Como os vulcões funcionam"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "ZzbdHP"
@@ -947,7 +947,7 @@ msgstr "Império Romano"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "gyEihl"
-msgstr "Criaturas do fundo do mar"
+msgstr "Animais do fundo do mar"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 msgid "0MqSJ1"
@@ -971,7 +971,7 @@ msgstr "Digite um assunto"
 
 #: src/app/(catalog)/start/learn/page.tsx
 msgid "JlJVf1"
-msgstr "Diga ao Zoonk o que você quer aprender e receba um curso criado com IA. Comece a aprender qualquer assunto com aulas interativas."
+msgstr "Diga ao Zoonk o que você quer aprender e receba um curso criado com IA. Comece a estudar qualquer assunto com aulas interativas."
 
 #: src/app/(catalog)/start/learn/page.tsx
 msgid "Zs1QEq"
@@ -1019,7 +1019,7 @@ msgstr "Preparamos uma trilha para você passar em um concurso, ENEM, certifica�
 
 #: src/app/(catalog)/start/start-content.tsx
 msgid "AaFZIp"
-msgstr "Qual é o seu objetivo?"
+msgstr "Qual é seu objetivo?"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 msgid "pev_fB"
@@ -1064,15 +1064,15 @@ msgstr "Ano"
 
 #: src/app/(progress)/_components/progress-chart-layout.tsx
 msgid "OlW5Z8"
-msgstr "Nenhum dado disponível para este período"
+msgstr "Nenhum dado disponível neste período"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "FVh2Tr"
-msgstr "Comece a aprender para acompanhar seu progresso"
+msgstr "Comece a estudar para acompanhar seu progresso"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
 msgid "Y1zzQt"
-msgstr "Faça login para acompanhar seu progresso"
+msgstr "Entre para acompanhar seu progresso"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
 msgid "J3fNDZ"
@@ -1101,15 +1101,15 @@ msgstr "O que é Energia?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "OvOWOR"
-msgstr "Energia é uma pontuação de 0% a 100% que mostra sua constância recente e seus acertos."
+msgstr "Energia é uma nota de 0% a 100% para sua constância e precisão nos estudos recentes."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "K3jN6p"
-msgstr "Como melhorar a Energia?"
+msgstr "Como melhoro a Energia?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "pssms6"
-msgstr "Responda corretamente e estude com regularidade. Respostas certas aumentam a Energia; respostas erradas e dias sem estudar fazem ela diminuir."
+msgstr "Responda às perguntas corretamente e continue estudando com frequência. Respostas certas aumentam a Energia; respostas erradas e dias sem estudar diminuem ela."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "-8Qx8X"
@@ -1117,11 +1117,11 @@ msgstr "Por que a Energia é importante?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
 msgid "UfEfhq"
-msgstr "Energia é como a frequência cardíaca em um app de saúde: mostra seu ritmo atual de estudo. Perder um dia não zera seu progresso; você se recupera assim que voltar a estudar."
+msgstr "Energia é como os batimentos cardíacos em um app de saúde: mostra seu ritmo de estudo atual. Perder um dia não zera seu progresso; você se recupera assim que volta a estudar."
 
 #: src/app/(progress)/energy/energy-insights.tsx
 msgid "XxS-he"
-msgstr "Dia de maior energia"
+msgstr "Dia com mais energia"
 
 #: src/app/(progress)/energy/energy-insights.tsx
 msgid "aaiQkv"
@@ -1137,11 +1137,11 @@ msgstr "{percentage} em média"
 
 #: src/app/(progress)/energy/page.tsx
 msgid "AZMpf3"
-msgstr "Energia é uma pontuação de 0% a 100% baseada em atividade recente e precisão."
+msgstr "Energia é uma nota de 0% a 100% com base na atividade e precisão recentes."
 
 #: src/app/(progress)/energy/page.tsx
 msgid "rsIaGW"
-msgstr "Uma pontuação de 0% a 100% para atividade recente e precisão"
+msgstr "Uma nota de 0% a 100% para atividade e precisão recentes"
 
 #: src/app/(progress)/level/level-chart-client.tsx
 msgid "GA8RuL"
@@ -1153,7 +1153,7 @@ msgstr "{value} PM"
 
 #: src/app/(progress)/level/level-chart-client.tsx
 msgid "tDbspx"
-msgstr "Poder Mental total conquistado: {total}"
+msgstr "Poder Mental total ganho: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "EMy5Vs"
@@ -1169,7 +1169,7 @@ msgstr "Como aumento o Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "Gzq1tT"
-msgstr "Conclua aulas. O Poder Mental nunca diminui, mesmo quando sua Energia cai ou você faz uma pausa."
+msgstr "Complete aulas. O Poder Mental nunca diminui, mesmo quando sua Energia cai ou você faz uma pausa."
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "JGLOtn"
@@ -1177,7 +1177,7 @@ msgstr "Por que o Poder Mental é importante?"
 
 #: src/app/(progress)/level/level-explanation.tsx
 msgid "tC6vNz"
-msgstr "É como os passos em um app de saúde: um registro do quanto você aprendeu. Também funciona como artes marciais para sua mente: aumente o Poder Mental para avançar de faixa branca à faixa preta."
+msgstr "É como passos em um app de saúde: um registro de quanto você aprendeu. Também funciona como artes marciais para a sua mente: ganhe Poder Mental para avançar da faixa branca até a faixa preta."
 
 #: src/app/(progress)/level/level-insights.tsx
 msgid "elq-tg"
@@ -1189,15 +1189,15 @@ msgstr "{date} com {value} PM"
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "WfaE4H"
-msgstr "{belt}, nível {level} de 10. Nível máximo alcançado."
+msgstr "{belt}, Nível {level} de 10. Nível máximo alcançado."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "2Y-P4e"
-msgstr "{belt}, nível {level} de 10. Falta {bp} de Poder Mental para o próximo nível."
+msgstr "{belt}, Nível {level} de 10. Faltam {bp} de Poder Mental para o próximo nível."
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "n_mgOm"
-msgstr "Progressão de Faixa"
+msgstr "Progressão de faixas"
 
 #: src/app/(progress)/level/level-progression.tsx
 msgid "ZKbTsS"
@@ -1221,11 +1221,11 @@ msgstr "{value} PM ganhos"
 
 #: src/app/(progress)/level/page.tsx
 msgid "4-USpX"
-msgstr "Acompanhe sua progressão de nível e veja como você avança."
+msgstr "Acompanhe seu progresso de nível e veja como você avança."
 
 #: src/app/(progress)/level/page.tsx
 msgid "L9hqMH"
-msgstr "Acompanhe sua progressão de nível"
+msgstr "Acompanhe seu progresso de nível"
 
 #: src/app/(progress)/score/page.tsx
 msgid "qHWZBu"
@@ -1245,7 +1245,7 @@ msgstr "O que é Pontuação?"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "JA-N5Z"
-msgstr "Pontuação é a porcentagem de perguntas que você respondeu corretamente durante este período."
+msgstr "Pontuação é a porcentagem de perguntas que você respondeu corretamente neste período."
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "z9kvhA"
@@ -1253,7 +1253,7 @@ msgstr "Como melhoro a Pontuação?"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "7_C9do"
-msgstr "Revise os erros e refaça aulas. À medida que você responder mais perguntas corretamente, sua Pontuação aumenta."
+msgstr "Revise erros e refaça aulas. Conforme você responde mais perguntas corretamente, sua Pontuação aumenta."
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "WqH8eP"
@@ -1261,7 +1261,7 @@ msgstr "Por que a Pontuação é importante?"
 
 #: src/app/(progress)/score/score-explanation.tsx
 msgid "E0saoA"
-msgstr "A Pontuação mostra precisão, não atividade. O melhor dia e o melhor horário te ajudam a descobrir quando aprende com mais eficiência."
+msgstr "A Pontuação mostra precisão, não atividade. Melhor dia e melhor horário te ajudam a descobrir quando você aprende melhor."
 
 #: src/app/(settings)/_components/protected-section.tsx
 msgid "yOFm9C"
@@ -1269,11 +1269,11 @@ msgstr "Você precisa estar logado para acessar esta página."
 
 #: src/app/(settings)/language/page.tsx
 msgid "2WHx14"
-msgstr "Atualize o idioma do app para estudar em inglês, português, espanhol, francês ou outros idiomas compatíveis."
+msgstr "Atualize o idioma do app para aprender em inglês, português, espanhol, francês ou outros idiomas disponíveis."
 
 #: src/app/(settings)/language/page.tsx
 msgid "aNLa1G"
-msgstr "Escolha o idioma do app que você prefere para este dispositivo."
+msgstr "Escolha o idioma do app que você prefere neste dispositivo."
 
 #: src/app/(settings)/profile/page.tsx
 msgid "dSVD13"
@@ -1285,7 +1285,7 @@ msgstr "Seu nome e nome de usuário como aparecem para outras pessoas."
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "1SvspN"
-msgstr "Verificando..."
+msgstr "Verificando…"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "9N4_rz"
@@ -1297,7 +1297,7 @@ msgstr "{username} já está em uso"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "vLl7z0"
-msgstr "3-30 caracteres. Apenas letras, números e sublinhados."
+msgstr "De 3 a 30 caracteres. Só letras, números e sublinhados."
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "HAlOn1"
@@ -1309,11 +1309,11 @@ msgstr "Seu perfil foi atualizado com sucesso!"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "VT-G_7"
-msgstr "Esse nome ficará visível para outros usuários."
+msgstr "Este nome vai ficar visível para outros usuários."
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "wYCHCR"
-msgstr "Falha ao atualizar seu perfil. Tente novamente ou entre em contato com contato@zoonk.com"
+msgstr "Não foi possível atualizar seu perfil. Tente de novo ou fale com contato@zoonk.com"
 
 #: src/app/(settings)/profile/profile-form.tsx
 msgid "JCIgkj"
@@ -1333,23 +1333,23 @@ msgstr "Gerenciar no Google Play"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "Tp4wJB"
-msgstr "Esta assinatura é gerenciada pela App Store. Para alterá‑la ou cancelá‑la, use as configurações de assinaturas da Apple."
+msgstr "Esta assinatura é gerenciada pela App Store. Para mudar ou cancelar, use os ajustes de assinatura da Apple."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "unNUPf"
-msgstr "Esta assinatura é gerenciada pelo Google Play. Para alterá‑la ou cancelá‑la, use o Google Play."
+msgstr "Esta assinatura é gerenciada pelo Google Play. Para mudar ou cancelar, use o Google Play."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "P0ZHma"
-msgstr "Esta assinatura é gerenciada pelo Zoonk. Entre em contato com o suporte se precisar de ajuda para alterar ou cancelar."
+msgstr "Esta assinatura é gerenciada pelo Zoonk. Fale com o suporte se precisar de ajuda para mudar ou cancelar."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
 msgid "5CI3KH"
-msgstr "Entrar em contato com o suporte"
+msgstr "Falar com o suporte"
 
 #: src/app/(settings)/subscription/page.tsx
 msgid "TKk9oj"
-msgstr "Compare planos e gerencie sua assinatura do Zoonk. Veja preços, troque de plano ou atualize o faturamento."
+msgstr "Compare planos e gerencie sua assinatura do Zoonk. Veja preços, troque de plano ou atualize a cobrança."
 
 #: src/app/(settings)/subscription/page.tsx
 msgid "NBEnVd"
@@ -1381,7 +1381,7 @@ msgstr "Anual"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "s1ZXI0"
-msgstr "Não foi possível atualizar sua assinatura. Entre em contato pelo email contato@zoonk.com"
+msgstr "Não foi possível atualizar sua assinatura. Fale com a gente em contato@zoonk.com"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 msgid "2EsPdm"
@@ -1418,7 +1418,7 @@ msgstr "Pro"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "9o8O4m"
-msgstr "Sua assinatura terminará em {date}."
+msgstr "Sua assinatura termina em {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
 msgid "vaN1qz"
@@ -1443,7 +1443,7 @@ msgstr "Aulas personalizadas, IA rápida"
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
 msgid "B5MLC7"
-msgstr "Compartilhe feedback, tire dúvidas ou peça ajuda com sua conta e cursos."
+msgstr "Envie feedback, faça perguntas ou receba ajuda com sua conta e cursos."
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "cDAb4a"
@@ -1451,19 +1451,19 @@ msgstr "GitHub Discussions"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "7h49qt"
-msgstr "Conecte-se com a comunidade e tire suas dúvidas"
+msgstr "Converse com a comunidade e receba respostas"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "YdQxfw"
-msgstr "Contatar suporte"
+msgstr "Falar com o suporte"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "dQIo6c"
-msgstr "Envie um e‑mail para contato@zoonk.com"
+msgstr "Envie um email para contato@zoonk.com"
 
 #: src/app/(settings)/support/support-content.tsx
 msgid "l1XTI5"
-msgstr "Siga-nos"
+msgstr "Siga a gente"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 msgid "rCpmYD"
@@ -1486,11 +1486,11 @@ msgstr "Voltar ao capítulo"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 msgid "ZnMcrz"
-msgstr "Desbloqueie o resto do curso"
+msgstr "Desbloquear o resto deste curso"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "A_uNk-"
-msgstr "Crie aulas antes de revisar"
+msgstr "Crie as aulas antes de revisar"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "Qy4EsI"
@@ -1498,7 +1498,7 @@ msgstr "Nada para revisar ainda"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "4w9Y_P"
-msgstr "A revisão será liberada depois que as aulas anteriores deste capítulo forem criadas."
+msgstr "A revisão fica disponível depois que as aulas anteriores deste capítulo forem criadas."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgid "9AOq2-"
@@ -1510,11 +1510,11 @@ msgstr "Criando o capítulo {title}"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "kiZUDf"
-msgstr "Isso normalmente leva cerca de um minuto"
+msgstr "Isso costuma levar cerca de um minuto"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "5c2xtK"
-msgstr "Levando você para seu capítulo..."
+msgstr "Te levando para o seu capítulo…"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
 msgid "45uo73"
@@ -1522,7 +1522,7 @@ msgstr "Suas aulas estão prontas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "gnxL73"
-msgstr "Escolhendo tipos de aula"
+msgstr "Escolhendo os tipos de aula"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
@@ -1532,7 +1532,7 @@ msgstr "Começando"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "SF9AtA"
-msgstr "Preparando aulas"
+msgstr "Preparando as aulas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "L7nQzn"
@@ -1540,52 +1540,52 @@ msgstr "Salvando suas aulas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "Sbsm52"
-msgstr "Verificando como cada aula deve ser ensinada..."
+msgstr "Conferindo como cada aula deve ser ensinada…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "0xCLwv"
-msgstr "Escolhendo o tipo da aula {number}..."
+msgstr "Escolhendo o tipo da aula {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "Vbn5Wz"
-msgstr "Revisando a combinação de aulas..."
+msgstr "Revisando a mistura de aulas…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "5342HA"
-msgstr "Começando..."
+msgstr "Começando…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "nwGJ65"
-msgstr "Explorando seu tema..."
+msgstr "Explorando seu tema…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "VKFa_t"
-msgstr "Mapeando o caminho de aprendizado..."
+msgstr "Montando a trilha de estudo…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "zQWv1_"
-msgstr "Escrevendo a aula {number}..."
+msgstr "Escrevendo a aula {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 msgid "HWSnYS"
-msgstr "Revisando o fluxo até agora..."
+msgstr "Revisando o fluxo até aqui…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "txvxwS"
-msgstr "Salvando seu progresso..."
+msgstr "Salvando seu progresso…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JUr8Er"
-msgstr "Finalizando..."
+msgstr "Finalizando…"
 
 #: src/app/generate/course/[id]/generate-course-start-request-content.tsx
 msgid "rPgekg"
-msgstr "Voltar para a página inicial"
+msgstr "Voltar para o início"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 msgid "15FsdE"
@@ -1603,7 +1603,7 @@ msgstr "Te levando para o seu curso…"
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
 msgid "T2TGxR"
-msgstr "Levando você à sua aula..."
+msgstr "Te levando para a sua aula…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 msgid "u6ROZF"
@@ -1611,7 +1611,7 @@ msgstr "Criando o curso {title}"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 msgid "GJKrUK"
-msgstr "Isso geralmente leva cerca de 2 minutos"
+msgstr "Isso costuma levar cerca de 2 minutos"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "i3JgLB"
@@ -1619,19 +1619,19 @@ msgstr "Categorizando seu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "WOe-OA"
-msgstr "Verificando duplicatas"
+msgstr "Conferindo duplicatas"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Gjutu-"
-msgstr "Criando a imagem da capa"
+msgstr "Criando a imagem de capa"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "SQFyKH"
-msgstr "Encontrando cursos semelhantes"
+msgstr "Encontrando cursos parecidos"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "WZpB8D"
-msgstr "Escrevendo capítulos"
+msgstr "Escrevendo os capítulos"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "vEOpTk"
@@ -1659,115 +1659,115 @@ msgstr "Escrevendo a primeira aula"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "e1myvm"
-msgstr "Escrevendo sua página do curso"
+msgstr "Escrevendo a página do seu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "aev_pt"
-msgstr "Descobrindo as categorias certas..."
+msgstr "Descobrindo as categorias certas…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "EKAN6s"
-msgstr "Adicionando etiquetas ao seu curso..."
+msgstr "Adicionando tags ao seu curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "JJrUOR"
-msgstr "Comparando cursos similares..."
+msgstr "Comparando cursos parecidos…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "uw23V-"
-msgstr "Verificando se este curso já existe..."
+msgstr "Conferindo se este curso já existe…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "qFmZfG"
-msgstr "Evitando cursos duplicados..."
+msgstr "Evitando cursos duplicados…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "lxBtcx"
-msgstr "Desenhando a capa..."
+msgstr "Criando a capa…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "W8n2i3"
-msgstr "Escolhendo o visual certo..."
+msgstr "Escolhendo o visual certo…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "At4rk1"
-msgstr "Dando os retoques finais..."
+msgstr "Dando os toques finais…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "NgONb4"
-msgstr "Buscando tópicos similares..."
+msgstr "Buscando temas relacionados…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Auz1tl"
-msgstr "Procurando nomes alternativos..."
+msgstr "Procurando nomes alternativos…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "Gt_VNO"
-msgstr "Ampliando a busca por cursos..."
+msgstr "Ampliando a busca do curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "AEG3Ol"
-msgstr "Planejando a estrutura do curso..."
+msgstr "Planejando a estrutura do curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "OW9vMd"
-msgstr "Escrevendo o capítulo {number}..."
+msgstr "Escrevendo o capítulo {number}…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "tXkuD8"
-msgstr "Revisando o fluxo geral..."
+msgstr "Revisando o fluxo geral…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "8-bhNP"
-msgstr "Encontrando o melhor gancho inicial..."
+msgstr "Encontrando o melhor começo…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "xrFhkn"
-msgstr "Escrevendo um guia amigável sobre a área..."
+msgstr "Escrevendo um guia amigável sobre o tema…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "c_e4hk"
-msgstr "Deixando o primeiro capítulo fácil de começar..."
+msgstr "Deixando o primeiro capítulo fácil de começar…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "4LsE_n"
-msgstr "Criando a base do curso..."
+msgstr "Criando a base do curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "3hEaI4"
-msgstr "Preparando o espaço de trabalho..."
+msgstr "Preparando o espaço de trabalho…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "7Pw3r5"
-msgstr "Salvando o capítulo de introdução..."
+msgstr "Salvando o capítulo de introdução…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "cc6_Yn"
-msgstr "Preparando as primeiras aulas..."
+msgstr "Preparando as primeiras aulas…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "a7FJJd"
-msgstr "Resumindo o que você vai aprender..."
+msgstr "Resumindo o que você vai aprender…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "9r_4zz"
-msgstr "Escrevendo a visão geral..."
+msgstr "Escrevendo a visão geral…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "QqKzYM"
-msgstr "Escrevendo a primeira aula..."
+msgstr "Escrevendo a primeira aula…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "XxRMuO"
-msgstr "Adicionando exemplos e visuais..."
+msgstr "Adicionando exemplos e imagens…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "kmuvIN"
-msgstr "Preparando a primeira aula..."
+msgstr "Preparando a primeira aula…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "chqN-J"
-msgstr "Definindo por que este curso é útil…"
+msgstr "Mostrando por que este curso é útil…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
 msgid "twf4n2"
@@ -1783,311 +1783,311 @@ msgstr "Criando a aula {title}"
 
 #: src/app/generate/l/[id]/generation-client.tsx
 msgid "3vY0Zu"
-msgstr "Isso geralmente leva 1–2 minutos"
+msgstr "Isso costuma levar de 1 a 2 minutos"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "cVoRCh"
-msgstr "Preparando alternativas..."
+msgstr "Preparando alternativas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "BBwnPG"
-msgstr "Adicionando mais alternativas..."
+msgstr "Adicionando mais alternativas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "4wkMNX"
-msgstr "Preparando as alternativas de resposta..."
+msgstr "Preparando as alternativas de resposta…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "WsjFV2"
-msgstr "Preparando o banco de palavras..."
+msgstr "Preparando o banco de palavras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "6xEJTk"
-msgstr "Criando exercícios práticos..."
+msgstr "Criando exercícios práticos…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "6hjA6_"
-msgstr "Criando exemplos para tentar..."
+msgstr "Criando exemplos para praticar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "KddvJw"
-msgstr "Escrevendo exercícios de preencher lacunas..."
+msgstr "Criando lacunas para preencher…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "C05-tM"
-msgstr "Criando atividades interativas..."
+msgstr "Criando atividades interativas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "JGNN92"
-msgstr "Desenhando uma ilustração..."
+msgstr "Desenhando uma ilustração…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "a08k7g"
-msgstr "Gerando as imagens..."
+msgstr "Gerando as imagens…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "bJVUNz"
-msgstr "Adicionando cor..."
+msgstr "Adicionando um pouco de cor…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "Yoev2R"
-msgstr "Aprimorando os detalhes..."
+msgstr "Ajustando os detalhes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "xBaVAH"
-msgstr "Finalizando a arte..."
+msgstr "Finalizando a arte…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "W2b0tx"
-msgstr "Desenhando a miniatura da aula..."
+msgstr "Planejando a capa da aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "fRAHqN"
-msgstr "Criando a miniatura da aula..."
+msgstr "Criando a capa da aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "elwtxf"
-msgstr "Aprimorando a miniatura da aula..."
+msgstr "Ajustando a capa da aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "uDzgwu"
-msgstr "Escrevendo frases de exemplo..."
+msgstr "Escrevendo frases de exemplo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "SHIHyL"
-msgstr "Criando textos para leitura..."
+msgstr "Criando textos de leitura…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "0Zum4g"
-msgstr "Colocando as palavras em contexto..."
+msgstr "Colocando as palavras em contexto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "jixTNM"
-msgstr "Montando frases naturais..."
+msgstr "Criando frases naturais…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "txIcop"
-msgstr "Carregando dados da aula..."
+msgstr "Carregando os dados da aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "l486Kx"
-msgstr "Verificando o que precisamos..."
+msgstr "Vendo o que a gente precisa…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "EAqAX_"
-msgstr "Pensando no que ilustrar..."
+msgstr "Pensando no que ilustrar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "2Tovpk"
-msgstr "Planejando cada imagem..."
+msgstr "Planejando cada imagem…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "sQsQbH"
-msgstr "Escolhendo as cenas certas..."
+msgstr "Escolhendo as cenas certas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "iUUJom"
-msgstr "Planejando as ilustrações..."
+msgstr "Planejando as ilustrações…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "BszFlm"
-msgstr "Salvando sua aula..."
+msgstr "Salvando sua aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "bC9979"
-msgstr "Quase pronto..."
+msgstr "Quase pronto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "5Jyenk"
-msgstr "Preparando para o próximo passo..."
+msgstr "Preparando o próximo passo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "r8xznK"
-msgstr "Pesquisando o tema..."
+msgstr "Pesquisando o tema…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "K_JznZ"
-msgstr "Escrevendo a explicação..."
+msgstr "Escrevendo a explicação…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "19fPwV"
-msgstr "Deixando claro..."
+msgstr "Deixando tudo claro…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "65JXIy"
-msgstr "Montando a aula..."
+msgstr "Montando a aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "nwi1Ym"
-msgstr "Elaborando o conteúdo..."
+msgstr "Criando o conteúdo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "-QrqeN"
-msgstr "Escrevendo a explicação primeiro..."
+msgstr "Escrevendo a explicação primeiro…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "epxxAx"
-msgstr "Construindo a base..."
+msgstr "Criando a base…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "GyThaR"
-msgstr "Preparando o contexto..."
+msgstr "Preparando o contexto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
 msgid "0AWsLH"
-msgstr "Explicando o tema..."
+msgstr "Explicando o tema…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "KL34l5"
-msgstr "Adicionando romanização para a gramática..."
+msgstr "Adicionando romanização da gramática…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "GILb0l"
-msgstr "Convertendo o texto gramatical para o alfabeto latino..."
+msgstr "Convertendo o texto de gramática para o alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "OFH7dE"
-msgstr "Tornando o conteúdo de gramática mais legível..."
+msgstr "Deixando o conteúdo de gramática mais fácil de ler…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "VADOBa"
-msgstr "Verificando como cada palavra soa..."
+msgstr "Buscando como cada palavra soa…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "WnqJeL"
-msgstr "Mapeando a pronúncia..."
+msgstr "Mapeando a pronúncia…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "HDNFHk"
-msgstr "Verificando como pronunciar cada palavra..."
+msgstr "Verificando como dizer cada palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "_Fl7bm"
-msgstr "Encontrando os sons corretos..."
+msgstr "Encontrando os sons certos…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "DLZ9fl"
-msgstr "Convertendo para o alfabeto latino..."
+msgstr "Convertendo para o alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "boocfl"
-msgstr "Adicionando ajudas de leitura..."
+msgstr "Adicionando ajuda de leitura…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "AQMVYX"
-msgstr "Tornando mais fácil de ler..."
+msgstr "Deixando mais fácil de ler…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "ud2yWh"
-msgstr "Escrevendo os sons..."
+msgstr "Escrevendo os sons…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "kxBeWt"
-msgstr "Adicionando romanização para o vocabulário..."
+msgstr "Adicionando romanização do vocabulário…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "Ch9BcP"
-msgstr "Convertendo o vocabulário para o alfabeto latino..."
+msgstr "Convertendo o vocabulário para o alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "1aPaHZ"
-msgstr "Tornando o vocabulário mais legível..."
+msgstr "Deixando o vocabulário mais fácil de ler…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "zYx0UG"
-msgstr "Adicionando pronúncia para cada palavra..."
+msgstr "Adicionando pronúncia de cada palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "VQ3-C2"
-msgstr "Anotando como cada palavra soa..."
+msgstr "Anotando como cada palavra soa…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "YWB-K_"
-msgstr "Detalhando os sons das palavras..."
+msgstr "Detalhando os sons das palavras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "L6f1Zq"
-msgstr "Registrando informações de pronúncia..."
+msgstr "Registrando informações de pronúncia…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "i-rNdh"
-msgstr "Selecionando o vocabulário principal..."
+msgstr "Escolhendo o vocabulário principal…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "IdWf9_"
-msgstr "Escolhendo palavras para praticar..."
+msgstr "Escolhendo palavras para praticar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "UFDKHM"
-msgstr "Buscando as palavras mais úteis..."
+msgstr "Encontrando as palavras mais úteis…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "YgG70c"
-msgstr "Selecionando termos importantes..."
+msgstr "Selecionando termos importantes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "6BQo6o"
-msgstr "Traduzindo palavras individuais..."
+msgstr "Traduzindo palavras individuais…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "k0Q_Ph"
-msgstr "Consultando cada termo..."
+msgstr "Buscando cada termo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "hZLCkp"
-msgstr "Buscando os significados das palavras..."
+msgstr "Encontrando significados das palavras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "SC0o7J"
-msgstr "Montando o guia de vocabulário..."
+msgstr "Criando o guia de vocabulário…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "5InW8H"
-msgstr "Gravando o áudio..."
+msgstr "Gravando o áudio…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "4xvh9e"
-msgstr "Ajustando a pronúncia..."
+msgstr "Acertando a pronúncia…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "oB01Wc"
-msgstr "Preparando a voz..."
+msgstr "Preparando a voz…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "ScA7Xm"
-msgstr "Fazendo soar natural..."
+msgstr "Deixando o som natural…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "1vO-bV"
-msgstr "Gravando áudio do vocabulário..."
+msgstr "Gravando o áudio do vocabulário…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "jV2zI1"
-msgstr "Captando o som de cada palavra..."
+msgstr "Criando o som de cada palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "FahI7K"
-msgstr "Preparando o áudio do vocabulário..."
+msgstr "Preparando o áudio do vocabulário…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "JfNFGM"
-msgstr "Deixando as palavras audíveis..."
+msgstr "Deixando as palavras prontas para ouvir…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "muXaEm"
-msgstr "Gravando a pronúncia de cada palavra..."
+msgstr "Gravando a pronúncia de cada palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "QDv0wS"
-msgstr "Obtendo o áudio de cada termo..."
+msgstr "Criando o áudio de cada termo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "OJkDgV"
-msgstr "Preparando áudio palavra por palavra..."
+msgstr "Preparando áudio palavra por palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
 msgid "C2ELVi"
-msgstr "Deixando cada palavra audível..."
+msgstr "Deixando cada palavra pronta para ouvir…"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "58heST"
@@ -2135,11 +2135,11 @@ msgstr "Criando frases"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "0zeST_"
-msgstr "Consultando palavras"
+msgstr "Buscando palavras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "v7HGj3"
-msgstr "Planejando as imagens"
+msgstr "Planejando imagens"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
 msgid "T00GEW"
@@ -2171,19 +2171,19 @@ msgstr "Criando conteúdo"
 
 #: src/app/privacy/page.tsx
 msgid "afKQHy"
-msgstr "Leia a Política de Privacidade do Zoonk para entender como usamos e protegemos suas informações pessoais."
+msgstr "Leia a política de privacidade do Zoonk para entender como a gente usa e protege suas informações pessoais."
 
 #: src/app/privacy/page.tsx
 msgid "vx0nkZ"
-msgstr "Política de Privacidade"
+msgstr "Política de privacidade"
 
 #: src/app/terms/page.tsx
 msgid "DaGtoz"
-msgstr "Leia os termos de uso do Zoonk para entender as regras e condições de uso da nossa plataforma e serviços"
+msgstr "Leia os termos de uso do Zoonk para entender as regras e condições para usar nossa plataforma e serviços"
 
 #: src/app/terms/page.tsx
 msgid "UhkSyx"
-msgstr "Termos de Uso"
+msgstr "Termos de uso"
 
 #: src/components/catalog/ai-warning.tsx
 msgid "FYZlTZ"
@@ -2191,7 +2191,7 @@ msgstr "Criado com IA"
 
 #: src/components/catalog/catalog-actions.tsx
 msgid "F0tnKc"
-msgstr "Obrigado pelo feedback"
+msgstr "Valeu pelo feedback"
 
 #: src/components/catalog/catalog-actions.tsx
 msgid "IzCVhG"
@@ -2230,7 +2230,7 @@ msgstr "Voltar ao topo"
 
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "AvySqa"
-msgstr "{percent}% concluído"
+msgstr "{percent}% completo"
 
 #: src/components/catalog/continue-lesson-link.tsx
 msgid "mOFG3K"
@@ -2243,7 +2243,7 @@ msgstr "Revisar"
 
 #: src/components/feedback/contact-form.tsx
 msgid "WzCvaN"
-msgstr "Usaremos este e-mail para entrar em contato com você."
+msgstr "A gente vai usar este email para falar com você."
 
 #: src/components/feedback/contact-form.tsx
 msgid "T7Ry38"
@@ -2251,19 +2251,19 @@ msgstr "Mensagem"
 
 #: src/components/feedback/contact-form.tsx
 msgid "M6PcEI"
-msgstr "Como podemos ajudar você?"
+msgstr "Como a gente pode te ajudar?"
 
 #: src/components/feedback/contact-form.tsx
 msgid "vD72E5"
-msgstr "Mensagem enviada com sucesso! Entraremos em contato em breve."
+msgstr "Mensagem enviada! A gente vai responder em breve."
 
 #: src/components/feedback/contact-form.tsx
 msgid "-5vOOu"
-msgstr "Descreva com o máximo de detalhes possível."
+msgstr "Dê o máximo de detalhes que puder."
 
 #: src/components/feedback/contact-form.tsx
 msgid "1WHPmV"
-msgstr "Não foi possível enviar a mensagem. Tente novamente ou envie um e-mail diretamente para contato@zoonk.com"
+msgstr "Não foi possível enviar a mensagem. Tente de novo ou fale com a gente direto pelo email contato@zoonk.com"
 
 #: src/components/feedback/contact-form.tsx
 msgid "Xx0WZV"
@@ -2279,15 +2279,15 @@ msgstr "Feedback"
 
 #: src/components/feedback/feedback-dialog.tsx
 msgid "eUzs3M"
-msgstr "Envie feedback, perguntas ou sugestões para a gente. Preencha o formulário abaixo ou mande um e-mail diretamente para contato@zoonk.com."
+msgstr "Envie feedback, perguntas ou sugestões. Preencha o formulário abaixo ou fale com a gente direto pelo email contato@zoonk.com."
 
 #: src/components/generation/workflow-generation-error.tsx
 msgid "ctqXbT"
-msgstr "A conexão de progresso foi perdida. Seu conteúdo pode ainda estar sendo criado."
+msgstr "A conexão do progresso caiu. Seu conteúdo ainda pode estar sendo gerado."
 
 #: src/components/generation/workflow-generation-error.tsx
 msgid "1A8Z_l"
-msgstr "Verificar novamente"
+msgstr "Verificar de novo"
 
 #: src/components/generation/workflow-generation-error.tsx
 msgid "yHqv96"
@@ -2327,7 +2327,7 @@ msgstr "Tempo de estudo"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "IS_YjO"
-msgstr "Assine para criar"
+msgstr "Faça upgrade para criar"
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "ZMU6iN"
@@ -2335,7 +2335,7 @@ msgstr "Você atingiu o limite de aulas grátis. Faça upgrade para ter aulas il
 
 #: src/components/subscription/upgrade-cta.tsx
 msgid "0h_lPM"
-msgstr "Assinar"
+msgstr "Fazer upgrade"
 
 #: src/lib/belt-colors.ts
 msgid "znY9eW"
@@ -2435,7 +2435,7 @@ msgstr "Tutorial"
 
 #: src/lib/lessons.ts
 msgid "22k1CY"
-msgstr "Aprenda como letras e sons funcionam nesse sistema de escrita."
+msgstr "Aprenda como as letras e sons funcionam neste sistema de escrita."
 
 #: src/lib/lessons.ts
 msgid "LZC7R9"
@@ -2447,19 +2447,19 @@ msgstr "Entenda as ideias principais com linguagem simples e exemplos práticos.
 
 #: src/lib/lessons.ts
 msgid "dHmgw1"
-msgstr "Pratique padrões gramaticais com exemplos e exercícios."
+msgstr "Pratique padrões de gramática com exemplos e exercícios."
 
 #: src/lib/lessons.ts
 msgid "AetsPy"
-msgstr "Ouça frases com palavras que você aprendeu recentemente."
+msgstr "Escute frases com palavras que você aprendeu recentemente."
 
 #: src/lib/lessons.ts
 msgid "6oNgY9"
-msgstr "Use o que aprendeu na aula anterior para resolver problemas do mundo real."
+msgstr "Use o que você aprendeu na aula anterior para resolver problemas do mundo real."
 
 #: src/lib/lessons.ts
 msgid "vO6aLm"
-msgstr "Confira o que entendeu com um quiz curto."
+msgstr "Confira o que você entendeu com um quiz curto."
 
 #: src/lib/lessons.ts
 msgid "OIim7M"
@@ -2467,7 +2467,7 @@ msgstr "Leia frases com palavras que você aprendeu recentemente."
 
 #: src/lib/lessons.ts
 msgid "pwrprO"
-msgstr "Revise este capítulo com exercícios baseados nos seus erros."
+msgstr "Revise este capítulo com prática baseada nos seus erros."
 
 #: src/lib/lessons.ts
 msgid "IQOJhk"
@@ -2479,7 +2479,7 @@ msgstr "Siga um tutorial guiado passo a passo."
 
 #: src/lib/lessons.ts
 msgid "IHSVS5"
-msgstr "Aprenda palavras novas e pratique usá-las."
+msgstr "Aprenda palavras novas e pratique usando elas."
 
 #: src/lib/lessons.ts
 msgid "OjyuQ-"
@@ -2487,35 +2487,35 @@ msgstr "Aprenda o sistema de escrita de {topic} com prática focada."
 
 #: src/lib/lessons.ts
 msgid "pSQZ7W"
-msgstr "Aprenda sobre {topic} por meio de uma aula interativa."
+msgstr "Aprenda sobre {topic} com uma aula interativa."
 
 #: src/lib/lessons.ts
 msgid "THPcKi"
-msgstr "Entenda o que é {topic} — conceitos centrais e definições explicados com metáforas e analogias claras."
+msgstr "Entenda o que é {topic}: conceitos principais e definições explicados com metáforas e analogias claras."
 
 #: src/lib/lessons.ts
 msgid "tlgfSZ"
-msgstr "Pratique as regras gramaticais de {topic} com exercícios feitos para ajudar você a lembrar e aplicar."
+msgstr "Pratique as regras de gramática de {topic} com exercícios feitos para te ajudar a lembrar e usar elas."
 
 #: src/lib/lessons.ts
 msgid "xCvEE1"
-msgstr "Pratique a escuta em {topic} traduzindo frases em áudio."
+msgstr "Pratique escuta em {topic} traduzindo frases em áudio."
 
 #: src/lib/lessons.ts
 msgid "wHBT6R"
-msgstr "Aplique {topic} em um problema visual do mundo real com decisões rápidas."
+msgstr "Aplique {topic} em um problema visual do mundo real com decisões curtas."
 
 #: src/lib/lessons.ts
 msgid "h2acN8"
-msgstr "Teste seu entendimento de {topic} com perguntas feitas para checar compreensão real, não só memorização."
+msgstr "Teste seu entendimento sobre {topic} com perguntas feitas para checar se você entendeu de verdade, não só memorizou."
 
 #: src/lib/lessons.ts
 msgid "XzxpBZ"
-msgstr "Melhore sua compreensão de leitura de {topic} traduzindo frases e trechos."
+msgstr "Melhore sua compreensão de leitura em {topic} traduzindo frases e trechos."
 
 #: src/lib/lessons.ts
 msgid "bzFQEy"
-msgstr "Revise tudo o que aprendeu sobre {topic} com um quiz abrangente."
+msgstr "Revise tudo que você aprendeu sobre {topic} com um quiz completo."
 
 #: src/lib/lessons.ts
 msgid "X8Gqiq"
@@ -2527,7 +2527,7 @@ msgstr "Aprenda {topic} com um tutorial guiado passo a passo."
 
 #: src/lib/lessons.ts
 msgid "77SLH5"
-msgstr "Aprenda novas palavras em {topic} com flashcards — veja cada palavra, sua tradução e pronúncia."
+msgstr "Aprenda palavras novas em {topic} com flashcards — veja cada palavra, a tradução e a pronúncia."
 
 #: src/lib/lessons.ts
 msgid "oCxmX9"

--- a/packages/i18n/.eloqnt/styleguide.pt.md
+++ b/packages/i18n/.eloqnt/styleguide.pt.md
@@ -38,3 +38,4 @@
 - For belt colors, use feminine forms. For example, "White Belt" = "Faixa Branca", "Yellow Belt" = "Faixa Amarela", etc. If it's color alone in the context of belts, use "Yellow" = "Amarela", "White" = "Branca", etc.
 - Don't use "{verb} você". Instead, use "te {verb}". For example, instead of "We help you learn", use "A gente te ajuda a aprender".
 - When "path" is used in the context of a learning path, use "trilha". For example, "The path starts with the basics" = "A trilha começa com o básico", not "O caminho começa com o básico".
+- Don't repeat articles and pronoums unnecessarily. For example, instead of "nossos termos de uso e nossa política de privacidade", use "nossos termos de uso e política de privacidade"; instead of "um nome e um email", use "um nome e email"; etc.

--- a/packages/i18n/.eloqnt/styleguide.pt.md
+++ b/packages/i18n/.eloqnt/styleguide.pt.md
@@ -38,4 +38,4 @@
 - For belt colors, use feminine forms. For example, "White Belt" = "Faixa Branca", "Yellow Belt" = "Faixa Amarela", etc. If it's color alone in the context of belts, use "Yellow" = "Amarela", "White" = "Branca", etc.
 - Don't use "{verb} você". Instead, use "te {verb}". For example, instead of "We help you learn", use "A gente te ajuda a aprender".
 - When "path" is used in the context of a learning path, use "trilha". For example, "The path starts with the basics" = "A trilha começa com o básico", not "O caminho começa com o básico".
-- Don't repeat articles and pronoums unnecessarily. For example, instead of "nossos termos de uso e nossa política de privacidade", use "nossos termos de uso e política de privacidade"; instead of "um nome e um email", use "um nome e email"; etc.
+- Don't repeat articles and pronouns unnecessarily. For example, instead of "nossos termos de uso e nossa política de privacidade", use "nossos termos de uso e política de privacidade"; instead of "um nome e um email", use "um nome e email"; etc.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -9,7 +9,8 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@eloqnt/cli": "catalog:"
+    "@eloqnt/cli": "catalog:",
+    "ai-sdk-provider-codex-cli": "1.2.2"
   },
   "devDependencies": {
     "@typescript/native-preview": "catalog:",

--- a/packages/i18n/src/define-eloqnt-config.ts
+++ b/packages/i18n/src/define-eloqnt-config.ts
@@ -1,7 +1,17 @@
 import { defineConfig } from "@eloqnt/cli";
+import { codexCli } from "ai-sdk-provider-codex-cli";
 
 // Can be extended as necessary
 type EloqntProjectOptions = { srcPath?: string | string[] };
+
+/**
+ * Points Eloqnt at a Codex CLI installed outside this repo.
+ * This avoids running the optional Codex binary that the provider can install
+ * under node_modules while still letting each developer choose a trusted CLI path.
+ */
+function getCodexPath() {
+  return process.env.CODEX_PATH ?? "codex";
+}
 
 /**
  * Shares configuration for consumers while allowing local overrides.
@@ -10,6 +20,7 @@ type EloqntProjectOptions = { srcPath?: string | string[] };
 export default function defineEloqntConfig(options: EloqntProjectOptions = {}) {
   return defineConfig({
     messages: { format: "po", locales: "infer", path: "./messages", sourceLocale: "en" },
+    model: codexCli("gpt-5.5", { codexPath: getCodexPath() }),
     srcPath: options.srcPath ?? "./src",
   });
 }

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -69,35 +69,35 @@ msgstr "Nuevo récord diario"
 
 #: src/components/completion-brain-power-milestone.tsx
 msgid "VaM8Q9"
-msgstr "Alcanzaste {brainPower} PM hoy, tu mayor Poder Mental en un día. Sigue aprendiendo cada día para superar ese récord."
+msgstr "Hoy alcanzaste {brainPower} PM, tu mayor Poder Mental en un solo día. Sigue estudiando cada día para marcar un nuevo récord."
 
 #: src/components/completion-energy-milestone.tsx
 msgid "m2WzLQ"
-msgstr "¡Energía máxima!"
+msgstr "¡Energía al máximo!"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "Fo6YtA"
-msgstr "¡Felicidades! Has alcanzado la Energía máxima. Practica todos los días para mantener tu Energía al 100%."
+msgstr "¡Felicidades! Alcanzaste el máximo de Energía. Sigue practicando cada día para mantener tu Energía al 100 %."
 
 #: src/components/completion-energy-milestone.tsx
 msgid "J89SkG"
-msgstr "{percentage} Energía"
+msgstr "{percentage} de Energía"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "3Jd-mJ"
-msgstr "Tu esfuerzo está dando frutos. Completa lecciones todos los días para aumentar tu Energía."
+msgstr "Tu esfuerzo está dando resultado. Completa lecciones cada día para aumentar tu Energía."
 
 #: src/components/completion-energy-milestone.tsx
 msgid "5YVYKd"
-msgstr "1 año con Energía máxima"
+msgstr "1 año de Energía al máximo"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "1WNk4i"
-msgstr "{days} días con Energía máxima"
+msgstr "{days} días de Energía al máximo"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "cIxpmv"
-msgstr "¡Vaya, qué constancia increíble! Sigue estudiando todos los días para mantener tu Energía al 100%."
+msgstr "¡Guau, qué constancia tan increíble! Sigue estudiando cada día para mantener tu Energía al 100 %."
 
 #: src/components/completion-learning-days-milestone.tsx
 msgid "SIXtG5"
@@ -105,7 +105,7 @@ msgstr "{days} días de estudio"
 
 #: src/components/completion-learning-days-milestone.tsx
 msgid "hjXoGI"
-msgstr "Has completado lecciones en {days} días distintos. Practicar a menudo te ayuda a recordar lo que aprendes."
+msgstr "Completaste lecciones en {days} días diferentes. Practicar a menudo te ayuda a recordar lo que aprendes."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgid "dZvEPp"
@@ -141,15 +141,15 @@ msgstr "Alcanzaste un nuevo nivel: {belt}, nivel {level}. ¡Felicidades!"
 
 #: src/components/completion-level-milestone.tsx
 msgid "Bk6B6r"
-msgstr "Casi lo consigues"
+msgstr "Ya casi"
 
 #: src/components/completion-level-milestone.tsx
 msgid "b7ZoLo"
-msgstr "Tu conocimiento está creciendo. Completa {count, plural, one {# lección más} other {# lecciones más}} para alcanzar {belt}, nivel {level}."
+msgstr "Tu conocimiento está creciendo. Completa {count, plural, one {# lección más} other {# lecciones más}} para llegar a {belt}, nivel {level}."
 
 #: src/components/completion-milestone-actions.tsx
 msgid "DiIkZH"
-msgstr "Siguiente capítulo"
+msgstr "Capítulo siguiente"
 
 #: src/components/completion-milestone-actions.tsx
 msgid "w0D7HC"
@@ -161,11 +161,11 @@ msgstr "Repasar capítulo"
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgid "iSioEh"
-msgstr "Aprende sobre la Energía"
+msgstr "Aprende sobre Energía"
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgid "DC0WoT"
-msgstr "Aprende sobre Score"
+msgstr "Aprende sobre la puntuación"
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgid "Q0R3MU"
@@ -182,7 +182,7 @@ msgstr "{day} es tu mejor día"
 
 #: src/components/completion-score-milestone.tsx
 msgid "PTQ0ah"
-msgstr "Sueles acertar el {percentage} de las respuestas en {day}, tu mejor promedio de la semana."
+msgstr "Sueles acertar el {percentage} de las respuestas los {day}, tu promedio más alto de la semana."
 
 #: src/components/completion-screen.tsx
 msgid "95stPq"
@@ -207,7 +207,7 @@ msgstr "Progreso del capítulo"
 
 #: src/components/completion-screen.tsx
 msgid "P768k7"
-msgstr "correcto"
+msgstr "correctas"
 
 #: src/components/feedback-answer-blocks.tsx
 msgid "3nOd8f"
@@ -224,7 +224,7 @@ msgstr "Pregunta"
 
 #: src/components/feedback-screen.tsx
 msgid "fpO9TK"
-msgstr "Traducir:"
+msgstr "Traduce:"
 
 #: src/components/fill-blank-step.tsx
 msgid "SL2Bob"
@@ -240,28 +240,28 @@ msgstr "Espacio {position}"
 
 #: src/components/inline-feedback.tsx
 msgid "HvLGEN"
-msgstr "Comentarios de la respuesta"
+msgstr "Comentarios sobre la respuesta"
 
 #: src/components/lesson-info-popover.tsx
 msgid "RwePAQ"
-msgstr "Info de la lección"
+msgstr "Información de la lección"
 
 #: src/components/listening-step.tsx
 msgid "aAmWaS"
-msgstr "¿Qué oyes?"
+msgstr "¿Qué escuchas?"
 
 #: src/components/listening-step.tsx
 #: src/components/reading-step.tsx
 msgid "19nXyC"
-msgstr "Traduce esta frase:"
+msgstr "Traduce esta oración:"
 
 #: src/components/match-columns-step.tsx
 msgid "fV1MzK"
-msgstr "Empareja los pares."
+msgstr "Une las parejas."
 
 #: src/components/match-columns-step.tsx
 msgid "ja1JDt"
-msgstr "Todas las parejas emparejadas. Pulsa Comprobar para continuar."
+msgstr "Todas las parejas están unidas. Pulsa Revisar para continuar."
 
 #: src/components/play-audio-button.tsx
 msgid "WGft2H"
@@ -314,7 +314,7 @@ msgstr "Arrastra los elementos al orden correcto"
 
 #: src/components/step-action-button.tsx
 msgid "RDZVQL"
-msgstr "Comprobar"
+msgstr "Revisar"
 
 #: src/components/step-navigation-button-group.tsx
 msgid "JJNc3c"
@@ -342,19 +342,19 @@ msgstr "Continuar sin guardar"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "O781mu"
-msgstr "El progreso no se guardará"
+msgstr "No se guardará el progreso"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "JDumQX"
-msgstr "Puedes probar esta lección sin una cuenta, pero tu puntuación, el progreso del curso, los niveles y la Energía no se guardarán."
+msgstr "Puedes probar esta lección sin una cuenta, pero no se guardarán tu puntuación, el progreso del curso, los niveles ni la Energía."
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "rxdOwg"
-msgstr "Esta lección no se guardó."
+msgstr "Esta lección no se guardó"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "Wamgyz"
-msgstr "Inicia sesión antes de tu próxima lección para conservar el progreso, las puntuaciones, los niveles y la Energía."
+msgstr "Inicia sesión antes de tu próxima lección para conservar tu progreso, puntuaciones, niveles y Energía en el futuro."
 
 #: src/components/verdict-label.tsx
 msgid "xmF49T"
@@ -362,7 +362,7 @@ msgstr "¡Correcto!"
 
 #: src/components/verdict-label.tsx
 msgid "--l7ni"
-msgstr "No del todo"
+msgstr "Casi"
 
 #: src/components/vocabulary-step.tsx
 msgid "lqtP-R"
@@ -370,4 +370,4 @@ msgstr "Vocabulario"
 
 #: src/use-belt-label.ts
 msgid "znY9eW"
-msgstr "{color, select, white {Cinturón Blanco} yellow {Cinturón Amarillo} orange {Cinturón Naranja} green {Cinturón Verde} blue {Cinturón Azul} purple {Cinturón Morado} brown {Cinturón Marrón} red {Cinturón Rojo} gray {Cinturón Gris} black {Cinturón Negro} other {Cinturón}}"
+msgstr "{color, select, white {Cinturón blanco} yellow {Cinturón amarillo} orange {Cinturón naranja} green {Cinturón verde} blue {Cinturón azul} purple {Cinturón morado} brown {Cinturón marrón} red {Cinturón rojo} gray {Cinturón gris} black {Cinturón negro} other {Cinturón}}"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -14,13 +14,13 @@ msgstr "Alphabet"
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
 msgid "6NoIUl"
-msgstr "Correcte"
+msgstr "Correct"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
 msgid "Ypr9T5"
-msgstr "Incorrecte"
+msgstr "Incorrect"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/sort-order-step.tsx
@@ -29,7 +29,7 @@ msgstr "{item}. {result}."
 
 #: src/components/arrange-words-answer-area.tsx
 msgid "vPyO9S"
-msgstr "Position {position} : {item}. Tape pour enlever."
+msgstr "Position {position} : {item}. Appuie pour retirer."
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/select-image-step.tsx
@@ -38,7 +38,7 @@ msgstr "Ta réponse"
 
 #: src/components/arrange-words-answer-area.tsx
 msgid "7R_rOB"
-msgstr "Tape les mots pour construire ta réponse"
+msgstr "Appuie sur les mots pour construire ta réponse"
 
 #: src/components/arrange-words.tsx
 #: src/components/fill-blank-word-bank.tsx
@@ -65,19 +65,19 @@ msgstr "Se connecter"
 
 #: src/components/completion-brain-power-milestone.tsx
 msgid "fS3hB9"
-msgstr "Nouveau record quotidien"
+msgstr "Nouveau record du jour"
 
 #: src/components/completion-brain-power-milestone.tsx
 msgid "VaM8Q9"
-msgstr "Tu as atteint {brainPower} PM aujourd’hui, ton record de Puissance Mentale sur une journée. Continue d’apprendre chaque jour pour battre ce record."
+msgstr "Tu as atteint {brainPower} PM aujourd’hui, ta plus grande Puissance Mentale en une seule journée. Continue à apprendre chaque jour pour battre ton record."
 
 #: src/components/completion-energy-milestone.tsx
 msgid "m2WzLQ"
-msgstr "Énergie maximale !"
+msgstr "Énergie au max !"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "Fo6YtA"
-msgstr "Bravo ! Tu as atteint l’Énergie max. Pratique chaque jour pour garder ton Énergie à 100 %."
+msgstr "Bravo ! Tu as atteint le maximum d’Énergie. Continue à t’entraîner chaque jour pour garder ton Énergie à 100 %."
 
 #: src/components/completion-energy-milestone.tsx
 msgid "J89SkG"
@@ -85,19 +85,19 @@ msgstr "{percentage} Énergie"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "3Jd-mJ"
-msgstr "Ton effort paie. Fais des leçons tous les jours pour augmenter ton Énergie."
+msgstr "Tes efforts paient. Termine des leçons chaque jour pour augmenter ton Énergie."
 
 #: src/components/completion-energy-milestone.tsx
 msgid "5YVYKd"
-msgstr "1 an d’Énergie max"
+msgstr "1 an d’Énergie au max"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "1WNk4i"
-msgstr "{days} jours d’Énergie max"
+msgstr "{days} jours d’Énergie au max"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "cIxpmv"
-msgstr "Wow, quelle régularité ! Continue d’étudier chaque jour pour garder ton Énergie à 100 %."
+msgstr "Waouh, quelle régularité incroyable ! Continue à étudier chaque jour pour garder ton Énergie à 100 %."
 
 #: src/components/completion-learning-days-milestone.tsx
 msgid "SIXtG5"
@@ -105,7 +105,7 @@ msgstr "{days} jours d’apprentissage"
 
 #: src/components/completion-learning-days-milestone.tsx
 msgid "hjXoGI"
-msgstr "Tu as terminé des leçons sur {days} jours différents. S’entraîner souvent t’aide à retenir ce que tu apprends."
+msgstr "Tu as terminé des leçons sur {days} jours différents. T’entraîner souvent t’aide à retenir ce que tu apprends."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgid "dZvEPp"
@@ -113,7 +113,7 @@ msgstr "{minutes} minutes d’apprentissage"
 
 #: src/components/completion-learning-time-milestone.tsx
 msgid "kw1W3C"
-msgstr "1 journée entière d’apprentissage"
+msgstr "1 journée complète d’apprentissage"
 
 #: src/components/completion-learning-time-milestone.tsx
 msgid "BlVoPr"
@@ -125,11 +125,11 @@ msgstr "Tu peux apprendre beaucoup en t’entraînant quelques minutes par jour.
 
 #: src/components/completion-learning-time-milestone.tsx
 msgid "LzEQnT"
-msgstr "Ça fait une journée entière de pratique concentrée."
+msgstr "C’est une journée complète d’entraînement concentré."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgid "PpK3hX"
-msgstr "Ça fait plus de {days, plural, one {# journée entière} other {# journées entières}} de pratique concentrée."
+msgstr "C’est plus de {days, plural, one {# journée complète} other {# journées complètes}} d’entraînement concentré."
 
 #: src/components/completion-level-milestone.tsx
 msgid "155cHi"
@@ -137,15 +137,15 @@ msgstr "Niveau atteint"
 
 #: src/components/completion-level-milestone.tsx
 msgid "Ar7dNY"
-msgstr "Tu as atteint un nouveau niveau : {belt}, niveau {level}. Félicitations !"
+msgstr "Tu as atteint un nouveau niveau : {belt}, niveau {level}. Bravo !"
 
 #: src/components/completion-level-milestone.tsx
 msgid "Bk6B6r"
-msgstr "Presque là"
+msgstr "Presque"
 
 #: src/components/completion-level-milestone.tsx
 msgid "b7ZoLo"
-msgstr "Ta connaissance grandit. Termine {count, plural, one {encore # leçon} other {encore # leçons}} pour atteindre {belt}, niveau {level}."
+msgstr "Tes connaissances progressent. Termine encore {count, plural, one {# leçon} other {# leçons}} pour atteindre {belt}, niveau {level}."
 
 #: src/components/completion-milestone-actions.tsx
 msgid "DiIkZH"
@@ -153,23 +153,23 @@ msgstr "Chapitre suivant"
 
 #: src/components/completion-milestone-actions.tsx
 msgid "w0D7HC"
-msgstr "Revoir le cours"
+msgstr "Réviser le cours"
 
 #: src/components/completion-milestone-actions.tsx
 msgid "wm_M34"
-msgstr "Revoir le chapitre"
+msgstr "Réviser le chapitre"
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgid "iSioEh"
-msgstr "En savoir plus sur l’Énergie"
+msgstr "Découvrir l’Énergie"
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgid "DC0WoT"
-msgstr "En savoir plus sur Score"
+msgstr "Découvrir le score"
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgid "Q0R3MU"
-msgstr "En savoir plus sur les niveaux"
+msgstr "Découvrir les niveaux"
 
 #: src/components/completion-progress-milestone-screen.tsx
 #: src/components/step-action-button.tsx
@@ -178,11 +178,11 @@ msgstr "Continuer"
 
 #: src/components/completion-score-milestone.tsx
 msgid "e6_3Ke"
-msgstr "Le {day} est ton meilleur jour"
+msgstr "{day} est ton meilleur jour"
 
 #: src/components/completion-score-milestone.tsx
 msgid "PTQ0ah"
-msgstr "Tu réponds juste à {percentage} des questions en général le {day}, ta meilleure moyenne de la semaine."
+msgstr "Tu obtiens généralement {percentage} de bonnes réponses le {day}, ta meilleure moyenne de la semaine."
 
 #: src/components/completion-screen.tsx
 msgid "95stPq"
@@ -207,7 +207,7 @@ msgstr "Progression du chapitre"
 
 #: src/components/completion-screen.tsx
 msgid "P768k7"
-msgstr "correcte"
+msgstr "correctes"
 
 #: src/components/feedback-answer-blocks.tsx
 msgid "3nOd8f"
@@ -216,7 +216,7 @@ msgstr "Ta réponse :"
 #: src/components/feedback-answer-blocks.tsx
 #: src/components/inline-feedback.tsx
 msgid "QAJ_Tl"
-msgstr "Réponse correcte :"
+msgstr "Bonne réponse :"
 
 #: src/components/feedback-screen.tsx
 msgid "kgOBET"
@@ -224,19 +224,19 @@ msgstr "Question"
 
 #: src/components/feedback-screen.tsx
 msgid "fpO9TK"
-msgstr "Traduire :"
+msgstr "Traduis :"
 
 #: src/components/fill-blank-step.tsx
 msgid "SL2Bob"
-msgstr "Vide {position} : {item}. {result}."
+msgstr "Case {position} : {item}. {result}."
 
 #: src/components/fill-blank-step.tsx
 msgid "wUEGVH"
-msgstr "Vide {position} : {item}. Tape pour enlever."
+msgstr "Case {position} : {item}. Appuie pour retirer."
 
 #: src/components/fill-blank-step.tsx
 msgid "FmmJ_j"
-msgstr "Vide {position}"
+msgstr "Case {position}"
 
 #: src/components/inline-feedback.tsx
 msgid "HvLGEN"
@@ -248,12 +248,12 @@ msgstr "Infos sur la leçon"
 
 #: src/components/listening-step.tsx
 msgid "aAmWaS"
-msgstr "Qu’entends-tu ?"
+msgstr "Qu’est-ce que tu entends ?"
 
 #: src/components/listening-step.tsx
 #: src/components/reading-step.tsx
 msgid "19nXyC"
-msgstr "Traduis cette phrase :"
+msgstr "Traduis cette phrase :"
 
 #: src/components/match-columns-step.tsx
 msgid "fV1MzK"
@@ -273,7 +273,7 @@ msgstr "Écouter la prononciation"
 
 #: src/components/player-choice-scene.tsx
 msgid "akd-cv"
-msgstr "Options de réponse"
+msgstr "Choix de réponse"
 
 #: src/components/player-header.tsx
 msgid "rbrahO"
@@ -290,7 +290,7 @@ msgstr "Contenu de la leçon"
 #: src/components/player-shell.tsx
 #: src/components/swipe-navigable-step-layout.tsx
 msgid "41rDiT"
-msgstr "Contrôles de la leçon"
+msgstr "Commandes de la leçon"
 
 #: src/components/select-image-step.tsx
 msgid "mhiTW7"
@@ -298,7 +298,7 @@ msgstr "Bonne réponse"
 
 #: src/components/select-image-step.tsx
 msgid "NA6C_-"
-msgstr "Options d'image"
+msgstr "Choix d’images"
 
 #: src/components/sort-order-step.tsx
 msgid "p5llOK"
@@ -306,11 +306,11 @@ msgstr "Trier les éléments"
 
 #: src/components/sort-order-step.tsx
 msgid "VA8c_A"
-msgstr "Ordre correct :"
+msgstr "Bon ordre :"
 
 #: src/components/sort-order-step.tsx
 msgid "9lc1oV"
-msgstr "Fais glisser les éléments dans l'ordre correct"
+msgstr "Fais glisser les éléments dans le bon ordre"
 
 #: src/components/step-action-button.tsx
 msgid "RDZVQL"
@@ -334,7 +334,7 @@ msgstr "Traduis ce mot :"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "czygLT"
-msgstr "Connecte‑toi pour sauvegarder ta progression"
+msgstr "Connecte-toi pour sauvegarder ta progression"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "yBJVJw"
@@ -346,15 +346,15 @@ msgstr "La progression ne sera pas sauvegardée"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "JDumQX"
-msgstr "Tu peux essayer cette leçon sans compte, mais ton score, ta progression dans le cours, tes niveaux et ton énergie ne seront pas sauvegardés."
+msgstr "Tu peux essayer cette leçon sans compte, mais ton score, ta progression dans le cours, tes niveaux et ton Énergie ne seront pas sauvegardés."
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "rxdOwg"
-msgstr "Cette leçon n'a pas été sauvegardée"
+msgstr "Cette leçon n’a pas été sauvegardée"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "Wamgyz"
-msgstr "Connecte‑toi avant la prochaine leçon pour conserver tes progrès, tes scores, tes niveaux et ton énergie."
+msgstr "Connecte-toi avant ta prochaine leçon pour garder tes futures progressions, tes scores, tes niveaux et ton Énergie."
 
 #: src/components/verdict-label.tsx
 msgid "xmF49T"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -38,7 +38,7 @@ msgstr "Sua resposta"
 
 #: src/components/arrange-words-answer-area.tsx
 msgid "7R_rOB"
-msgstr "Toque nas palavras para formar sua resposta"
+msgstr "Toque nas palavras para montar sua resposta"
 
 #: src/components/arrange-words.tsx
 #: src/components/fill-blank-word-bank.tsx
@@ -51,7 +51,7 @@ msgstr "Sair"
 
 #: src/components/completion-auth-branch.tsx
 msgid "FazwRl"
-msgstr "Tente novamente"
+msgstr "Tentar de novo"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
@@ -69,7 +69,7 @@ msgstr "Novo recorde diário"
 
 #: src/components/completion-brain-power-milestone.tsx
 msgid "VaM8Q9"
-msgstr "Você alcançou {brainPower} PM hoje, seu maior Poder Mental em um único dia. Continue estudando todos os dias para superar esse recorde."
+msgstr "Você chegou a {brainPower} PM hoje, seu maior Poder Mental em um só dia. Continue estudando todos os dias para bater esse recorde."
 
 #: src/components/completion-energy-milestone.tsx
 msgid "m2WzLQ"
@@ -77,7 +77,7 @@ msgstr "Energia máxima!"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "Fo6YtA"
-msgstr "Parabéns! Você alcançou Energia máxima. Pratique todos os dias para manter sua Energia em 100%."
+msgstr "Parabéns! Você chegou à Energia máxima. Continue praticando todos os dias para manter sua Energia em 100%."
 
 #: src/components/completion-energy-milestone.tsx
 msgid "J89SkG"
@@ -85,19 +85,19 @@ msgstr "{percentage} de Energia"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "3Jd-mJ"
-msgstr "Seu esforço está valendo a pena. Faça aulas todos os dias para aumentar sua Energia."
+msgstr "Seu esforço está dando resultado. Complete aulas todos os dias para aumentar sua Energia."
 
 #: src/components/completion-energy-milestone.tsx
 msgid "5YVYKd"
-msgstr "1 ano com Energia máxima"
+msgstr "1 ano de Energia máxima"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "1WNk4i"
-msgstr "{days} dias com Energia máxima"
+msgstr "{days} dias de Energia máxima"
 
 #: src/components/completion-energy-milestone.tsx
 msgid "cIxpmv"
-msgstr "Uau, que consistência incrível! Estude todo dia para manter sua Energia em 100%."
+msgstr "Uau, que consistência incrível! Continue estudando todos os dias para manter sua Energia em 100%."
 
 #: src/components/completion-learning-days-milestone.tsx
 msgid "SIXtG5"
@@ -105,7 +105,7 @@ msgstr "{days} dias de estudo"
 
 #: src/components/completion-learning-days-milestone.tsx
 msgid "hjXoGI"
-msgstr "Você completou aulas em {days} dias diferentes. Praticar com frequência te ajuda a lembrar do que você aprende."
+msgstr "Você completou aulas em {days} dias diferentes. Praticar com frequência te ajuda a lembrar o que você aprende."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgid "dZvEPp"
@@ -121,7 +121,7 @@ msgstr "{hours, plural, one {# hora de estudo} other {# horas de estudo}}"
 
 #: src/components/completion-learning-time-milestone.tsx
 msgid "WcAhMT"
-msgstr "Você pode aprender muita coisa praticando alguns minutos por dia."
+msgstr "Você pode aprender muito praticando por alguns minutos por dia."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgid "LzEQnT"
@@ -133,11 +133,11 @@ msgstr "Isso é mais de {days, plural, one {# dia inteiro} other {# dias inteiro
 
 #: src/components/completion-level-milestone.tsx
 msgid "155cHi"
-msgstr "Nível conquistado"
+msgstr "Nível alcançado"
 
 #: src/components/completion-level-milestone.tsx
 msgid "Ar7dNY"
-msgstr "Você alcançou um novo nível: {belt}, nível {level}. Parabéns!"
+msgstr "Você chegou a um novo nível: {belt}, nível {level}. Parabéns!"
 
 #: src/components/completion-level-milestone.tsx
 msgid "Bk6B6r"
@@ -145,7 +145,7 @@ msgstr "Quase lá"
 
 #: src/components/completion-level-milestone.tsx
 msgid "b7ZoLo"
-msgstr "Seu conhecimento está crescendo. Complete {count, plural, one {mais # aula} other {mais # aulas}} para alcançar {belt}, nível {level}."
+msgstr "Seu conhecimento está crescendo. Complete {count, plural, one {mais # aula} other {mais # aulas}} para chegar a {belt}, nível {level}."
 
 #: src/components/completion-milestone-actions.tsx
 msgid "DiIkZH"
@@ -178,7 +178,7 @@ msgstr "Continuar"
 
 #: src/components/completion-score-milestone.tsx
 msgid "e6_3Ke"
-msgstr "{day} é o seu melhor dia"
+msgstr "{day} é seu melhor dia"
 
 #: src/components/completion-score-milestone.tsx
 msgid "PTQ0ah"
@@ -207,7 +207,7 @@ msgstr "Progresso do capítulo"
 
 #: src/components/completion-screen.tsx
 msgid "P768k7"
-msgstr "correto"
+msgstr "corretas"
 
 #: src/components/feedback-answer-blocks.tsx
 msgid "3nOd8f"
@@ -224,23 +224,23 @@ msgstr "Pergunta"
 
 #: src/components/feedback-screen.tsx
 msgid "fpO9TK"
-msgstr "Traduzir:"
+msgstr "Traduza:"
 
 #: src/components/fill-blank-step.tsx
 msgid "SL2Bob"
-msgstr "Espaço {position}: {item}. {result}."
+msgstr "Lacuna {position}: {item}. {result}."
 
 #: src/components/fill-blank-step.tsx
 msgid "wUEGVH"
-msgstr "Espaço {position}: {item}. Toque para remover."
+msgstr "Lacuna {position}: {item}. Toque para remover."
 
 #: src/components/fill-blank-step.tsx
 msgid "FmmJ_j"
-msgstr "Espaço {position}"
+msgstr "Lacuna {position}"
 
 #: src/components/inline-feedback.tsx
 msgid "HvLGEN"
-msgstr "Resultado da resposta"
+msgstr "Comentário sobre a resposta"
 
 #: src/components/lesson-info-popover.tsx
 msgid "RwePAQ"
@@ -248,7 +248,7 @@ msgstr "Informações da aula"
 
 #: src/components/listening-step.tsx
 msgid "aAmWaS"
-msgstr "O que você ouviu?"
+msgstr "O que você ouve?"
 
 #: src/components/listening-step.tsx
 #: src/components/reading-step.tsx
@@ -261,7 +261,7 @@ msgstr "Combine os pares."
 
 #: src/components/match-columns-step.tsx
 msgid "ja1JDt"
-msgstr "Todos os pares foram combinados. Pressione Verificar para continuar."
+msgstr "Todos os pares foram combinados. Toque em Conferir para continuar."
 
 #: src/components/play-audio-button.tsx
 msgid "WGft2H"
@@ -269,11 +269,11 @@ msgstr "Pausar pronúncia"
 
 #: src/components/play-audio-button.tsx
 msgid "lYWSeP"
-msgstr "Tocar pronúncia"
+msgstr "Ouvir pronúncia"
 
 #: src/components/player-choice-scene.tsx
 msgid "akd-cv"
-msgstr "Opções de resposta"
+msgstr "Alternativas de resposta"
 
 #: src/components/player-header.tsx
 msgid "rbrahO"
@@ -298,7 +298,7 @@ msgstr "Resposta correta"
 
 #: src/components/select-image-step.tsx
 msgid "NA6C_-"
-msgstr "Opções de imagem"
+msgstr "Alternativas de imagem"
 
 #: src/components/sort-order-step.tsx
 msgid "p5llOK"
@@ -314,7 +314,7 @@ msgstr "Arraste os itens para a ordem correta"
 
 #: src/components/step-action-button.tsx
 msgid "RDZVQL"
-msgstr "Verificar"
+msgstr "Conferir"
 
 #: src/components/step-navigation-button-group.tsx
 msgid "JJNc3c"
@@ -322,11 +322,11 @@ msgstr "Anterior"
 
 #: src/components/swipe-navigable-step-layout.tsx
 msgid "aNzy1T"
-msgstr "Passo anterior"
+msgstr "Etapa anterior"
 
 #: src/components/swipe-navigable-step-layout.tsx
 msgid "d-qgix"
-msgstr "Próximo passo"
+msgstr "Próxima etapa"
 
 #: src/components/translation-step.tsx
 msgid "MxLxkr"
@@ -334,7 +334,7 @@ msgstr "Traduza esta palavra:"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "czygLT"
-msgstr "Faça login para salvar o progresso"
+msgstr "Entre para salvar seu progresso"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "yBJVJw"
@@ -346,7 +346,7 @@ msgstr "O progresso não será salvo"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "JDumQX"
-msgstr "Você pode testar esta aula sem conta, mas sua pontuação, progresso no curso, níveis e Energia não serão salvos."
+msgstr "Você pode testar esta aula sem uma conta, mas sua pontuação, progresso no curso, níveis e Energia não serão salvos."
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "rxdOwg"
@@ -354,7 +354,7 @@ msgstr "Esta aula não foi salva"
 
 #: src/components/unauthenticated-progress-prompt.tsx
 msgid "Wamgyz"
-msgstr "Faça login antes da próxima aula para manter seu progresso, pontuações, níveis e Energia."
+msgstr "Entre antes da próxima aula para salvar seu progresso, pontuações, níveis e Energia daqui para frente."
 
 #: src/components/verdict-label.tsx
 msgid "xmF49T"
@@ -362,7 +362,7 @@ msgstr "Correto!"
 
 #: src/components/verdict-label.tsx
 msgid "--l7ni"
-msgstr "Quase lá"
+msgstr "Quase"
 
 #: src/components/vocabulary-step.tsx
 msgid "lqtP-R"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ catalogs:
       specifier: 3.2.2
       version: 3.2.2
     '@eloqnt/cli':
-      specifier: 0.2.0
-      version: 0.2.0
+      specifier: 0.4.0
+      version: 0.4.0
     '@mdx-js/loader':
       specifier: 3.1.1
       version: 3.1.1
@@ -116,6 +116,7 @@ catalogs:
       version: 4.4.3
 
 overrides:
+  ai-sdk-provider-codex-cli@1.2.2>@openai/codex: '-'
   '@hono/node-server@<1.19.13': ^1.19.13
   '@types/pg': 8.20.0
   esbuild@>=0.17.0 <0.28.1: ^0.28.1
@@ -128,7 +129,7 @@ importers:
     devDependencies:
       '@eloqnt/cli':
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 0.4.0
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -759,7 +760,10 @@ importers:
     dependencies:
       '@eloqnt/cli':
         specifier: 'catalog:'
-        version: 0.2.0
+        version: 0.4.0
+      ai-sdk-provider-codex-cli:
+        specifier: 1.2.2
+        version: 1.2.2(zod@4.4.3)
     devDependencies:
       '@typescript/native-preview':
         specifier: 'catalog:'
@@ -1447,15 +1451,12 @@ packages:
   '@electric-sql/pglite@0.4.1':
     resolution: {integrity: sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==}
 
-  '@eloqnt/cli@0.2.0':
-    resolution: {integrity: sha512-o3gY0iCjXy5f2jNOMbGvMLFGnmKSqd//V5ra2PAz64/IoSZNcB7bf7Yyxe/gxrquKo2+G3PcTm2deOY/V3dNBg==}
+  '@eloqnt/cli@0.4.0':
+    resolution: {integrity: sha512-AfDdUl3AwW8+2kbIhcfb+ntAcrIBXjvO9488CJB0VlXTcfhncNiLrsXlMUzuhstuO9sMQvpdl3l88on0/Ha2Qw==}
     hasBin: true
 
-  '@eloqnt/inference@0.1.0':
-    resolution: {integrity: sha512-YXE7NYlFlePN6q2QmE2/8i+ferRK4DfJQNvQMqkIyeJP6ysBbFIUlesJT19oorV8hkL8adA7IwOVjX6TMAZIEg==}
-
-  '@eloqnt/sdk@0.2.0':
-    resolution: {integrity: sha512-hP29liax3kfVfH2FEv0LDtFFksTgUAH5F81IlZZnTMg+zHYqctdlUj78Bcxw1ZY4RD4yxhjh2EqbkU0c7KO36g==}
+  '@eloqnt/sdk@0.4.0':
+    resolution: {integrity: sha512-liTCulNG+kkgf4lNbz3PIDFuZoqLFFwDAwGLIYvspoIivA1XMtb4w6EG4tdfb3Vq1r0cpK3NI6raulJICICYUQ==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -4259,6 +4260,12 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ai-sdk-provider-codex-cli@1.2.2:
+    resolution: {integrity: sha512-hlIWo9KP7/hJaEjXZbxgjVO/FvMn3I+5RSht0PBp3GOBKVFkKeKlrIDvaA8Wi/nAYiAePESPem+fi1NVNfNQJA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0 || ^4.0.0
+
   ai@6.0.203:
     resolution: {integrity: sha512-2Qi1ZPGF/FnlvnRqntVgRbUYGeA5ZKFYwTtgu8rcUzMmddArM/nLsvCW69Ip99B1cop6XHRHl+GCKk9t9B+GDA==}
     engines: {node: '>=18'}
@@ -5596,6 +5603,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
@@ -5999,8 +6009,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next-intl-swc-plugin-extractor@0.0.0-canary-375b031:
-    resolution: {integrity: sha512-6zDb6H3vkn3Nz3Vrfk0DJsaNcwqpVf6kIxfeqLJ8s1a+fNGKnrp3ggV5ikc1S3R85cxleHJqelR8KVvvmBXdUQ==}
+  next-intl-swc-plugin-extractor@0.0.0-canary-9f1cde4:
+    resolution: {integrity: sha512-amr9tzbCMfIWOa25CLYx5/BNm7P2xRSJ7kz2YmdR6DSaCOzGUO9hb82prgHHBsLW25Y+TtbauEGyTVYCG4uKUA==}
 
   next-intl-swc-plugin-extractor@4.13.0:
     resolution: {integrity: sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==}
@@ -7970,28 +7980,24 @@ snapshots:
 
   '@electric-sql/pglite@0.4.1': {}
 
-  '@eloqnt/cli@0.2.0':
+  '@eloqnt/cli@0.4.0':
     dependencies:
       '@clack/prompts': 1.6.0
-      '@eloqnt/sdk': 0.2.0
+      '@eloqnt/sdk': 0.4.0
       citty: 0.1.6
       open: 11.0.0
       picocolors: 1.1.1
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@eloqnt/inference@0.1.0':
+  '@eloqnt/sdk@0.4.0':
     dependencies:
-      ai: 7.0.8(zod@4.4.3)
-      zod: 4.4.3
-
-  '@eloqnt/sdk@0.2.0':
-    dependencies:
-      '@eloqnt/inference': 0.1.0
       '@formatjs/icu-messageformat-parser': 3.5.11
       '@swc/core': 1.15.41
       ai: 7.0.8(zod@4.4.3)
-      next-intl-swc-plugin-extractor: 0.0.0-canary-375b031
+      jiti: 2.7.0
+      magic-string: 0.30.21
+      next-intl-swc-plugin-extractor: 0.0.0-canary-9f1cde4
       po-parser: 2.1.1
       zod: 4.4.3
     transitivePeerDependencies:
@@ -10530,6 +10536,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ai-sdk-provider-codex-cli@1.2.2(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
+      jsonc-parser: 3.3.1
+      zod: 4.4.3
+
   ai@6.0.203(zod@4.4.3):
     dependencies:
       '@ai-sdk/gateway': 3.0.129(zod@4.4.3)
@@ -11841,6 +11854,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
@@ -12384,7 +12399,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-intl-swc-plugin-extractor@0.0.0-canary-375b031: {}
+  next-intl-swc-plugin-extractor@0.0.0-canary-9f1cde4: {}
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   "@dnd-kit/core": 6.3.1
   "@dnd-kit/sortable": 10.0.0
   "@dnd-kit/utilities": 3.2.2
-  "@eloqnt/cli": 0.2.0
+  "@eloqnt/cli": 0.4.0
   "@mdx-js/loader": 3.1.1
   "@mdx-js/react": 3.1.1
   "@next/mdx": 16.2.9
@@ -58,6 +58,7 @@ catalog:
 minimumReleaseAge: 0
 
 overrides:
+  "ai-sdk-provider-codex-cli@1.2.2>@openai/codex": "-"
   "@hono/node-server@<1.19.13": ^1.19.13
   "@types/pg": 8.20.0
   esbuild@>=0.17.0 <0.28.1: ^0.28.1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches Eloqnt i18n to a custom Codex CLI model and refreshes ES/FR/PT translations for clarity and consistency. Adds `CODEX_PATH` so each dev can point to a local Codex binary, and updates e2e tests to match new copy and ARIA roles.

- **New Features**
  - Configure Eloqnt to use `ai-sdk-provider-codex-cli` with model `gpt-5.5` in `define-eloqnt-config`.
  - Support `CODEX_PATH` env var; defaults to `codex` on PATH.
  - Update ES/FR/PT `.po` strings across `apps/api`, `apps/main`, and `packages/player`, and align e2e tests (command palette, language, locale) with the new texts and roles.
  - Add PT styleguide rule to avoid repeating articles/pronouns.
  - Dependencies: add `ai-sdk-provider-codex-cli@1.2.2`, bump `@eloqnt/cli` to `0.4.0`, and override `@openai/codex`.

- **Migration**
  - Install the Codex CLI and ensure `codex` is on PATH, or set `CODEX_PATH` to its full path.

<sup>Written for commit c8e339a4ef23c56065725c78400e1db39cd3aae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

