### PR TITLE
chore(deps): upgrade ai and workflow sdks

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -56,3 +56,4 @@ messages/*.d.json.ts
 
 # workflow
 */.well-known/workflow
+/.swc

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,7 +36,7 @@
     "react": "catalog:",
     "react-dom": "catalog:",
     "server-only": "catalog:",
-    "workflow": "4.4.0",
+    "workflow": "5.0.0-beta.30",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/evals/src/lib/battle-score.ts
+++ b/apps/evals/src/lib/battle-score.ts
@@ -67,10 +67,10 @@ async function generateBattleRankingResult({
 }): Promise<BattleRankingResult> {
   const generationResult = await safeAsync(() =>
     generateText({
+      instructions: battleSystemPrompt,
       model: judgeId,
       output: Output.object({ schema: battleRankingSchema }),
       prompt,
-      system: battleSystemPrompt,
     }),
   );
 
@@ -92,11 +92,11 @@ async function generateBattleRankingResult({
     finishReason,
     judgeModelId: judgeId,
     rawFinishReason,
-    responseId: generation.response.id,
+    responseId: generation.finalStep.response.id,
   });
 
   logError(error.message, {
-    providerMetadata: generation.providerMetadata,
+    providerMetadata: generation.finalStep.providerMetadata,
     textLength: generation.text.length,
     usage: generation.usage,
     warnings: generation.warnings,

--- a/apps/evals/src/lib/score.ts
+++ b/apps/evals/src/lib/score.ts
@@ -62,10 +62,10 @@ export async function generateScore(params: {
   `;
 
   const { output: result } = await generateText({
+    instructions: systemPrompt,
     model: "openai/gpt-5.6-sol",
     output: Output.object({ schema: scoreSchema }),
     prompt: evalPrompt,
-    system: systemPrompt,
   });
 
   return { score: calculateScore(result.steps), steps: result.steps };

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -45,8 +45,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ai-sdk/gateway": "3.0.129",
-    "@ai-sdk/openai": "3.0.71",
+    "@ai-sdk/gateway": "4.0.16",
+    "@ai-sdk/openai": "4.0.11",
     "@google/genai": "2.8.0",
     "@zoonk/utils": "workspace:*",
     "ai": "catalog:"

--- a/packages/ai/src/tasks/audio/provider-openai.ts
+++ b/packages/ai/src/tasks/audio/provider-openai.ts
@@ -1,6 +1,6 @@
 import { openai } from "@ai-sdk/openai";
 import { type TTSVoice } from "@zoonk/utils/languages";
-import { experimental_generateSpeech as generateSpeech } from "ai";
+import { generateSpeech } from "ai";
 import { type AudioResult } from "./generate-language-audio";
 
 const MODEL = openai.speech("gpt-4o-mini-tts");

--- a/packages/ai/src/tasks/chapters/chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.ts
@@ -65,11 +65,11 @@ export async function generateChapterLessons({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
@@ -56,11 +56,11 @@ export async function generateLanguageChapterLessons({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-canonical-title.ts
+++ b/packages/ai/src/tasks/courses/course-canonical-title.ts
@@ -52,11 +52,11 @@ export async function generateCanonicalCourseTitle({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
     temperature: 0,
   });
 

--- a/packages/ai/src/tasks/courses/course-categories.ts
+++ b/packages/ai/src/tasks/courses/course-categories.ts
@@ -42,11 +42,11 @@ export async function generateCourseCategories({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-chapters.ts
+++ b/packages/ai/src/tasks/courses/course-chapters.ts
@@ -50,11 +50,11 @@ export async function generateCourseChapters({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-description.ts
+++ b/packages/ai/src/tasks/courses/course-description.ts
@@ -42,11 +42,11 @@ export async function generateCourseDescription({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-format.ts
+++ b/packages/ai/src/tasks/courses/course-format.ts
@@ -63,11 +63,11 @@ export async function classifyCourseFormat({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-identity-search.ts
+++ b/packages/ai/src/tasks/courses/course-identity-search.ts
@@ -55,11 +55,11 @@ export async function generateCourseIdentitySearchQueries({
   });
 
   const { output, usage } = await generateText({
+    instructions: searchPrompt,
     model,
     output: Output.object({ schema: searchSchema }),
     prompt: userPrompt,
     providerOptions,
-    system: searchPrompt,
   });
 
   return { data: output, systemPrompt: searchPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-identity.ts
+++ b/packages/ai/src/tasks/courses/course-identity.ts
@@ -87,11 +87,11 @@ export async function resolveCourseIdentity({
   });
 
   const { output, usage } = await generateText({
+    instructions: classificationPrompt,
     model,
     output: Output.object({ schema: identitySchema }),
     prompt: userPrompt,
     providerOptions,
-    system: classificationPrompt,
   });
 
   return {

--- a/packages/ai/src/tasks/courses/course-intent.ts
+++ b/packages/ai/src/tasks/courses/course-intent.ts
@@ -50,11 +50,11 @@ export async function classifyCourseIntent({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-introduction.ts
+++ b/packages/ai/src/tasks/courses/course-introduction.ts
@@ -56,11 +56,11 @@ export async function generateCourseIntroduction({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-landing-page.ts
+++ b/packages/ai/src/tasks/courses/course-landing-page.ts
@@ -84,11 +84,11 @@ export async function generateCourseLandingPage({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-personalization.ts
+++ b/packages/ai/src/tasks/courses/course-personalization.ts
@@ -53,11 +53,11 @@ export async function classifyCoursePersonalization({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/language-course-chapters.ts
+++ b/packages/ai/src/tasks/courses/language-course-chapters.ts
@@ -45,11 +45,11 @@ export async function generateLanguageCourseChapters({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/images/image-prompt-safety-rewrite.ts
+++ b/packages/ai/src/tasks/images/image-prompt-safety-rewrite.ts
@@ -43,11 +43,11 @@ export async function rewriteImageInputForSafetyRetry({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
@@ -62,11 +62,11 @@ export async function generateLessonExplanation({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/core/lesson-practice.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.ts
@@ -65,11 +65,11 @@ export async function generateLessonPractice({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
@@ -103,11 +103,11 @@ export async function generateLessonQuiz({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-alphabet.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-alphabet.ts
@@ -73,11 +73,11 @@ export async function generateLessonAlphabet({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
@@ -82,11 +82,11 @@ export async function generateLessonDistractors({
   ].join("\n");
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-grammar.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-grammar.ts
@@ -79,11 +79,11 @@ export async function generateLessonGrammar({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-pronunciation.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-pronunciation.ts
@@ -50,11 +50,11 @@ export async function generateLessonPronunciation({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-romanization.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-romanization.ts
@@ -62,11 +62,11 @@ export async function generateLessonRomanization({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema: buildSchema(texts.length) }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
@@ -65,11 +65,11 @@ export async function generateLessonSentences({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-translation.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-translation.ts
@@ -55,11 +55,11 @@ export async function generateTranslation({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-vocabulary.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-vocabulary.ts
@@ -58,11 +58,11 @@ export async function generateLessonVocabulary({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/lesson-kind.ts
+++ b/packages/ai/src/tasks/lessons/lesson-kind.ts
@@ -62,11 +62,11 @@ export async function generateLessonKind({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/tutorial/lesson-tutorial.ts
+++ b/packages/ai/src/tasks/lessons/tutorial/lesson-tutorial.ts
@@ -55,11 +55,11 @@ export async function generateLessonTutorial({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/steps/step-image-prompts.ts
+++ b/packages/ai/src/tasks/steps/step-image-prompts.ts
@@ -70,11 +70,11 @@ export async function generateStepImagePrompts({
   });
 
   const { output, usage } = await generateText({
+    instructions: systemPrompt,
     model,
     output: Output.object({ schema: buildSchema(steps.length) }),
     prompt: userPrompt,
     providerOptions,
-    system: systemPrompt,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: 2.0.1
       version: 2.0.1
     ai:
-      specifier: 6.0.203
-      version: 6.0.203
+      specifier: 7.0.22
+      version: 7.0.22
     babel-plugin-react-compiler:
       specifier: 1.0.0
       version: 1.0.0
@@ -180,7 +180,7 @@ importers:
         version: 1.18.0(react@19.2.7)
       next:
         specifier: 'catalog:'
-        version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nuqs:
         specifier: 'catalog:'
         version: 2.8.9(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -223,7 +223,7 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.57.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(supports-color@8.1.1)(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.28.1))
+        version: 10.57.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.28.1))
       '@tabler/icons-react':
         specifier: 'catalog:'
         version: 3.44.0(react@19.2.7)
@@ -250,7 +250,7 @@ importers:
         version: 1.18.0(react@19.2.7)
       next:
         specifier: 'catalog:'
-        version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: 'catalog:'
         version: 4.13.0(@typescript/typescript6@6.0.2)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -270,15 +270,15 @@ importers:
         specifier: 'catalog:'
         version: 0.0.1
       workflow:
-        specifier: 4.4.0
-        version: 4.4.0(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(@typescript/typescript6@6.0.2)(next@16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)(ws@8.21.0)
+        specifier: 5.0.0-beta.30
+        version: 5.0.0-beta.30(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(@typescript/typescript6@6.0.2)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(ws@8.21.0)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
       '@scalar/nextjs-api-reference':
         specifier: 0.11.3
-        version: 0.11.3(next@16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 0.11.3(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
@@ -338,7 +338,7 @@ importers:
         version: link:../../packages/utils
       next:
         specifier: 'catalog:'
-        version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -396,13 +396,13 @@ importers:
         version: link:../../packages/utils
       ai:
         specifier: 'catalog:'
-        version: 6.0.203(zod@4.4.3)
+        version: 7.0.22(zod@4.4.3)
       lucide-react:
         specifier: 'catalog:'
         version: 1.18.0(react@19.2.7)
       next:
         specifier: 'catalog:'
-        version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -481,7 +481,7 @@ importers:
         version: 1.18.0(react@19.2.7)
       next:
         specifier: 'catalog:'
-        version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: 'catalog:'
         version: 4.13.0(@typescript/typescript6@6.0.2)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -574,20 +574,20 @@ importers:
   packages/ai:
     dependencies:
       '@ai-sdk/gateway':
-        specifier: 3.0.129
-        version: 3.0.129(zod@4.4.3)
+        specifier: 4.0.16
+        version: 4.0.16(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: 3.0.71
-        version: 3.0.71(zod@4.4.3)
+        specifier: 4.0.11
+        version: 4.0.11(zod@4.4.3)
       '@google/genai':
         specifier: 2.8.0
-        version: 2.8.0(supports-color@8.1.1)
+        version: 2.8.0
       '@zoonk/utils':
         specifier: workspace:*
         version: link:../utils
       ai:
         specifier: 'catalog:'
-        version: 6.0.203(zod@4.4.3)
+        version: 7.0.22(zod@4.4.3)
       server-only:
         specifier: 'catalog:'
         version: 0.0.1
@@ -633,7 +633,7 @@ importers:
         version: 6.2.3
       next:
         specifier: 'catalog:'
-        version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -682,7 +682,7 @@ importers:
         version: link:../utils
       next:
         specifier: 'catalog:'
-        version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -816,7 +816,7 @@ importers:
     dependencies:
       next:
         specifier: 'catalog:'
-        version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: 'catalog:'
         version: 4.13.0(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
@@ -880,7 +880,7 @@ importers:
         version: 1.18.0(react@19.2.7)
       next:
         specifier: 'catalog:'
-        version: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl:
         specifier: 'catalog:'
         version: 4.13.0(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
@@ -1061,9 +1061,9 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@3.0.129':
-    resolution: {integrity: sha512-KEQpZGJuCksc4iFxYtVHeHHG7yH0izGFzJLmRZlriI0hFIzJF9bT2AzJoaTHUI6minlxtP0WKYh84dP18o/Cuw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.16':
+    resolution: {integrity: sha512-9iYxdOLquoOFk5e+02P9qfBIA+EJU0FNJvyjGxi4iXJabt2+GlbaCg7TX0sTtxOsBVkdabkatqWM6+kvp53tBg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -1073,9 +1073,9 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.71':
-    resolution: {integrity: sha512-j6eBAa5oHFZ4U5CxpIV3T4zXNM/BviodNCZCL1qHkA4aqkwK9iQ18TWYz2DZcXpw4BO5pikKzqpXORxb1EnZGA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/openai@4.0.11':
+    resolution: {integrity: sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -1091,12 +1091,22 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.7':
+    resolution: {integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@4.0.1':
     resolution: {integrity: sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
     engines: {node: '>=22'}
 
   '@alloc/quick-lru@5.2.0':
@@ -2130,8 +2140,8 @@ packages:
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
-  '@nuxt/kit@4.4.7':
-    resolution: {integrity: sha512-QwtpqNxSOLyJH1UoDpcgsfzVEw95J0893hn1A+CvgeOxoTos1BGvD15D1v/OVQ2MK1EpfnFZJby51t1yudOvBA==}
+  '@nuxt/kit@4.4.8':
+    resolution: {integrity: sha512-ZUlZ5iYfyfJFDPluhn6ZxFWcsuxWbLnZBc8w3MAROcQ4lYfZ+qFpALBLSNlpc0zhOa++33EE+5PEbOAdVIY+dw==}
     engines: {node: '>=18.12.0'}
 
   '@oclif/core@4.11.4':
@@ -4081,9 +4091,14 @@ packages:
     resolution: {integrity: sha512-8ipTFoiX3WBRrvXLjSrmgAiwtMDQk3EgSxe8N7v2rXBz39NBIIyoGXeVbJRoBcP8WEuVnvjvIQsggbGU7ZKrMw==}
     engines: {node: '>= 20'}
 
-  '@vercel/queue@0.3.0':
-    resolution: {integrity: sha512-TGZlA2GGZtUVR592d5ORAqZXqWqUs7JD8MjazXMv07AxpsbLtUAbCxXOqRj/weoX7j6LrfZfD6cGfd7Llk24/Q==}
+  '@vercel/queue@0.4.0':
+    resolution: {integrity: sha512-2HctPb2+6Pj1DMxbPohMq574rE9OP3fUAGhwV0R4Qv1FHQIR+qti92G8FGjFMJGUSFxVlWdNwVfgHU2hZlM6Dw==}
     engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@vitejs/plugin-react@6.0.2':
     resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
@@ -4183,29 +4198,29 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@workflow/astro@4.0.9':
-    resolution: {integrity: sha512-vZ9FUQZoeAF0jQn0aOxpBxWCmJ5pxWWiI6kNG5MNdwBzaiACBbvuz0TE/bzEOCG8vCvTygEZ85sZvuIK7s3L4w==}
+  '@workflow/astro@5.0.0-beta.30':
+    resolution: {integrity: sha512-mwT3a0m3SjVK8acygViKbxFvVhaqE0+o/9KQ4gZUBQ/FcrT9OqGB+igbJ68ZEFwtGg0EJuAJhQTmIzRtdFQYQQ==}
 
-  '@workflow/builders@4.0.10':
-    resolution: {integrity: sha512-9vUBmGwZaaHeomnp5N2z3FECYhBkB+0a4mto32g9QVcBEVRvvmZQS0+V8ZUEJT3S+V/qoWEmnITEzpSYKodX1w==}
+  '@workflow/builders@5.0.0-beta.30':
+    resolution: {integrity: sha512-Cr5hL0Z0OZ95jL1yB46aVa6zB1CslTM4vM8soPVGwkdHFUTs7vzspyH0HQLcLCdct1ePxnoXx7JzmVU1ebUbOg==}
 
-  '@workflow/cli@4.2.9':
-    resolution: {integrity: sha512-asTNld5KvOCWlJaN4vgzF/9k6O3mwm9X6NSXnPzM6KSLzyrhWmpWBwVgVY3LIJcMHyOo5Qhs09XOq3gXlj+Scg==}
+  '@workflow/cli@5.0.0-beta.30':
+    resolution: {integrity: sha512-IbEMp/Nrr1gkNQmpaTWLM2OjDsfxbamOn/NSAaKOo/ZsNEBxPtvkepIReFLundpvk0bh7p/TAfgnWKfhKjhXoQ==}
     hasBin: true
 
-  '@workflow/core@4.4.0':
-    resolution: {integrity: sha512-OuOM56/hWutRK3B2YLyGYn8fjXpZjSuzWhVN4rZHwh19t4ywvXSmdQxc3bnuvBUSkIzf3EXXveDz7VYOb/qN8w==}
+  '@workflow/core@5.0.0-beta.30':
+    resolution: {integrity: sha512-amhmUNsMhDafgTbWg6GA1Pw/aaL4FZ2gp6ZM3VG1VRclqSyGCbPoNknb7/9ie0zMvwTRkpVaV3XrXMo9aMdfpA==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/errors@4.1.4':
-    resolution: {integrity: sha512-snRTDNNUWMqxuIrj9TsN3KJHXwCIpNLkT5v5VuIGbrfH+fhm0s2SWXCL0IERcXZd6lNpugZfOkn6ubS+/CBVyw==}
+  '@workflow/errors@5.0.0-beta.10':
+    resolution: {integrity: sha512-l/6+Ukys3FBVjbND3Vs+PDgCYgM9LjFnEPQmD7mTLWkgBg9nvlb8Th09MKhDRo2rBX86VT2lcpXtEThubjasuQ==}
 
-  '@workflow/nest@0.0.9':
-    resolution: {integrity: sha512-PuUtHKtOzghqKGpvKqsrXEmLfJ/3K9NgwbDKdHaubir7r1oQsNKEnJBZFp/ynkbl5NoTMqf909nQZgZ7p647Mw==}
+  '@workflow/nest@5.0.0-beta.30':
+    resolution: {integrity: sha512-S3z522TubxOX7TI7qg5BIWJ9O880VyZvxWdN+/oGSWnaAAR+FlMGnfivT8KNwj9gR/7HmxY2dlY4VD592AVpXQ==}
     hasBin: true
     peerDependencies:
       '@nestjs/common': '>=10.0.0'
@@ -4213,71 +4228,72 @@ packages:
       '@swc/cli': '>=0.4.0'
       '@swc/core': '>=1.5.0'
 
-  '@workflow/next@4.0.10':
-    resolution: {integrity: sha512-h8fAPJ+1QLXNYoFjYcuz+y2ejZRl9rSB1F6E/94Uw0lr21qAgXPRYBJrhsKuhESwMUySfVHCkzpNRcjwxf0OOg==}
+  '@workflow/next@5.0.0-beta.30':
+    resolution: {integrity: sha512-4f1WAXWIF3yf5Yhw3HeehcnL3a0w7I733ZPlqhagZa/Q2xru/wh8UgNO2CNBWq/XCgTuh6dIWzrIF4ecvJecaQ==}
     peerDependencies:
       next: '>13'
     peerDependenciesMeta:
       next:
         optional: true
 
-  '@workflow/nitro@4.1.0':
-    resolution: {integrity: sha512-mtfnwNl92eSlfu9Dx6j947zjCgkm8glScPP25PPz94ESu02wVAMKYul5CJsPlP1nglHzVx3vkqY7G68t86r79A==}
+  '@workflow/nitro@5.0.0-beta.30':
+    resolution: {integrity: sha512-AxNYSIP3Sh4e+T4rYz4ac37eQrfXZMOnj/RtJa46jw8FKh+w9Q6LgLZsB50e13PhD0M9FigGtP6vzh/aS4ynEA==}
 
-  '@workflow/nuxt@4.0.10':
-    resolution: {integrity: sha512-lao5KKZG+aCBqeSxSRbba0BDU8ABbXi7bx0YNAqKSiKRG74FI/tP7YVQULXRaCIDNYex1z6UzaBEBiE6CQz0sw==}
+  '@workflow/nuxt@5.0.0-beta.30':
+    resolution: {integrity: sha512-musQr9/xjPmAbsFD68v/My2Hjjpl4WXTYEYJBn6ZbJ++5l3R0xSKSkb948YxUkI8Qu+SDd3pTPhPUQ1uLkvq8A==}
 
-  '@workflow/rollup@4.0.9':
-    resolution: {integrity: sha512-opbd58othmzJFh0LA60K4FHdjwN4AwYCAhEgTcqX+a4OD5bjvv+hN0VSbIM2ofFTI6uuGbm0jzY/LU/EWahUcg==}
+  '@workflow/rollup@5.0.0-beta.30':
+    resolution: {integrity: sha512-P7ks/C0LI2Lg/AViXxSERisBR4y9x+c/t6V+9gnkRe//vQR7bO3tv/YFsB3GZueRIOqaGXtWKjy3yF1TSvERPw==}
 
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
-  '@workflow/serde@4.1.2':
-    resolution: {integrity: sha512-KkkSUddEcaIvW7/QfVUk2PR93117HkDum45cXQEGkoxEmHOmqfOLJ4T1m4a1QABVC7O9TIqPxsBtDPgKIO+LOw==}
+  '@workflow/serde@5.0.0-beta.2':
+    resolution: {integrity: sha512-INB+FcEKQkkFZa+s53sEMTNRFiBa2g9vzjsNuEDagvWxtI0t/cnCyoc57i7kS7nj+3/vGeRjO4Yn5ccbT0hyBQ==}
 
-  '@workflow/sveltekit@4.0.9':
-    resolution: {integrity: sha512-esMJiDe6j2e0PgqfchQfBZVSMqbDAZEu95aCVbxV2+A1io7xURduhdlzi4CoaqPqF/7F3QacNhzvDDD5ZUojwA==}
+  '@workflow/sveltekit@5.0.0-beta.30':
+    resolution: {integrity: sha512-ZcSEsG2NPLSK+KUKqcky/QOo7NK9wfM7uSW8zLBlG9vTK32X/kS1Q5I2kISKDO9t6eT64tPF0GcnDzPkH9I+3w==}
 
-  '@workflow/swc-plugin@4.1.1':
-    resolution: {integrity: sha512-Bi1K/z7Fjxzf5DY9BCBZHMd6Y4SvuCPOAyslydcDD9m38Suz3xCcfrEDvXo8R5mnEnTuLIB4GEJyB54CkMuuiQ==}
+  '@workflow/swc-plugin@5.0.0-beta.5':
+    resolution: {integrity: sha512-Xk2UQePkuxTrgqU0EWZPRWM9Ttj9bcMAY+x700yg/0TQnD3MSxjY6/yC3e8wGr2dfzXik5zuH+Ixrog1CdBqeg==}
     peerDependencies:
       '@swc/core': 1.15.3
 
-  '@workflow/typescript-plugin@4.0.3':
-    resolution: {integrity: sha512-QJ7hmPHrrudgSsOFMML6AbHQpOzAThcQL9AKS06QWX96ZGba+bfsjq/czlyAVXtoluBfN4fw0pSfz/itUB7XVQ==}
+  '@workflow/typescript-plugin@5.0.0-beta.5':
+    resolution: {integrity: sha512-IcP+tMktxXT02H60+Or+0rSKcydhg3CMM5CWTzpnnXlhW3rqBniA/FheWYvtR7HTM7x+Xht1W1eFm8PsaGQpxg==}
     peerDependencies:
       typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@workflow/utils@4.1.3':
-    resolution: {integrity: sha512-SOJ7uwwD3HKtS/QIHIzhyL+2LiKSb+IjisSf25F9GnR+bNH9y1BHaZCrwb4PaXXq0nAO+baRxLbuB5Gr4NI0KA==}
+  '@workflow/utils@5.0.0-beta.6':
+    resolution: {integrity: sha512-YMZqvtRMzlmWkgshURp4ilvcY8VMrNxwXxDEXQ/gkppKWhJ1xdJBpq3plZLf8LWS7JHXd32Wqll/UvQeARu93Q==}
 
-  '@workflow/vite@4.0.9':
-    resolution: {integrity: sha512-/2dXSz4QAszWjcFboQ7+6FxpZ3TYrFsNNcfCZDEnokqXO1VPyDyyRHKys19pGqvQhc6gvrnKV3GhJTofVuZQNg==}
+  '@workflow/vite@5.0.0-beta.30':
+    resolution: {integrity: sha512-/2m7jpR8veDZXt6ClGEFk9fWJvuyQyGGo14RpyKCWnPtZEE3zV/oLJSE7nVOSb3LheofNkMm2Oe1ua6YjnkVCQ==}
 
-  '@workflow/web@4.1.10':
-    resolution: {integrity: sha512-yOcPsB4PNX2zmUNYMOAF3bqPhu03ntlWdFIb9qlKtWmWqK/tfqBP/5w2jk90epIsYjiUMt8tZQA7lxVJsMaxiA==}
+  '@workflow/web@5.0.0-beta.30':
+    resolution: {integrity: sha512-9Xlf3Nde5fWN4bZ0ISmLOBEqmpg0wSkhoF0rIsLjOEIZ35A9Awg37MD5Q/0PrCOPLSz3ylwBKdkau3vhXc+m9w==}
 
-  '@workflow/world-local@4.1.5':
-    resolution: {integrity: sha512-GNf+UTXEhIKuzavig55i/Dg/9Wd0Do8c1NEuPlLfpOn9fQLSn+lW1mm4hyXYg9vbiiZ2DzcOJtsELH8yYwICpw==}
+  '@workflow/world-local@5.0.0-beta.26':
+    resolution: {integrity: sha512-o5TT93tF1CMQ9RLSRjAuiNJIiAnJ0XwKO1HgY9oonSSWuhrwaD9CUefTSI24fp+ZlmR0g68rstYuctowAK5kkA==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/world-vercel@4.4.0':
-    resolution: {integrity: sha512-hfcK71rL2HXDw/gzkV6bgQfvEMN8D1Elt+qtoVzGBFdF3JlIObwqB3cX1PdUzI1Ceo8qrKNpMlLV0BqaK/Awnw==}
+  '@workflow/world-vercel@5.0.0-beta.26':
+    resolution: {integrity: sha512-x2eq1KkJnk5ugfyEgvOnhHlIFzFzbehALMTc787mlXYrDjmjtXhXN3bF7p0Kg8OV8jIEmL/xCHL1xuwdjdx5FA==}
     peerDependencies:
       '@opentelemetry/api': '1'
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
 
-  '@workflow/world@4.1.5':
-    resolution: {integrity: sha512-ABBqSlMKHTvTLXmducnEXHjXGElHPhvBoltqZ+u7MlsH4JrobGsjSsrMyQHJ6PoSaBOXaN4z7vWu9vaaORjn9g==}
-    peerDependencies:
-      zod: 4.3.6
+  '@workflow/world@5.0.0-beta.18':
+    resolution: {integrity: sha512-xq4KybRba4WnNtYMagGa4qqx7Fg8wqWrUklcUYvE2HMz/IPnDbYspvTCsvOrZjsAgcIpqX5XBIcZyVRqRO/WYA==}
 
   '@xhmikosr/archive-type@8.1.0':
     resolution: {integrity: sha512-EXOjEbnZFE5c/nFMf4FOrEURVanzHpnkPYmnmr78u02/8hAhE0FMq8p9TK1IM0/bFr5VcyBUY0gfLm8f7dKy+Q==}
@@ -4364,9 +4380,9 @@ packages:
     peerDependencies:
       zod: ^3.0.0 || ^4.0.0
 
-  ai@6.0.203:
-    resolution: {integrity: sha512-2Qi1ZPGF/FnlvnRqntVgRbUYGeA5ZKFYwTtgu8rcUzMmddArM/nLsvCW69Ip99B1cop6XHRHl+GCKk9t9B+GDA==}
-    engines: {node: '>=18'}
+  ai@7.0.22:
+    resolution: {integrity: sha512-iAXYwQtR18qN7GXwNmGVAQM4uSJOh2+nZ5RP9NtDXfH5d4tlYyYzAM133O3U+eVcyWrvNRzecN9yW58xpCdfMg==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -7014,6 +7030,11 @@ packages:
     resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
     engines: {node: '>=20'}
 
+  swr@2.4.2:
+    resolution: {integrity: sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -7245,12 +7266,12 @@ packages:
     resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
     engines: {node: '>=18.17'}
 
-  undici@7.26.0:
-    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.27.2:
     resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -7433,10 +7454,6 @@ packages:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
 
-  watchpack@2.5.1:
-    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
-    engines: {node: '>=10.13.0'}
-
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
@@ -7527,8 +7544,8 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
-  workflow@4.4.0:
-    resolution: {integrity: sha512-VPgpUoo5Jp0tfLdFNX6v2o1A75u0IIqJt8Fq7IwijTS458VlnYTHyD39wW2JyO5jN0Ge+NAITXbhVbKFIhuZnQ==}
+  workflow@5.0.0-beta.30:
+    resolution: {integrity: sha512-GPljfceMklZBUXHak+bpN6aRYctK9jGDB4yDzRCPp02k7Y1YoHtunKKpckeS32I9OYRhoiV46BOEcOxNWlOj2A==}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': '1'
@@ -7641,10 +7658,10 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.129(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.16(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
@@ -7655,10 +7672,10 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.71(zod@4.4.3)':
+  '@ai-sdk/openai@4.0.11(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.29(zod@4.4.3)':
@@ -7676,11 +7693,23 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.1':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -7803,12 +7832,12 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7(supports-color@8.1.1)':
+  '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
@@ -7848,9 +7877,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7
@@ -8238,9 +8267,9 @@ snapshots:
     dependencies:
       '@formatjs/fast-memoize': 3.1.6
 
-  '@google/genai@2.8.0(supports-color@8.1.1)':
+  '@google/genai@2.8.0':
     dependencies:
-      google-auth-library: 10.7.0(supports-color@8.1.1)
+      google-auth-library: 10.7.0
       p-retry: 4.6.2
       protobufjs: 7.6.4
       ws: 8.21.0
@@ -8577,7 +8606,7 @@ snapshots:
 
   '@next/third-parties@16.2.9(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       third-party-capital: 1.0.20
 
@@ -8587,7 +8616,7 @@ snapshots:
 
   '@nodable/entities@2.2.0': {}
 
-  '@nuxt/kit@4.4.7':
+  '@nuxt/kit@4.4.8':
     dependencies:
       c12: 3.3.4
       consola: 3.4.2
@@ -8648,12 +8677,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.214.0
       import-in-the-middle: 3.0.2
-      require-in-the-middle: 8.0.1(supports-color@8.1.1)
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9346,10 +9375,10 @@ snapshots:
 
   '@scalar/helpers@0.8.2': {}
 
-  '@scalar/nextjs-api-reference@0.11.3(next@16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+  '@scalar/nextjs-api-reference@0.11.3(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@scalar/client-side-rendering': 0.2.3
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
   '@scalar/schemas@0.4.3':
@@ -9402,11 +9431,11 @@ snapshots:
       '@sentry-internal/replay-canvas': 10.57.0
       '@sentry/core': 10.57.0
 
-  '@sentry/bundler-plugin-core@5.3.0(supports-color@8.1.1)':
+  '@sentry/bundler-plugin-core@5.3.0':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
       '@sentry/babel-plugin-component-annotate': 5.3.0
-      '@sentry/cli': 2.58.6(supports-color@8.1.1)
+      '@sentry/cli': 2.58.6
       dotenv: 16.6.1
       find-up: 5.0.0
       glob: 13.0.6
@@ -9439,9 +9468,9 @@ snapshots:
   '@sentry/cli-win32-x64@2.58.6':
     optional: true
 
-  '@sentry/cli@2.58.6(supports-color@8.1.1)':
+  '@sentry/cli@2.58.6':
     dependencies:
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
       progress: 2.0.3
       proxy-from-env: 1.1.0
@@ -9461,20 +9490,20 @@ snapshots:
 
   '@sentry/core@10.57.0': {}
 
-  '@sentry/nextjs@10.57.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(supports-color@8.1.1)(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.28.1))':
+  '@sentry/nextjs@10.57.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.28.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.61.1)
       '@sentry-internal/browser-utils': 10.57.0
-      '@sentry/bundler-plugin-core': 5.3.0(supports-color@8.1.1)
+      '@sentry/bundler-plugin-core': 5.3.0
       '@sentry/core': 10.57.0
-      '@sentry/node': 10.57.0(supports-color@8.1.1)
+      '@sentry/node': 10.57.0
       '@sentry/opentelemetry': 10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
       '@sentry/react': 10.57.0(react@19.2.7)
       '@sentry/vercel-edge': 10.57.0
       '@sentry/webpack-plugin': 5.3.0(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.28.1))
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rollup: 4.61.1
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -9492,14 +9521,14 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.41.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.61.1)
       '@sentry-internal/browser-utils': 10.57.0
-      '@sentry/bundler-plugin-core': 5.3.0(supports-color@8.1.1)
+      '@sentry/bundler-plugin-core': 5.3.0
       '@sentry/core': 10.57.0
-      '@sentry/node': 10.57.0(supports-color@8.1.1)
+      '@sentry/node': 10.57.0
       '@sentry/opentelemetry': 10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
       '@sentry/react': 10.57.0(react@19.2.7)
       '@sentry/vercel-edge': 10.57.0
       '@sentry/webpack-plugin': 5.3.0(webpack@5.107.2(esbuild@0.28.1))
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       rollup: 4.61.1
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -9519,15 +9548,15 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@sentry/node@10.57.0(supports-color@8.1.1)':
+  '@sentry/node@10.57.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
       '@sentry-internal/server-utils': 10.57.0
@@ -9561,7 +9590,7 @@ snapshots:
 
   '@sentry/webpack-plugin@5.3.0(webpack@5.107.2(@swc/core@1.15.3)(esbuild@0.28.1))':
     dependencies:
-      '@sentry/bundler-plugin-core': 5.3.0(supports-color@8.1.1)
+      '@sentry/bundler-plugin-core': 5.3.0
       webpack: 5.107.2(@swc/core@1.15.3)(esbuild@0.28.1)
     transitivePeerDependencies:
       - encoding
@@ -9569,7 +9598,7 @@ snapshots:
 
   '@sentry/webpack-plugin@5.3.0(webpack@5.107.2(esbuild@0.28.1))':
     dependencies:
-      '@sentry/bundler-plugin-core': 5.3.0(supports-color@8.1.1)
+      '@sentry/bundler-plugin-core': 5.3.0
       webpack: 5.107.2(esbuild@0.28.1)
     transitivePeerDependencies:
       - encoding
@@ -10052,7 +10081,7 @@ snapshots:
 
   '@vercel/analytics@2.0.1(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
   '@vercel/blob@2.4.0':
@@ -10067,7 +10096,7 @@ snapshots:
     dependencies:
       async-listen: 3.0.0
       open: 8.4.0
-      xdg-app-paths: 5.1.0
+      xdg-app-paths: 5.5.1
       zod: 4.1.11
 
   '@vercel/cli-config@0.2.0':
@@ -10094,12 +10123,14 @@ snapshots:
       '@vercel/cli-exec': 0.1.1
       jose: 5.10.0
 
-  '@vercel/queue@0.3.0':
+  '@vercel/queue@0.4.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@vercel/oidc': 3.6.1
       minimatch: 10.2.5
       mixpart: 0.0.6
       picocolors: 1.1.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
 
   '@vitejs/plugin-react@6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -10295,13 +10326,13 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@workflow/astro@4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)':
+  '@workflow/astro@5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/rollup': 4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3)
-      '@workflow/vite': 4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/builders': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/rollup': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
+      '@workflow/vite': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
@@ -10310,13 +10341,15 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/builders@4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)':
+  '@workflow/builders@5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/core': 4.4.0(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/errors': 4.1.4
-      '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3)
-      '@workflow/utils': 4.1.3
+      '@workflow/core': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/errors': 5.0.0-beta.10
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
+      '@workflow/utils': 5.0.0-beta.6
+      '@workflow/world-local': 5.0.0-beta.26(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 5.0.0-beta.26(@opentelemetry/api@1.9.1)
       builtin-modules: 5.0.0
       chalk: 5.6.2
       enhanced-resolve: 5.19.0
@@ -10330,21 +10363,21 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/cli@4.2.9(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.0)':
+  '@workflow/cli@5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)(ws@8.21.0)':
     dependencies:
       '@oclif/core': 4.11.4
       '@oclif/plugin-help': 6.2.37
       '@swc/core': 1.15.3
       '@vercel/cli-auth': 0.0.1
-      '@workflow/builders': 4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/core': 4.4.0(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/errors': 4.1.4
-      '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3)
-      '@workflow/utils': 4.1.3
-      '@workflow/web': 4.1.10(supports-color@8.1.1)
-      '@workflow/world': 4.1.5(zod@4.3.6)
-      '@workflow/world-local': 4.1.5(@opentelemetry/api@1.9.1)
-      '@workflow/world-vercel': 4.4.0(@opentelemetry/api@1.9.1)
+      '@workflow/builders': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/core': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/errors': 5.0.0-beta.10
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
+      '@workflow/utils': 5.0.0-beta.6
+      '@workflow/web': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)
+      '@workflow/world': 5.0.0-beta.18
+      '@workflow/world-local': 5.0.0-beta.26(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 5.0.0-beta.26(@opentelemetry/api@1.9.1)
       boxen: 8.0.1
       builtin-modules: 5.0.0
       chalk: 5.6.2
@@ -10365,22 +10398,23 @@ snapshots:
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - react
       - supports-color
       - ws
 
-  '@workflow/core@4.4.0(@opentelemetry/api@1.9.1)(ws@8.21.0)':
+  '@workflow/core@5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       '@jridgewell/trace-mapping': 0.3.31
       '@standard-schema/spec': 1.0.0
       '@types/ms': 2.1.0
       '@vercel/functions': 3.7.1(@aws-sdk/credential-provider-web-identity@3.972.49)(ws@8.21.0)
-      '@workflow/errors': 4.1.4
-      '@workflow/serde': 4.1.2
-      '@workflow/utils': 4.1.3
-      '@workflow/world': 4.1.5(zod@4.3.6)
-      '@workflow/world-local': 4.1.5(@opentelemetry/api@1.9.1)
-      '@workflow/world-vercel': 4.4.0(@opentelemetry/api@1.9.1)
+      '@workflow/errors': 5.0.0-beta.10
+      '@workflow/serde': 5.0.0-beta.2
+      '@workflow/utils': 5.0.0-beta.6
+      '@workflow/world': 5.0.0-beta.18
+      '@workflow/world-local': 5.0.0-beta.26(@opentelemetry/api@1.9.1)
+      '@workflow/world-vercel': 5.0.0-beta.26(@opentelemetry/api@1.9.1)
       debug: 4.4.3(supports-color@8.1.1)
       devalue: 5.8.1
       ms: 2.1.3
@@ -10395,19 +10429,19 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/errors@4.1.4':
+  '@workflow/errors@5.0.0-beta.10':
     dependencies:
-      '@workflow/utils': 4.1.3
+      '@workflow/utils': 5.0.0-beta.6
       ms: 2.1.3
 
-  '@workflow/nest@0.0.9(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(ws@8.21.0)':
+  '@workflow/nest@5.0.0-beta.30(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(ws@8.21.0)':
     dependencies:
       '@nestjs/common': 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@swc/cli': 0.8.1(@swc/core@1.15.3)(chokidar@5.0.0)
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3)
+      '@workflow/builders': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
       pathe: 2.0.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -10415,55 +10449,58 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/next@4.0.10(@opentelemetry/api@1.9.1)(next@16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ws@8.21.0)':
+  '@workflow/next@5.0.0-beta.30(@opentelemetry/api@1.9.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ws@8.21.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/core': 4.4.0(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3)
+      '@workflow/builders': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/core': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
+      chokidar: 4.0.3
       semver: 7.7.4
-      watchpack: 2.5.1
     optionalDependencies:
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
       - supports-color
       - ws
 
-  '@workflow/nitro@4.1.0(@opentelemetry/api@1.9.1)(ws@8.21.0)':
+  '@workflow/nitro@5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)(ws@8.21.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/core': 4.4.0(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/rollup': 4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3)
-      '@workflow/vite': 4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/web': 4.1.10(supports-color@8.1.1)
+      '@workflow/builders': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/core': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/rollup': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
+      '@workflow/vite': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/web': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)
       exsolve: 1.0.8
       pathe: 2.0.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
+      - react
       - supports-color
       - ws
 
-  '@workflow/nuxt@4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)':
+  '@workflow/nuxt@5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)(ws@8.21.0)':
     dependencies:
-      '@nuxt/kit': 4.4.7
-      '@workflow/nitro': 4.1.0(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@nuxt/kit': 4.4.8
+      '@workflow/builders': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/nitro': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)(ws@8.21.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
       - magicast
+      - react
       - supports-color
       - ws
 
-  '@workflow/rollup@4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)':
+  '@workflow/rollup@5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3)
+      '@workflow/builders': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
       exsolve: 1.0.7
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -10473,15 +10510,15 @@ snapshots:
 
   '@workflow/serde@4.1.0': {}
 
-  '@workflow/serde@4.1.2': {}
+  '@workflow/serde@5.0.0-beta.2': {}
 
-  '@workflow/sveltekit@4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)':
+  '@workflow/sveltekit@5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)':
     dependencies:
       '@swc/core': 1.15.3
-      '@workflow/builders': 4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/rollup': 4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/swc-plugin': 4.1.1(@swc/core@1.15.3)
-      '@workflow/vite': 4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/builders': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/rollup': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/swc-plugin': 5.0.0-beta.5(@swc/core@1.15.3)
+      '@workflow/vite': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
       exsolve: 1.0.8
       fs-extra: 11.3.5
       pathe: 2.0.3
@@ -10491,59 +10528,63 @@ snapshots:
       - supports-color
       - ws
 
-  '@workflow/swc-plugin@4.1.1(@swc/core@1.15.3)':
+  '@workflow/swc-plugin@5.0.0-beta.5(@swc/core@1.15.3)':
     dependencies:
       '@swc/core': 1.15.3
 
-  '@workflow/typescript-plugin@4.0.3(@typescript/typescript6@6.0.2)':
-    dependencies:
+  '@workflow/typescript-plugin@5.0.0-beta.5(@typescript/typescript6@6.0.2)':
+    optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
-  '@workflow/utils@4.1.3':
+  '@workflow/utils@5.0.0-beta.6':
     dependencies:
       ms: 2.1.3
 
-  '@workflow/vite@4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)':
+  '@workflow/vite@5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)':
     dependencies:
-      '@workflow/builders': 4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/builders': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
       - supports-color
       - ws
 
-  '@workflow/web@4.1.10(supports-color@8.1.1)':
+  '@workflow/web@5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)':
     dependencies:
-      express: 5.2.1(supports-color@8.1.1)
+      '@workflow/world-local': 5.0.0-beta.26(@opentelemetry/api@1.9.1)
+      express: 5.2.1
+      swr: 2.4.2(react@19.2.7)
     transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - react
       - supports-color
 
-  '@workflow/world-local@4.1.5(@opentelemetry/api@1.9.1)':
+  '@workflow/world-local@5.0.0-beta.26(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@vercel/queue': 0.3.0
-      '@workflow/errors': 4.1.4
-      '@workflow/utils': 4.1.3
-      '@workflow/world': 4.1.5(zod@4.3.6)
+      '@vercel/queue': 0.4.0(@opentelemetry/api@1.9.1)
+      '@workflow/errors': 5.0.0-beta.10
+      '@workflow/utils': 5.0.0-beta.6
+      '@workflow/world': 5.0.0-beta.18
       async-sema: 3.1.1
       ulid: 3.0.2
-      undici: 7.26.0
+      undici: 7.28.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@workflow/world-vercel@4.4.0(@opentelemetry/api@1.9.1)':
+  '@workflow/world-vercel@5.0.0-beta.26(@opentelemetry/api@1.9.1)':
     dependencies:
       '@vercel/oidc': 3.2.0
-      '@vercel/queue': 0.3.0
-      '@workflow/errors': 4.1.4
-      '@workflow/world': 4.1.5(zod@4.3.6)
+      '@vercel/queue': 0.4.0(@opentelemetry/api@1.9.1)
+      '@workflow/errors': 5.0.0-beta.10
+      '@workflow/world': 5.0.0-beta.18
       cbor-x: 1.6.0
-      undici: 7.26.0
+      undici: 7.28.0
       zod: 4.3.6
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@workflow/world@4.1.5(zod@4.3.6)':
+  '@workflow/world@5.0.0-beta.18':
     dependencies:
       ulid: 3.0.2
       zod: 4.3.6
@@ -10664,7 +10705,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2(supports-color@8.1.1):
+  agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -10679,12 +10720,11 @@ snapshots:
       jsonc-parser: 3.3.1
       zod: 4.4.3
 
-  ai@6.0.203(zod@4.4.3):
+  ai@7.0.22(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.129(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.16(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
       zod: 4.4.3
 
   ai@7.0.8(zod@4.4.3):
@@ -10809,7 +10849,7 @@ snapshots:
     optionalDependencies:
       '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2))(typescript@7.0.2)
       mysql2: 3.15.3
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       pg: 8.21.0
       prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
       react: 19.2.7
@@ -10849,7 +10889,7 @@ snapshots:
       execa: 8.0.1
       find-versions: 6.0.0
 
-  body-parser@2.2.2(supports-color@8.1.1):
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -10865,7 +10905,7 @@ snapshots:
 
   botid@1.5.11(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     optionalDependencies:
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
   bowser@2.14.1: {}
@@ -11421,10 +11461,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@5.2.1(supports-color@8.1.1):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2(supports-color@8.1.1)
+      body-parser: 2.2.2
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -11434,7 +11474,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@8.1.1)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -11445,8 +11485,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.2
       range-parser: 1.2.1
-      router: 2.2.0(supports-color@8.1.1)
-      send: 1.2.1(supports-color@8.1.1)
+      router: 2.2.0
+      send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
@@ -11543,7 +11583,7 @@ snapshots:
     dependencies:
       filename-reserved-regex: 4.0.0
 
-  finalhandler@2.1.1(supports-color@8.1.1):
+  finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -11605,17 +11645,17 @@ snapshots:
 
   function-timeout@1.0.2: {}
 
-  gaxios@7.1.5(supports-color@8.1.1):
+  gaxios@7.1.5:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
   gcp-metadata@8.1.2:
     dependencies:
-      gaxios: 7.1.5(supports-color@8.1.1)
+      gaxios: 7.1.5
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -11674,11 +11714,11 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  google-auth-library@10.7.0(supports-color@8.1.1):
+  google-auth-library@10.7.0:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.5(supports-color@8.1.1)
+      gaxios: 7.1.5
       gcp-metadata: 8.1.2
       google-logging-utils: 1.1.3
       jws: 4.0.1
@@ -11790,14 +11830,14 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -12546,7 +12586,7 @@ snapshots:
       '@swc/core': 1.15.41
       icu-minify: 4.13.0
       negotiator: 1.0.0
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl-swc-plugin-extractor: 4.13.0
       po-parser: 2.1.1
       react: 19.2.7
@@ -12563,7 +12603,7 @@ snapshots:
       '@swc/core': 1.15.41
       icu-minify: 4.13.0
       negotiator: 1.0.0
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-intl-swc-plugin-extractor: 4.13.0
       po-parser: 2.1.1
       react: 19.2.7
@@ -12578,7 +12618,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
@@ -12587,7 +12627,7 @@ snapshots:
       postcss: 8.5.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.9
       '@next/swc-darwin-x64': 16.2.9
@@ -12646,7 +12686,7 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       react: 19.2.7
     optionalDependencies:
-      next: 16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   object-inspect@1.13.4: {}
 
@@ -13226,7 +13266,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1(supports-color@8.1.1):
+  require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
@@ -13308,7 +13348,7 @@ snapshots:
 
   rou3@0.7.12: {}
 
-  router@2.2.0(supports-color@8.1.1):
+  router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
@@ -13367,7 +13407,7 @@ snapshots:
 
   semver@7.8.4: {}
 
-  send@1.2.1(supports-color@8.1.1):
+  send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -13390,7 +13430,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@8.1.1)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13594,12 +13634,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@8.1.1))(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
     optionalDependencies:
-      '@babel/core': 7.29.7(supports-color@8.1.1)
+      '@babel/core': 7.29.7
 
   super-regex@1.1.0:
     dependencies:
@@ -13617,6 +13657,12 @@ snapshots:
     dependencies:
       has-flag: 5.0.1
       supports-color: 10.2.2
+
+  swr@2.4.2(react@19.2.7):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
 
   symbol-tree@3.2.4: {}
 
@@ -13831,9 +13877,9 @@ snapshots:
 
   undici@6.26.0: {}
 
-  undici@7.26.0: {}
-
   undici@7.27.2: {}
+
+  undici@7.28.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -14050,11 +14096,6 @@ snapshots:
 
   walk-up-path@4.0.0: {}
 
-  watchpack@2.5.1:
-    dependencies:
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-
   watchpack@2.5.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -14234,20 +14275,20 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.4.0(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(@typescript/typescript6@6.0.2)(next@16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@8.1.1)(ws@8.21.0):
+  workflow@5.0.0-beta.30(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(@typescript/typescript6@6.0.2)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(ws@8.21.0):
     dependencies:
-      '@workflow/astro': 4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/cli': 4.2.9(@opentelemetry/api@1.9.1)(supports-color@8.1.1)(ws@8.21.0)
-      '@workflow/core': 4.4.0(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/errors': 4.1.4
-      '@workflow/nest': 0.0.9(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(ws@8.21.0)
-      '@workflow/next': 4.0.10(@opentelemetry/api@1.9.1)(next@16.2.9(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ws@8.21.0)
-      '@workflow/nitro': 4.1.0(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/nuxt': 4.0.10(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/rollup': 4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/sveltekit': 4.0.9(@opentelemetry/api@1.9.1)(ws@8.21.0)
-      '@workflow/typescript-plugin': 4.0.3(@typescript/typescript6@6.0.2)
-      '@workflow/utils': 4.1.3
+      '@workflow/astro': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/cli': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)(ws@8.21.0)
+      '@workflow/core': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/errors': 5.0.0-beta.10
+      '@workflow/nest': 5.0.0-beta.30(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(ws@8.21.0)
+      '@workflow/next': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(ws@8.21.0)
+      '@workflow/nitro': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)(ws@8.21.0)
+      '@workflow/nuxt': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(react@19.2.7)(ws@8.21.0)
+      '@workflow/rollup': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/sveltekit': 5.0.0-beta.30(@opentelemetry/api@1.9.1)(ws@8.21.0)
+      '@workflow/typescript-plugin': 5.0.0-beta.5(@typescript/typescript6@6.0.2)
+      '@workflow/utils': 5.0.0-beta.6
       ms: 2.1.3
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -14259,6 +14300,7 @@ snapshots:
       - '@swc/helpers'
       - magicast
       - next
+      - react
       - supports-color
       - typescript
       - ws

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   "@typescript/native": npm:typescript@7.0.2
   typescript: npm:@typescript/typescript6@6.0.2
   "@vercel/analytics": 2.0.1
-  ai: 6.0.203
+  ai: 7.0.22
   babel-plugin-react-compiler: 1.0.0
   botid: 1.5.11
   jsdom: 29.1.1

--- a/turbo.json
+++ b/turbo.json
@@ -32,11 +32,23 @@
     "//#quality:fix": { "dependsOn": ["//#lint:fix", "//#format:fix"] },
     "build": {
       "dependsOn": ["db:generate", "db:deploy", "^build"],
-      "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**", "messages/**"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "!.next/dev/**",
+        "messages/**",
+        "src/app/.well-known/workflow/**"
+      ]
     },
     "build:e2e": {
       "dependsOn": ["db:generate", "^build:e2e"],
-      "outputs": [".next-e2e/**", "!.next-e2e/cache/**", "!.next-e2e/dev/**", "messages/**"]
+      "outputs": [
+        ".next-e2e/**",
+        "!.next-e2e/cache/**",
+        "!.next-e2e/dev/**",
+        "messages/**",
+        "src/app/.well-known/workflow/**"
+      ]
     },
     "db:deploy": { "cache": false },
     "db:generate": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded `ai` to v7 and `workflow` to v5 beta, updating all AI task calls to the new API (uses instructions, stable speech API, and new response shape). Also adjusted build outputs and added `/.swc` to `.gitignore`.

- **Dependencies**
  - `ai` → 7.0.22; `@ai-sdk/gateway` → 4.x; `@ai-sdk/openai` → 4.x
  - `workflow` → 5.0.0-beta.30

- **Migration**
  - Requires Node 22+
  - Replace `generateText({ system })` with `generateText({ instructions })`
  - Use `generateSpeech` from `ai` (drop `experimental_generateSpeech`)
  - Update result access: `generation.response` → `generation.finalStep.response` and `generation.providerMetadata` → `generation.finalStep.providerMetadata`
  - New Turbo outputs include `src/app/.well-known/workflow/**`; run a clean build after `pnpm i`

<sup>Written for commit 43d906b04c259a409a05382339b0896fa2362b76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

