### PR TITLE
feat(analytics): add username to posthog person

### DIFF
--- a/apps/main/src/app/app-analytics.tsx
+++ b/apps/main/src/app/app-analytics.tsx
@@ -10,11 +10,16 @@ const googleAdsTagId = process.env.NEXT_PUBLIC_GOOGLE_ADS_TAG_ID;
  * root layout can stream the rest of the route without waiting on this flag.
  */
 export async function AppAnalytics() {
-  const { analyticsDisabled, plan, userId } = await getCurrentUserAnalyticsState();
+  const { analyticsDisabled, plan, userId, username } = await getCurrentUserAnalyticsState();
 
   return (
     <>
-      <PostHogIdentify analyticsDisabled={analyticsDisabled} plan={plan} userId={userId} />
+      <PostHogIdentify
+        analyticsDisabled={analyticsDisabled}
+        plan={plan}
+        userId={userId}
+        username={username}
+      />
       {analyticsDisabled ? null : (
         <>
           <Analytics debug={false} />

--- a/apps/main/src/app/posthog-identify.tsx
+++ b/apps/main/src/app/posthog-identify.tsx
@@ -4,21 +4,23 @@ import { identifyPostHogUser } from "@/lib/posthog";
 import { useEffect } from "react";
 
 /**
- * Identifies signed-in users with the stable app user id and a filterable flag
- * for excluding internal users from PostHog reports.
+ * Identifies signed-in users with the stable app user id and profile metadata
+ * PostHog reports can use for filtering and finding people.
  */
 export function PostHogIdentify({
   analyticsDisabled,
   plan,
   userId,
+  username,
 }: {
   analyticsDisabled: boolean;
   plan: string;
   userId: string | null;
+  username: string | null;
 }) {
   useEffect(() => {
-    identifyPostHogUser({ analyticsDisabled, plan, userId });
-  }, [analyticsDisabled, plan, userId]);
+    identifyPostHogUser({ analyticsDisabled, plan, userId, username });
+  }, [analyticsDisabled, plan, userId, username]);
 
   return null;
 }

--- a/apps/main/src/data/users/get-current-user-analytics-disabled.ts
+++ b/apps/main/src/data/users/get-current-user-analytics-disabled.ts
@@ -15,7 +15,7 @@ export const getCurrentUserAnalyticsState = cache(async () => {
   const session = await getSession(requestHeaders);
 
   if (!session) {
-    return { analyticsDisabled: false, plan: "free", userId: null };
+    return { analyticsDisabled: false, plan: "free", userId: null, username: null };
   }
 
   const [subscription, user] = await Promise.all([
@@ -24,13 +24,14 @@ export const getCurrentUserAnalyticsState = cache(async () => {
   ]);
 
   if (!user) {
-    return { analyticsDisabled: false, plan: "free", userId: null };
+    return { analyticsDisabled: false, plan: "free", userId: null, username: null };
   }
 
   return {
     analyticsDisabled: user.analyticsDisabled,
     plan: subscription?.plan ?? "free",
     userId: user.id,
+    username: user.username,
   };
 });
 

--- a/apps/main/src/lib/posthog.ts
+++ b/apps/main/src/lib/posthog.ts
@@ -2,17 +2,19 @@ import { getPostHogConfig } from "@zoonk/utils/posthog";
 import posthog from "posthog-js";
 
 /**
- * Links browser events to the authenticated Zoonk user and stores the user flag
- * PostHog reports can use to filter internal users out of stats.
+ * Links browser events to the authenticated Zoonk user and keeps durable person
+ * properties current for analytics filters and user lookup.
  */
 export function identifyPostHogUser({
   analyticsDisabled,
   plan,
   userId,
+  username,
 }: {
   analyticsDisabled: boolean;
   plan: string;
   userId: string | null;
+  username: string | null;
 }) {
   if (!getPostHogConfig()) {
     return;
@@ -22,7 +24,7 @@ export function identifyPostHogUser({
     return;
   }
 
-  posthog.identify(userId, { analyticsDisabled, plan });
+  posthog.identify(userId, { analyticsDisabled, plan, userId, username });
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `username` to PostHog person properties when identifying authenticated users to improve filtering and user lookup. Also store `userId` as a person property.

- **New Features**
  - Return `username` from `getCurrentUserAnalyticsState` and wire it through `AppAnalytics` → `PostHogIdentify`.
  - Update `identifyPostHogUser` to call `posthog.identify(userId, { analyticsDisabled, plan, userId, username })` (no-op when not authenticated).

<sup>Written for commit 1f0826383563f9b7c980abf023e860882f7eeec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

