### PR TITLE
fix(player): keep selected word bank tiles in place

### DIFF
--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -85,7 +85,7 @@ describe("player browser integration: word bank steps", () => {
     await expect.element(page.getByText("100%")).toBeInTheDocument();
   });
 
-  it("hides selected arrange-word options without number shortcuts", async () => {
+  it("keeps selected arrange-word options as disabled placeholders", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         kind: "reading",
@@ -113,6 +113,7 @@ describe("player browser integration: word bank steps", () => {
     const answerArea = page.getByRole("group", { name: /your answer/iu });
 
     await expect.element(mundoOption).not.toHaveAttribute("aria-keyshortcuts");
+    await expect.element(mundoOption).toBeEnabled();
 
     fireEvent.keyDown(globalThis.window, { key: "2" });
 
@@ -125,10 +126,7 @@ describe("player browser integration: word bank steps", () => {
     await mundoOption.click();
 
     await expect.element(answerArea.getByRole("button", { name: /mundo/iu })).toBeInTheDocument();
-
-    await expect
-      .element(wordBank.getByRole("button", { exact: true, name: "mundo" }))
-      .not.toBeInTheDocument();
+    await expect.element(mundoOption).toBeDisabled();
 
     await expect
       .element(wordBank.getByRole("button", { exact: true, name: "Hola" }))
@@ -136,12 +134,10 @@ describe("player browser integration: word bank steps", () => {
 
     await answerArea.getByRole("button", { name: /mundo/iu }).click();
 
-    await expect
-      .element(wordBank.getByRole("button", { exact: true, name: "mundo" }))
-      .toBeInTheDocument();
+    await expect.element(mundoOption).toBeEnabled();
   });
 
-  it("hides selected fill-blank options without number shortcuts", async () => {
+  it("keeps selected fill-blank options as disabled placeholders", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         steps: [
@@ -167,6 +163,7 @@ describe("player browser integration: word bank steps", () => {
     const catOption = wordBank.getByRole("button", { exact: true, name: "cat" });
 
     await expect.element(catOption).not.toHaveAttribute("aria-keyshortcuts");
+    await expect.element(catOption).toBeEnabled();
 
     fireEvent.keyDown(globalThis.window, { key: "2" });
 
@@ -182,16 +179,11 @@ describe("player browser integration: word bank steps", () => {
 
     await expect.element(selectedBlank).toBeInTheDocument();
     await expect.element(page.getByRole("button", { name: /check/iu })).toBeEnabled();
-
-    await expect
-      .element(wordBank.getByRole("button", { exact: true, name: "cat" }))
-      .not.toBeInTheDocument();
+    await expect.element(catOption).toBeDisabled();
 
     await selectedBlank.click();
 
-    await expect
-      .element(wordBank.getByRole("button", { exact: true, name: "cat" }))
-      .toBeInTheDocument();
+    await expect.element(catOption).toBeEnabled();
 
     await expect.element(page.getByRole("button", { name: /check/iu })).toBeDisabled();
   });

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -40,19 +40,17 @@ function getWordBankTile({
 }
 
 /**
- * The word bank should only show words the learner can still choose. Selected
- * words remain removable from the answer area, then reappear here.
+ * The word bank keeps used words in place as disabled placeholders so selecting
+ * a tile does not make the remaining choices jump around.
  */
-function getVisibleWordBankTiles({
+function getWordBankTiles({
   placedWords,
   words,
 }: {
   placedWords: PlacedWord[];
   words: WordBankOption[];
 }): WordBankTile[] {
-  return words
-    .map((option, index) => getWordBankTile({ index, option, placedWords, words }))
-    .filter((tile) => !tile.isUsed);
+  return words.map((option, index) => getWordBankTile({ index, option, placedWords, words }));
 }
 
 function WordBank({
@@ -67,7 +65,7 @@ function WordBank({
   words: WordBankOption[];
 }) {
   const t = useExtracted();
-  const tiles = getVisibleWordBankTiles({ placedWords, words });
+  const tiles = getWordBankTiles({ placedWords, words });
 
   return (
     <div
@@ -78,6 +76,7 @@ function WordBank({
       {tiles.map((tile) => (
         <WordBankOptionButton
           disabled={disabled}
+          isSelected={tile.isUsed}
           key={tile.key}
           onToggle={() => onPlace(tile.option)}
           option={tile.option}

--- a/packages/player/src/components/fill-blank-word-bank.tsx
+++ b/packages/player/src/components/fill-blank-word-bank.tsx
@@ -66,8 +66,8 @@ function getWordTileData({
 }
 
 /**
- * Renders only the fill-blank words learners can still choose. Selected words
- * are removed from the bank and become removable from their blank slot instead.
+ * Keeps every fill-blank option in the bank so used words can become disabled
+ * placeholders instead of causing the remaining options to shift position.
  */
 export function FillBlankWordBank({
   blanks,
@@ -89,16 +89,15 @@ export function FillBlankWordBank({
       className={cn("flex flex-wrap gap-2.5", disabled && "pointer-events-none opacity-50")}
       role="group"
     >
-      {tiles
-        .filter((tile) => !tile.isUsed)
-        .map((tile) => (
-          <WordBankOptionButton
-            disabled={disabled}
-            key={tile.key}
-            onToggle={() => onPlaceWord(tile.option.word)}
-            option={tile.option}
-          />
-        ))}
+      {tiles.map((tile) => (
+        <WordBankOptionButton
+          disabled={disabled}
+          isSelected={tile.isUsed}
+          key={tile.key}
+          onToggle={() => onPlaceWord(tile.option.word)}
+          option={tile.option}
+        />
+      ))}
     </div>
   );
 }

--- a/packages/player/src/components/word-bank-option-content.tsx
+++ b/packages/player/src/components/word-bank-option-content.tsx
@@ -4,12 +4,26 @@ import { type ReactNode, useId } from "react";
 import { RomanizationText } from "./romanization-text";
 
 /**
- * Word-bank buttons keep the word, romanization, and pronunciation in one
- * vertical stack so metadata reads as a hint for the word instead of a separate
- * option.
+ * Word-bank buttons keep their content in one stack so selected placeholders
+ * can hide the text while preserving the tile's original width and height.
  */
-function WordBankOptionContent({ children }: { children: ReactNode }) {
-  return <span className="flex min-w-0 flex-col items-center gap-0.5 text-center">{children}</span>;
+function WordBankOptionContent({
+  children,
+  isInvisible = false,
+}: {
+  children: ReactNode;
+  isInvisible?: boolean;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex min-w-0 flex-col items-center gap-0.5 text-center",
+        isInvisible && "invisible",
+      )}
+    >
+      {children}
+    </span>
+  );
 }
 
 /**
@@ -33,37 +47,61 @@ function hasWordBankOptionDescription(option: WordBankOption): boolean {
 }
 
 /**
+ * Word-bank tiles have three visual states: available, globally disabled after
+ * an answer is checked, and selected placeholders that stay visible only to
+ * preserve the bank layout.
+ */
+function getWordBankButtonStateClass({
+  disabled,
+  isSelected,
+}: {
+  disabled: boolean;
+  isSelected: boolean;
+}) {
+  if (isSelected) {
+    return "border-transparent bg-muted/50 opacity-70";
+  }
+
+  if (disabled) {
+    return "opacity-50";
+  }
+
+  return "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]";
+}
+
+/**
  * Shared word-bank button chrome keeps fill-blank, reading, and listening tiles
  * visually identical. The compact centered layout lets short words size to
  * their text plus padding instead of reserving space for unavailable controls.
  */
 export function WordBankOptionButton({
   disabled,
+  isSelected = false,
   onToggle,
   option,
 }: {
   disabled: boolean;
+  isSelected?: boolean;
   onToggle: () => void;
   option: WordBankOption;
 }) {
   const descriptionId = useId();
   const hasDescription = hasWordBankOptionDescription(option);
+  const isDisabled = disabled || isSelected;
 
   return (
     <button
-      aria-describedby={hasDescription ? descriptionId : undefined}
+      aria-describedby={hasDescription && !isSelected ? descriptionId : undefined}
       aria-label={option.word}
       className={cn(
         "border-border flex min-h-11 flex-col items-center justify-center rounded-lg border px-4 py-2.5 text-center transition-all duration-150 outline-none",
-        disabled
-          ? "opacity-50"
-          : "hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        getWordBankButtonStateClass({ disabled, isSelected }),
       )}
-      disabled={disabled}
+      disabled={isDisabled}
       onClick={onToggle}
       type="button"
     >
-      <WordBankOptionContent>
+      <WordBankOptionContent isInvisible={isSelected}>
         <span>{option.word}</span>
 
         {hasDescription && (


### PR DESCRIPTION
## Summary
- Keep selected word bank tiles in place as disabled placeholders
- Preserve word-bank layout for arrange-word and fill-blank steps
- Update browser coverage for selecting and removing word-bank tiles

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep selected word-bank tiles in place as disabled placeholders to stop options from jumping around. Applies to arrange-words and fill-blank steps.

- **Bug Fixes**
  - Render all word-bank tiles; mark used ones as disabled placeholders with invisible text to preserve size.
  - Add selected state to `WordBankOptionButton` with proper styling and ARIA behavior; disabled when selected.
  - Update browser tests to check enabled/disabled states and ensure keyboard shortcuts still work.

<sup>Written for commit 6887c6a68d8dc434143b8083609981439426b63c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

