### PR TITLE
chore(ai): use ai sdk v7 `reasoning` field

### DIFF
--- a/apps/evals/src/lib/models.ts
+++ b/apps/evals/src/lib/models.ts
@@ -1,9 +1,11 @@
+import { type Reasoning } from "@zoonk/ai/provider-options";
+
 export type ModelConfig = {
   id: string;
   name: string;
   inputCost: number;
   outputCost: number;
-  reasoningEffort?: "auto" | "low" | "medium" | "high";
+  reasoning?: Reasoning;
 };
 
 export const EVAL_MODELS: ModelConfig[] = [
@@ -41,8 +43,8 @@ export const EVAL_MODELS: ModelConfig[] = [
 ];
 
 export function getModelDisplayName(model: ModelConfig): string {
-  if (model.reasoningEffort) {
-    return `${model.name} (${model.reasoningEffort})`;
+  if (model.reasoning) {
+    return `${model.name} (${model.reasoning})`;
   }
 
   return model.name;
@@ -54,7 +56,7 @@ export function getModelById(modelId: string): ModelConfig | null {
 
 /**
  * Get the base model ID to pass to the AI gateway.
- * Strips any reasoning effort suffix (e.g., "openai/gpt-5.2:high" -> "openai/gpt-5.2")
+ * Strips any reasoning suffix (e.g., "openai/gpt-5.2:high" -> "openai/gpt-5.2")
  */
 export function getGatewayModelId(modelId: string): string {
   const colonIndex = modelId.indexOf(":");

--- a/apps/evals/src/lib/output-generator.ts
+++ b/apps/evals/src/lib/output-generator.ts
@@ -17,7 +17,7 @@ function getTaskGenerateInput({ modelId, testCase }: { modelId: string; testCase
   return {
     ...testCase.userInput,
     model: gatewayModelId,
-    reasoningEffort: model?.reasoningEffort,
+    reasoning: model?.reasoning,
     useFallback: false,
   };
 }

--- a/apps/evals/src/lib/types.ts
+++ b/apps/evals/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { type ReasoningEffort } from "@zoonk/ai/provider-options";
+import { type Reasoning } from "@zoonk/ai/provider-options";
 import { type LanguageModelUsage } from "ai";
 import z from "zod";
 
@@ -66,7 +66,7 @@ export type TaskScorer<TExpected = unknown> = (
 type TaskGenerateInput<TInput> = TInput & {
   model: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 export type EvalResult = {

--- a/packages/ai/src/provider-options.test.ts
+++ b/packages/ai/src/provider-options.test.ts
@@ -2,12 +2,11 @@ import { describe, expect, it } from "vitest";
 import { buildImageProviderOptions, buildProviderOptions } from "./provider-options";
 
 describe(buildProviderOptions, () => {
-  it("adds provider order and reasoning effort for fallback-enabled models", () => {
+  it("adds provider order for fallback-enabled models", () => {
     expect(
       buildProviderOptions({
         fallbackModels: ["google/gemini-3-flash", "anthropic/claude-haiku-4.5"],
         model: "openai/gpt-5.4",
-        reasoningEffort: "high",
         useFallback: true,
       }),
     ).toStrictEqual({
@@ -15,7 +14,6 @@ describe(buildProviderOptions, () => {
         models: ["google/gemini-3-flash", "anthropic/claude-haiku-4.5"],
         order: ["openai", "azure", "google", "anthropic", "vertex"],
       },
-      openai: { reasoningEffort: "high" },
     });
   });
 

--- a/packages/ai/src/provider-options.ts
+++ b/packages/ai/src/provider-options.ts
@@ -1,7 +1,7 @@
 import { type GatewayProviderOptions } from "@ai-sdk/gateway";
-import { type OpenAILanguageModelResponsesOptions } from "@ai-sdk/openai";
+import { type LanguageModelCallOptions } from "ai";
 
-export type ReasoningEffort = "auto" | "low" | "medium" | "high";
+export type Reasoning = NonNullable<LanguageModelCallOptions["reasoning"]>;
 export type ImageGenerationQuality = "auto" | "low" | "medium" | "high";
 
 const providerOrderByModelPrefix = {
@@ -12,10 +12,7 @@ const providerOrderByModelPrefix = {
 
 type SupportedModelPrefix = keyof typeof providerOrderByModelPrefix;
 
-type ProviderOptionsResult = {
-  gateway: Pick<GatewayProviderOptions, "models" | "order">;
-  openai?: Pick<OpenAILanguageModelResponsesOptions, "reasoningEffort">;
-};
+type ProviderOptionsResult = { gateway: Pick<GatewayProviderOptions, "models" | "order"> };
 
 type ImageProviderOptionsResult = {
   gateway: Pick<GatewayProviderOptions, "models">;
@@ -84,27 +81,17 @@ export function buildImageProviderOptions({
 
 /**
  * Builds the shared provider options object for text-generation tasks.
- * This exists so fallback models, gateway routing, and provider-specific
- * reasoning settings stay consistent across every task in this package.
+ * This exists so fallback models and gateway routing stay consistent across
+ * every task in this package.
  */
 export function buildProviderOptions({
   model,
   useFallback,
   fallbackModels,
-  reasoningEffort,
 }: {
   model: string;
   useFallback: boolean;
   fallbackModels: readonly string[];
-  reasoningEffort?: ReasoningEffort;
 }): ProviderOptionsResult {
-  const options: ProviderOptionsResult = {
-    gateway: buildGatewayProviderOptions({ fallbackModels, model, useFallback }),
-  };
-
-  if (reasoningEffort && reasoningEffort !== "auto") {
-    options.openai = { reasoningEffort };
-  }
-
-  return options;
+  return { gateway: buildGatewayProviderOptions({ fallbackModels, model, useFallback }) };
 }

--- a/packages/ai/src/tasks/chapters/chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/chapter-lessons.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./chapter-lessons.prompt.md";
 
@@ -33,7 +33,7 @@ export async function generateChapterLessons({
   neighboringChapters,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: {
   chapterDescription: string;
   chapterTitle: string;
@@ -42,7 +42,7 @@ export async function generateChapterLessons({
   neighboringChapters?: { title: string; description: string }[];
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 }) {
   const neighboringSection = neighboringChapters
     ? formatNeighboringChapters(neighboringChapters)
@@ -57,12 +57,7 @@ export async function generateChapterLessons({
     CHAPTER_DESCRIPTION: ${chapterDescription}${neighboringSection}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -70,6 +65,7 @@ export async function generateChapterLessons({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./language-chapter-lessons.prompt.md";
 
@@ -28,7 +28,7 @@ export async function generateLanguageChapterLessons({
   targetLanguage,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: {
   chapterDescription: string;
   chapterTitle: string;
@@ -36,7 +36,7 @@ export async function generateLanguageChapterLessons({
   targetLanguage: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 }) {
   const targetLanguageName = getPromptLanguageName({ language: targetLanguage, userLanguage });
   const userLanguageName = getPromptLanguageName({ language: userLanguage });
@@ -48,12 +48,7 @@ export async function generateLanguageChapterLessons({
     TARGET_LANGUAGE: ${targetLanguageName}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -61,6 +56,7 @@ export async function generateLanguageChapterLessons({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-canonical-title.ts
+++ b/packages/ai/src/tasks/courses/course-canonical-title.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-canonical-title.prompt.md";
 
@@ -22,7 +22,7 @@ export type CourseCanonicalTitleParams = {
   prompt: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 /**
@@ -34,7 +34,7 @@ export async function generateCanonicalCourseTitle({
   language,
   model = defaultModel,
   prompt,
-  reasoningEffort,
+  reasoning,
   useFallback = true,
 }: CourseCanonicalTitleParams) {
   const promptLanguage = getPromptLanguageName({ language });
@@ -44,12 +44,7 @@ export async function generateCanonicalCourseTitle({
     USER_INPUT: ${prompt}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -57,6 +52,7 @@ export async function generateCanonicalCourseTitle({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
     temperature: 0,
   });
 

--- a/packages/ai/src/tasks/courses/course-categories.ts
+++ b/packages/ai/src/tasks/courses/course-categories.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { AI_COURSE_CATEGORIES } from "@zoonk/utils/categories";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import promptTemplate from "./course-categories.prompt.md";
 
 const defaultModel = "google/gemini-3.1-flash-lite";
@@ -17,14 +17,14 @@ export type CourseCategoriesParams = {
   courseTitle: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 export async function generateCourseCategories({
   courseTitle,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: CourseCategoriesParams) {
   const userPrompt = `
     COURSE_TITLE: ${courseTitle}
@@ -34,12 +34,7 @@ export async function generateCourseCategories({
     AI_COURSE_CATEGORIES.join(", "),
   );
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -47,6 +42,7 @@ export async function generateCourseCategories({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-chapters.ts
+++ b/packages/ai/src/tasks/courses/course-chapters.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-chapters.prompt.md";
 
@@ -25,7 +25,7 @@ export type CourseChaptersParams = {
   courseTitle: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 export async function generateCourseChapters({
@@ -33,7 +33,7 @@ export async function generateCourseChapters({
   courseTitle,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: CourseChaptersParams) {
   const promptLanguage = getPromptLanguageName({ language });
 
@@ -42,12 +42,7 @@ export async function generateCourseChapters({
     COURSE_TITLE: ${courseTitle}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -55,6 +50,7 @@ export async function generateCourseChapters({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-description.ts
+++ b/packages/ai/src/tasks/courses/course-description.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-description.prompt.md";
 
@@ -17,7 +17,7 @@ export type CourseDescriptionParams = {
   language: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 export async function generateCourseDescription({
@@ -25,7 +25,7 @@ export async function generateCourseDescription({
   language,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: CourseDescriptionParams) {
   const promptLanguage = getPromptLanguageName({ language });
 
@@ -34,12 +34,7 @@ export async function generateCourseDescription({
     LANGUAGE: ${promptLanguage}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -47,6 +42,7 @@ export async function generateCourseDescription({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-format.ts
+++ b/packages/ai/src/tasks/courses/course-format.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-format.prompt.md";
 
@@ -33,7 +33,7 @@ export type CourseFormatParams = {
   prompt: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 /**
@@ -45,7 +45,7 @@ export async function classifyCourseFormat({
   language,
   model = defaultModel,
   prompt,
-  reasoningEffort,
+  reasoning,
   useFallback = true,
 }: CourseFormatParams) {
   const promptLanguage = getPromptLanguageName({ language });
@@ -55,12 +55,7 @@ export async function classifyCourseFormat({
     USER_INPUT: ${prompt}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -68,6 +63,7 @@ export async function classifyCourseFormat({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-identity-search.ts
+++ b/packages/ai/src/tasks/courses/course-identity-search.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import searchPrompt from "./course-identity-search.prompt.md";
 
 const defaultModel = "openai/gpt-5.6-luna";
@@ -22,7 +22,7 @@ export type CourseIdentitySearchParams = {
   proposedCourse: CourseIdentityProposedCourse;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 /**
@@ -42,17 +42,12 @@ function buildSearchUserPrompt(params: CourseIdentitySearchParams): string {
 export async function generateCourseIdentitySearchQueries({
   model = defaultModel,
   proposedCourse,
-  reasoningEffort,
+  reasoning,
   useFallback = true,
 }: CourseIdentitySearchParams) {
   const userPrompt = buildSearchUserPrompt({ proposedCourse });
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: searchPrompt,
@@ -60,6 +55,7 @@ export async function generateCourseIdentitySearchQueries({
     output: Output.object({ schema: searchSchema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt: searchPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-identity.ts
+++ b/packages/ai/src/tasks/courses/course-identity.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import classificationPrompt from "./course-identity.prompt.md";
 
 const defaultModel = "google/gemini-3.1-flash-lite";
@@ -35,7 +35,7 @@ export type CourseIdentityParams = {
   proposedCourse: CourseIdentityProposedCourse;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 /**
@@ -74,17 +74,12 @@ export async function resolveCourseIdentity({
   candidates,
   model = defaultModel,
   proposedCourse,
-  reasoningEffort,
+  reasoning,
   useFallback = true,
 }: CourseIdentityParams) {
   const userPrompt = buildIdentityUserPrompt({ candidates, proposedCourse });
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: classificationPrompt,
@@ -92,6 +87,7 @@ export async function resolveCourseIdentity({
     output: Output.object({ schema: identitySchema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return {

--- a/packages/ai/src/tasks/courses/course-intent.ts
+++ b/packages/ai/src/tasks/courses/course-intent.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-intent.prompt.md";
 
@@ -20,7 +20,7 @@ export type CourseIntentParams = {
   prompt: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 /**
@@ -32,7 +32,7 @@ export async function classifyCourseIntent({
   language,
   model = defaultModel,
   prompt,
-  reasoningEffort,
+  reasoning,
   useFallback = true,
 }: CourseIntentParams) {
   const promptLanguage = getPromptLanguageName({ language });
@@ -42,12 +42,7 @@ export async function classifyCourseIntent({
     USER_INPUT: ${prompt}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -55,6 +50,7 @@ export async function classifyCourseIntent({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-introduction.ts
+++ b/packages/ai/src/tasks/courses/course-introduction.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-introduction.prompt.md";
 
@@ -30,7 +30,7 @@ export type CourseIntroductionParams = {
   courseTitle: string;
   language: string;
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   useFallback?: boolean;
 };
 
@@ -38,7 +38,7 @@ export async function generateCourseIntroduction({
   courseTitle,
   language,
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   useFallback = true,
 }: CourseIntroductionParams) {
   const promptLanguage = getPromptLanguageName({ language });
@@ -48,12 +48,7 @@ export async function generateCourseIntroduction({
     COURSE_TITLE: ${courseTitle}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -61,6 +56,7 @@ export async function generateCourseIntroduction({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-landing-page.ts
+++ b/packages/ai/src/tasks/courses/course-landing-page.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import { type CourseChapter } from "./course-chapters";
 import systemPrompt from "./course-landing-page.prompt.md";
@@ -25,7 +25,7 @@ export type CourseLandingPageParams = {
   description?: string | null;
   language: string;
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   targetLanguage?: string | null;
   title: string;
   useFallback?: boolean;
@@ -57,7 +57,7 @@ export async function generateCourseLandingPage({
   description,
   language,
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   targetLanguage,
   title,
   useFallback = true,
@@ -76,12 +76,7 @@ export async function generateCourseLandingPage({
     TARGET_LANGUAGE: ${targetLanguageName}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -89,6 +84,7 @@ export async function generateCourseLandingPage({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/course-personalization.ts
+++ b/packages/ai/src/tasks/courses/course-personalization.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-personalization.prompt.md";
 
@@ -23,7 +23,7 @@ export type CoursePersonalizationParams = {
   prompt: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 /**
@@ -35,7 +35,7 @@ export async function classifyCoursePersonalization({
   language,
   model = defaultModel,
   prompt,
-  reasoningEffort,
+  reasoning,
   useFallback = true,
 }: CoursePersonalizationParams) {
   const promptLanguage = getPromptLanguageName({ language });
@@ -45,12 +45,7 @@ export async function classifyCoursePersonalization({
     USER_INPUT: ${prompt}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -58,6 +53,7 @@ export async function classifyCoursePersonalization({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/courses/language-course-chapters.ts
+++ b/packages/ai/src/tasks/courses/language-course-chapters.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./language-course-chapters.prompt.md";
 
@@ -19,7 +19,7 @@ export type LanguageCourseChaptersParams = {
   targetLanguage: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 export async function generateLanguageCourseChapters({
@@ -27,7 +27,7 @@ export async function generateLanguageCourseChapters({
   targetLanguage,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: LanguageCourseChaptersParams) {
   const targetLanguageName = getPromptLanguageName({ language: targetLanguage, userLanguage });
   const userLanguageName = getPromptLanguageName({ language: userLanguage });
@@ -37,12 +37,7 @@ export async function generateLanguageCourseChapters({
     TARGET_LANGUAGE: ${targetLanguageName}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -50,6 +45,7 @@ export async function generateLanguageCourseChapters({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/images/image-prompt-safety-rewrite.ts
+++ b/packages/ai/src/tasks/images/image-prompt-safety-rewrite.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import systemPrompt from "./image-prompt-safety-rewrite.prompt.md";
@@ -17,7 +17,7 @@ export type ImageInputSafetyRewriteParams = {
   input: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 /**
@@ -31,16 +31,11 @@ export async function rewriteImageInputForSafetyRetry({
   input,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: ImageInputSafetyRewriteParams) {
   const userPrompt = getImageInputSafetyRewriteUserPrompt({ errorContext, input });
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -48,6 +43,7 @@ export async function rewriteImageInputForSafetyRetry({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
@@ -29,7 +29,7 @@ export type LessonExplanationParams = {
   otherLessonTitles: string[];
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 export async function generateLessonExplanation({
@@ -41,7 +41,7 @@ export async function generateLessonExplanation({
   otherLessonTitles,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: LessonExplanationParams) {
   const promptLanguage = getPromptLanguageName({ language });
 
@@ -54,12 +54,7 @@ export async function generateLessonExplanation({
     OTHER_EXPLANATION_LESSON_TITLES: ${otherLessonTitles.join(", ")}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -67,6 +62,7 @@ export async function generateLessonExplanation({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/core/lesson-practice.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
@@ -35,7 +35,7 @@ export type LessonPracticeParams = {
   lesson: SourceLesson;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 export async function generateLessonPractice({
@@ -45,7 +45,7 @@ export async function generateLessonPractice({
   lesson,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: LessonPracticeParams) {
   const formattedLesson = formatSourceLessonForPrompt(lesson);
   const promptLanguage = getPromptLanguageName({ language });
@@ -57,12 +57,7 @@ export async function generateLessonPractice({
     LESSON: ${formattedLesson}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -70,6 +65,7 @@ export async function generateLessonPractice({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
@@ -73,7 +73,7 @@ export type LessonQuizParams = {
   lesson: SourceLesson;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 export async function generateLessonQuiz({
@@ -83,7 +83,7 @@ export async function generateLessonQuiz({
   lesson,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: LessonQuizParams) {
   const formattedLesson = formatSourceLessonForPrompt(lesson);
   const promptLanguage = getPromptLanguageName({ language });
@@ -95,12 +95,7 @@ export async function generateLessonQuiz({
     LESSON: ${formattedLesson}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -108,6 +103,7 @@ export async function generateLessonQuiz({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-alphabet.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-alphabet.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
@@ -32,7 +32,7 @@ export type LessonAlphabetParams = {
   lessonDescription: string;
   lessonTitle: string;
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   targetLanguage: string;
   useFallback?: boolean;
   userLanguage: string;
@@ -50,7 +50,7 @@ export async function generateLessonAlphabet({
   lessonDescription,
   lessonTitle,
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   targetLanguage,
   useFallback = true,
   userLanguage,
@@ -65,12 +65,7 @@ export async function generateLessonAlphabet({
     LESSON_DESCRIPTION: ${lessonDescription}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -78,6 +73,7 @@ export async function generateLessonAlphabet({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { type DistractorShape } from "@zoonk/utils/distractors";
 import { Output, generateText } from "ai";
 import { z } from "zod";
@@ -21,7 +21,7 @@ export type LessonDistractorsParams = {
   shape: DistractorShape;
   translation?: LessonDistractorTranslation;
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   useFallback?: boolean;
 };
 
@@ -62,17 +62,12 @@ export async function generateLessonDistractors({
   shape,
   translation,
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   useFallback = true,
 }: LessonDistractorsParams) {
   const languageName = getPromptLanguageName({ language });
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const userPrompt = [
     `INPUT: ${input}`,
@@ -87,6 +82,7 @@ export async function generateLessonDistractors({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-grammar.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-grammar.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
@@ -37,7 +37,7 @@ export type LessonGrammarParams = {
   lessonDescription: string;
   lessonTitle: string;
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   targetLanguage: string;
   useFallback?: boolean;
   userLanguage: string;
@@ -56,7 +56,7 @@ export async function generateLessonGrammar({
   lessonDescription,
   lessonTitle,
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   targetLanguage,
   useFallback = true,
   userLanguage,
@@ -71,12 +71,7 @@ export async function generateLessonGrammar({
     LESSON_DESCRIPTION: ${lessonDescription}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -84,6 +79,7 @@ export async function generateLessonGrammar({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-pronunciation.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-pronunciation.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
@@ -19,7 +19,7 @@ export type LessonPronunciationSchema = z.infer<typeof schema>;
 
 export type LessonPronunciationParams = {
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   targetLanguage: string;
   userLanguage: string;
   useFallback?: boolean;
@@ -28,7 +28,7 @@ export type LessonPronunciationParams = {
 
 export async function generateLessonPronunciation({
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   targetLanguage,
   userLanguage,
   useFallback = true,
@@ -42,12 +42,7 @@ export async function generateLessonPronunciation({
     USER_LANGUAGE: ${promptContext.userLanguageName}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -55,6 +50,7 @@ export async function generateLessonPronunciation({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-romanization.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-romanization.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
@@ -28,7 +28,7 @@ export type LessonRomanizationSchema = z.infer<ReturnType<typeof buildSchema>>;
 
 export type LessonRomanizationParams = {
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   targetLanguage: string;
   texts: string[];
   useFallback?: boolean;
@@ -41,7 +41,7 @@ export type LessonRomanizationParams = {
  */
 export async function generateLessonRomanization({
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   targetLanguage,
   texts,
   useFallback = true,
@@ -54,12 +54,7 @@ export async function generateLessonRomanization({
     TEXTS: ${formattedTexts}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -67,6 +62,7 @@ export async function generateLessonRomanization({
     output: Output.object({ schema: buildSchema(texts.length) }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
@@ -24,7 +24,7 @@ export type LessonSentencesParams = {
   lessonDescription?: string;
   lessonTitle: string;
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   sourceLessons: SourceLesson[];
   targetLanguage: string;
   userLanguage: string;
@@ -40,7 +40,7 @@ export async function generateLessonSentences({
   lessonDescription,
   lessonTitle,
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   sourceLessons,
   targetLanguage,
   userLanguage,
@@ -57,12 +57,7 @@ export async function generateLessonSentences({
     SOURCE_LESSONS: ${formatSourceLessonsForPrompt(sourceLessons)}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -70,6 +65,7 @@ export async function generateLessonSentences({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-translation.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-translation.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
@@ -19,7 +19,7 @@ export type TranslationSchema = z.infer<typeof schema>;
 
 export type TranslationParams = {
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   targetLanguage: string;
   userLanguage: string;
   useFallback?: boolean;
@@ -33,7 +33,7 @@ export type TranslationParams = {
  */
 export async function generateTranslation({
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   targetLanguage,
   userLanguage,
   useFallback = true,
@@ -47,12 +47,7 @@ export async function generateTranslation({
     USER_LANGUAGE: ${promptContext.userLanguageName}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -60,6 +55,7 @@ export async function generateTranslation({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/language/lesson-vocabulary.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-vocabulary.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
@@ -20,7 +20,7 @@ export type LessonVocabularyParams = {
   lessonDescription: string;
   lessonTitle: string;
   model?: string;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
   targetLanguage: string;
   userLanguage: string;
   useFallback?: boolean;
@@ -35,7 +35,7 @@ export async function generateLessonVocabulary({
   lessonDescription,
   lessonTitle,
   model = defaultModel,
-  reasoningEffort,
+  reasoning,
   targetLanguage,
   userLanguage,
   useFallback = true,
@@ -50,12 +50,7 @@ export async function generateLessonVocabulary({
     LESSON_DESCRIPTION: ${lessonDescription}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -63,6 +58,7 @@ export async function generateLessonVocabulary({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/lesson-kind.ts
+++ b/packages/ai/src/tasks/lessons/lesson-kind.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./lesson-kind.prompt.md";
 
@@ -26,7 +26,7 @@ type LessonKindParams = {
   lessonTitle: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 /**
@@ -42,7 +42,7 @@ export async function generateLessonKind({
   lessonTitle,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: LessonKindParams) {
   const promptLanguage = getPromptLanguageName({ language });
 
@@ -54,12 +54,7 @@ export async function generateLessonKind({
     LANGUAGE: ${promptLanguage}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -67,6 +62,7 @@ export async function generateLessonKind({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/lessons/tutorial/lesson-tutorial.ts
+++ b/packages/ai/src/tasks/lessons/tutorial/lesson-tutorial.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { type ReasoningEffort, buildProviderOptions } from "@zoonk/ai/provider-options";
+import { type Reasoning, buildProviderOptions } from "@zoonk/ai/provider-options";
 import { Output, generateText } from "ai";
 import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
@@ -24,7 +24,7 @@ export type LessonTutorialParams = {
   language: string;
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 export async function generateLessonTutorial({
@@ -35,7 +35,7 @@ export async function generateLessonTutorial({
   language,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: LessonTutorialParams) {
   const promptLanguage = getPromptLanguageName({ language });
 
@@ -47,12 +47,7 @@ export async function generateLessonTutorial({
     LANGUAGE: ${promptLanguage}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -60,6 +55,7 @@ export async function generateLessonTutorial({
     output: Output.object({ schema }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };

--- a/packages/ai/src/tasks/steps/step-image-prompts.ts
+++ b/packages/ai/src/tasks/steps/step-image-prompts.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { Output, generateText } from "ai";
 import { z } from "zod";
-import { type ReasoningEffort, buildProviderOptions } from "../../provider-options";
+import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./step-image-prompts.prompt.md";
 
@@ -28,7 +28,7 @@ type StepImagePromptsParams = {
   steps: { title: string; text: string }[];
   model?: string;
   useFallback?: boolean;
-  reasoningEffort?: ReasoningEffort;
+  reasoning?: Reasoning;
 };
 
 /**
@@ -45,7 +45,7 @@ export async function generateStepImagePrompts({
   steps,
   model = defaultModel,
   useFallback = true,
-  reasoningEffort,
+  reasoning,
 }: StepImagePromptsParams) {
   const formattedSteps = steps
     .map((step, index) => `${index}. ${step.title}: ${step.text}`)
@@ -62,12 +62,7 @@ export async function generateStepImagePrompts({
     STEPS: ${formattedSteps}
   `;
 
-  const providerOptions = buildProviderOptions({
-    fallbackModels,
-    model,
-    reasoningEffort,
-    useFallback,
-  });
+  const providerOptions = buildProviderOptions({ fallbackModels, model, useFallback });
 
   const { output, usage } = await generateText({
     instructions: systemPrompt,
@@ -75,6 +70,7 @@ export async function generateStepImagePrompts({
     output: Output.object({ schema: buildSchema(steps.length) }),
     prompt: userPrompt,
     providerOptions,
+    reasoning,
   });
 
   return { data: output, systemPrompt, usage, userPrompt };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch to AI SDK v7 `reasoning` field, replacing `reasoningEffort` across `@zoonk/ai` tasks and evals. Provider options no longer set OpenAI reasoning; tasks now pass `reasoning` directly to `generateText`.

- **Refactors**
  - Introduced `Reasoning` type aligned with `LanguageModelCallOptions["reasoning"]`.
  - All task params now accept `reasoning` and forward it to `generateText`.
  - Removed `reasoningEffort` from `buildProviderOptions`; it now only configures gateway models/order.
  - Evals: model config/type updated to `reasoning`; display names and generator input forward `reasoning`.
  - Updated tests to reflect removal of OpenAI-specific reasoning options.

- **Migration**
  - Replace any `reasoningEffort` parameter with `reasoning` in task and eval calls.
  - Stop using `providerOptions.openai.reasoningEffort`; if reasoning is needed, pass `reasoning` to the task or directly to `generateText`.
  - `buildProviderOptions` signature changed: drop the `reasoningEffort` argument; no change to fallback behavior.

<sup>Written for commit 766ac6e15232e59e4be606b6e45869eafdb28f2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

