### PR TITLE
feat(i18n): use source as ids in PO files

### DIFF
--- a/apps/api/messages/de.po
+++ b/apps/api/messages/de.po
@@ -4,127 +4,156 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/auth/layout.tsx
-msgid "dVItHD"
+msgctxt "dVItHD"
+msgid "Sign in to Zoonk"
 msgstr "Bei Zoonk anmelden"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "sy-pv5"
+msgctxt "sy-pv5"
+msgid "Email"
 msgstr "E-Mail"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "apQW0E"
+msgctxt "apQW0E"
+msgid "me@gmail.com"
 msgstr "me@gmail.com"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "YRe93Y"
+msgctxt "YRe93Y"
+msgid "Enter a valid email address"
 msgstr "Gib eine gültige E-Mail‑Adresse ein"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/login/social-login.tsx
-msgid "pN2p0t"
+msgctxt "pN2p0t"
+msgid "There was an error signing you in. Please try again or contact hello@zoonk.com"
 msgstr "Beim Anmelden ist ein Fehler aufgetreten. Bitte versuche es erneut oder kontaktiere hello@zoonk.com"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/otp/otp-form.tsx
 #: src/app/auth/setup/setup-form.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Weiter"
 
 #: src/app/auth/login/page.tsx
-msgid "eN8MTJ"
+msgctxt "eN8MTJ"
+msgid "Sign in or create an account"
 msgstr "Anmelden oder ein Konto erstellen"
 
 #: src/app/auth/login/page.tsx
-msgid "4wpUNc"
+msgctxt "4wpUNc"
+msgid "Or"
 msgstr "Oder"
 
 #: src/app/auth/login/page.tsx
-msgid "Ju9oB-"
+msgctxt "Ju9oB-"
+msgid "By clicking on Continue, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>."
 msgstr "Indem du auf Weiter klickst, stimmst du unseren <terms>Nutzungsbedingungen</terms> und der <privacy>Datenschutzrichtlinie</privacy> zu."
 
 #: src/app/auth/login/social-login.tsx
-msgid "FJ6r9E"
+msgctxt "FJ6r9E"
+msgid "Continue with Google"
 msgstr "Weiter mit Google"
 
 #: src/app/auth/login/social-login.tsx
-msgid "BmecBA"
+msgctxt "BmecBA"
+msgid "Continue with Apple"
 msgstr "Weiter mit Apple"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "HkHvQv"
+msgctxt "HkHvQv"
+msgid "The code you entered is incorrect. Please try again or contact hello@zoonk.com"
 msgstr "Der eingegebene Code ist falsch. Bitte versuche es erneut oder kontaktiere hello@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "ChATeO"
+msgctxt "ChATeO"
+msgid "Change email"
 msgstr "E‑Mail ändern"
 
 #: src/app/auth/otp/page.tsx
-msgid "zx7CKB"
+msgctxt "zx7CKB"
+msgid "Check your email"
 msgstr "Schau in dein Postfach"
 
 #: src/app/auth/otp/page.tsx
-msgid "LZHcmZ"
+msgctxt "LZHcmZ"
+msgid "Enter the code we sent to {email}:"
 msgstr "Gib den Code ein, den wir an {email} gesendet haben:"
 
 #: src/app/auth/setup/page.tsx
-msgid "CYqIel"
+msgctxt "CYqIel"
+msgid "Complete your profile"
 msgstr "Vervollständige dein Profil"
 
 #: src/app/auth/setup/page.tsx
-msgid "7463XU"
+msgctxt "7463XU"
+msgid "Choose a name and username before continuing."
 msgstr "Wähle einen Namen und einen Benutzernamen, bevor du fortfährst."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Wird geprüft..."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} ist verfügbar"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} ist bereits vergeben"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "3–30 Zeichen. Nur Buchstaben, Zahlen und Unterstriche."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Name"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Benutzername"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "XLl_pd"
+msgctxt "XLl_pd"
+msgid "your-username"
 msgstr "dein-benutzername"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "yCCLud"
+msgctxt "yCCLud"
+msgid "Failed to set up your profile. Please try again or contact hello@zoonk.com"
 msgstr "Dein Profil konnte nicht eingerichtet werden. Bitte versuche es erneut oder kontaktiere hello@zoonk.com"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "1vqX2W"
+msgctxt "1vqX2W"
+msgid "Unable to redirect"
 msgstr "Weiterleitung nicht möglich"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "83K2kN"
+msgctxt "83K2kN"
+msgid "The destination URL is not recognized as a trusted Zoonk application."
 msgstr "Die Ziel-URL wird nicht als vertrauenswürdige Zoonk-Anwendung erkannt."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "wkO19y"
+msgctxt "wkO19y"
+msgid "Security warning"
 msgstr "Sicherheitshinweis"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "585u5Z"
+msgctxt "585u5Z"
+msgid "For your safety, we cannot redirect you to an unrecognized destination."
 msgstr "Zu deiner Sicherheit können wir dich nicht zu einer unbekannten Zieladresse weiterleiten."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "-e4BVR"
+msgctxt "-e4BVR"
+msgid "Continue to Zoonk"
 msgstr "Weiter zu Zoonk"

--- a/apps/api/messages/en.po
+++ b/apps/api/messages/en.po
@@ -4,127 +4,156 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/auth/layout.tsx
-msgid "dVItHD"
+msgctxt "dVItHD"
+msgid "Sign in to Zoonk"
 msgstr "Sign in to Zoonk"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "sy-pv5"
+msgctxt "sy-pv5"
+msgid "Email"
 msgstr "Email"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "apQW0E"
+msgctxt "apQW0E"
+msgid "me@gmail.com"
 msgstr "me@gmail.com"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "YRe93Y"
+msgctxt "YRe93Y"
+msgid "Enter a valid email address"
 msgstr "Enter a valid email address"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/login/social-login.tsx
-msgid "pN2p0t"
+msgctxt "pN2p0t"
+msgid "There was an error signing you in. Please try again or contact hello@zoonk.com"
 msgstr "There was an error signing you in. Please try again or contact hello@zoonk.com"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/otp/otp-form.tsx
 #: src/app/auth/setup/setup-form.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continue"
 
 #: src/app/auth/login/page.tsx
-msgid "eN8MTJ"
+msgctxt "eN8MTJ"
+msgid "Sign in or create an account"
 msgstr "Sign in or create an account"
 
 #: src/app/auth/login/page.tsx
-msgid "4wpUNc"
+msgctxt "4wpUNc"
+msgid "Or"
 msgstr "Or"
 
 #: src/app/auth/login/page.tsx
-msgid "Ju9oB-"
+msgctxt "Ju9oB-"
+msgid "By clicking on Continue, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>."
 msgstr "By clicking on Continue, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>."
 
 #: src/app/auth/login/social-login.tsx
-msgid "FJ6r9E"
+msgctxt "FJ6r9E"
+msgid "Continue with Google"
 msgstr "Continue with Google"
 
 #: src/app/auth/login/social-login.tsx
-msgid "BmecBA"
+msgctxt "BmecBA"
+msgid "Continue with Apple"
 msgstr "Continue with Apple"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "HkHvQv"
+msgctxt "HkHvQv"
+msgid "The code you entered is incorrect. Please try again or contact hello@zoonk.com"
 msgstr "The code you entered is incorrect. Please try again or contact hello@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "ChATeO"
+msgctxt "ChATeO"
+msgid "Change email"
 msgstr "Change email"
 
 #: src/app/auth/otp/page.tsx
-msgid "zx7CKB"
+msgctxt "zx7CKB"
+msgid "Check your email"
 msgstr "Check your email"
 
 #: src/app/auth/otp/page.tsx
-msgid "LZHcmZ"
+msgctxt "LZHcmZ"
+msgid "Enter the code we sent to {email}:"
 msgstr "Enter the code we sent to {email}:"
 
 #: src/app/auth/setup/page.tsx
-msgid "CYqIel"
+msgctxt "CYqIel"
+msgid "Complete your profile"
 msgstr "Complete your profile"
 
 #: src/app/auth/setup/page.tsx
-msgid "7463XU"
+msgctxt "7463XU"
+msgid "Choose a name and username before continuing."
 msgstr "Choose a name and username before continuing."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Checking..."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} is available"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} is already taken"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "3-30 characters. Letters, numbers, and underscores only."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Name"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Username"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "XLl_pd"
+msgctxt "XLl_pd"
+msgid "your-username"
 msgstr "your-username"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "yCCLud"
+msgctxt "yCCLud"
+msgid "Failed to set up your profile. Please try again or contact hello@zoonk.com"
 msgstr "Failed to set up your profile. Please try again or contact hello@zoonk.com"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "1vqX2W"
+msgctxt "1vqX2W"
+msgid "Unable to redirect"
 msgstr "Unable to redirect"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "83K2kN"
+msgctxt "83K2kN"
+msgid "The destination URL is not recognized as a trusted Zoonk application."
 msgstr "The destination URL is not recognized as a trusted Zoonk application."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "wkO19y"
+msgctxt "wkO19y"
+msgid "Security warning"
 msgstr "Security warning"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "585u5Z"
+msgctxt "585u5Z"
+msgid "For your safety, we cannot redirect you to an unrecognized destination."
 msgstr "For your safety, we cannot redirect you to an unrecognized destination."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "-e4BVR"
+msgctxt "-e4BVR"
+msgid "Continue to Zoonk"
 msgstr "Continue to Zoonk"

--- a/apps/api/messages/es.po
+++ b/apps/api/messages/es.po
@@ -4,127 +4,156 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/auth/layout.tsx
-msgid "dVItHD"
+msgctxt "dVItHD"
+msgid "Sign in to Zoonk"
 msgstr "Inicia sesión en Zoonk"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "sy-pv5"
+msgctxt "sy-pv5"
+msgid "Email"
 msgstr "Correo electrónico"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "apQW0E"
+msgctxt "apQW0E"
+msgid "me@gmail.com"
 msgstr "yo@gmail.com"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "YRe93Y"
+msgctxt "YRe93Y"
+msgid "Enter a valid email address"
 msgstr "Ingresa un correo electrónico válido"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/login/social-login.tsx
-msgid "pN2p0t"
+msgctxt "pN2p0t"
+msgid "There was an error signing you in. Please try again or contact hello@zoonk.com"
 msgstr "Hubo un error al iniciar sesión. Inténtalo de nuevo o escribe a contacto@zoonk.com"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/otp/otp-form.tsx
 #: src/app/auth/setup/setup-form.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continuar"
 
 #: src/app/auth/login/page.tsx
-msgid "eN8MTJ"
+msgctxt "eN8MTJ"
+msgid "Sign in or create an account"
 msgstr "Inicia sesión o crea una cuenta"
 
 #: src/app/auth/login/page.tsx
-msgid "4wpUNc"
+msgctxt "4wpUNc"
+msgid "Or"
 msgstr "O"
 
 #: src/app/auth/login/page.tsx
-msgid "Ju9oB-"
+msgctxt "Ju9oB-"
+msgid "By clicking on Continue, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>."
 msgstr "Al hacer clic en Continuar, aceptas nuestros <terms>Términos del Servicio</terms> y nuestra <privacy>Política de Privacidad</privacy>."
 
 #: src/app/auth/login/social-login.tsx
-msgid "FJ6r9E"
+msgctxt "FJ6r9E"
+msgid "Continue with Google"
 msgstr "Continuar con Google"
 
 #: src/app/auth/login/social-login.tsx
-msgid "BmecBA"
+msgctxt "BmecBA"
+msgid "Continue with Apple"
 msgstr "Continuar con Apple"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "HkHvQv"
+msgctxt "HkHvQv"
+msgid "The code you entered is incorrect. Please try again or contact hello@zoonk.com"
 msgstr "El código que ingresaste es incorrecto. Inténtalo de nuevo o escribe a contacto@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "ChATeO"
+msgctxt "ChATeO"
+msgid "Change email"
 msgstr "Cambiar correo"
 
 #: src/app/auth/otp/page.tsx
-msgid "zx7CKB"
+msgctxt "zx7CKB"
+msgid "Check your email"
 msgstr "Revisa tu correo"
 
 #: src/app/auth/otp/page.tsx
-msgid "LZHcmZ"
+msgctxt "LZHcmZ"
+msgid "Enter the code we sent to {email}:"
 msgstr "Ingresa el código que enviamos a {email}:"
 
 #: src/app/auth/setup/page.tsx
-msgid "CYqIel"
+msgctxt "CYqIel"
+msgid "Complete your profile"
 msgstr "Completa tu perfil"
 
 #: src/app/auth/setup/page.tsx
-msgid "7463XU"
+msgctxt "7463XU"
+msgid "Choose a name and username before continuing."
 msgstr "Elige un nombre y un nombre de usuario antes de continuar."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Comprobando…"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} está disponible"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} ya está en uso"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "De 3 a 30 caracteres. Solo letras, números y guiones bajos."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Nombre"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Nombre de usuario"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "XLl_pd"
+msgctxt "XLl_pd"
+msgid "your-username"
 msgstr "tu-nombre-de-usuario"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "yCCLud"
+msgctxt "yCCLud"
+msgid "Failed to set up your profile. Please try again or contact hello@zoonk.com"
 msgstr "No pudimos configurar tu perfil. Inténtalo de nuevo o escribe a contacto@zoonk.com"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "1vqX2W"
+msgctxt "1vqX2W"
+msgid "Unable to redirect"
 msgstr "No se puede redirigir"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "83K2kN"
+msgctxt "83K2kN"
+msgid "The destination URL is not recognized as a trusted Zoonk application."
 msgstr "La URL de destino no se reconoce como una aplicación de Zoonk confiable."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "wkO19y"
+msgctxt "wkO19y"
+msgid "Security warning"
 msgstr "Advertencia de seguridad"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "585u5Z"
+msgctxt "585u5Z"
+msgid "For your safety, we cannot redirect you to an unrecognized destination."
 msgstr "Por tu seguridad, no podemos redirigirte a un destino no reconocido."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "-e4BVR"
+msgctxt "-e4BVR"
+msgid "Continue to Zoonk"
 msgstr "Continuar a Zoonk"

--- a/apps/api/messages/fr.po
+++ b/apps/api/messages/fr.po
@@ -4,127 +4,156 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/auth/layout.tsx
-msgid "dVItHD"
+msgctxt "dVItHD"
+msgid "Sign in to Zoonk"
 msgstr "Connecte-toi à Zoonk"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "sy-pv5"
+msgctxt "sy-pv5"
+msgid "Email"
 msgstr "E-mail"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "apQW0E"
+msgctxt "apQW0E"
+msgid "me@gmail.com"
 msgstr "me@gmail.com"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "YRe93Y"
+msgctxt "YRe93Y"
+msgid "Enter a valid email address"
 msgstr "Saisis une adresse e-mail valide"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/login/social-login.tsx
-msgid "pN2p0t"
+msgctxt "pN2p0t"
+msgid "There was an error signing you in. Please try again or contact hello@zoonk.com"
 msgstr "Impossible de te connecter. Réessaie ou contacte hello@zoonk.com"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/otp/otp-form.tsx
 #: src/app/auth/setup/setup-form.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continuer"
 
 #: src/app/auth/login/page.tsx
-msgid "eN8MTJ"
+msgctxt "eN8MTJ"
+msgid "Sign in or create an account"
 msgstr "Connecte-toi ou crée un compte"
 
 #: src/app/auth/login/page.tsx
-msgid "4wpUNc"
+msgctxt "4wpUNc"
+msgid "Or"
 msgstr "Ou"
 
 #: src/app/auth/login/page.tsx
-msgid "Ju9oB-"
+msgctxt "Ju9oB-"
+msgid "By clicking on Continue, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>."
 msgstr "En cliquant sur Continuer, tu acceptes nos <terms>Conditions d’utilisation</terms> et notre <privacy>Politique de confidentialité</privacy>."
 
 #: src/app/auth/login/social-login.tsx
-msgid "FJ6r9E"
+msgctxt "FJ6r9E"
+msgid "Continue with Google"
 msgstr "Continuer avec Google"
 
 #: src/app/auth/login/social-login.tsx
-msgid "BmecBA"
+msgctxt "BmecBA"
+msgid "Continue with Apple"
 msgstr "Continuer avec Apple"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "HkHvQv"
+msgctxt "HkHvQv"
+msgid "The code you entered is incorrect. Please try again or contact hello@zoonk.com"
 msgstr "Le code saisi est incorrect. Réessaie ou contacte hello@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "ChATeO"
+msgctxt "ChATeO"
+msgid "Change email"
 msgstr "Changer d’e-mail"
 
 #: src/app/auth/otp/page.tsx
-msgid "zx7CKB"
+msgctxt "zx7CKB"
+msgid "Check your email"
 msgstr "Consulte tes e-mails"
 
 #: src/app/auth/otp/page.tsx
-msgid "LZHcmZ"
+msgctxt "LZHcmZ"
+msgid "Enter the code we sent to {email}:"
 msgstr "Saisis le code envoyé à {email} :"
 
 #: src/app/auth/setup/page.tsx
-msgid "CYqIel"
+msgctxt "CYqIel"
+msgid "Complete your profile"
 msgstr "Complète ton profil"
 
 #: src/app/auth/setup/page.tsx
-msgid "7463XU"
+msgctxt "7463XU"
+msgid "Choose a name and username before continuing."
 msgstr "Choisis un nom et un nom d’utilisateur avant de continuer."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Vérification…"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} est disponible"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} est déjà pris"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "3 à 30 caractères. Lettres, chiffres et tirets bas uniquement."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Nom"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Nom d’utilisateur"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "XLl_pd"
+msgctxt "XLl_pd"
+msgid "your-username"
 msgstr "ton-nom-utilisateur"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "yCCLud"
+msgctxt "yCCLud"
+msgid "Failed to set up your profile. Please try again or contact hello@zoonk.com"
 msgstr "Impossible de configurer ton profil. Réessaie ou contacte hello@zoonk.com"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "1vqX2W"
+msgctxt "1vqX2W"
+msgid "Unable to redirect"
 msgstr "Redirection impossible"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "83K2kN"
+msgctxt "83K2kN"
+msgid "The destination URL is not recognized as a trusted Zoonk application."
 msgstr "L’URL de destination n’est pas reconnue comme une application Zoonk de confiance."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "wkO19y"
+msgctxt "wkO19y"
+msgid "Security warning"
 msgstr "Avertissement de sécurité"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "585u5Z"
+msgctxt "585u5Z"
+msgid "For your safety, we cannot redirect you to an unrecognized destination."
 msgstr "Pour ta sécurité, nous ne pouvons pas te rediriger vers une destination non reconnue."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "-e4BVR"
+msgctxt "-e4BVR"
+msgid "Continue to Zoonk"
 msgstr "Continuer vers Zoonk"

--- a/apps/api/messages/pt.po
+++ b/apps/api/messages/pt.po
@@ -4,127 +4,156 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/auth/layout.tsx
-msgid "dVItHD"
+msgctxt "dVItHD"
+msgid "Sign in to Zoonk"
 msgstr "Entrar no Zoonk"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "sy-pv5"
+msgctxt "sy-pv5"
+msgid "Email"
 msgstr "Email"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "apQW0E"
+msgctxt "apQW0E"
+msgid "me@gmail.com"
 msgstr "meu@email.com"
 
 #: src/app/auth/login/email-login-form.tsx
-msgid "YRe93Y"
+msgctxt "YRe93Y"
+msgid "Enter a valid email address"
 msgstr "Digite um email válido"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/login/social-login.tsx
-msgid "pN2p0t"
+msgctxt "pN2p0t"
+msgid "There was an error signing you in. Please try again or contact hello@zoonk.com"
 msgstr "Houve um erro ao entrar. Tente de novo ou fale com contato@zoonk.com"
 
 #: src/app/auth/login/email-login-form.tsx
 #: src/app/auth/otp/otp-form.tsx
 #: src/app/auth/setup/setup-form.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continuar"
 
 #: src/app/auth/login/page.tsx
-msgid "eN8MTJ"
+msgctxt "eN8MTJ"
+msgid "Sign in or create an account"
 msgstr "Entre ou crie uma conta"
 
 #: src/app/auth/login/page.tsx
-msgid "4wpUNc"
+msgctxt "4wpUNc"
+msgid "Or"
 msgstr "Ou"
 
 #: src/app/auth/login/page.tsx
-msgid "Ju9oB-"
+msgctxt "Ju9oB-"
+msgid "By clicking on Continue, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>."
 msgstr "Ao clicar em Continuar, você concorda com nossos <terms>Termos de Serviço</terms> e <privacy>Política de Privacidade</privacy>."
 
 #: src/app/auth/login/social-login.tsx
-msgid "FJ6r9E"
+msgctxt "FJ6r9E"
+msgid "Continue with Google"
 msgstr "Continuar com Google"
 
 #: src/app/auth/login/social-login.tsx
-msgid "BmecBA"
+msgctxt "BmecBA"
+msgid "Continue with Apple"
 msgstr "Continuar com Apple"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "HkHvQv"
+msgctxt "HkHvQv"
+msgid "The code you entered is incorrect. Please try again or contact hello@zoonk.com"
 msgstr "O código que você digitou está incorreto. Tente de novo ou fale com contato@zoonk.com"
 
 #: src/app/auth/otp/otp-form.tsx
-msgid "ChATeO"
+msgctxt "ChATeO"
+msgid "Change email"
 msgstr "Trocar email"
 
 #: src/app/auth/otp/page.tsx
-msgid "zx7CKB"
+msgctxt "zx7CKB"
+msgid "Check your email"
 msgstr "Confira seu email"
 
 #: src/app/auth/otp/page.tsx
-msgid "LZHcmZ"
+msgctxt "LZHcmZ"
+msgid "Enter the code we sent to {email}:"
 msgstr "Digite o código que a gente enviou para {email}:"
 
 #: src/app/auth/setup/page.tsx
-msgid "CYqIel"
+msgctxt "CYqIel"
+msgid "Complete your profile"
 msgstr "Complete seu perfil"
 
 #: src/app/auth/setup/page.tsx
-msgid "7463XU"
+msgctxt "7463XU"
+msgid "Choose a name and username before continuing."
 msgstr "Escolha um nome e nome de usuário antes de continuar."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Verificando…"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} está disponível"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} já está em uso"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "3 a 30 caracteres. Use apenas letras, números e sublinhados."
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Nome"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Nome de usuário"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "XLl_pd"
+msgctxt "XLl_pd"
+msgid "your-username"
 msgstr "seu-nome-de-usuario"
 
 #: src/app/auth/setup/setup-form.tsx
-msgid "yCCLud"
+msgctxt "yCCLud"
+msgid "Failed to set up your profile. Please try again or contact hello@zoonk.com"
 msgstr "Não foi possível configurar seu perfil. Tente de novo ou fale com contato@zoonk.com"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "1vqX2W"
+msgctxt "1vqX2W"
+msgid "Unable to redirect"
 msgstr "Não foi possível redirecionar"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "83K2kN"
+msgctxt "83K2kN"
+msgid "The destination URL is not recognized as a trusted Zoonk application."
 msgstr "A URL de destino não é reconhecida como um aplicativo confiável do Zoonk."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "wkO19y"
+msgctxt "wkO19y"
+msgid "Security warning"
 msgstr "Aviso de segurança"
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "585u5Z"
+msgctxt "585u5Z"
+msgid "For your safety, we cannot redirect you to an unrecognized destination."
 msgstr "Para sua segurança, a gente não pode te redirecionar para um destino não reconhecido."
 
 #: src/app/auth/untrusted-origin/page.tsx
-msgid "-e4BVR"
+msgctxt "-e4BVR"
+msgid "Continue to Zoonk"
 msgstr "Continuar para o Zoonk"

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -1,4 +1,5 @@
 import { withSentryConfig } from "@sentry/nextjs";
+import { NEXT_INTL_PO_FORMAT } from "@zoonk/i18n/next-intl/po-format";
 import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
 import { type NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
@@ -31,7 +32,7 @@ const withNextIntl = createNextIntlPlugin({
   experimental: {
     extract: { path: "./messages" },
     messages: {
-      format: "po",
+      format: NEXT_INTL_PO_FORMAT,
       locales: "infer",
       path: ["./messages"],
       precompile: true,

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -4,93 +4,109 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
+msgctxt "xmcVZ0"
+msgid "Search"
 msgstr "Suche"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
+msgctxt "PSiLeL"
+msgid "Search courses, chapters, or pages..."
 msgstr "Kurse, Kapitel oder Seiten durchsuchen..."
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
+msgctxt "I-38K2"
+msgid "My courses"
 msgstr "Meine Kurse"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
+msgctxt "Oj9Phc"
+msgid "Manage subscription"
 msgstr "Abo verwalten"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
+msgctxt "OhXwmw"
+msgid "Update language"
 msgstr "Sprache ändern"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
+msgctxt "O7ozeo"
+msgid "Update profile"
 msgstr "Profil aktualisieren"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
+msgctxt "C81_uG"
+msgid "Logout"
 msgstr "Abmelden"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(progress)/_components/progress-empty-state.tsx
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
+msgctxt "AyGauy"
+msgid "Login"
 msgstr "Anmelden"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
+msgctxt "y1Z3or"
+msgid "Language"
 msgstr "Sprache"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "U3l-Q9"
+msgctxt "U3l-Q9"
+msgid "Home page"
 msgstr "Startseite"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "jboh4c"
+msgctxt "jboh4c"
+msgid "Start a new course"
 msgstr "Neuen Kurs starten"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "rS0suY"
+msgctxt "rS0suY"
+msgid "Speak a language"
 msgstr "Eine Sprache sprechen"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "L6kaJv"
+msgctxt "L6kaJv"
+msgid "Learn something"
 msgstr "Etwas lernen"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "3wvH7G"
+msgctxt "3wvH7G"
+msgid "Pass an exam"
 msgstr "Prüfung bestehen"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
+msgctxt "CxfKLC"
+msgid "Pages"
 msgstr "Seiten"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
+msgctxt "dXSivY"
+msgid "My account"
 msgstr "Mein Konto"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "tv5FG3"
+msgctxt "tv5FG3"
+msgid "Blog"
 msgstr "Blog"
 
 #: src/app/(catalog)/_components/command-palette.tsx
@@ -98,2184 +114,2713 @@ msgstr "Blog"
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "fFZ0Wd"
+msgctxt "fFZ0Wd"
+msgid "Feedback & Support"
 msgstr "Feedback & Support"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "SENRqu"
+msgctxt "SENRqu"
+msgid "Help"
 msgstr "Hilfe"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "R85gsW"
+msgctxt "R85gsW"
+msgid "Courses"
 msgstr "Kurse"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Do1Pfd"
+msgctxt "Do1Pfd"
+msgid "Chapters"
 msgstr "Kapitel"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "hX5PAb"
+msgctxt "hX5PAb"
+msgid "No results found"
 msgstr "Keine Ergebnisse gefunden"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "OXAZiT"
+msgctxt "OXAZiT"
+msgid "Create a course about {term}"
 msgstr "Kurs über {term} erstellen"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "onRJrc"
+msgctxt "onRJrc"
+msgid "Course page"
 msgstr "Kursseite"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "m826WB"
+msgctxt "m826WB"
+msgid "New course"
 msgstr "Neuer Kurs"
 
 #: src/app/(catalog)/_components/user-avatar-menu.tsx
-msgid "6b2CRH"
+msgctxt "6b2CRH"
+msgid "User menu"
 msgstr "Benutzermenü"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/profile/page.tsx
-msgid "itPgxd"
+msgctxt "itPgxd"
+msgid "Profile"
 msgstr "Profil"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/subscription/page.tsx
-msgid "R_6nsx"
+msgctxt "R_6nsx"
+msgid "Subscription"
 msgstr "Abo"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "HHFpcy"
+msgctxt "HHFpcy"
+msgid "Best day"
 msgstr "Bester Tag"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/energy/energy-insights.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "auPwZG"
+msgctxt "auPwZG"
+msgid "{day} with {percentage}"
 msgstr "{day} mit {percentage}"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(catalog)/(home)/score.tsx
-msgid "zml1_y"
+msgctxt "zml1_y"
+msgid "Past 3 months"
 msgstr "Letzte 3 Monate"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "00_IyC"
+msgctxt "00_IyC"
+msgid "Night"
 msgstr "Nacht"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "_kzk_m"
+msgctxt "_kzk_m"
+msgid "Morning"
 msgstr "Morgen"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mF-J9o"
+msgctxt "mF-J9o"
+msgid "Afternoon"
 msgstr "Nachmittag"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mPEpnN"
+msgctxt "mPEpnN"
+msgid "Evening"
 msgstr "Abend"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "dFW9lU"
+msgctxt "dFW9lU"
+msgid "Best time"
 msgstr "Beste Zeit"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "r0R6ZG"
+msgctxt "r0R6ZG"
+msgid "{period} with {percentage}"
 msgstr "{period} mit {percentage}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
-msgid "NubPSk"
+msgctxt "NubPSk"
+msgid "Next: {lesson}"
 msgstr "Als Nächstes: {lesson}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Weiter"
 
 #: src/app/(catalog)/(home)/continue-learning.tsx
-msgid "0X-xfW"
+msgctxt "0X-xfW"
+msgid "Continue learning"
 msgstr "Weiterlernen"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "soDmlG"
+msgctxt "soDmlG"
+msgid "Keep learning to increase it"
 msgstr "Lerne weiter, um sie zu steigern"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "WgeB0r"
+msgctxt "WgeB0r"
+msgid "Keep learning to maintain it"
 msgstr "Lerne weiter, um sie zu halten"
 
 #: src/app/(catalog)/(home)/energy.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/energy/page.tsx
-msgid "cVpmV7"
+msgctxt "cVpmV7"
+msgid "Energy"
 msgstr "Energie"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "AV5XNu"
+msgctxt "AV5XNu"
+msgid "Your energy is {percentage}"
 msgstr "Deine Energie liegt bei {percentage}"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
-msgid "8F6teD"
+msgctxt "8F6teD"
+msgid "Learning days"
 msgstr "Lerntage"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
-msgid "QbNcMh"
+msgctxt "QbNcMh"
+msgid "At least one completed lesson"
 msgstr "Mindestens eine abgeschlossene Lektion"
 
 #: src/app/(catalog)/(home)/learning-time.tsx
-msgid "F6B8A3"
+msgctxt "F6B8A3"
+msgid "Time spent in lessons"
 msgstr "In Lektionen verbrachte Zeit"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "pgt3eW"
+msgctxt "pgt3eW"
+msgid "Max level reached"
 msgstr "Höchstes Level erreicht"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "8N9BRu"
+msgctxt "8N9BRu"
+msgid "{value} BP to next level"
 msgstr "{value} BP bis zum nächsten Level"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/level/page.tsx
-msgid "y1Qr81"
+msgctxt "y1Qr81"
+msgid "Level"
 msgstr "Level"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "s0KB2i"
+msgctxt "s0KB2i"
+msgid "{belt} - Level {level}"
 msgstr "{belt} – Level {level}"
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "a50ZRn"
+msgctxt "a50ZRn"
+msgid "Zoonk is an AI learning platform and study app to create courses about any topic using AI. Study for your exams or learn new skills."
 msgstr "Zoonk ist eine KI-Lernplattform und Lern-App, mit der du zu jedem Thema Kurse per KI erstellen kannst. Lerne für Prüfungen oder erwirb neue Fähigkeiten."
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "leBFvu"
+msgctxt "leBFvu"
+msgid "Zoonk: Study App with AI"
 msgstr "Zoonk: Lern‑App mit KI"
 
 #: src/app/(catalog)/(home)/progress.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "sIMS7i"
+msgctxt "sIMS7i"
+msgid "Progress"
 msgstr "Fortschritt"
 
 #: src/app/(catalog)/(home)/score.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/score/page.tsx
-msgid "oLkLww"
+msgctxt "oLkLww"
+msgid "Score"
 msgstr "Punktestand"
 
 #: src/app/(catalog)/(home)/score.tsx
-msgid "_lCW0j"
+msgctxt "_lCW0j"
+msgid "{percentage} correct answers"
 msgstr "{percentage} richtige Antworten"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "QhvU1f"
+msgctxt "QhvU1f"
+msgid "Create this chapter"
 msgstr "Dieses Kapitel erstellen"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "YQGe0H"
+msgctxt "YQGe0H"
+msgid "This chapter is part of the course, but it hasn't been created yet. Create it to see all of its lessons."
 msgstr "Dieses Kapitel ist Teil des Kurses, wurde aber noch nicht erstellt. Erstelle es, um alle Lektionen zu sehen."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "3IOFp2"
+msgctxt "3IOFp2"
+msgid "Create chapter"
 msgstr "Kapitel erstellen"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
+msgctxt "qrEiLa"
+msgid "Back to course"
 msgstr "Zurück zum Kurs"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "Ap-oRa"
+msgctxt "Ap-oRa"
+msgid "Could not apply lesson filters. Please try again."
 msgstr "Filter für Lektionen konnten nicht angewendet werden. Bitte versuche es erneut."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "d6tcJn"
+msgctxt "d6tcJn"
+msgid "Filter lesson types"
 msgstr "Lektionstypen filtern"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "kxP9GJ"
+msgctxt "kxP9GJ"
+msgid "Types"
 msgstr "Typen"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "wi5osl"
+msgctxt "wi5osl"
+msgid "Show lesson types"
 msgstr "Lektionstypen anzeigen"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "OhgOkH"
+msgctxt "OhgOkH"
+msgid "Clear filter"
 msgstr "Filter löschen"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "orGV_i"
+msgctxt "orGV_i"
+msgid "Current lesson"
 msgstr "Aktuelle Lektion"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "ssvp3R"
+msgctxt "ssvp3R"
+msgid "Search lessons..."
 msgstr "Lektionen suchen..."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "FuT9vz"
+msgctxt "FuT9vz"
+msgid "No lessons found"
 msgstr "Keine Lektionen gefunden"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Abgeschlossen"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "xTTP0x"
+msgctxt "xTTP0x"
+msgid "Not started"
 msgstr "Nicht begonnen"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "iRubpl"
+msgctxt "iRubpl"
+msgid "Current chapter"
 msgstr "Aktuelles Kapitel"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "3SOcGR"
+msgctxt "3SOcGR"
+msgid "Search chapters..."
 msgstr "Kapitel suchen..."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "8udPa-"
+msgctxt "8udPa-"
+msgid "No chapters found"
 msgstr "Keine Kapitel gefunden"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "vcaAXp"
+msgctxt "vcaAXp"
+msgid "{completed, number}/{total, number} done"
 msgstr "{completed, number}/{total, number} erledigt"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-curriculum-pending-notice.tsx
-msgid "Pf4uqS"
+msgctxt "Pf4uqS"
+msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "Das Einführungskapitel ist fertig. Wir erstellen noch den kompletten Lehrplan, daher werden hier bald mehr Kapitel erscheinen."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "_allXG"
+msgctxt "_allXG"
+msgid "Learn {course} online with practical examples and everyday language. {description}"
 msgstr "Lerne {course} online mit praxisnahen Beispielen und einfacher Sprache. {description}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "gyGolN"
+msgctxt "gyGolN"
+msgid "Learn {course}"
 msgstr "Lerne {course}"
 
 #: src/app/(catalog)/courses/category-pills.tsx
-msgid "tuZsq-"
+msgctxt "tuZsq-"
+msgid "Course categories"
 msgstr "Kurskategorien"
 
 #: src/app/(catalog)/courses/category-pills.tsx
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "zQvVDJ"
+msgctxt "zQvVDJ"
+msgid "All"
 msgstr "Alle"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "Wc7aau"
+msgctxt "Wc7aau"
+msgid "No courses available yet."
 msgstr "Noch keine Kurse verfügbar."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "zJxO2f"
+msgctxt "zJxO2f"
+msgid "No courses"
 msgstr "Keine Kurse"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "T0mfNV"
+msgctxt "T0mfNV"
+msgid "Loading more courses…"
 msgstr "Lade mehr Kurse…"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "W_5hwr"
+msgctxt "W_5hwr"
+msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schiefgelaufen. Bitte versuche es erneut."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Erneut versuchen"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "WgPMAP"
+msgctxt "WgPMAP"
+msgid "Explore all Zoonk courses to learn anything using AI. Find interactive lessons to learn subjects like science, math, technology, and more."
 msgstr "Entdecke alle Zoonk‑Kurse, um mit KI alles Mögliche zu lernen. Finde interaktive Lektionen zu Themen wie Naturwissenschaften, Mathe, Technik und mehr."
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "P5jxUC"
+msgctxt "P5jxUC"
+msgid "Online Courses using AI"
 msgstr "Online‑Kurse mit KI"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "s-Ncqj"
+msgctxt "s-Ncqj"
+msgid "Explore courses"
 msgstr "Kurse entdecken"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "hUF3bo"
+msgctxt "hUF3bo"
+msgid "Start learning something new today"
 msgstr "Fang noch heute an, etwas Neues zu lernen"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "riE3I5"
+msgctxt "riE3I5"
+msgid "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons."
 msgstr "Sieh dir alle Kurse an, die du auf Zoonk begonnen hast. Mach dort weiter, wo du aufgehört hast, und verfolge deinen Fortschritt in interaktiven Lektionen."
 
 #: src/app/(catalog)/my/page.tsx
-msgid "eeNr_Y"
+msgctxt "eeNr_Y"
+msgid "My Courses"
 msgstr "Meine Kurse"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "Dr13kE"
+msgctxt "Dr13kE"
+msgid "Continue where you left off"
 msgstr "Mach dort weiter, wo du aufgehört hast"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "BDHWkf"
+msgctxt "BDHWkf"
+msgid "No courses yet"
 msgstr "Noch keine Kurse"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "azX41u"
+msgctxt "azX41u"
+msgid "Start learning something new today."
 msgstr "Fang noch heute an, etwas Neues zu lernen."
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "9m9h0p"
+msgctxt "9m9h0p"
+msgid "Start a course"
 msgstr "Kurs starten"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "e61Jf3"
+msgctxt "e61Jf3"
+msgid "Coming soon"
 msgstr "Demnächst verfügbar"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
-msgid "dtRj3N"
+msgctxt "dtRj3N"
+msgid "Personalized courses are coming soon."
 msgstr "Personalisierte Kurse kommen bald."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "hJZwTS"
+msgctxt "hJZwTS"
+msgid "Email address"
 msgstr "E‑Mail‑Adresse"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "OiSL94"
+msgctxt "OiSL94"
+msgid "myemail@gmail.com"
 msgstr "meineemail@gmail.com"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "45yKj9"
+msgctxt "45yKj9"
+msgid "We'll use this email to notify you when exam prep is ready."
 msgstr "Wir nutzen diese E‑Mail, um dich zu benachrichtigen, wenn die Prüfungsvorbereitung verfügbar ist."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "Xy7a7A"
+msgctxt "Xy7a7A"
+msgid "Exam"
 msgstr "Prüfung"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "cDZwI_"
+msgctxt "cDZwI_"
+msgid "TOEFL, SAT, CFA, CPA..."
 msgstr "TOEFL, SAT, CFA, CPA..."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "E_0Y4u"
+msgctxt "E_0Y4u"
+msgid "Tell us the test, certification, or school exam you care about."
 msgstr "Sag uns, für welchen Test, welche Zertifizierung oder Schulprüfung du dich interessierst"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "6eV4UR"
+msgctxt "6eV4UR"
+msgid "We couldn't add you to the waitlist. Please try again."
 msgstr "Wir konnten dich nicht zur Warteliste hinzufügen. Bitte versuche es erneut."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "W78DIe"
+msgctxt "W78DIe"
+msgid "You're on the list. We'll let you know when exam prep is ready."
 msgstr "Du stehst auf der Liste. Wir melden uns, sobald die Prüfungsvorbereitung bereit ist."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "ipGe-B"
+msgctxt "ipGe-B"
+msgid "Notify me"
 msgstr "Benachrichtige mich"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "gs2Dwu"
+msgctxt "gs2Dwu"
+msgid "Online AI exam prep for certifications and tests. Hands-on explanation and practice questions to help you pass your exam."
 msgstr "Online‑KI‑Prüfungsvorbereitung für Zertifikate und Tests. Praktische Erklärungen und Übungsfragen, damit du die Prüfung bestehst."
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "z8OyvL"
+msgctxt "z8OyvL"
+msgid "Online AI Exam Prep"
 msgstr "Online‑KI‑Prüfungsvorbereitung"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "CzV5fE"
+msgctxt "CzV5fE"
+msgid "Exam prep is not available yet. Tell us what you're preparing for and we'll notify you when it launches."
 msgstr "Die Prüfungsvorbereitung ist noch nicht verfügbar. Sag uns, wofür du lernst, und wir benachrichtigen dich, wenn sie startet."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "8Zy06C"
+msgctxt "8Zy06C"
+msgid "This option isn't available yet"
 msgstr "Diese Option ist noch nicht verfügbar"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "TV5hlz"
+msgctxt "TV5hlz"
+msgid "Join the waitlist and we'll let you know when you can learn <strong>{title}</strong> with Zoonk."
 msgstr "Trag dich auf die Warteliste ein und wir benachrichtigen dich, wenn du <strong>{title}</strong> mit Zoonk lernen kannst."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "cPhKTw"
+msgctxt "cPhKTw"
+msgid "Not available"
 msgstr "Nicht verfügbar"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "5DZYgN"
+msgctxt "5DZYgN"
+msgid "We can't create this course"
 msgstr "Wir können diesen Kurs nicht erstellen"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "m6ju4Q"
+msgctxt "m6ju4Q"
+msgid "Zoonk can't help with requests that involve unsafe, illegal, or harmful activity. Try a different subject instead."
 msgstr "Zoonk kann bei Anfragen zu unsicheren, illegalen oder schädlichen Aktivitäten nicht helfen. Versuch stattdessen ein anderes Thema."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "PDFZz6"
+msgctxt "PDFZz6"
+msgid "Try another goal"
 msgstr "Probier ein anderes Ziel"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "hCixWc"
+msgctxt "hCixWc"
+msgid "You're on the list. We'll email you when it's available."
 msgstr "Du stehst auf der Liste. Wir schicken dir eine E‑Mail, sobald sie verfügbar ist."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "UdDpuW"
+msgctxt "UdDpuW"
+msgid "Finding the best way to help"
 msgstr "Wir suchen den besten Weg, dir zu helfen"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "1A36NM"
+msgctxt "1A36NM"
+msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "Wir prüfen dein Lernziel. Das kann ein paar Sekunden dauern."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "47FYwb"
+msgctxt "47FYwb"
+msgid "Cancel"
 msgstr "Abbrechen"
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "CaU_nf"
+msgctxt "CaU_nf"
+msgid "Discover personalized courses and resources to learn {prompt}. Zoonk uses AI to create interactive lessons tailored to you."
 msgstr "Entdecke personalisierte Kurse und Materialien, um {prompt} zu lernen. Zoonk nutzt KI, um interaktive Lektionen auf dich zuzuschneiden."
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "X2b6pH"
+msgctxt "X2b6pH"
+msgid "Learn {prompt} with AI"
 msgstr "Lerne {prompt} mit KI"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "l450Bl"
+msgctxt "l450Bl"
+msgid "Computer Science"
 msgstr "Informatik"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ElyVN0"
+msgctxt "ElyVN0"
+msgid "Psychology"
 msgstr "Psychologie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "KOuDOE"
+msgctxt "KOuDOE"
+msgid "Economics"
 msgstr "Volkswirtschaft"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "cHCwbF"
+msgctxt "cHCwbF"
+msgid "Photography"
 msgstr "Fotografie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zE1J_t"
+msgctxt "zE1J_t"
+msgid "Philosophy"
 msgstr "Philosophie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "y68y7h"
+msgctxt "y68y7h"
+msgid "Data Science"
 msgstr "Datenwissenschaft"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1qsU2j"
+msgctxt "1qsU2j"
+msgid "Creative Writing"
 msgstr "Kreatives Schreiben"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "RGkBg_"
+msgctxt "RGkBg_"
+msgid "Biology"
 msgstr "Biologie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oiUZCZ"
+msgctxt "oiUZCZ"
+msgid "Graphic Design"
 msgstr "Grafikdesign"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "djJp6c"
+msgctxt "djJp6c"
+msgid "History"
 msgstr "Geschichte"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "O9mDkA"
+msgctxt "O9mDkA"
+msgid "Marketing"
 msgstr "Marketing"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "9zLpJ_"
+msgctxt "9zLpJ_"
+msgid "What do you want to learn?"
 msgstr "Was möchtest du lernen?"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zfDq-e"
+msgctxt "zfDq-e"
+msgid "Quantum physics"
 msgstr "Quantenphysik"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oqfOwA"
+msgctxt "oqfOwA"
+msgid "Ancient philosophy"
 msgstr "Antike Philosophie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "Osb4bp"
+msgctxt "Osb4bp"
+msgid "Machine learning"
 msgstr "Maschinelles Lernen"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "OdZ_n1"
+msgctxt "OdZ_n1"
+msgid "Creative writing"
 msgstr "Kreatives Schreiben"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "N9FWiz"
+msgctxt "N9FWiz"
+msgid "Molecular biology"
 msgstr "Molekularbiologie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XFPrU4"
+msgctxt "XFPrU4"
+msgid "Behavioral economics"
 msgstr "Verhaltensökonomie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "-0gz_i"
+msgctxt "-0gz_i"
+msgid "Organic chemistry"
 msgstr "Organische Chemie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1axOcX"
+msgctxt "1axOcX"
+msgid "UFOs"
 msgstr "UFOs"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "e7q85h"
+msgctxt "e7q85h"
+msgid "Dinosaur extinction"
 msgstr "Aussterben der Dinosaurier"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "MO2lwh"
+msgctxt "MO2lwh"
+msgid "How volcanoes work"
 msgstr "Wie Vulkane funktionieren"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ZzbdHP"
+msgctxt "ZzbdHP"
+msgid "World history"
 msgstr "Weltgeschichte"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XfC6Cs"
+msgctxt "XfC6Cs"
+msgid "Cognitive psychology"
 msgstr "Kognitive Psychologie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "X5XXVF"
+msgctxt "X5XXVF"
+msgid "Linear algebra"
 msgstr "Lineare Algebra"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5gOFKJ"
+msgctxt "5gOFKJ"
+msgid "Black holes"
 msgstr "Schwarze Löcher"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "eQHeGX"
+msgctxt "eQHeGX"
+msgid "How the internet works"
 msgstr "Wie das Internet funktioniert"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "QOSGzc"
+msgctxt "QOSGzc"
+msgid "Roman Empire"
 msgstr "Römisches Reich"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "gyEihl"
+msgctxt "gyEihl"
+msgid "Deep sea creatures"
 msgstr "Tiefseewesen"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "0MqSJ1"
+msgctxt "0MqSJ1"
+msgid "Solar system"
 msgstr "Sonnensystem"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5qPAxv"
+msgctxt "5qPAxv"
+msgid "Artificial intelligence"
 msgstr "Künstliche Intelligenz"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "3WiAG4"
+msgctxt "3WiAG4"
+msgid "Harry Potter"
 msgstr "Harry Potter"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "NvSCuG"
+msgctxt "NvSCuG"
+msgid "Suggested subjects"
 msgstr "Vorgeschlagene Themen"
 
 #: src/app/(catalog)/start/learn/learn-form.tsx
-msgid "uCb1nG"
+msgctxt "uCb1nG"
+msgid "Enter a subject"
 msgstr "Thema eingeben"
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "JlJVf1"
+msgctxt "JlJVf1"
+msgid "Tell Zoonk what you want to learn and get a course created with AI. Start learning any subject with interactive lessons."
 msgstr "Sag Zoonk, was du lernen willst, und erhalte mit KI erstellte Kurse. Starte interaktive Lektionen zu jedem Thema."
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "Zs1QEq"
+msgctxt "Zs1QEq"
+msgid "Learn Anything with AI"
 msgstr "Lerne alles mit KI"
 
 #: src/app/(catalog)/start/page.tsx
-msgid "UFOGo9"
+msgctxt "UFOGo9"
+msgid "Start online courses to learn languages and more on Zoonk. Practice language learning, learn English or Spanish, and create AI-powered courses for any subject."
 msgstr "Beginne Online‑Kurse auf Zoonk, um Sprachen und mehr zu lernen. Übe Sprachen, lerne Englisch oder Spanisch und erstelle KI‑gestützte Kurse zu jedem Thema."
 
 #: src/app/(catalog)/start/page.tsx
-msgid "rqpQgj"
+msgctxt "rqpQgj"
+msgid "Online Courses to Learn Languages and More"
 msgstr "Online‑Kurse zum Sprachenlernen und mehr"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "K4jMHW"
+msgctxt "K4jMHW"
+msgid "Online language courses with AI. Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Online‑Sprachkurse mit KI. Lerne mit Aussprachetipps, Vokabeln, Lese‑ und Hören‑Übungen."
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "Ht6aMH"
+msgctxt "Ht6aMH"
+msgid "Learn a language online with AI"
 msgstr "Lerne online eine Sprache mit KI"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "lSAK6U"
+msgctxt "lSAK6U"
+msgid "What language do you want to learn?"
 msgstr "Welche Sprache möchtest du lernen?"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "ptPPVk"
+msgctxt "ptPPVk"
+msgid "No languages found"
 msgstr "Keine Sprachen gefunden"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "L820yz"
+msgctxt "L820yz"
+msgid "Search languages"
 msgstr "Sprachen suchen"
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "ah2CR6"
+msgctxt "ah2CR6"
+msgid "Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Lerne mit Aussprachetipps, Vokabeln, Lese‑ und Hören‑Übungen."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "_E8OKF"
+msgctxt "_E8OKF"
+msgid "Turn any subject into a clear course you can follow step by step, with practical examples and no fluff."
 msgstr "Mach aus jedem Thema einen klaren Kurs, dem du Schritt für Schritt folgen kannst – mit praktischen Beispielen und ohne Schnickschnack."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "IF6NT-"
+msgctxt "IF6NT-"
+msgid "We'll prepare a study path to help you pass an entrance exam, certification, or school test."
 msgstr "Wir erstellen einen Lernplan, damit du eine Aufnahmeprüfung, Zertifizierung oder Schulprüfung bestehst."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "AaFZIp"
+msgctxt "AaFZIp"
+msgid "What's your goal?"
 msgstr "Was ist dein Ziel?"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "pev_fB"
+msgctxt "pev_fB"
+msgid "vs last month"
 msgstr "vs. letzten Monat"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "R9qHBU"
+msgctxt "R9qHBU"
+msgid "vs last 6 months"
 msgstr "vs. letzten 6 Monaten"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "s-lPP3"
+msgctxt "s-lPP3"
+msgid "All time"
 msgstr "Gesamt"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "YFV6dH"
+msgctxt "YFV6dH"
+msgid "vs last year"
 msgstr "vs. letztes Jahr"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "hCCWuZ"
+msgctxt "hCCWuZ"
+msgid "Previous period"
 msgstr "Vorheriger Zeitraum"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "I2z5s_"
+msgctxt "I2z5s_"
+msgid "Next period"
 msgstr "Nächster Zeitraum"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "PIaUh-"
+msgctxt "PIaUh-"
+msgid "Period selection"
 msgstr "Zeitauswahl"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "TBovrx"
+msgctxt "TBovrx"
+msgid "Month"
 msgstr "Monat"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "NPrFLC"
+msgctxt "NPrFLC"
+msgid "6 Months"
 msgstr "6 Monate"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "IFo1oo"
+msgctxt "IFo1oo"
+msgid "Year"
 msgstr "Jahr"
 
 #: src/app/(progress)/_components/progress-chart-layout.tsx
-msgid "OlW5Z8"
+msgctxt "OlW5Z8"
+msgid "No data available for this period"
 msgstr "Für diesen Zeitraum sind keine Daten verfügbar"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "FVh2Tr"
+msgctxt "FVh2Tr"
+msgid "Start learning to track your progress"
 msgstr "Beginne zu lernen, um deinen Fortschritt zu verfolgen"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "Y1zzQt"
+msgctxt "Y1zzQt"
+msgid "Log in to track your progress"
 msgstr "Melde dich an, um deinen Fortschritt zu verfolgen"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "J3fNDZ"
+msgctxt "J3fNDZ"
+msgid "This month"
 msgstr "Dieser Monat"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "eWUXBX"
+msgctxt "eWUXBX"
+msgid "Past 6 months"
 msgstr "Letzte 6 Monate"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "lPShsT"
+msgctxt "lPShsT"
+msgid "This year"
 msgstr "Dieses Jahr"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
-msgid "M-JIpD"
+msgctxt "M-JIpD"
+msgid "Energy chart"
 msgstr "Energie‑Diagramm"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "rGSqvt"
+msgctxt "rGSqvt"
+msgid "Avg"
 msgstr "Durchschn."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "TLPAMC"
+msgctxt "TLPAMC"
+msgid "What is Energy?"
 msgstr "Was ist Energie?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "OvOWOR"
+msgctxt "OvOWOR"
+msgid "Energy is a 0% to 100% score for your recent learning consistency and accuracy."
 msgstr "Energie ist ein Wert von 0–100 %, der zeigt, wie regelmäßig und genau du in letzter Zeit gelernt hast."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "K3jN6p"
+msgctxt "K3jN6p"
+msgid "How do I improve Energy?"
 msgstr "Wie verbessere ich meine Energie?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "pssms6"
+msgctxt "pssms6"
+msgid "Answer questions correctly and keep learning regularly. Correct answers raise Energy; wrong answers and days away from studying lower it."
 msgstr "Beantworte Fragen richtig und lerne regelmäßig. Richtige Antworten erhöhen die Energie; falsche Antworten und Tage ohne Lernen senken sie."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "-8Qx8X"
+msgctxt "-8Qx8X"
+msgid "Why is Energy important?"
 msgstr "Warum ist Energie wichtig?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "UfEfhq"
+msgctxt "UfEfhq"
+msgid "Energy is like heart rate in a health app: it shows your current learning rhythm. Missing a day doesn't reset your progress; you recover as soon as you start learning again."
 msgstr "Energie ist wie der Herzschlag in einer Gesundheits-App: Sie zeigt deinen aktuellen Lernrhythmus. Wenn du einen Tag aussetzt, wird dein Fortschritt nicht zurückgesetzt; du erholst dich, sobald du wieder lernst."
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "XxS-he"
+msgctxt "XxS-he"
+msgid "Highest energy day"
 msgstr "Tag mit höchster Energie"
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "aaiQkv"
+msgctxt "aaiQkv"
+msgid "Full energy"
 msgstr "Volle Energie"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "zLCmVM"
+msgctxt "zLCmVM"
+msgid "Current Energy"
 msgstr "Aktuelle Energie"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "e9DcQa"
+msgctxt "e9DcQa"
+msgid "{percentage} average"
 msgstr "{percentage} im Schnitt"
 
 #: src/app/(progress)/energy/page.tsx
-msgid "AZMpf3"
+msgctxt "AZMpf3"
+msgid "Energy is a 0% to 100% score based on recent activity and accuracy."
 msgstr "Energie ist ein 0%–100%‑Wert basierend auf jüngster Aktivität und Genauigkeit."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "rsIaGW"
+msgctxt "rsIaGW"
+msgid "A 0% to 100% score for recent activity and accuracy"
 msgstr "Ein 0%–100%‑Wert für jüngste Aktivität und Genauigkeit"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "GA8RuL"
+msgctxt "GA8RuL"
+msgid "Brain Power chart"
 msgstr "Brain-Power-Diagramm"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "XdkaHc"
+msgctxt "XdkaHc"
+msgid "{value} BP"
 msgstr "{value} BP"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "tDbspx"
+msgctxt "tDbspx"
+msgid "Total Brain Power earned: {total}"
 msgstr "Insgesamt erreichte Brain Power: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "EMy5Vs"
+msgctxt "EMy5Vs"
+msgid "What is Brain Power?"
 msgstr "Was ist Brain Power?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "MIjvOA"
+msgctxt "MIjvOA"
+msgid "Brain Power (BP) is the total learning credit you have earned. Each completed lesson adds {brainPower} BP."
 msgstr "Brain Power (BP) ist das gesamte Lernguthaben, das du erarbeitet hast. Jede abgeschlossene Lektion fügt {brainPower} BP hinzu."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "jzKXJS"
+msgctxt "jzKXJS"
+msgid "How do I increase Brain Power?"
 msgstr "Wie erhöhe ich Brain Power?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "Gzq1tT"
+msgctxt "Gzq1tT"
+msgid "Complete lessons. Brain Power never goes down, even when your Energy drops or you take a break."
 msgstr "Schließe Lektionen ab. Brain Power sinkt nie, auch wenn deine Energie abnimmt oder du eine Pause machst."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "JGLOtn"
+msgctxt "JGLOtn"
+msgid "Why is Brain Power important?"
 msgstr "Warum ist Brain Power wichtig?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "tC6vNz"
+msgctxt "tC6vNz"
+msgid "It is like steps in a health app: a record of how much you have learned. It also works like martial arts for your mind: build Brain Power to advance from white belt to black belt."
 msgstr "Sie ist wie Schritte in einer Gesundheits-App: ein Protokoll dessen, wie viel du gelernt hast. Sie funktioniert auch wie Kampfkunst für deinen Geist: Baue Geisteskraft auf, um vom weißen Gürtel zum schwarzem Gürtel aufzusteigen"
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "elq-tg"
+msgctxt "elq-tg"
+msgid "Highest BP"
 msgstr "Höchster BP-Wert"
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "BW4bMl"
+msgctxt "BW4bMl"
+msgid "{date} with {value} BP"
 msgstr "{date} mit {value} BP"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "WfaE4H"
+msgctxt "WfaE4H"
+msgid "{belt}, Level {level} of 10. Maximum level achieved."
 msgstr "{belt}, Level {level} von 10. Maximales Level erreicht."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "2Y-P4e"
+msgctxt "2Y-P4e"
+msgid "{belt}, Level {level} of 10. {bp} Brain Power until next level."
 msgstr "{belt}, Level {level} von 10. Noch {bp} Brain Power bis zum nächsten Level."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "n_mgOm"
+msgctxt "n_mgOm"
+msgid "Belt Progression"
 msgstr "Gürtel-Fortschritt"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "ZKbTsS"
+msgctxt "ZKbTsS"
+msgid "{current}/10"
 msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "-Sn2yd"
+msgctxt "-Sn2yd"
+msgid "{belt}: Level {current} of 10"
 msgstr "{belt}: Level {current} von 10"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "v5yNm3"
+msgctxt "v5yNm3"
+msgid "Total Brain Power"
 msgstr "Gesamte Brain Power"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "_Q0taG"
+msgctxt "_Q0taG"
+msgid "BP"
 msgstr "BP"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "u_oEJA"
+msgctxt "u_oEJA"
+msgid "{value} BP earned"
 msgstr "{value} BP erreicht"
 
 #: src/app/(progress)/level/page.tsx
-msgid "4-USpX"
+msgctxt "4-USpX"
+msgid "Track your level progress and see how you advance."
 msgstr "Verfolge deinen Fortschritt in den Stufen und sieh, wie du vorankommst."
 
 #: src/app/(progress)/level/page.tsx
-msgid "L9hqMH"
+msgctxt "L9hqMH"
+msgid "Track your level progress"
 msgstr "Verfolge deinen Level-Fortschritt"
 
 #: src/app/(progress)/score/page.tsx
-msgid "qHWZBu"
+msgctxt "qHWZBu"
+msgid "Track your score over time and see your best days and times."
 msgstr "Verfolge deine Punktzahl im Zeitverlauf und sieh deine besten Tage und Zeiten."
 
 #: src/app/(progress)/score/page.tsx
-msgid "GWkswX"
+msgctxt "GWkswX"
+msgid "Track your score and progress trends"
 msgstr "Verfolge deine Punktzahl und Entwicklungstrends"
 
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "J-05ol"
+msgctxt "J-05ol"
+msgid "Score chart"
 msgstr "Punktzahlen-Diagramm"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "bIZaXJ"
+msgctxt "bIZaXJ"
+msgid "What is Score?"
 msgstr "Was ist die Punktzahl?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "JA-N5Z"
+msgctxt "JA-N5Z"
+msgid "Score is the percentage of questions you answered correctly during this period."
 msgstr "Die Punktzahl ist der Prozentsatz der Fragen, die du in diesem Zeitraum richtig beantwortet hast."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "z9kvhA"
+msgctxt "z9kvhA"
+msgid "How do I improve Score?"
 msgstr "Wie verbessere ich meine Punktzahl?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "7_C9do"
+msgctxt "7_C9do"
+msgid "Review mistakes and retry lessons. As you answer more questions correctly, your Score goes up."
 msgstr "Wiederhole Fehler und versuche Lektionen erneut. Wenn du mehr Fragen richtig beantwortest, steigt deine Punktzahl."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "WqH8eP"
+msgctxt "WqH8eP"
+msgid "Why is Score important?"
 msgstr "Warum ist die Punktzahl wichtig?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "E0saoA"
+msgctxt "E0saoA"
+msgid "Score shows accuracy, not activity. Best day and best time help you find when you learn most effectively."
 msgstr "Die Punktzahl zeigt Genauigkeit, nicht Aktivität. Bester Tag und beste Zeit helfen dir zu erkennen, wann du am effektivsten lernst."
 
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "yOFm9C"
+msgctxt "yOFm9C"
+msgid "You need to be logged in to access this page."
 msgstr "Du musst eingeloggt sein, um auf diese Seite zuzugreifen."
 
 #: src/app/(settings)/language/page.tsx
-msgid "2WHx14"
+msgctxt "2WHx14"
+msgid "Update your app language to learn in English, Portuguese, Spanish, French, or other supported languages."
 msgstr "Ändere die App‑Sprache, um auf Englisch, Portugiesisch, Spanisch, Französisch oder anderen unterstützten Sprachen zu lernen."
 
 #: src/app/(settings)/language/page.tsx
-msgid "aNLa1G"
+msgctxt "aNLa1G"
+msgid "Choose the app language you prefer for this device."
 msgstr "Wähle die App‑Sprache, die du auf diesem Gerät bevorzugst."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "dSVD13"
+msgctxt "dSVD13"
+msgid "Update your name and username on Zoonk."
 msgstr "Aktualisiere deinen Namen und Benutzernamen auf Zoonk."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "wjIStY"
+msgctxt "wjIStY"
+msgid "Your name and username as they appear to others."
 msgstr "Dein Name und Benutzername, wie sie anderen angezeigt werden."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Wird geprüft..."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} ist verfügbar"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} ist bereits vergeben"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "3–30 Zeichen. Nur Buchstaben, Zahlen und Unterstriche."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Name"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "yNHZ-a"
+msgctxt "yNHZ-a"
+msgid "Your profile has been updated successfully!"
 msgstr "Dein Profil wurde erfolgreich aktualisiert!"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "VT-G_7"
+msgctxt "VT-G_7"
+msgid "This name will be visible to other users."
 msgstr "Dieser Name ist für andere Nutzer sichtbar."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "wYCHCR"
+msgctxt "wYCHCR"
+msgid "Failed to update your profile. Please try again or contact hello@zoonk.com"
 msgstr "Profilaktualisierung fehlgeschlagen. Bitte versuche es erneut oder kontaktiere hello@zoonk.com"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Benutzername"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "X0ha1a"
+msgctxt "X0ha1a"
+msgid "Save changes"
 msgstr "Änderungen speichern"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "3iCRcP"
+msgctxt "3iCRcP"
+msgid "Manage in App Store"
 msgstr "Im App Store verwalten"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "tiFovn"
+msgctxt "tiFovn"
+msgid "Manage in Google Play"
 msgstr "In Google Play verwalten"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "Tp4wJB"
+msgctxt "Tp4wJB"
+msgid "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
 msgstr "Dieses Abonnement wird über den App Store verwaltet. Ändere oder kündige es über die Apple‑Abonnement‑Einstellungen."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "unNUPf"
+msgctxt "unNUPf"
+msgid "This subscription is managed through Google Play. To change or cancel it, use Google Play."
 msgstr "Dieses Abonnement wird über Google Play verwaltet. Ändere oder kündige es über Google Play."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "P0ZHma"
+msgctxt "P0ZHma"
+msgid "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
 msgstr "Dieses Abonnement wird von Zoonk verwaltet. Kontaktiere den Support, wenn du Hilfe beim Ändern oder Kündigen brauchst."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "5CI3KH"
+msgctxt "5CI3KH"
+msgid "Contact support"
 msgstr "Support kontaktieren"
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "TKk9oj"
+msgctxt "TKk9oj"
+msgid "Compare plans and manage your Zoonk subscription. See pricing, switch plans, or update billing."
 msgstr "Vergleiche Pläne und verwalte dein Zoonk-Abonnement. Sieh dir Preise an, wechsle den Plan oder aktualisiere deine Zahlungsdaten."
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "NBEnVd"
+msgctxt "NBEnVd"
+msgid "Compare plans and manage your subscription."
 msgstr "Vergleiche Pläne und verwalte dein Abonnement."
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "PJfdJl"
+msgctxt "PJfdJl"
+msgid "Save up to {amount}"
 msgstr "Spare bis zu {amount}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "KAb0Yr"
+msgctxt "KAb0Yr"
+msgid "Switch to {plan}"
 msgstr "Zu {plan} wechseln"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0Azlrb"
+msgctxt "0Azlrb"
+msgid "Manage"
 msgstr "Verwalten"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "_gko4g"
+msgctxt "_gko4g"
+msgid "Upgrade to {plan}"
 msgstr "Auf {plan} upgraden"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "wYsv4Z"
+msgctxt "wYsv4Z"
+msgid "Monthly"
 msgstr "Monatlich"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "dqD39h"
+msgctxt "dqD39h"
+msgid "Yearly"
 msgstr "Jährlich"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "s1ZXI0"
+msgctxt "s1ZXI0"
+msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "Wir konnten dein Abonnement nicht aktualisieren. Kontaktiere uns unter hello@zoonk.com"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "2EsPdm"
+msgctxt "2EsPdm"
+msgid "/yr"
 msgstr "/Jahr"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0jIMEb"
+msgctxt "0jIMEb"
+msgid "/mo"
 msgstr "/Monat"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "tf1lIh"
+msgctxt "tf1lIh"
+msgid "Free"
 msgstr "Kostenlos"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "ZBALng"
+msgctxt "ZBALng"
+msgid "Current plan"
 msgstr "Aktueller Plan"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "fF376U"
+msgctxt "fF376U"
+msgid "Current"
 msgstr "Aktuell"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "kkjl2v"
+msgctxt "kkjl2v"
+msgid "Max"
 msgstr "Max"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "lOdoIb"
+msgctxt "lOdoIb"
+msgid "Plus"
 msgstr "Plus"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "R_eOkj"
+msgctxt "R_eOkj"
+msgid "Pro"
 msgstr "Pro"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "9o8O4m"
+msgctxt "9o8O4m"
+msgid "Your subscription will end on {date}."
 msgstr "Dein Abonnement endet am {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "vaN1qz"
+msgctxt "vaN1qz"
+msgid "Current billing period ends on {date}."
 msgstr "Der aktuelle Abrechnungszeitraum endet am {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "EV_gJ6"
+msgctxt "EV_gJ6"
+msgid "First chapter included"
 msgstr "Erstes Kapitel enthalten"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "mqHNd6"
+msgctxt "mqHNd6"
+msgid "Personalized lessons, smartest AI"
 msgstr "Personalisierte Lektionen, klügste KI"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "SC0MFR"
+msgctxt "SC0MFR"
+msgid "Unlimited lessons"
 msgstr "Unbegrenzte Lektionen"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "eaOADK"
+msgctxt "eaOADK"
+msgid "Personalized lessons, fast AI"
 msgstr "Personalisierte Lektionen, schnelle KI"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "B5MLC7"
+msgctxt "B5MLC7"
+msgid "Share feedback, ask questions, or get help with your account and courses."
 msgstr "Teile Feedback, stelle Fragen oder erhalte Hilfe zu deinem Konto und deinen Kursen."
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "cDAb4a"
+msgctxt "cDAb4a"
+msgid "GitHub Discussions"
 msgstr "GitHub Discussions"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "7h49qt"
+msgctxt "7h49qt"
+msgid "Connect with the community and get answers"
 msgstr "Vernetze dich mit der Community und erhalte Antworten"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "YdQxfw"
+msgctxt "YdQxfw"
+msgid "Contact Support"
 msgstr "Support kontaktieren"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "dQIo6c"
+msgctxt "dQIo6c"
+msgid "Email us at hello@zoonk.com"
 msgstr "Schreib uns an hello@zoonk.com"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "l1XTI5"
+msgctxt "l1XTI5"
+msgid "Follow us"
 msgstr "Folge uns"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "rCpmYD"
+msgctxt "rCpmYD"
+msgid "Create this lesson"
 msgstr "Diese Lektion erstellen"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "AtnLyn"
+msgctxt "AtnLyn"
+msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "Diese Lektion ist Teil des Kurses, wurde aber noch nicht erstellt. Erstelle sie, um mit dem Lernen zu beginnen."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "ZzznjM"
+msgctxt "ZzznjM"
+msgid "Create lesson"
 msgstr "Lektion erstellen"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
-msgid "_N8rYN"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
 msgstr "Zurück zum Kapitel"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "ZnMcrz"
+msgctxt "ZnMcrz"
+msgid "Unlock the rest of this course"
 msgstr "Den Rest dieses Kurses freischalten"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "A_uNk-"
+msgctxt "A_uNk-"
+msgid "Create lessons before reviewing"
 msgstr "Erstelle Lektionen, bevor du mit der Überprüfung beginnst"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "Qy4EsI"
+msgctxt "Qy4EsI"
+msgid "Nothing to review yet"
 msgstr "Noch nichts zu wiederholen"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "4w9Y_P"
+msgctxt "4w9Y_P"
+msgid "Review unlocks after the earlier lessons in this chapter have been created."
 msgstr "Die Überprüfung wird freigeschaltet, nachdem die vorherigen Lektionen in diesem Kapitel erstellt wurden."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "9AOq2-"
+msgctxt "9AOq2-"
+msgid "There are no practice questions to review yet."
 msgstr "Es gibt noch keine Übungsfragen zum Wiederholen."
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "txNTbP"
+msgctxt "txNTbP"
+msgid "Creating the {title} chapter"
 msgstr "Kapitel {title} wird erstellt"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "kiZUDf"
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
 msgstr "Das dauert normalerweise etwa eine Minute"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "5c2xtK"
+msgctxt "5c2xtK"
+msgid "Taking you to your chapter..."
 msgstr "Wir leiten dich zu deinem Kapitel..."
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "45uo73"
+msgctxt "45uo73"
+msgid "Your lessons are ready"
 msgstr "Deine Lektionen sind bereit"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "gnxL73"
+msgctxt "gnxL73"
+msgid "Choosing lesson types"
 msgstr "Lektionstypen auswählen"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "EKtClK"
+msgctxt "EKtClK"
+msgid "Getting started"
 msgstr "Erste Schritte"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "SF9AtA"
+msgctxt "SF9AtA"
+msgid "Preparing lessons"
 msgstr "Lektionen vorbereiten"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "L7nQzn"
+msgctxt "L7nQzn"
+msgid "Saving your lessons"
 msgstr "Lektionen speichern"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Sbsm52"
+msgctxt "Sbsm52"
+msgid "Checking how each lesson should be taught..."
 msgstr "Prüfe, wie jede Lektion vermittelt werden soll..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "0xCLwv"
+msgctxt "0xCLwv"
+msgid "Choosing type for lesson {number}..."
 msgstr "Wähle Typ für Lektion {number}..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Vbn5Wz"
+msgctxt "Vbn5Wz"
+msgid "Reviewing the lesson mix..."
 msgstr "Überprüfe die Zusammenstellung der Lektionen..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5342HA"
+msgctxt "5342HA"
+msgid "Getting started..."
 msgstr "Los geht's..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "nwGJ65"
+msgctxt "nwGJ65"
+msgid "Exploring your topic..."
 msgstr "Dein Thema erkunden..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "VKFa_t"
+msgctxt "VKFa_t"
+msgid "Mapping out the learning path..."
 msgstr "Lernpfad planen..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "zQWv1_"
+msgctxt "zQWv1_"
+msgid "Writing lesson {number}..."
 msgstr "Lektion {number} schreiben..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "HWSnYS"
+msgctxt "HWSnYS"
+msgid "Reviewing the flow so far..."
 msgstr "Bisherigen Ablauf prüfen..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "txvxwS"
+msgctxt "txvxwS"
+msgid "Saving your progress..."
 msgstr "Deinen Fortschritt speichern..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JUr8Er"
+msgctxt "JUr8Er"
+msgid "Finishing up..."
 msgstr "Abschließen..."
 
 #: src/app/generate/course/[id]/generate-course-prompt-content.tsx
-msgid "rPgekg"
+msgctxt "rPgekg"
+msgid "Back home"
 msgstr "Zurück zur Startseite"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "15FsdE"
+msgctxt "15FsdE"
+msgid "Your course is ready"
 msgstr "Dein Kurs ist bereit"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "4Wktrz"
+msgctxt "4Wktrz"
+msgid "Your lesson is ready"
 msgstr "Deine Lektion ist fertig"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "0o41MR"
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
 msgstr "Wir leiten dich zu deinem Kurs weiter…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "T2TGxR"
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
 msgstr "Deine Lektion öffnen..."
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "u6ROZF"
+msgctxt "u6ROZF"
+msgid "Creating the {title} course"
 msgstr "Kurs {title} erstellen"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "GJKrUK"
+msgctxt "GJKrUK"
+msgid "This usually takes about 2 minutes"
 msgstr "Das dauert normalerweise etwa 2 Minuten"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "i3JgLB"
+msgctxt "i3JgLB"
+msgid "Categorizing your course"
 msgstr "Deinen Kurs kategorisieren..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WOe-OA"
+msgctxt "WOe-OA"
+msgid "Checking for duplicates"
 msgstr "Nach Duplikaten suchen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gjutu-"
+msgctxt "Gjutu-"
+msgid "Creating the cover image"
 msgstr "Titelbild erstellen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "SQFyKH"
+msgctxt "SQFyKH"
+msgid "Finding similar courses"
 msgstr "Ähnliche Kurse finden..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WZpB8D"
+msgctxt "WZpB8D"
+msgid "Writing chapters"
 msgstr "Kapitel schreiben..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "vEOpTk"
+msgctxt "vEOpTk"
+msgid "Planning the introduction"
 msgstr "Die Einführung wird geplant"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "d2xrsv"
+msgctxt "d2xrsv"
+msgid "Preparing your course"
 msgstr "Deinen Kurs vorbereiten..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "CFWOGF"
+msgctxt "CFWOGF"
+msgid "Saving your course"
 msgstr "Deinen Kurs speichern..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XPla-v"
+msgctxt "XPla-v"
+msgid "Preparing the introduction"
 msgstr "Die Einführung wird vorbereitet"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "HbhIvm"
+msgctxt "HbhIvm"
+msgid "Writing your course description"
 msgstr "Kursbeschreibung schreiben..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Y4F0xn"
+msgctxt "Y4F0xn"
+msgid "Writing the first lesson"
 msgstr "Die erste Lektion wird geschrieben"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "e1myvm"
+msgctxt "e1myvm"
+msgid "Writing your course page"
 msgstr "Deine Kursseite wird erstellt"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "aev_pt"
+msgctxt "aev_pt"
+msgid "Figuring out the right categories..."
 msgstr "Passende Kategorien finden..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "EKAN6s"
+msgctxt "EKAN6s"
+msgid "Tagging your course..."
 msgstr "Kurs taggen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "JJrUOR"
+msgctxt "JJrUOR"
+msgid "Comparing nearby courses..."
 msgstr "Ähnliche Kurse vergleichen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "uw23V-"
+msgctxt "uw23V-"
+msgid "Checking whether this course already exists..."
 msgstr "Prüfen, ob dieser Kurs schon existiert..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "qFmZfG"
+msgctxt "qFmZfG"
+msgid "Avoiding duplicate courses..."
 msgstr "Doppelte Kurse vermeiden..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "lxBtcx"
+msgctxt "lxBtcx"
+msgid "Designing the cover..."
 msgstr "Titelbild gestalten..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "W8n2i3"
+msgctxt "W8n2i3"
+msgid "Picking the right look..."
 msgstr "Passendes Design wählen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "At4rk1"
+msgctxt "At4rk1"
+msgid "Adding finishing touches..."
 msgstr "Letzte Anpassungen vornehmen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "NgONb4"
+msgctxt "NgONb4"
+msgid "Searching for matching topics..."
 msgstr "Passende Themen suchen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Auz1tl"
+msgctxt "Auz1tl"
+msgid "Looking for alternate names..."
 msgstr "Alternative Namen suchen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gt_VNO"
+msgctxt "Gt_VNO"
+msgid "Expanding the course search..."
 msgstr "Kurssuche erweitern..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "AEG3Ol"
+msgctxt "AEG3Ol"
+msgid "Planning the course structure..."
 msgstr "Kursstruktur planen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "OW9vMd"
+msgctxt "OW9vMd"
+msgid "Writing chapter {number}..."
 msgstr "Kapitel {number} schreiben..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "tXkuD8"
+msgctxt "tXkuD8"
+msgid "Reviewing the overall flow..."
 msgstr "Gesamten Ablauf prüfen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "8-bhNP"
+msgctxt "8-bhNP"
+msgid "Finding the best first hook..."
 msgstr "Der beste erste Einstieg wird gesucht…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "xrFhkn"
+msgctxt "xrFhkn"
+msgid "Writing a friendly guide to the field..."
 msgstr "Ein freundlicher Leitfaden zum Thema wird geschrieben…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "c_e4hk"
+msgctxt "c_e4hk"
+msgid "Keeping the first chapter easy to start..."
 msgstr "Das erste Kapitel einfach zugänglich halten…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "4LsE_n"
+msgctxt "4LsE_n"
+msgid "Creating the course shell..."
 msgstr "Kursgerüst erstellen..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "3hEaI4"
+msgctxt "3hEaI4"
+msgid "Preparing the workspace..."
 msgstr "Arbeitsbereich vorbereiten..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "7Pw3r5"
+msgctxt "7Pw3r5"
+msgid "Saving the intro chapter..."
 msgstr "Das Einführungskapitel wird gespeichert…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "cc6_Yn"
+msgctxt "cc6_Yn"
+msgid "Preparing the first lessons..."
 msgstr "Die ersten Lektionen werden vorbereitet…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "a7FJJd"
+msgctxt "a7FJJd"
+msgid "Summarizing what you'll learn..."
 msgstr "Zusammenfassen, was du lernen wirst..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "9r_4zz"
+msgctxt "9r_4zz"
+msgid "Writing the overview..."
 msgstr "Überblick schreiben..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "QqKzYM"
+msgctxt "QqKzYM"
+msgid "Writing the first lesson..."
 msgstr "Die erste Lektion wird geschrieben…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XxRMuO"
+msgctxt "XxRMuO"
+msgid "Adding examples and visuals..."
 msgstr "Beispiele und Bilder werden hinzugefügt…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "kmuvIN"
+msgctxt "kmuvIN"
+msgid "Getting the first lesson ready..."
 msgstr "Die erste Lektion wird vorbereitet…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "chqN-J"
+msgctxt "chqN-J"
+msgid "Framing why this course is useful..."
 msgstr "Warum dieser Kurs nützlich ist…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "twf4n2"
+msgctxt "twf4n2"
+msgid "Writing the course page..."
 msgstr "Kursseite wird erstellt…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "k15wFf"
+msgctxt "k15wFf"
+msgid "Shaping the starting point..."
 msgstr "Der Einstieg wird festgelegt…"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "WihX6L"
+msgctxt "WihX6L"
+msgid "Creating the {title} lesson"
 msgstr "Lektion {title} erstellen"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "3vY0Zu"
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
 msgstr "Das dauert normalerweise 1–2 Minuten"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "cVoRCh"
+msgctxt "cVoRCh"
+msgid "Preparing options..."
 msgstr "Optionen werden vorbereitet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BBwnPG"
+msgctxt "BBwnPG"
+msgid "Adding more options..."
 msgstr "Weitere Optionen werden hinzugefügt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "4wkMNX"
+msgctxt "4wkMNX"
+msgid "Getting answer options ready..."
 msgstr "Antwortoptionen werden vorbereitet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "WsjFV2"
+msgctxt "WsjFV2"
+msgid "Preparing the word bank..."
 msgstr "Wortliste wird vorbereitet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6xEJTk"
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
 msgstr "Übungsaufgaben werden gestaltet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6hjA6_"
+msgctxt "6hjA6_"
+msgid "Creating examples to try..."
 msgstr "Beispiele werden erstellt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "KddvJw"
+msgctxt "KddvJw"
+msgid "Writing fill-in-the-blanks..."
 msgstr "Lückentexte werden geschrieben…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "C05-tM"
+msgctxt "C05-tM"
+msgid "Building interactive tasks..."
 msgstr "Interaktive Aufgaben werden erstellt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JGNN92"
+msgctxt "JGNN92"
+msgid "Drawing an illustration..."
 msgstr "Illustration wird gezeichnet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "a08k7g"
+msgctxt "a08k7g"
+msgid "Generating the images..."
 msgstr "Bilder werden erzeugt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bJVUNz"
+msgctxt "bJVUNz"
+msgid "Adding some color..."
 msgstr "Farbe wird hinzugefügt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "Yoev2R"
+msgctxt "Yoev2R"
+msgid "Refining the details..."
 msgstr "Details werden verfeinert…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "xBaVAH"
+msgctxt "xBaVAH"
+msgid "Finishing the artwork..."
 msgstr "Artwork wird fertiggestellt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "W2b0tx"
+msgctxt "W2b0tx"
+msgid "Designing the lesson thumbnail..."
 msgstr "Vorschaubild wird entworfen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "fRAHqN"
+msgctxt "fRAHqN"
+msgid "Creating the lesson thumbnail..."
 msgstr "Vorschaubild wird erstellt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "elwtxf"
+msgctxt "elwtxf"
+msgid "Refining the lesson thumbnail..."
 msgstr "Vorschaubild wird verfeinert…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "uDzgwu"
+msgctxt "uDzgwu"
+msgid "Writing example sentences..."
 msgstr "Beispielsätze werden geschrieben…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "SHIHyL"
+msgctxt "SHIHyL"
+msgid "Creating reading passages..."
 msgstr "Lesetexte werden erstellt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0Zum4g"
+msgctxt "0Zum4g"
+msgid "Putting words in context..."
 msgstr "Wörter werden in Kontext gesetzt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "jixTNM"
+msgctxt "jixTNM"
+msgid "Building natural sentences..."
 msgstr "Natürliche Sätze werden formuliert…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "txIcop"
+msgctxt "txIcop"
+msgid "Loading lesson data..."
 msgstr "Lektionsdaten werden geladen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "l486Kx"
+msgctxt "l486Kx"
+msgid "Checking what we need..."
 msgstr "Anforderungen werden geprüft…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "EAqAX_"
+msgctxt "EAqAX_"
+msgid "Thinking about what to illustrate..."
 msgstr "Illustrationsideen werden überlegt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "2Tovpk"
+msgctxt "2Tovpk"
+msgid "Planning each image..."
 msgstr "Jedes Bild wird geplant…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "sQsQbH"
+msgctxt "sQsQbH"
+msgid "Choosing the right scenes..."
 msgstr "Passende Szenen werden ausgewählt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "iUUJom"
+msgctxt "iUUJom"
+msgid "Planning the illustrations..."
 msgstr "Illustrationen werden geplant…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BszFlm"
+msgctxt "BszFlm"
+msgid "Saving your lesson..."
 msgstr "Lektion wird gespeichert…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bC9979"
+msgctxt "bC9979"
+msgid "Almost done..."
 msgstr "Fast fertig…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5Jyenk"
+msgctxt "5Jyenk"
+msgid "Getting ready for the next step..."
 msgstr "Nächster Schritt wird vorbereitet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "r8xznK"
+msgctxt "r8xznK"
+msgid "Researching the topic..."
 msgstr "Thema wird recherchiert…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "K_JznZ"
+msgctxt "K_JznZ"
+msgid "Writing the explanation..."
 msgstr "Erklärung wird geschrieben…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "19fPwV"
+msgctxt "19fPwV"
+msgid "Making it clear..."
 msgstr "Klarheit wird geschaffen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "65JXIy"
+msgctxt "65JXIy"
+msgid "Putting together the lesson..."
 msgstr "Lektion wird zusammengestellt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "nwi1Ym"
+msgctxt "nwi1Ym"
+msgid "Crafting the content..."
 msgstr "Inhalte werden ausgearbeitet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "-QrqeN"
+msgctxt "-QrqeN"
+msgid "Writing the explanation first..."
 msgstr "Erklärung wird zuerst geschrieben…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "epxxAx"
+msgctxt "epxxAx"
+msgid "Building the foundation..."
 msgstr "Fundament wird aufgebaut…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "GyThaR"
+msgctxt "GyThaR"
+msgid "Preparing background context..."
 msgstr "Hintergrundkontext wird vorbereitet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0AWsLH"
+msgctxt "0AWsLH"
+msgid "Explaining the topic..."
 msgstr "Thema wird erklärt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "KL34l5"
+msgctxt "KL34l5"
+msgid "Adding romanization for grammar..."
 msgstr "Romanisierung für Grammatik wird hinzugefügt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "GILb0l"
+msgctxt "GILb0l"
+msgid "Converting grammar text to Latin script..."
 msgstr "Grammatik wird in lateinische Schrift umgewandelt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OFH7dE"
+msgctxt "OFH7dE"
+msgid "Making grammar content easier to read..."
 msgstr "Grammatik wird leichter lesbar gemacht…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VADOBa"
+msgctxt "VADOBa"
+msgid "Looking up how each word sounds..."
 msgstr "Aussprache jedes Wortes wird nachgeschlagen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "WnqJeL"
+msgctxt "WnqJeL"
+msgid "Mapping out the pronunciation..."
 msgstr "Ausspracheplan wird erstellt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "HDNFHk"
+msgctxt "HDNFHk"
+msgid "Checking how to say each word..."
 msgstr "Aussprache jedes Wortes wird geprüft…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "_Fl7bm"
+msgctxt "_Fl7bm"
+msgid "Finding the right sounds..."
 msgstr "Richtige Laute werden gefunden…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "DLZ9fl"
+msgctxt "DLZ9fl"
+msgid "Converting to Latin script..."
 msgstr "Text wird in lateinische Schrift umgewandelt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "boocfl"
+msgctxt "boocfl"
+msgid "Adding reading aids..."
 msgstr "Lesehilfen werden hinzugefügt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "AQMVYX"
+msgctxt "AQMVYX"
+msgid "Making it easier to read..."
 msgstr "Lesen wird erleichtert…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ud2yWh"
+msgctxt "ud2yWh"
+msgid "Writing out the sounds..."
 msgstr "Laute werden ausgeschrieben…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "kxBeWt"
+msgctxt "kxBeWt"
+msgid "Adding romanization for vocabulary..."
 msgstr "Romanisierung für Vokabular wird hinzugefügt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "Ch9BcP"
+msgctxt "Ch9BcP"
+msgid "Converting vocabulary to Latin script..."
 msgstr "Wortschatz wird in lateinische Schrift umgewandelt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1aPaHZ"
+msgctxt "1aPaHZ"
+msgid "Making vocabulary easier to read..."
 msgstr "Vokabular wird leichter lesbar gemacht…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "zYx0UG"
+msgctxt "zYx0UG"
+msgid "Adding pronunciation for each word..."
 msgstr "Aussprache für jedes Wort wird hinzugefügt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VQ3-C2"
+msgctxt "VQ3-C2"
+msgid "Noting how each word sounds..."
 msgstr "Klang jedes Wortes wird notiert…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YWB-K_"
+msgctxt "YWB-K_"
+msgid "Detailing the word sounds..."
 msgstr "Wortlaute werden festgehalten…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "L6f1Zq"
+msgctxt "L6f1Zq"
+msgid "Recording pronunciation info..."
 msgstr "Ausspracheinformationen werden erfasst…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "i-rNdh"
+msgctxt "i-rNdh"
+msgid "Picking the key vocabulary..."
 msgstr "Schlüsselvokabeln werden ausgewählt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "IdWf9_"
+msgctxt "IdWf9_"
+msgid "Choosing words to practice..."
 msgstr "Wörter zum Üben werden ausgewählt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "UFDKHM"
+msgctxt "UFDKHM"
+msgid "Finding the most useful words..."
 msgstr "Nützlichste Wörter werden gefunden…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YgG70c"
+msgctxt "YgG70c"
+msgid "Selecting important terms..."
 msgstr "Wichtige Begriffe werden ausgewählt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "6BQo6o"
+msgctxt "6BQo6o"
+msgid "Translating individual words..."
 msgstr "Einzelne Wörter werden übersetzt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "k0Q_Ph"
+msgctxt "k0Q_Ph"
+msgid "Looking up each term..."
 msgstr "Jeder Begriff wird nachgeschlagen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "hZLCkp"
+msgctxt "hZLCkp"
+msgid "Finding word meanings..."
 msgstr "Wortbedeutungen werden gefunden…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "SC0o7J"
+msgctxt "SC0o7J"
+msgid "Building the vocabulary guide..."
 msgstr "Vokabelhilfe wird erstellt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "5InW8H"
+msgctxt "5InW8H"
+msgid "Recording the audio..."
 msgstr "Audio wird aufgenommen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "4xvh9e"
+msgctxt "4xvh9e"
+msgid "Getting the pronunciation right..."
 msgstr "Aussprache wird geprüft…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "oB01Wc"
+msgctxt "oB01Wc"
+msgid "Preparing the voice..."
 msgstr "Stimme wird vorbereitet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ScA7Xm"
+msgctxt "ScA7Xm"
+msgid "Making it sound natural..."
 msgstr "Natürlicher Klang wird erzeugt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1vO-bV"
+msgctxt "1vO-bV"
+msgid "Recording vocabulary audio..."
 msgstr "Vokabel-Audio wird aufgenommen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "jV2zI1"
+msgctxt "jV2zI1"
+msgid "Getting the sound for each word..."
 msgstr "Klang jedes Wortes wird geholt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "FahI7K"
+msgctxt "FahI7K"
+msgid "Preparing vocabulary audio..."
 msgstr "Vokabel-Audio wird vorbereitet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "JfNFGM"
+msgctxt "JfNFGM"
+msgid "Making words listenable..."
 msgstr "Wörter werden hörbar gemacht…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "muXaEm"
+msgctxt "muXaEm"
+msgid "Recording pronunciation for each word..."
 msgstr "Aussprache für jedes Wort wird aufgenommen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "QDv0wS"
+msgctxt "QDv0wS"
+msgid "Getting the audio for each term..."
 msgstr "Audio für jeden Begriff wird geholt…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OJkDgV"
+msgctxt "OJkDgV"
+msgid "Preparing word-by-word audio..."
 msgstr "Wort-für-Wort-Audio wird vorbereitet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "C2ELVi"
+msgctxt "C2ELVi"
+msgid "Making each word listenable..."
 msgstr "Jedes Wort wird hörbar gemacht…"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "58heST"
+msgctxt "58heST"
+msgid "Adding grammar romanization"
 msgstr "Grammatik-Romanisierung hinzufügen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "TlrPFF"
+msgctxt "TlrPFF"
+msgid "Adding pronunciation"
 msgstr "Aussprache hinzufügen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "V0mPLK"
+msgctxt "V0mPLK"
+msgid "Adding romanization"
 msgstr "Romanisierung hinzufügen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "HXMA75"
+msgctxt "HXMA75"
+msgid "Adding vocabulary romanization"
 msgstr "Vokabel-Romanisierung hinzufügen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "4OjRPB"
+msgctxt "4OjRPB"
+msgid "Adding word pronunciation"
 msgstr "Wort-Aussprache hinzufügen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "RXfSEl"
+msgctxt "RXfSEl"
+msgid "Building word list"
 msgstr "Wortliste erstellen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "viluaR"
+msgctxt "viluaR"
+msgid "Preparing options"
 msgstr "Optionen vorbereiten"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "c7xJGQ"
+msgctxt "c7xJGQ"
+msgid "Creating exercises"
 msgstr "Übungen erstellen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "aKNA_b"
+msgctxt "aKNA_b"
+msgid "Creating images"
 msgstr "Bilder erstellen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "WI2yui"
+msgctxt "WI2yui"
+msgid "Creating lesson thumbnail"
 msgstr "Lektionsvorschau erstellen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "mIpv67"
+msgctxt "mIpv67"
+msgid "Creating sentences"
 msgstr "Sätze erstellen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "0zeST_"
+msgctxt "0zeST_"
+msgid "Looking up words"
 msgstr "Wörter nachschlagen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v7HGj3"
+msgctxt "v7HGj3"
+msgid "Planning the images"
 msgstr "Bilder planen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "T00GEW"
+msgctxt "T00GEW"
+msgid "Recording audio"
 msgstr "Audio aufnehmen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v2DAdY"
+msgctxt "v2DAdY"
+msgid "Recording vocabulary audio"
 msgstr "Vokabel-Audio aufnehmen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "j-pO55"
+msgctxt "j-pO55"
+msgid "Recording word audio"
 msgstr "Wort-Audio aufnehmen"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "2ZPUqg"
+msgctxt "2ZPUqg"
+msgid "Saving your lesson"
 msgstr "Deine Lektion speichern"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v4iFHN"
+msgctxt "v4iFHN"
+msgid "Writing the content"
 msgstr "Inhalte schreiben"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "ZA0_P-"
+msgctxt "ZA0_P-"
+msgid "Writing the explanation"
 msgstr "Erklärung schreiben"
 
 #: src/app/generate/layout.tsx
-msgid "_tq5fR"
+msgctxt "_tq5fR"
+msgid "Creating content"
 msgstr "Inhalte erstellen"
 
 #: src/app/privacy/page.tsx
-msgid "afKQHy"
+msgctxt "afKQHy"
+msgid "Read Zoonk's privacy policy to understand how we use and protect your personal information."
 msgstr "Lies Zoonks Datenschutzerklärung, um zu verstehen, wie wir deine persönlichen Daten verwenden und schützen."
 
 #: src/app/privacy/page.tsx
-msgid "vx0nkZ"
+msgctxt "vx0nkZ"
+msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
 
 #: src/app/terms/page.tsx
-msgid "DaGtoz"
+msgctxt "DaGtoz"
+msgid "Read Zoonk's terms of use to understand the rules and conditions for using our platform and services"
 msgstr "Lies Zoonks Nutzungsbedingungen, um die Regeln und Bedingungen für die Nutzung unserer Plattform und Dienste zu verstehen"
 
 #: src/app/terms/page.tsx
-msgid "UhkSyx"
+msgctxt "UhkSyx"
+msgid "Terms of Use"
 msgstr "Nutzungsbedingungen"
 
 #: src/components/catalog/ai-warning.tsx
-msgid "FYZlTZ"
+msgctxt "FYZlTZ"
+msgid "Created with AI"
 msgstr "Mit KI erstellt"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "F0tnKc"
+msgctxt "F0tnKc"
+msgid "Thanks for your feedback"
 msgstr "Danke für dein Feedback"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "IzCVhG"
+msgctxt "IzCVhG"
+msgid "More options"
 msgstr "Weitere Optionen"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "rTFrsw"
+msgctxt "rTFrsw"
+msgid "I liked it"
 msgstr "Gefällt mir"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "Hqn5Uo"
+msgctxt "Hqn5Uo"
+msgid "I didn't like it"
 msgstr "Gefällt mir nicht"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "G5YSJR"
+msgctxt "G5YSJR"
+msgid "Send feedback"
 msgstr "Feedback senden"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "PAKDzS"
+msgctxt "PAKDzS"
+msgid "Go to current chapter"
 msgstr "Zum aktuellen Kapitel"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "Js2dT3"
+msgctxt "Js2dT3"
+msgid "Go to current lesson"
 msgstr "Zur aktuellen Lektion"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "izuy1D"
+msgctxt "izuy1D"
+msgid "Current item"
 msgstr "Aktuelles Element"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "Gs9Kfp"
+msgctxt "Gs9Kfp"
+msgid "Back to top"
 msgstr "Nach oben"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "AvySqa"
+msgctxt "AvySqa"
+msgid "{percent}% complete"
 msgstr "{percent}% abgeschlossen"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "mOFG3K"
+msgctxt "mOFG3K"
+msgid "Start"
 msgstr "Start"
 
 #: src/components/catalog/continue-lesson-link.tsx
 #: src/lib/lessons.ts
-msgid "R-J5ox"
+msgctxt "R-J5ox"
+msgid "Review"
 msgstr "Wiederholen"
 
 #: src/components/feedback/contact-form.tsx
-msgid "WzCvaN"
+msgctxt "WzCvaN"
+msgid "We'll use this email to contact you."
 msgstr "Wir nutzen diese E‑Mail, um dich zu kontaktieren."
 
 #: src/components/feedback/contact-form.tsx
-msgid "T7Ry38"
+msgctxt "T7Ry38"
+msgid "Message"
 msgstr "Nachricht"
 
 #: src/components/feedback/contact-form.tsx
-msgid "M6PcEI"
+msgctxt "M6PcEI"
+msgid "How can we help you?"
 msgstr "Wie können wir dir helfen?"
 
 #: src/components/feedback/contact-form.tsx
-msgid "vD72E5"
+msgctxt "vD72E5"
+msgid "Message sent successfully! We'll get back to you soon."
 msgstr "Nachricht erfolgreich gesendet! Wir melden uns bald bei dir."
 
 #: src/components/feedback/contact-form.tsx
-msgid "-5vOOu"
+msgctxt "-5vOOu"
+msgid "Please provide as much detail as possible."
 msgstr "Bitte gib so viele Details wie möglich an."
 
 #: src/components/feedback/contact-form.tsx
-msgid "1WHPmV"
+msgctxt "1WHPmV"
+msgid "Failed to send message. Please try again or email us directly at hello@zoonk.com"
 msgstr "Senden fehlgeschlagen. Bitte versuche es erneut oder schreibe uns direkt an hello@zoonk.com"
 
 #: src/components/feedback/contact-form.tsx
-msgid "Xx0WZV"
+msgctxt "Xx0WZV"
+msgid "Send message"
 msgstr "Nachricht senden"
 
 #: src/components/feedback/content-feedback.tsx
-msgid "BlI1_9"
+msgctxt "BlI1_9"
+msgid "Did you like this content?"
 msgstr "Hat dir dieser Inhalt gefallen?"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "Ejhdi4"
+msgctxt "Ejhdi4"
+msgid "Feedback"
 msgstr "Feedback"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "eUzs3M"
+msgctxt "eUzs3M"
+msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Sende Feedback, Fragen oder Vorschläge an uns. Fülle das Formular aus oder schreibe uns direkt an hello@zoonk.com."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "ctqXbT"
+msgctxt "ctqXbT"
+msgid "We lost the progress connection. Your content may still be generating."
 msgstr "Die Verbindung zum Fortschritt wurde unterbrochen. Deine Inhalte werden möglicherweise noch erstellt."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "1A8Z_l"
+msgctxt "1A8Z_l"
+msgid "Check again"
 msgstr "Erneut prüfen"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "yHqv96"
+msgctxt "yHqv96"
+msgid "Connection interrupted"
 msgstr "Verbindung unterbrochen"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "JqiqNj"
+msgctxt "JqiqNj"
+msgid "Something went wrong"
 msgstr "Etwas ist schiefgelaufen"
 
 #: src/components/progress/progress-day-count-label.ts
-msgid "r9koty"
+msgctxt "r9koty"
+msgid "{count, plural, =0 {# days} one {# day} other {# days}}"
 msgstr "{count, plural, =0 {0 Tage} one {# Tag} other {# Tage}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "tRA46q"
+msgctxt "tRA46q"
+msgid "0 min"
 msgstr "0 Min."
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "yMhrnF"
+msgctxt "yMhrnF"
+msgid "{seconds, plural, one {# sec} other {# sec}}"
 msgstr "{seconds, plural, one {# Sek.} other {# Sek.}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "a-oHjQ"
+msgctxt "a-oHjQ"
+msgid "{minutes, plural, one {# min} other {# min}}"
 msgstr "{minutes, plural, one {# Min.} other {# Min.}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "QqnZaw"
+msgctxt "QqnZaw"
+msgid "{hours, plural, one {# hr} other {# hr}}"
 msgstr "{hours, plural, one {# Std.} other {# Std.}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "Frd5VU"
+msgctxt "Frd5VU"
+msgid "{hours, plural, one {# hr} other {# hr}} {minutes, plural, one {# min} other {# min}}"
 msgstr "{hours, plural, one {# Std.} other {# Std.}} {minutes, plural, one {# Min.} other {# Min.}}"
 
 #: src/components/progress/total-learning-time-card.tsx
-msgid "-V74AY"
+msgctxt "-V74AY"
+msgid "Learning time"
 msgstr "Lernzeit"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "IS_YjO"
+msgctxt "IS_YjO"
+msgid "Upgrade to create"
 msgstr "Zum Erstellen upgraden"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "ZMU6iN"
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
 msgstr "Du hast dein Limit für kostenlose Lektionen erreicht. Upgrade für unbegrenzte Lektionen"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "0h_lPM"
+msgctxt "0h_lPM"
+msgid "Upgrade"
 msgstr "Upgrade"
 
 #: src/lib/belt-colors.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {Weißer Gürtel} yellow {Gelber Gürtel} orange {Orangefarbener Gürtel} green {Grüner Gürtel} blue {Blauer Gürtel} purple {Lilafarbener Gürtel} brown {Brauner Gürtel} red {Roter Gürtel} gray {Grauer Gürtel} black {Schwarzer Gürtel} other {Gürtel}}"
 
 #: src/lib/categories/category.ts
-msgid "fFt3il"
+msgctxt "fFt3il"
+msgid "Arts"
 msgstr "Kunst"
 
 #: src/lib/categories/category.ts
-msgid "w1Fanr"
+msgctxt "w1Fanr"
+msgid "Business"
 msgstr "Wirtschaft"
 
 #: src/lib/categories/category.ts
-msgid "n5D_Ku"
+msgctxt "n5D_Ku"
+msgid "Communication"
 msgstr "Kommunikation"
 
 #: src/lib/categories/category.ts
-msgid "mn6pIm"
+msgctxt "mn6pIm"
+msgid "Culture"
 msgstr "Kultur"
 
 #: src/lib/categories/category.ts
-msgid "hwL7a0"
+msgctxt "hwL7a0"
+msgid "Engineering"
 msgstr "Technik"
 
 #: src/lib/categories/category.ts
-msgid "YMDBNH"
+msgctxt "YMDBNH"
+msgid "Geography"
 msgstr "Geografie"
 
 #: src/lib/categories/category.ts
-msgid "hlmkcL"
+msgctxt "hlmkcL"
+msgid "Health"
 msgstr "Gesundheit"
 
 #: src/lib/categories/category.ts
-msgid "GsBRWL"
+msgctxt "GsBRWL"
+msgid "Languages"
 msgstr "Sprachen"
 
 #: src/lib/categories/category.ts
-msgid "u3ovjm"
+msgctxt "u3ovjm"
+msgid "Law"
 msgstr "Recht"
 
 #: src/lib/categories/category.ts
-msgid "dPgwrL"
+msgctxt "dPgwrL"
+msgid "Math"
 msgstr "Mathematik"
 
 #: src/lib/categories/category.ts
-msgid "qydxOd"
+msgctxt "qydxOd"
+msgid "Science"
 msgstr "Naturwissenschaften"
 
 #: src/lib/categories/category.ts
-msgid "OV_2-4"
+msgctxt "OV_2-4"
+msgid "Society"
 msgstr "Gesellschaft"
 
 #: src/lib/categories/category.ts
-msgid "I1ZCPK"
+msgctxt "I1ZCPK"
+msgid "Technology"
 msgstr "Technologie"
 
 #: src/lib/categories/category.ts
-msgid "XL8IWT"
+msgctxt "XL8IWT"
+msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
 msgstr "{category}-Kurse. Die besten {category}-Onlinekurse, interaktive Lektionen zum Lernen."
 
 #: src/lib/categories/category.ts
-msgid "4HKnmB"
+msgctxt "4HKnmB"
+msgid "{category} Courses"
 msgstr "{category}-Kurse"
 
 #: src/lib/categories/category.ts
-msgid "EMi23I"
+msgctxt "EMi23I"
+msgid "Explore all {category} courses"
 msgstr "Alle {category}-Kurse entdecken"
 
 #: src/lib/categories/category.ts
-msgid "Rz9oL-"
+msgctxt "Rz9oL-"
+msgid "{category} courses"
 msgstr "{category}-Kurse"
 
 #: src/lib/lessons.ts
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alphabet"
 
 #: src/lib/lessons.ts
-msgid "4TTYDR"
+msgctxt "4TTYDR"
+msgid "Custom lesson"
 msgstr "Eigene Lektion"
 
 #: src/lib/lessons.ts
-msgid "E1bF_X"
+msgctxt "E1bF_X"
+msgid "Explanation"
 msgstr "Erklärung"
 
 #: src/lib/lessons.ts
-msgid "QzTY8x"
+msgctxt "QzTY8x"
+msgid "Grammar"
 msgstr "Grammatik"
 
 #: src/lib/lessons.ts
-msgid "1TOMnj"
+msgctxt "1TOMnj"
+msgid "Listening"
 msgstr "Hören"
 
 #: src/lib/lessons.ts
-msgid "KV-O0y"
+msgctxt "KV-O0y"
+msgid "Practice"
 msgstr "Üben"
 
 #: src/lib/lessons.ts
-msgid "OuR_Ij"
+msgctxt "OuR_Ij"
+msgid "Quiz"
 msgstr "Quiz"
 
 #: src/lib/lessons.ts
-msgid "MOK_yK"
+msgctxt "MOK_yK"
+msgid "Reading"
 msgstr "Lesen"
 
 #: src/lib/lessons.ts
-msgid "_vCXIP"
+msgctxt "_vCXIP"
+msgid "Translation"
 msgstr "Übersetzung"
 
 #: src/lib/lessons.ts
-msgid "Ox-Z-K"
+msgctxt "Ox-Z-K"
+msgid "Tutorial"
 msgstr "Tutorial"
 
 #: src/lib/lessons.ts
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Wortschatz"
 
 #: src/lib/lessons.ts
-msgid "22k1CY"
+msgctxt "22k1CY"
+msgid "Learn how letters and sounds work in this writing system."
 msgstr "Lerne, wie Buchstaben und Laute in diesem Schriftsystem funktionieren."
 
 #: src/lib/lessons.ts
-msgid "LZC7R9"
+msgctxt "LZC7R9"
+msgid "Work through a lesson created for your goal."
 msgstr "Bearbeite eine Lektion, die für dein Ziel erstellt wurde."
 
 #: src/lib/lessons.ts
-msgid "fOfLbt"
+msgctxt "fOfLbt"
+msgid "Understand the key ideas using everyday language and practical examples."
 msgstr "Verstehe die wichtigsten Ideen mit alltäglicher Sprache und praktischen Beispielen."
 
 #: src/lib/lessons.ts
-msgid "dHmgw1"
+msgctxt "dHmgw1"
+msgid "Practice grammar patterns with examples and exercises."
 msgstr "Übe Grammatikmuster mit Beispielen und Übungen."
 
 #: src/lib/lessons.ts
-msgid "AetsPy"
+msgctxt "AetsPy"
+msgid "Listen to sentences using words you recently learned."
 msgstr "Höre Sätze mit Wörtern, die du kürzlich gelernt hast."
 
 #: src/lib/lessons.ts
-msgid "6oNgY9"
+msgctxt "6oNgY9"
+msgid "Use what you learned in the previous lesson to solve real-world problems."
 msgstr "Wende das Gelernte aus der vorherigen Lektion auf reale Probleme an."
 
 #: src/lib/lessons.ts
-msgid "vO6aLm"
+msgctxt "vO6aLm"
+msgid "Check what you understood with a short quiz."
 msgstr "Überprüfe, was du verstanden hast, mit einem kurzen Quiz."
 
 #: src/lib/lessons.ts
-msgid "OIim7M"
+msgctxt "OIim7M"
+msgid "Read sentences using words you recently learned."
 msgstr "Lies Sätze mit Wörtern, die du kürzlich gelernt hast."
 
 #: src/lib/lessons.ts
-msgid "pwrprO"
+msgctxt "pwrprO"
+msgid "Review this chapter with practice based on your mistakes."
 msgstr "Wiederhole dieses Kapitel mit Übungen, die auf deinen Fehlern basieren."
 
 #: src/lib/lessons.ts
-msgid "IQOJhk"
+msgctxt "IQOJhk"
+msgid "Translate words from your previous vocabulary lesson."
 msgstr "Übersetze Wörter aus deiner letzten Wortschatz-Lektion."
 
 #: src/lib/lessons.ts
-msgid "9XByXq"
+msgctxt "9XByXq"
+msgid "Follow a guided step-by-step tutorial."
 msgstr "Folge einem geführten Schritt-für-Schritt-Tutorial."
 
 #: src/lib/lessons.ts
-msgid "IHSVS5"
+msgctxt "IHSVS5"
+msgid "Learn new words and practice using them."
 msgstr "Lerne neue Wörter und übe, sie zu verwenden."
 
 #: src/lib/lessons.ts
-msgid "OjyuQ-"
+msgctxt "OjyuQ-"
+msgid "Learn the writing system for {topic} with focused practice."
 msgstr "Lerne das Schriftsystem für {topic} mit gezieltem Training."
 
 #: src/lib/lessons.ts
-msgid "pSQZ7W"
+msgctxt "pSQZ7W"
+msgid "Learn about {topic} through an interactive lesson."
 msgstr "Lerne etwas über {topic} durch eine interaktive Lektion."
 
 #: src/lib/lessons.ts
-msgid "THPcKi"
+msgctxt "THPcKi"
+msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
 msgstr "Verstehe, was {topic} ist – Kernkonzepte und Definitionen erklärt mit klaren Metaphern und Vergleichen."
 
 #: src/lib/lessons.ts
-msgid "tlgfSZ"
+msgctxt "tlgfSZ"
+msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 msgstr "Übe die Grammatikregeln zu {topic} mit Übungen, die dir helfen, sie zu behalten und anzuwenden."
 
 #: src/lib/lessons.ts
-msgid "xCvEE1"
+msgctxt "xCvEE1"
+msgid "Practice listening in {topic} by translating audio sentences."
 msgstr "Übe Hören in {topic}, indem du Audiosätze übersetzt."
 
 #: src/lib/lessons.ts
-msgid "wHBT6R"
+msgctxt "wHBT6R"
+msgid "Apply {topic} through a visual real-world problem with short decisions."
 msgstr "Wende {topic} an durch ein visuelles Alltagsproblem mit kurzen Entscheidungen."
 
 #: src/lib/lessons.ts
-msgid "h2acN8"
+msgctxt "h2acN8"
+msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Teste dein Verständnis von {topic} mit Fragen, die echtes Verstehen prüfen, nicht nur Auswendiglernen."
 
 #: src/lib/lessons.ts
-msgid "XzxpBZ"
+msgctxt "XzxpBZ"
+msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Verbessere dein Leseverständnis zu {topic}, indem du Sätze und Texte übersetzt."
 
 #: src/lib/lessons.ts
-msgid "bzFQEy"
+msgctxt "bzFQEy"
+msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Wiederhole alles, was du über {topic} gelernt hast, mit einem umfassenden Quiz."
 
 #: src/lib/lessons.ts
-msgid "X8Gqiq"
+msgctxt "X8Gqiq"
+msgid "Practice vocabulary in {topic} by translating words you've learned."
 msgstr "Übe Vokabeln in {topic}, indem du die gelernten Wörter übersetzt."
 
 #: src/lib/lessons.ts
-msgid "3bJDQa"
+msgctxt "3bJDQa"
+msgid "Learn {topic} with a guided step-by-step tutorial."
 msgstr "Lerne {topic} mit einem geführten Schritt-für-Schritt-Tutorial."
 
 #: src/lib/lessons.ts
-msgid "77SLH5"
+msgctxt "77SLH5"
+msgid "Learn new words in {topic} with flashcards — see each word, its translation, and pronunciation."
 msgstr "Lerne neue Wörter in {topic} mit Karteikarten — sieh jedes Wort, seine Übersetzung und die Aussprache."
 
 #: src/lib/lessons.ts
-msgid "oCxmX9"
+msgctxt "oCxmX9"
+msgid "{chapter} {kind} {position}"
 msgstr "{chapter} {kind} {position}"
 
 #: src/lib/lessons.ts
-msgid "qHbgYB"
+msgctxt "qHbgYB"
+msgid "{lesson} - {course}"
 msgstr "{lesson} - {course}"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -4,93 +4,109 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
+msgctxt "xmcVZ0"
+msgid "Search"
 msgstr "Search"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
+msgctxt "PSiLeL"
+msgid "Search courses, chapters, or pages..."
 msgstr "Search courses, chapters, or pages..."
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
+msgctxt "I-38K2"
+msgid "My courses"
 msgstr "My courses"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
+msgctxt "Oj9Phc"
+msgid "Manage subscription"
 msgstr "Manage subscription"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
+msgctxt "OhXwmw"
+msgid "Update language"
 msgstr "Update language"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
+msgctxt "O7ozeo"
+msgid "Update profile"
 msgstr "Update profile"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
+msgctxt "C81_uG"
+msgid "Logout"
 msgstr "Logout"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(progress)/_components/progress-empty-state.tsx
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
+msgctxt "AyGauy"
+msgid "Login"
 msgstr "Login"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
+msgctxt "y1Z3or"
+msgid "Language"
 msgstr "Language"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "U3l-Q9"
+msgctxt "U3l-Q9"
+msgid "Home page"
 msgstr "Home page"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "jboh4c"
+msgctxt "jboh4c"
+msgid "Start a new course"
 msgstr "Start a new course"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "rS0suY"
+msgctxt "rS0suY"
+msgid "Speak a language"
 msgstr "Speak a language"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "L6kaJv"
+msgctxt "L6kaJv"
+msgid "Learn something"
 msgstr "Learn something"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "3wvH7G"
+msgctxt "3wvH7G"
+msgid "Pass an exam"
 msgstr "Pass an exam"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
+msgctxt "CxfKLC"
+msgid "Pages"
 msgstr "Pages"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
+msgctxt "dXSivY"
+msgid "My account"
 msgstr "My account"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "tv5FG3"
+msgctxt "tv5FG3"
+msgid "Blog"
 msgstr "Blog"
 
 #: src/app/(catalog)/_components/command-palette.tsx
@@ -98,2184 +114,2713 @@ msgstr "Blog"
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "fFZ0Wd"
+msgctxt "fFZ0Wd"
+msgid "Feedback & Support"
 msgstr "Feedback & Support"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "SENRqu"
+msgctxt "SENRqu"
+msgid "Help"
 msgstr "Help"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "R85gsW"
+msgctxt "R85gsW"
+msgid "Courses"
 msgstr "Courses"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Do1Pfd"
+msgctxt "Do1Pfd"
+msgid "Chapters"
 msgstr "Chapters"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "hX5PAb"
+msgctxt "hX5PAb"
+msgid "No results found"
 msgstr "No results found"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "OXAZiT"
+msgctxt "OXAZiT"
+msgid "Create a course about {term}"
 msgstr "Create a course about {term}"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "onRJrc"
+msgctxt "onRJrc"
+msgid "Course page"
 msgstr "Course page"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "m826WB"
+msgctxt "m826WB"
+msgid "New course"
 msgstr "New course"
 
 #: src/app/(catalog)/_components/user-avatar-menu.tsx
-msgid "6b2CRH"
+msgctxt "6b2CRH"
+msgid "User menu"
 msgstr "User menu"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/profile/page.tsx
-msgid "itPgxd"
+msgctxt "itPgxd"
+msgid "Profile"
 msgstr "Profile"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/subscription/page.tsx
-msgid "R_6nsx"
+msgctxt "R_6nsx"
+msgid "Subscription"
 msgstr "Subscription"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "HHFpcy"
+msgctxt "HHFpcy"
+msgid "Best day"
 msgstr "Best day"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/energy/energy-insights.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "auPwZG"
+msgctxt "auPwZG"
+msgid "{day} with {percentage}"
 msgstr "{day} with {percentage}"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(catalog)/(home)/score.tsx
-msgid "zml1_y"
+msgctxt "zml1_y"
+msgid "Past 3 months"
 msgstr "Past 3 months"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "00_IyC"
+msgctxt "00_IyC"
+msgid "Night"
 msgstr "Night"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "_kzk_m"
+msgctxt "_kzk_m"
+msgid "Morning"
 msgstr "Morning"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mF-J9o"
+msgctxt "mF-J9o"
+msgid "Afternoon"
 msgstr "Afternoon"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mPEpnN"
+msgctxt "mPEpnN"
+msgid "Evening"
 msgstr "Evening"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "dFW9lU"
+msgctxt "dFW9lU"
+msgid "Best time"
 msgstr "Best time"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "r0R6ZG"
+msgctxt "r0R6ZG"
+msgid "{period} with {percentage}"
 msgstr "{period} with {percentage}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
-msgid "NubPSk"
+msgctxt "NubPSk"
+msgid "Next: {lesson}"
 msgstr "Next: {lesson}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continue"
 
 #: src/app/(catalog)/(home)/continue-learning.tsx
-msgid "0X-xfW"
+msgctxt "0X-xfW"
+msgid "Continue learning"
 msgstr "Continue learning"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "soDmlG"
+msgctxt "soDmlG"
+msgid "Keep learning to increase it"
 msgstr "Keep learning to increase it"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "WgeB0r"
+msgctxt "WgeB0r"
+msgid "Keep learning to maintain it"
 msgstr "Keep learning to maintain it"
 
 #: src/app/(catalog)/(home)/energy.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/energy/page.tsx
-msgid "cVpmV7"
+msgctxt "cVpmV7"
+msgid "Energy"
 msgstr "Energy"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "AV5XNu"
+msgctxt "AV5XNu"
+msgid "Your energy is {percentage}"
 msgstr "Your energy is {percentage}"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
-msgid "8F6teD"
+msgctxt "8F6teD"
+msgid "Learning days"
 msgstr "Learning days"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
-msgid "QbNcMh"
+msgctxt "QbNcMh"
+msgid "At least one completed lesson"
 msgstr "At least one completed lesson"
 
 #: src/app/(catalog)/(home)/learning-time.tsx
-msgid "F6B8A3"
+msgctxt "F6B8A3"
+msgid "Time spent in lessons"
 msgstr "Time spent in lessons"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "pgt3eW"
+msgctxt "pgt3eW"
+msgid "Max level reached"
 msgstr "Max level reached"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "8N9BRu"
+msgctxt "8N9BRu"
+msgid "{value} BP to next level"
 msgstr "{value} BP to next level"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/level/page.tsx
-msgid "y1Qr81"
+msgctxt "y1Qr81"
+msgid "Level"
 msgstr "Level"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "s0KB2i"
+msgctxt "s0KB2i"
+msgid "{belt} - Level {level}"
 msgstr "{belt} - Level {level}"
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "a50ZRn"
+msgctxt "a50ZRn"
+msgid "Zoonk is an AI learning platform and study app to create courses about any topic using AI. Study for your exams or learn new skills."
 msgstr "Zoonk is an AI learning platform and study app to create courses about any topic using AI. Study for your exams or learn new skills."
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "leBFvu"
+msgctxt "leBFvu"
+msgid "Zoonk: Study App with AI"
 msgstr "Zoonk: Study App with AI"
 
 #: src/app/(catalog)/(home)/progress.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "sIMS7i"
+msgctxt "sIMS7i"
+msgid "Progress"
 msgstr "Progress"
 
 #: src/app/(catalog)/(home)/score.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/score/page.tsx
-msgid "oLkLww"
+msgctxt "oLkLww"
+msgid "Score"
 msgstr "Score"
 
 #: src/app/(catalog)/(home)/score.tsx
-msgid "_lCW0j"
+msgctxt "_lCW0j"
+msgid "{percentage} correct answers"
 msgstr "{percentage} correct answers"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "QhvU1f"
+msgctxt "QhvU1f"
+msgid "Create this chapter"
 msgstr "Create this chapter"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "YQGe0H"
+msgctxt "YQGe0H"
+msgid "This chapter is part of the course, but it hasn't been created yet. Create it to see all of its lessons."
 msgstr "This chapter is part of the course, but it hasn't been created yet. Create it to see all of its lessons."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "3IOFp2"
+msgctxt "3IOFp2"
+msgid "Create chapter"
 msgstr "Create chapter"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
+msgctxt "qrEiLa"
+msgid "Back to course"
 msgstr "Back to course"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "Ap-oRa"
+msgctxt "Ap-oRa"
+msgid "Could not apply lesson filters. Please try again."
 msgstr "Could not apply lesson filters. Please try again."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "d6tcJn"
+msgctxt "d6tcJn"
+msgid "Filter lesson types"
 msgstr "Filter lesson types"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "kxP9GJ"
+msgctxt "kxP9GJ"
+msgid "Types"
 msgstr "Types"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "wi5osl"
+msgctxt "wi5osl"
+msgid "Show lesson types"
 msgstr "Show lesson types"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "OhgOkH"
+msgctxt "OhgOkH"
+msgid "Clear filter"
 msgstr "Clear filter"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "orGV_i"
+msgctxt "orGV_i"
+msgid "Current lesson"
 msgstr "Current lesson"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "ssvp3R"
+msgctxt "ssvp3R"
+msgid "Search lessons..."
 msgstr "Search lessons..."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "FuT9vz"
+msgctxt "FuT9vz"
+msgid "No lessons found"
 msgstr "No lessons found"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Completed"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "xTTP0x"
+msgctxt "xTTP0x"
+msgid "Not started"
 msgstr "Not started"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "iRubpl"
+msgctxt "iRubpl"
+msgid "Current chapter"
 msgstr "Current chapter"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "3SOcGR"
+msgctxt "3SOcGR"
+msgid "Search chapters..."
 msgstr "Search chapters..."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "8udPa-"
+msgctxt "8udPa-"
+msgid "No chapters found"
 msgstr "No chapters found"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "vcaAXp"
+msgctxt "vcaAXp"
+msgid "{completed, number}/{total, number} done"
 msgstr "{completed, number}/{total, number} done"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-curriculum-pending-notice.tsx
-msgid "Pf4uqS"
+msgctxt "Pf4uqS"
+msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "_allXG"
+msgctxt "_allXG"
+msgid "Learn {course} online with practical examples and everyday language. {description}"
 msgstr "Learn {course} online with practical examples and everyday language. {description}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "gyGolN"
+msgctxt "gyGolN"
+msgid "Learn {course}"
 msgstr "Learn {course}"
 
 #: src/app/(catalog)/courses/category-pills.tsx
-msgid "tuZsq-"
+msgctxt "tuZsq-"
+msgid "Course categories"
 msgstr "Course categories"
 
 #: src/app/(catalog)/courses/category-pills.tsx
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "zQvVDJ"
+msgctxt "zQvVDJ"
+msgid "All"
 msgstr "All"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "Wc7aau"
+msgctxt "Wc7aau"
+msgid "No courses available yet."
 msgstr "No courses available yet."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "zJxO2f"
+msgctxt "zJxO2f"
+msgid "No courses"
 msgstr "No courses"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "T0mfNV"
+msgctxt "T0mfNV"
+msgid "Loading more courses…"
 msgstr "Loading more courses…"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "W_5hwr"
+msgctxt "W_5hwr"
+msgid "Something went wrong. Please try again."
 msgstr "Something went wrong. Please try again."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Try again"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "WgPMAP"
+msgctxt "WgPMAP"
+msgid "Explore all Zoonk courses to learn anything using AI. Find interactive lessons to learn subjects like science, math, technology, and more."
 msgstr "Explore all Zoonk courses to learn anything using AI. Find interactive lessons to learn subjects like science, math, technology, and more."
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "P5jxUC"
+msgctxt "P5jxUC"
+msgid "Online Courses using AI"
 msgstr "Online Courses using AI"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "s-Ncqj"
+msgctxt "s-Ncqj"
+msgid "Explore courses"
 msgstr "Explore courses"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "hUF3bo"
+msgctxt "hUF3bo"
+msgid "Start learning something new today"
 msgstr "Start learning something new today"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "riE3I5"
+msgctxt "riE3I5"
+msgid "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons."
 msgstr "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons."
 
 #: src/app/(catalog)/my/page.tsx
-msgid "eeNr_Y"
+msgctxt "eeNr_Y"
+msgid "My Courses"
 msgstr "My Courses"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "Dr13kE"
+msgctxt "Dr13kE"
+msgid "Continue where you left off"
 msgstr "Continue where you left off"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "BDHWkf"
+msgctxt "BDHWkf"
+msgid "No courses yet"
 msgstr "No courses yet"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "azX41u"
+msgctxt "azX41u"
+msgid "Start learning something new today."
 msgstr "Start learning something new today."
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "9m9h0p"
+msgctxt "9m9h0p"
+msgid "Start a course"
 msgstr "Start a course"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "e61Jf3"
+msgctxt "e61Jf3"
+msgid "Coming soon"
 msgstr "Coming soon"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
-msgid "dtRj3N"
+msgctxt "dtRj3N"
+msgid "Personalized courses are coming soon."
 msgstr "Personalized courses are coming soon."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "hJZwTS"
+msgctxt "hJZwTS"
+msgid "Email address"
 msgstr "Email address"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "OiSL94"
+msgctxt "OiSL94"
+msgid "myemail@gmail.com"
 msgstr "myemail@gmail.com"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "45yKj9"
+msgctxt "45yKj9"
+msgid "We'll use this email to notify you when exam prep is ready."
 msgstr "We'll use this email to notify you when exam prep is ready."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "Xy7a7A"
+msgctxt "Xy7a7A"
+msgid "Exam"
 msgstr "Exam"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "cDZwI_"
+msgctxt "cDZwI_"
+msgid "TOEFL, SAT, CFA, CPA..."
 msgstr "TOEFL, SAT, CFA, CPA..."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "E_0Y4u"
+msgctxt "E_0Y4u"
+msgid "Tell us the test, certification, or school exam you care about."
 msgstr "Tell us the test, certification, or school exam you care about."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "6eV4UR"
+msgctxt "6eV4UR"
+msgid "We couldn't add you to the waitlist. Please try again."
 msgstr "We couldn't add you to the waitlist. Please try again."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "W78DIe"
+msgctxt "W78DIe"
+msgid "You're on the list. We'll let you know when exam prep is ready."
 msgstr "You're on the list. We'll let you know when exam prep is ready."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "ipGe-B"
+msgctxt "ipGe-B"
+msgid "Notify me"
 msgstr "Notify me"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "gs2Dwu"
+msgctxt "gs2Dwu"
+msgid "Online AI exam prep for certifications and tests. Hands-on explanation and practice questions to help you pass your exam."
 msgstr "Online AI exam prep for certifications and tests. Hands-on explanation and practice questions to help you pass your exam."
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "z8OyvL"
+msgctxt "z8OyvL"
+msgid "Online AI Exam Prep"
 msgstr "Online AI Exam Prep"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "CzV5fE"
+msgctxt "CzV5fE"
+msgid "Exam prep is not available yet. Tell us what you're preparing for and we'll notify you when it launches."
 msgstr "Exam prep is not available yet. Tell us what you're preparing for and we'll notify you when it launches."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "8Zy06C"
+msgctxt "8Zy06C"
+msgid "This option isn't available yet"
 msgstr "This option isn't available yet"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "TV5hlz"
+msgctxt "TV5hlz"
+msgid "Join the waitlist and we'll let you know when you can learn <strong>{title}</strong> with Zoonk."
 msgstr "Join the waitlist and we'll let you know when you can learn <strong>{title}</strong> with Zoonk."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "cPhKTw"
+msgctxt "cPhKTw"
+msgid "Not available"
 msgstr "Not available"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "5DZYgN"
+msgctxt "5DZYgN"
+msgid "We can't create this course"
 msgstr "We can't create this course"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "m6ju4Q"
+msgctxt "m6ju4Q"
+msgid "Zoonk can't help with requests that involve unsafe, illegal, or harmful activity. Try a different subject instead."
 msgstr "Zoonk can't help with requests that involve unsafe, illegal, or harmful activity. Try a different subject instead."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "PDFZz6"
+msgctxt "PDFZz6"
+msgid "Try another goal"
 msgstr "Try another goal"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "hCixWc"
+msgctxt "hCixWc"
+msgid "You're on the list. We'll email you when it's available."
 msgstr "You're on the list. We'll email you when it's available."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "UdDpuW"
+msgctxt "UdDpuW"
+msgid "Finding the best way to help"
 msgstr "Finding the best way to help"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "1A36NM"
+msgctxt "1A36NM"
+msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "We're checking your learning goal. This may take a few seconds."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "47FYwb"
+msgctxt "47FYwb"
+msgid "Cancel"
 msgstr "Cancel"
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "CaU_nf"
+msgctxt "CaU_nf"
+msgid "Discover personalized courses and resources to learn {prompt}. Zoonk uses AI to create interactive lessons tailored to you."
 msgstr "Discover personalized courses and resources to learn {prompt}. Zoonk uses AI to create interactive lessons tailored to you."
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "X2b6pH"
+msgctxt "X2b6pH"
+msgid "Learn {prompt} with AI"
 msgstr "Learn {prompt} with AI"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "l450Bl"
+msgctxt "l450Bl"
+msgid "Computer Science"
 msgstr "Computer Science"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ElyVN0"
+msgctxt "ElyVN0"
+msgid "Psychology"
 msgstr "Psychology"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "KOuDOE"
+msgctxt "KOuDOE"
+msgid "Economics"
 msgstr "Economics"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "cHCwbF"
+msgctxt "cHCwbF"
+msgid "Photography"
 msgstr "Photography"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zE1J_t"
+msgctxt "zE1J_t"
+msgid "Philosophy"
 msgstr "Philosophy"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "y68y7h"
+msgctxt "y68y7h"
+msgid "Data Science"
 msgstr "Data Science"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1qsU2j"
+msgctxt "1qsU2j"
+msgid "Creative Writing"
 msgstr "Creative Writing"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "RGkBg_"
+msgctxt "RGkBg_"
+msgid "Biology"
 msgstr "Biology"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oiUZCZ"
+msgctxt "oiUZCZ"
+msgid "Graphic Design"
 msgstr "Graphic Design"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "djJp6c"
+msgctxt "djJp6c"
+msgid "History"
 msgstr "History"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "O9mDkA"
+msgctxt "O9mDkA"
+msgid "Marketing"
 msgstr "Marketing"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "9zLpJ_"
+msgctxt "9zLpJ_"
+msgid "What do you want to learn?"
 msgstr "What do you want to learn?"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zfDq-e"
+msgctxt "zfDq-e"
+msgid "Quantum physics"
 msgstr "Quantum physics"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oqfOwA"
+msgctxt "oqfOwA"
+msgid "Ancient philosophy"
 msgstr "Ancient philosophy"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "Osb4bp"
+msgctxt "Osb4bp"
+msgid "Machine learning"
 msgstr "Machine learning"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "OdZ_n1"
+msgctxt "OdZ_n1"
+msgid "Creative writing"
 msgstr "Creative writing"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "N9FWiz"
+msgctxt "N9FWiz"
+msgid "Molecular biology"
 msgstr "Molecular biology"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XFPrU4"
+msgctxt "XFPrU4"
+msgid "Behavioral economics"
 msgstr "Behavioral economics"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "-0gz_i"
+msgctxt "-0gz_i"
+msgid "Organic chemistry"
 msgstr "Organic chemistry"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1axOcX"
+msgctxt "1axOcX"
+msgid "UFOs"
 msgstr "UFOs"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "e7q85h"
+msgctxt "e7q85h"
+msgid "Dinosaur extinction"
 msgstr "Dinosaur extinction"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "MO2lwh"
+msgctxt "MO2lwh"
+msgid "How volcanoes work"
 msgstr "How volcanoes work"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ZzbdHP"
+msgctxt "ZzbdHP"
+msgid "World history"
 msgstr "World history"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XfC6Cs"
+msgctxt "XfC6Cs"
+msgid "Cognitive psychology"
 msgstr "Cognitive psychology"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "X5XXVF"
+msgctxt "X5XXVF"
+msgid "Linear algebra"
 msgstr "Linear algebra"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5gOFKJ"
+msgctxt "5gOFKJ"
+msgid "Black holes"
 msgstr "Black holes"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "eQHeGX"
+msgctxt "eQHeGX"
+msgid "How the internet works"
 msgstr "How the internet works"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "QOSGzc"
+msgctxt "QOSGzc"
+msgid "Roman Empire"
 msgstr "Roman Empire"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "gyEihl"
+msgctxt "gyEihl"
+msgid "Deep sea creatures"
 msgstr "Deep sea creatures"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "0MqSJ1"
+msgctxt "0MqSJ1"
+msgid "Solar system"
 msgstr "Solar system"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5qPAxv"
+msgctxt "5qPAxv"
+msgid "Artificial intelligence"
 msgstr "Artificial intelligence"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "3WiAG4"
+msgctxt "3WiAG4"
+msgid "Harry Potter"
 msgstr "Harry Potter"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "NvSCuG"
+msgctxt "NvSCuG"
+msgid "Suggested subjects"
 msgstr "Suggested subjects"
 
 #: src/app/(catalog)/start/learn/learn-form.tsx
-msgid "uCb1nG"
+msgctxt "uCb1nG"
+msgid "Enter a subject"
 msgstr "Enter a subject"
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "JlJVf1"
+msgctxt "JlJVf1"
+msgid "Tell Zoonk what you want to learn and get a course created with AI. Start learning any subject with interactive lessons."
 msgstr "Tell Zoonk what you want to learn and get a course created with AI. Start learning any subject with interactive lessons."
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "Zs1QEq"
+msgctxt "Zs1QEq"
+msgid "Learn Anything with AI"
 msgstr "Learn Anything with AI"
 
 #: src/app/(catalog)/start/page.tsx
-msgid "UFOGo9"
+msgctxt "UFOGo9"
+msgid "Start online courses to learn languages and more on Zoonk. Practice language learning, learn English or Spanish, and create AI-powered courses for any subject."
 msgstr "Start online courses to learn languages and more on Zoonk. Practice language learning, learn English or Spanish, and create AI-powered courses for any subject."
 
 #: src/app/(catalog)/start/page.tsx
-msgid "rqpQgj"
+msgctxt "rqpQgj"
+msgid "Online Courses to Learn Languages and More"
 msgstr "Online Courses to Learn Languages and More"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "K4jMHW"
+msgctxt "K4jMHW"
+msgid "Online language courses with AI. Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Online language courses with AI. Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "Ht6aMH"
+msgctxt "Ht6aMH"
+msgid "Learn a language online with AI"
 msgstr "Learn a language online with AI"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "lSAK6U"
+msgctxt "lSAK6U"
+msgid "What language do you want to learn?"
 msgstr "What language do you want to learn?"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "ptPPVk"
+msgctxt "ptPPVk"
+msgid "No languages found"
 msgstr "No languages found"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "L820yz"
+msgctxt "L820yz"
+msgid "Search languages"
 msgstr "Search languages"
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "ah2CR6"
+msgctxt "ah2CR6"
+msgid "Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "_E8OKF"
+msgctxt "_E8OKF"
+msgid "Turn any subject into a clear course you can follow step by step, with practical examples and no fluff."
 msgstr "Turn any subject into a clear course you can follow step by step, with practical examples and no fluff."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "IF6NT-"
+msgctxt "IF6NT-"
+msgid "We'll prepare a study path to help you pass an entrance exam, certification, or school test."
 msgstr "We'll prepare a study path to help you pass an entrance exam, certification, or school test."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "AaFZIp"
+msgctxt "AaFZIp"
+msgid "What's your goal?"
 msgstr "What's your goal?"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "pev_fB"
+msgctxt "pev_fB"
+msgid "vs last month"
 msgstr "vs last month"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "R9qHBU"
+msgctxt "R9qHBU"
+msgid "vs last 6 months"
 msgstr "vs last 6 months"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "s-lPP3"
+msgctxt "s-lPP3"
+msgid "All time"
 msgstr "All time"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "YFV6dH"
+msgctxt "YFV6dH"
+msgid "vs last year"
 msgstr "vs last year"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "hCCWuZ"
+msgctxt "hCCWuZ"
+msgid "Previous period"
 msgstr "Previous period"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "I2z5s_"
+msgctxt "I2z5s_"
+msgid "Next period"
 msgstr "Next period"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "PIaUh-"
+msgctxt "PIaUh-"
+msgid "Period selection"
 msgstr "Period selection"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "TBovrx"
+msgctxt "TBovrx"
+msgid "Month"
 msgstr "Month"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "NPrFLC"
+msgctxt "NPrFLC"
+msgid "6 Months"
 msgstr "6 Months"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "IFo1oo"
+msgctxt "IFo1oo"
+msgid "Year"
 msgstr "Year"
 
 #: src/app/(progress)/_components/progress-chart-layout.tsx
-msgid "OlW5Z8"
+msgctxt "OlW5Z8"
+msgid "No data available for this period"
 msgstr "No data available for this period"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "FVh2Tr"
+msgctxt "FVh2Tr"
+msgid "Start learning to track your progress"
 msgstr "Start learning to track your progress"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "Y1zzQt"
+msgctxt "Y1zzQt"
+msgid "Log in to track your progress"
 msgstr "Log in to track your progress"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "J3fNDZ"
+msgctxt "J3fNDZ"
+msgid "This month"
 msgstr "This month"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "eWUXBX"
+msgctxt "eWUXBX"
+msgid "Past 6 months"
 msgstr "Past 6 months"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "lPShsT"
+msgctxt "lPShsT"
+msgid "This year"
 msgstr "This year"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
-msgid "M-JIpD"
+msgctxt "M-JIpD"
+msgid "Energy chart"
 msgstr "Energy chart"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "rGSqvt"
+msgctxt "rGSqvt"
+msgid "Avg"
 msgstr "Avg"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "TLPAMC"
+msgctxt "TLPAMC"
+msgid "What is Energy?"
 msgstr "What is Energy?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "OvOWOR"
+msgctxt "OvOWOR"
+msgid "Energy is a 0% to 100% score for your recent learning consistency and accuracy."
 msgstr "Energy is a 0% to 100% score for your recent learning consistency and accuracy."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "K3jN6p"
+msgctxt "K3jN6p"
+msgid "How do I improve Energy?"
 msgstr "How do I improve Energy?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "pssms6"
+msgctxt "pssms6"
+msgid "Answer questions correctly and keep learning regularly. Correct answers raise Energy; wrong answers and days away from studying lower it."
 msgstr "Answer questions correctly and keep learning regularly. Correct answers raise Energy; wrong answers and days away from studying lower it."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "-8Qx8X"
+msgctxt "-8Qx8X"
+msgid "Why is Energy important?"
 msgstr "Why is Energy important?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "UfEfhq"
+msgctxt "UfEfhq"
+msgid "Energy is like heart rate in a health app: it shows your current learning rhythm. Missing a day doesn't reset your progress; you recover as soon as you start learning again."
 msgstr "Energy is like heart rate in a health app: it shows your current learning rhythm. Missing a day doesn't reset your progress; you recover as soon as you start learning again."
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "XxS-he"
+msgctxt "XxS-he"
+msgid "Highest energy day"
 msgstr "Highest energy day"
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "aaiQkv"
+msgctxt "aaiQkv"
+msgid "Full energy"
 msgstr "Full energy"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "zLCmVM"
+msgctxt "zLCmVM"
+msgid "Current Energy"
 msgstr "Current Energy"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "e9DcQa"
+msgctxt "e9DcQa"
+msgid "{percentage} average"
 msgstr "{percentage} average"
 
 #: src/app/(progress)/energy/page.tsx
-msgid "AZMpf3"
+msgctxt "AZMpf3"
+msgid "Energy is a 0% to 100% score based on recent activity and accuracy."
 msgstr "Energy is a 0% to 100% score based on recent activity and accuracy."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "rsIaGW"
+msgctxt "rsIaGW"
+msgid "A 0% to 100% score for recent activity and accuracy"
 msgstr "A 0% to 100% score for recent activity and accuracy"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "GA8RuL"
+msgctxt "GA8RuL"
+msgid "Brain Power chart"
 msgstr "Brain Power chart"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "XdkaHc"
+msgctxt "XdkaHc"
+msgid "{value} BP"
 msgstr "{value} BP"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "tDbspx"
+msgctxt "tDbspx"
+msgid "Total Brain Power earned: {total}"
 msgstr "Total Brain Power earned: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "EMy5Vs"
+msgctxt "EMy5Vs"
+msgid "What is Brain Power?"
 msgstr "What is Brain Power?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "MIjvOA"
+msgctxt "MIjvOA"
+msgid "Brain Power (BP) is the total learning credit you have earned. Each completed lesson adds {brainPower} BP."
 msgstr "Brain Power (BP) is the total learning credit you have earned. Each completed lesson adds {brainPower} BP."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "jzKXJS"
+msgctxt "jzKXJS"
+msgid "How do I increase Brain Power?"
 msgstr "How do I increase Brain Power?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "Gzq1tT"
+msgctxt "Gzq1tT"
+msgid "Complete lessons. Brain Power never goes down, even when your Energy drops or you take a break."
 msgstr "Complete lessons. Brain Power never goes down, even when your Energy drops or you take a break."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "JGLOtn"
+msgctxt "JGLOtn"
+msgid "Why is Brain Power important?"
 msgstr "Why is Brain Power important?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "tC6vNz"
+msgctxt "tC6vNz"
+msgid "It is like steps in a health app: a record of how much you have learned. It also works like martial arts for your mind: build Brain Power to advance from white belt to black belt."
 msgstr "It is like steps in a health app: a record of how much you have learned. It also works like martial arts for your mind: build Brain Power to advance from white belt to black belt."
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "elq-tg"
+msgctxt "elq-tg"
+msgid "Highest BP"
 msgstr "Highest BP"
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "BW4bMl"
+msgctxt "BW4bMl"
+msgid "{date} with {value} BP"
 msgstr "{date} with {value} BP"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "WfaE4H"
+msgctxt "WfaE4H"
+msgid "{belt}, Level {level} of 10. Maximum level achieved."
 msgstr "{belt}, Level {level} of 10. Maximum level achieved."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "2Y-P4e"
+msgctxt "2Y-P4e"
+msgid "{belt}, Level {level} of 10. {bp} Brain Power until next level."
 msgstr "{belt}, Level {level} of 10. {bp} Brain Power until next level."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "n_mgOm"
+msgctxt "n_mgOm"
+msgid "Belt Progression"
 msgstr "Belt Progression"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "ZKbTsS"
+msgctxt "ZKbTsS"
+msgid "{current}/10"
 msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "-Sn2yd"
+msgctxt "-Sn2yd"
+msgid "{belt}: Level {current} of 10"
 msgstr "{belt}: Level {current} of 10"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "v5yNm3"
+msgctxt "v5yNm3"
+msgid "Total Brain Power"
 msgstr "Total Brain Power"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "_Q0taG"
+msgctxt "_Q0taG"
+msgid "BP"
 msgstr "BP"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "u_oEJA"
+msgctxt "u_oEJA"
+msgid "{value} BP earned"
 msgstr "{value} BP earned"
 
 #: src/app/(progress)/level/page.tsx
-msgid "4-USpX"
+msgctxt "4-USpX"
+msgid "Track your level progress and see how you advance."
 msgstr "Track your level progress and see how you advance."
 
 #: src/app/(progress)/level/page.tsx
-msgid "L9hqMH"
+msgctxt "L9hqMH"
+msgid "Track your level progress"
 msgstr "Track your level progress"
 
 #: src/app/(progress)/score/page.tsx
-msgid "qHWZBu"
+msgctxt "qHWZBu"
+msgid "Track your score over time and see your best days and times."
 msgstr "Track your score over time and see your best days and times."
 
 #: src/app/(progress)/score/page.tsx
-msgid "GWkswX"
+msgctxt "GWkswX"
+msgid "Track your score and progress trends"
 msgstr "Track your score and progress trends"
 
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "J-05ol"
+msgctxt "J-05ol"
+msgid "Score chart"
 msgstr "Score chart"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "bIZaXJ"
+msgctxt "bIZaXJ"
+msgid "What is Score?"
 msgstr "What is Score?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "JA-N5Z"
+msgctxt "JA-N5Z"
+msgid "Score is the percentage of questions you answered correctly during this period."
 msgstr "Score is the percentage of questions you answered correctly during this period."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "z9kvhA"
+msgctxt "z9kvhA"
+msgid "How do I improve Score?"
 msgstr "How do I improve Score?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "7_C9do"
+msgctxt "7_C9do"
+msgid "Review mistakes and retry lessons. As you answer more questions correctly, your Score goes up."
 msgstr "Review mistakes and retry lessons. As you answer more questions correctly, your Score goes up."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "WqH8eP"
+msgctxt "WqH8eP"
+msgid "Why is Score important?"
 msgstr "Why is Score important?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "E0saoA"
+msgctxt "E0saoA"
+msgid "Score shows accuracy, not activity. Best day and best time help you find when you learn most effectively."
 msgstr "Score shows accuracy, not activity. Best day and best time help you find when you learn most effectively."
 
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "yOFm9C"
+msgctxt "yOFm9C"
+msgid "You need to be logged in to access this page."
 msgstr "You need to be logged in to access this page."
 
 #: src/app/(settings)/language/page.tsx
-msgid "2WHx14"
+msgctxt "2WHx14"
+msgid "Update your app language to learn in English, Portuguese, Spanish, French, or other supported languages."
 msgstr "Update your app language to learn in English, Portuguese, Spanish, French, or other supported languages."
 
 #: src/app/(settings)/language/page.tsx
-msgid "aNLa1G"
+msgctxt "aNLa1G"
+msgid "Choose the app language you prefer for this device."
 msgstr "Choose the app language you prefer for this device."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "dSVD13"
+msgctxt "dSVD13"
+msgid "Update your name and username on Zoonk."
 msgstr "Update your name and username on Zoonk."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "wjIStY"
+msgctxt "wjIStY"
+msgid "Your name and username as they appear to others."
 msgstr "Your name and username as they appear to others."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Checking..."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} is available"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} is already taken"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "3-30 characters. Letters, numbers, and underscores only."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Name"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "yNHZ-a"
+msgctxt "yNHZ-a"
+msgid "Your profile has been updated successfully!"
 msgstr "Your profile has been updated successfully!"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "VT-G_7"
+msgctxt "VT-G_7"
+msgid "This name will be visible to other users."
 msgstr "This name will be visible to other users."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "wYCHCR"
+msgctxt "wYCHCR"
+msgid "Failed to update your profile. Please try again or contact hello@zoonk.com"
 msgstr "Failed to update your profile. Please try again or contact hello@zoonk.com"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Username"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "X0ha1a"
+msgctxt "X0ha1a"
+msgid "Save changes"
 msgstr "Save changes"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "3iCRcP"
+msgctxt "3iCRcP"
+msgid "Manage in App Store"
 msgstr "Manage in App Store"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "tiFovn"
+msgctxt "tiFovn"
+msgid "Manage in Google Play"
 msgstr "Manage in Google Play"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "Tp4wJB"
+msgctxt "Tp4wJB"
+msgid "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
 msgstr "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "unNUPf"
+msgctxt "unNUPf"
+msgid "This subscription is managed through Google Play. To change or cancel it, use Google Play."
 msgstr "This subscription is managed through Google Play. To change or cancel it, use Google Play."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "P0ZHma"
+msgctxt "P0ZHma"
+msgid "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
 msgstr "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "5CI3KH"
+msgctxt "5CI3KH"
+msgid "Contact support"
 msgstr "Contact support"
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "TKk9oj"
+msgctxt "TKk9oj"
+msgid "Compare plans and manage your Zoonk subscription. See pricing, switch plans, or update billing."
 msgstr "Compare plans and manage your Zoonk subscription. See pricing, switch plans, or update billing."
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "NBEnVd"
+msgctxt "NBEnVd"
+msgid "Compare plans and manage your subscription."
 msgstr "Compare plans and manage your subscription."
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "PJfdJl"
+msgctxt "PJfdJl"
+msgid "Save up to {amount}"
 msgstr "Save up to {amount}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "KAb0Yr"
+msgctxt "KAb0Yr"
+msgid "Switch to {plan}"
 msgstr "Switch to {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0Azlrb"
+msgctxt "0Azlrb"
+msgid "Manage"
 msgstr "Manage"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "_gko4g"
+msgctxt "_gko4g"
+msgid "Upgrade to {plan}"
 msgstr "Upgrade to {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "wYsv4Z"
+msgctxt "wYsv4Z"
+msgid "Monthly"
 msgstr "Monthly"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "dqD39h"
+msgctxt "dqD39h"
+msgid "Yearly"
 msgstr "Yearly"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "s1ZXI0"
+msgctxt "s1ZXI0"
+msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "Unable to update your subscription. Contact us at hello@zoonk.com"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "2EsPdm"
+msgctxt "2EsPdm"
+msgid "/yr"
 msgstr "/yr"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0jIMEb"
+msgctxt "0jIMEb"
+msgid "/mo"
 msgstr "/mo"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "tf1lIh"
+msgctxt "tf1lIh"
+msgid "Free"
 msgstr "Free"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "ZBALng"
+msgctxt "ZBALng"
+msgid "Current plan"
 msgstr "Current plan"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "fF376U"
+msgctxt "fF376U"
+msgid "Current"
 msgstr "Current"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "kkjl2v"
+msgctxt "kkjl2v"
+msgid "Max"
 msgstr "Max"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "lOdoIb"
+msgctxt "lOdoIb"
+msgid "Plus"
 msgstr "Plus"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "R_eOkj"
+msgctxt "R_eOkj"
+msgid "Pro"
 msgstr "Pro"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "9o8O4m"
+msgctxt "9o8O4m"
+msgid "Your subscription will end on {date}."
 msgstr "Your subscription will end on {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "vaN1qz"
+msgctxt "vaN1qz"
+msgid "Current billing period ends on {date}."
 msgstr "Current billing period ends on {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "EV_gJ6"
+msgctxt "EV_gJ6"
+msgid "First chapter included"
 msgstr "First chapter included"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "mqHNd6"
+msgctxt "mqHNd6"
+msgid "Personalized lessons, smartest AI"
 msgstr "Personalized lessons, smartest AI"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "SC0MFR"
+msgctxt "SC0MFR"
+msgid "Unlimited lessons"
 msgstr "Unlimited lessons"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "eaOADK"
+msgctxt "eaOADK"
+msgid "Personalized lessons, fast AI"
 msgstr "Personalized lessons, fast AI"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "B5MLC7"
+msgctxt "B5MLC7"
+msgid "Share feedback, ask questions, or get help with your account and courses."
 msgstr "Share feedback, ask questions, or get help with your account and courses."
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "cDAb4a"
+msgctxt "cDAb4a"
+msgid "GitHub Discussions"
 msgstr "GitHub Discussions"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "7h49qt"
+msgctxt "7h49qt"
+msgid "Connect with the community and get answers"
 msgstr "Connect with the community and get answers"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "YdQxfw"
+msgctxt "YdQxfw"
+msgid "Contact Support"
 msgstr "Contact Support"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "dQIo6c"
+msgctxt "dQIo6c"
+msgid "Email us at hello@zoonk.com"
 msgstr "Email us at hello@zoonk.com"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "l1XTI5"
+msgctxt "l1XTI5"
+msgid "Follow us"
 msgstr "Follow us"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "rCpmYD"
+msgctxt "rCpmYD"
+msgid "Create this lesson"
 msgstr "Create this lesson"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "AtnLyn"
+msgctxt "AtnLyn"
+msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "ZzznjM"
+msgctxt "ZzznjM"
+msgid "Create lesson"
 msgstr "Create lesson"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
-msgid "_N8rYN"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
 msgstr "Back to chapter"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "ZnMcrz"
+msgctxt "ZnMcrz"
+msgid "Unlock the rest of this course"
 msgstr "Unlock the rest of this course"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "A_uNk-"
+msgctxt "A_uNk-"
+msgid "Create lessons before reviewing"
 msgstr "Create lessons before reviewing"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "Qy4EsI"
+msgctxt "Qy4EsI"
+msgid "Nothing to review yet"
 msgstr "Nothing to review yet"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "4w9Y_P"
+msgctxt "4w9Y_P"
+msgid "Review unlocks after the earlier lessons in this chapter have been created."
 msgstr "Review unlocks after the earlier lessons in this chapter have been created."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "9AOq2-"
+msgctxt "9AOq2-"
+msgid "There are no practice questions to review yet."
 msgstr "There are no practice questions to review yet."
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "txNTbP"
+msgctxt "txNTbP"
+msgid "Creating the {title} chapter"
 msgstr "Creating the {title} chapter"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "kiZUDf"
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
 msgstr "This usually takes about a minute"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "5c2xtK"
+msgctxt "5c2xtK"
+msgid "Taking you to your chapter..."
 msgstr "Taking you to your chapter..."
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "45uo73"
+msgctxt "45uo73"
+msgid "Your lessons are ready"
 msgstr "Your lessons are ready"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "gnxL73"
+msgctxt "gnxL73"
+msgid "Choosing lesson types"
 msgstr "Choosing lesson types"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "EKtClK"
+msgctxt "EKtClK"
+msgid "Getting started"
 msgstr "Getting started"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "SF9AtA"
+msgctxt "SF9AtA"
+msgid "Preparing lessons"
 msgstr "Preparing lessons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "L7nQzn"
+msgctxt "L7nQzn"
+msgid "Saving your lessons"
 msgstr "Saving your lessons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Sbsm52"
+msgctxt "Sbsm52"
+msgid "Checking how each lesson should be taught..."
 msgstr "Checking how each lesson should be taught..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "0xCLwv"
+msgctxt "0xCLwv"
+msgid "Choosing type for lesson {number}..."
 msgstr "Choosing type for lesson {number}..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Vbn5Wz"
+msgctxt "Vbn5Wz"
+msgid "Reviewing the lesson mix..."
 msgstr "Reviewing the lesson mix..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5342HA"
+msgctxt "5342HA"
+msgid "Getting started..."
 msgstr "Getting started..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "nwGJ65"
+msgctxt "nwGJ65"
+msgid "Exploring your topic..."
 msgstr "Exploring your topic..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "VKFa_t"
+msgctxt "VKFa_t"
+msgid "Mapping out the learning path..."
 msgstr "Mapping out the learning path..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "zQWv1_"
+msgctxt "zQWv1_"
+msgid "Writing lesson {number}..."
 msgstr "Writing lesson {number}..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "HWSnYS"
+msgctxt "HWSnYS"
+msgid "Reviewing the flow so far..."
 msgstr "Reviewing the flow so far..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "txvxwS"
+msgctxt "txvxwS"
+msgid "Saving your progress..."
 msgstr "Saving your progress..."
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JUr8Er"
+msgctxt "JUr8Er"
+msgid "Finishing up..."
 msgstr "Finishing up..."
 
 #: src/app/generate/course/[id]/generate-course-prompt-content.tsx
-msgid "rPgekg"
+msgctxt "rPgekg"
+msgid "Back home"
 msgstr "Back home"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "15FsdE"
+msgctxt "15FsdE"
+msgid "Your course is ready"
 msgstr "Your course is ready"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "4Wktrz"
+msgctxt "4Wktrz"
+msgid "Your lesson is ready"
 msgstr "Your lesson is ready"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "0o41MR"
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
 msgstr "Taking you to your course..."
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "T2TGxR"
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
 msgstr "Taking you to your lesson..."
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "u6ROZF"
+msgctxt "u6ROZF"
+msgid "Creating the {title} course"
 msgstr "Creating the {title} course"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "GJKrUK"
+msgctxt "GJKrUK"
+msgid "This usually takes about 2 minutes"
 msgstr "This usually takes about 2 minutes"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "i3JgLB"
+msgctxt "i3JgLB"
+msgid "Categorizing your course"
 msgstr "Categorizing your course"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WOe-OA"
+msgctxt "WOe-OA"
+msgid "Checking for duplicates"
 msgstr "Checking for duplicates"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gjutu-"
+msgctxt "Gjutu-"
+msgid "Creating the cover image"
 msgstr "Creating the cover image"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "SQFyKH"
+msgctxt "SQFyKH"
+msgid "Finding similar courses"
 msgstr "Finding similar courses"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WZpB8D"
+msgctxt "WZpB8D"
+msgid "Writing chapters"
 msgstr "Writing chapters"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "vEOpTk"
+msgctxt "vEOpTk"
+msgid "Planning the introduction"
 msgstr "Planning the introduction"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "d2xrsv"
+msgctxt "d2xrsv"
+msgid "Preparing your course"
 msgstr "Preparing your course"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "CFWOGF"
+msgctxt "CFWOGF"
+msgid "Saving your course"
 msgstr "Saving your course"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XPla-v"
+msgctxt "XPla-v"
+msgid "Preparing the introduction"
 msgstr "Preparing the introduction"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "HbhIvm"
+msgctxt "HbhIvm"
+msgid "Writing your course description"
 msgstr "Writing your course description"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Y4F0xn"
+msgctxt "Y4F0xn"
+msgid "Writing the first lesson"
 msgstr "Writing the first lesson"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "e1myvm"
+msgctxt "e1myvm"
+msgid "Writing your course page"
 msgstr "Writing your course page"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "aev_pt"
+msgctxt "aev_pt"
+msgid "Figuring out the right categories..."
 msgstr "Figuring out the right categories..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "EKAN6s"
+msgctxt "EKAN6s"
+msgid "Tagging your course..."
 msgstr "Tagging your course..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "JJrUOR"
+msgctxt "JJrUOR"
+msgid "Comparing nearby courses..."
 msgstr "Comparing nearby courses..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "uw23V-"
+msgctxt "uw23V-"
+msgid "Checking whether this course already exists..."
 msgstr "Checking whether this course already exists..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "qFmZfG"
+msgctxt "qFmZfG"
+msgid "Avoiding duplicate courses..."
 msgstr "Avoiding duplicate courses..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "lxBtcx"
+msgctxt "lxBtcx"
+msgid "Designing the cover..."
 msgstr "Designing the cover..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "W8n2i3"
+msgctxt "W8n2i3"
+msgid "Picking the right look..."
 msgstr "Picking the right look..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "At4rk1"
+msgctxt "At4rk1"
+msgid "Adding finishing touches..."
 msgstr "Adding finishing touches..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "NgONb4"
+msgctxt "NgONb4"
+msgid "Searching for matching topics..."
 msgstr "Searching for matching topics..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Auz1tl"
+msgctxt "Auz1tl"
+msgid "Looking for alternate names..."
 msgstr "Looking for alternate names..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gt_VNO"
+msgctxt "Gt_VNO"
+msgid "Expanding the course search..."
 msgstr "Expanding the course search..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "AEG3Ol"
+msgctxt "AEG3Ol"
+msgid "Planning the course structure..."
 msgstr "Planning the course structure..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "OW9vMd"
+msgctxt "OW9vMd"
+msgid "Writing chapter {number}..."
 msgstr "Writing chapter {number}..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "tXkuD8"
+msgctxt "tXkuD8"
+msgid "Reviewing the overall flow..."
 msgstr "Reviewing the overall flow..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "8-bhNP"
+msgctxt "8-bhNP"
+msgid "Finding the best first hook..."
 msgstr "Finding the best first hook..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "xrFhkn"
+msgctxt "xrFhkn"
+msgid "Writing a friendly guide to the field..."
 msgstr "Writing a friendly guide to the field..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "c_e4hk"
+msgctxt "c_e4hk"
+msgid "Keeping the first chapter easy to start..."
 msgstr "Keeping the first chapter easy to start..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "4LsE_n"
+msgctxt "4LsE_n"
+msgid "Creating the course shell..."
 msgstr "Creating the course shell..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "3hEaI4"
+msgctxt "3hEaI4"
+msgid "Preparing the workspace..."
 msgstr "Preparing the workspace..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "7Pw3r5"
+msgctxt "7Pw3r5"
+msgid "Saving the intro chapter..."
 msgstr "Saving the intro chapter..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "cc6_Yn"
+msgctxt "cc6_Yn"
+msgid "Preparing the first lessons..."
 msgstr "Preparing the first lessons..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "a7FJJd"
+msgctxt "a7FJJd"
+msgid "Summarizing what you'll learn..."
 msgstr "Summarizing what you'll learn..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "9r_4zz"
+msgctxt "9r_4zz"
+msgid "Writing the overview..."
 msgstr "Writing the overview..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "QqKzYM"
+msgctxt "QqKzYM"
+msgid "Writing the first lesson..."
 msgstr "Writing the first lesson..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XxRMuO"
+msgctxt "XxRMuO"
+msgid "Adding examples and visuals..."
 msgstr "Adding examples and visuals..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "kmuvIN"
+msgctxt "kmuvIN"
+msgid "Getting the first lesson ready..."
 msgstr "Getting the first lesson ready..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "chqN-J"
+msgctxt "chqN-J"
+msgid "Framing why this course is useful..."
 msgstr "Framing why this course is useful..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "twf4n2"
+msgctxt "twf4n2"
+msgid "Writing the course page..."
 msgstr "Writing the course page..."
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "k15wFf"
+msgctxt "k15wFf"
+msgid "Shaping the starting point..."
 msgstr "Shaping the starting point..."
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "WihX6L"
+msgctxt "WihX6L"
+msgid "Creating the {title} lesson"
 msgstr "Creating the {title} lesson"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "3vY0Zu"
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
 msgstr "This usually takes 1-2 minutes"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "cVoRCh"
+msgctxt "cVoRCh"
+msgid "Preparing options..."
 msgstr "Preparing options..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BBwnPG"
+msgctxt "BBwnPG"
+msgid "Adding more options..."
 msgstr "Adding more options..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "4wkMNX"
+msgctxt "4wkMNX"
+msgid "Getting answer options ready..."
 msgstr "Getting answer options ready..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "WsjFV2"
+msgctxt "WsjFV2"
+msgid "Preparing the word bank..."
 msgstr "Preparing the word bank..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6xEJTk"
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
 msgstr "Designing practice exercises..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6hjA6_"
+msgctxt "6hjA6_"
+msgid "Creating examples to try..."
 msgstr "Creating examples to try..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "KddvJw"
+msgctxt "KddvJw"
+msgid "Writing fill-in-the-blanks..."
 msgstr "Writing fill-in-the-blanks..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "C05-tM"
+msgctxt "C05-tM"
+msgid "Building interactive tasks..."
 msgstr "Building interactive tasks..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JGNN92"
+msgctxt "JGNN92"
+msgid "Drawing an illustration..."
 msgstr "Drawing an illustration..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "a08k7g"
+msgctxt "a08k7g"
+msgid "Generating the images..."
 msgstr "Generating the images..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bJVUNz"
+msgctxt "bJVUNz"
+msgid "Adding some color..."
 msgstr "Adding some color..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "Yoev2R"
+msgctxt "Yoev2R"
+msgid "Refining the details..."
 msgstr "Refining the details..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "xBaVAH"
+msgctxt "xBaVAH"
+msgid "Finishing the artwork..."
 msgstr "Finishing the artwork..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "W2b0tx"
+msgctxt "W2b0tx"
+msgid "Designing the lesson thumbnail..."
 msgstr "Designing the lesson thumbnail..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "fRAHqN"
+msgctxt "fRAHqN"
+msgid "Creating the lesson thumbnail..."
 msgstr "Creating the lesson thumbnail..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "elwtxf"
+msgctxt "elwtxf"
+msgid "Refining the lesson thumbnail..."
 msgstr "Refining the lesson thumbnail..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "uDzgwu"
+msgctxt "uDzgwu"
+msgid "Writing example sentences..."
 msgstr "Writing example sentences..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "SHIHyL"
+msgctxt "SHIHyL"
+msgid "Creating reading passages..."
 msgstr "Creating reading passages..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0Zum4g"
+msgctxt "0Zum4g"
+msgid "Putting words in context..."
 msgstr "Putting words in context..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "jixTNM"
+msgctxt "jixTNM"
+msgid "Building natural sentences..."
 msgstr "Building natural sentences..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "txIcop"
+msgctxt "txIcop"
+msgid "Loading lesson data..."
 msgstr "Loading lesson data..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "l486Kx"
+msgctxt "l486Kx"
+msgid "Checking what we need..."
 msgstr "Checking what we need..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "EAqAX_"
+msgctxt "EAqAX_"
+msgid "Thinking about what to illustrate..."
 msgstr "Thinking about what to illustrate..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "2Tovpk"
+msgctxt "2Tovpk"
+msgid "Planning each image..."
 msgstr "Planning each image..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "sQsQbH"
+msgctxt "sQsQbH"
+msgid "Choosing the right scenes..."
 msgstr "Choosing the right scenes..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "iUUJom"
+msgctxt "iUUJom"
+msgid "Planning the illustrations..."
 msgstr "Planning the illustrations..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BszFlm"
+msgctxt "BszFlm"
+msgid "Saving your lesson..."
 msgstr "Saving your lesson..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bC9979"
+msgctxt "bC9979"
+msgid "Almost done..."
 msgstr "Almost done..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5Jyenk"
+msgctxt "5Jyenk"
+msgid "Getting ready for the next step..."
 msgstr "Getting ready for the next step..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "r8xznK"
+msgctxt "r8xznK"
+msgid "Researching the topic..."
 msgstr "Researching the topic..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "K_JznZ"
+msgctxt "K_JznZ"
+msgid "Writing the explanation..."
 msgstr "Writing the explanation..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "19fPwV"
+msgctxt "19fPwV"
+msgid "Making it clear..."
 msgstr "Making it clear..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "65JXIy"
+msgctxt "65JXIy"
+msgid "Putting together the lesson..."
 msgstr "Putting together the lesson..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "nwi1Ym"
+msgctxt "nwi1Ym"
+msgid "Crafting the content..."
 msgstr "Crafting the content..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "-QrqeN"
+msgctxt "-QrqeN"
+msgid "Writing the explanation first..."
 msgstr "Writing the explanation first..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "epxxAx"
+msgctxt "epxxAx"
+msgid "Building the foundation..."
 msgstr "Building the foundation..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "GyThaR"
+msgctxt "GyThaR"
+msgid "Preparing background context..."
 msgstr "Preparing background context..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0AWsLH"
+msgctxt "0AWsLH"
+msgid "Explaining the topic..."
 msgstr "Explaining the topic..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "KL34l5"
+msgctxt "KL34l5"
+msgid "Adding romanization for grammar..."
 msgstr "Adding romanization for grammar..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "GILb0l"
+msgctxt "GILb0l"
+msgid "Converting grammar text to Latin script..."
 msgstr "Converting grammar text to Latin script..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OFH7dE"
+msgctxt "OFH7dE"
+msgid "Making grammar content easier to read..."
 msgstr "Making grammar content easier to read..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VADOBa"
+msgctxt "VADOBa"
+msgid "Looking up how each word sounds..."
 msgstr "Looking up how each word sounds..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "WnqJeL"
+msgctxt "WnqJeL"
+msgid "Mapping out the pronunciation..."
 msgstr "Mapping out the pronunciation..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "HDNFHk"
+msgctxt "HDNFHk"
+msgid "Checking how to say each word..."
 msgstr "Checking how to say each word..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "_Fl7bm"
+msgctxt "_Fl7bm"
+msgid "Finding the right sounds..."
 msgstr "Finding the right sounds..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "DLZ9fl"
+msgctxt "DLZ9fl"
+msgid "Converting to Latin script..."
 msgstr "Converting to Latin script..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "boocfl"
+msgctxt "boocfl"
+msgid "Adding reading aids..."
 msgstr "Adding reading aids..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "AQMVYX"
+msgctxt "AQMVYX"
+msgid "Making it easier to read..."
 msgstr "Making it easier to read..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ud2yWh"
+msgctxt "ud2yWh"
+msgid "Writing out the sounds..."
 msgstr "Writing out the sounds..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "kxBeWt"
+msgctxt "kxBeWt"
+msgid "Adding romanization for vocabulary..."
 msgstr "Adding romanization for vocabulary..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "Ch9BcP"
+msgctxt "Ch9BcP"
+msgid "Converting vocabulary to Latin script..."
 msgstr "Converting vocabulary to Latin script..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1aPaHZ"
+msgctxt "1aPaHZ"
+msgid "Making vocabulary easier to read..."
 msgstr "Making vocabulary easier to read..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "zYx0UG"
+msgctxt "zYx0UG"
+msgid "Adding pronunciation for each word..."
 msgstr "Adding pronunciation for each word..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VQ3-C2"
+msgctxt "VQ3-C2"
+msgid "Noting how each word sounds..."
 msgstr "Noting how each word sounds..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YWB-K_"
+msgctxt "YWB-K_"
+msgid "Detailing the word sounds..."
 msgstr "Detailing the word sounds..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "L6f1Zq"
+msgctxt "L6f1Zq"
+msgid "Recording pronunciation info..."
 msgstr "Recording pronunciation info..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "i-rNdh"
+msgctxt "i-rNdh"
+msgid "Picking the key vocabulary..."
 msgstr "Picking the key vocabulary..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "IdWf9_"
+msgctxt "IdWf9_"
+msgid "Choosing words to practice..."
 msgstr "Choosing words to practice..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "UFDKHM"
+msgctxt "UFDKHM"
+msgid "Finding the most useful words..."
 msgstr "Finding the most useful words..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YgG70c"
+msgctxt "YgG70c"
+msgid "Selecting important terms..."
 msgstr "Selecting important terms..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "6BQo6o"
+msgctxt "6BQo6o"
+msgid "Translating individual words..."
 msgstr "Translating individual words..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "k0Q_Ph"
+msgctxt "k0Q_Ph"
+msgid "Looking up each term..."
 msgstr "Looking up each term..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "hZLCkp"
+msgctxt "hZLCkp"
+msgid "Finding word meanings..."
 msgstr "Finding word meanings..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "SC0o7J"
+msgctxt "SC0o7J"
+msgid "Building the vocabulary guide..."
 msgstr "Building the vocabulary guide..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "5InW8H"
+msgctxt "5InW8H"
+msgid "Recording the audio..."
 msgstr "Recording the audio..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "4xvh9e"
+msgctxt "4xvh9e"
+msgid "Getting the pronunciation right..."
 msgstr "Getting the pronunciation right..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "oB01Wc"
+msgctxt "oB01Wc"
+msgid "Preparing the voice..."
 msgstr "Preparing the voice..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ScA7Xm"
+msgctxt "ScA7Xm"
+msgid "Making it sound natural..."
 msgstr "Making it sound natural..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1vO-bV"
+msgctxt "1vO-bV"
+msgid "Recording vocabulary audio..."
 msgstr "Recording vocabulary audio..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "jV2zI1"
+msgctxt "jV2zI1"
+msgid "Getting the sound for each word..."
 msgstr "Getting the sound for each word..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "FahI7K"
+msgctxt "FahI7K"
+msgid "Preparing vocabulary audio..."
 msgstr "Preparing vocabulary audio..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "JfNFGM"
+msgctxt "JfNFGM"
+msgid "Making words listenable..."
 msgstr "Making words listenable..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "muXaEm"
+msgctxt "muXaEm"
+msgid "Recording pronunciation for each word..."
 msgstr "Recording pronunciation for each word..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "QDv0wS"
+msgctxt "QDv0wS"
+msgid "Getting the audio for each term..."
 msgstr "Getting the audio for each term..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OJkDgV"
+msgctxt "OJkDgV"
+msgid "Preparing word-by-word audio..."
 msgstr "Preparing word-by-word audio..."
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "C2ELVi"
+msgctxt "C2ELVi"
+msgid "Making each word listenable..."
 msgstr "Making each word listenable..."
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "58heST"
+msgctxt "58heST"
+msgid "Adding grammar romanization"
 msgstr "Adding grammar romanization"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "TlrPFF"
+msgctxt "TlrPFF"
+msgid "Adding pronunciation"
 msgstr "Adding pronunciation"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "V0mPLK"
+msgctxt "V0mPLK"
+msgid "Adding romanization"
 msgstr "Adding romanization"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "HXMA75"
+msgctxt "HXMA75"
+msgid "Adding vocabulary romanization"
 msgstr "Adding vocabulary romanization"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "4OjRPB"
+msgctxt "4OjRPB"
+msgid "Adding word pronunciation"
 msgstr "Adding word pronunciation"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "RXfSEl"
+msgctxt "RXfSEl"
+msgid "Building word list"
 msgstr "Building word list"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "viluaR"
+msgctxt "viluaR"
+msgid "Preparing options"
 msgstr "Preparing options"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "c7xJGQ"
+msgctxt "c7xJGQ"
+msgid "Creating exercises"
 msgstr "Creating exercises"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "aKNA_b"
+msgctxt "aKNA_b"
+msgid "Creating images"
 msgstr "Creating images"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "WI2yui"
+msgctxt "WI2yui"
+msgid "Creating lesson thumbnail"
 msgstr "Creating lesson thumbnail"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "mIpv67"
+msgctxt "mIpv67"
+msgid "Creating sentences"
 msgstr "Creating sentences"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "0zeST_"
+msgctxt "0zeST_"
+msgid "Looking up words"
 msgstr "Looking up words"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v7HGj3"
+msgctxt "v7HGj3"
+msgid "Planning the images"
 msgstr "Planning the images"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "T00GEW"
+msgctxt "T00GEW"
+msgid "Recording audio"
 msgstr "Recording audio"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v2DAdY"
+msgctxt "v2DAdY"
+msgid "Recording vocabulary audio"
 msgstr "Recording vocabulary audio"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "j-pO55"
+msgctxt "j-pO55"
+msgid "Recording word audio"
 msgstr "Recording word audio"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "2ZPUqg"
+msgctxt "2ZPUqg"
+msgid "Saving your lesson"
 msgstr "Saving your lesson"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v4iFHN"
+msgctxt "v4iFHN"
+msgid "Writing the content"
 msgstr "Writing the content"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "ZA0_P-"
+msgctxt "ZA0_P-"
+msgid "Writing the explanation"
 msgstr "Writing the explanation"
 
 #: src/app/generate/layout.tsx
-msgid "_tq5fR"
+msgctxt "_tq5fR"
+msgid "Creating content"
 msgstr "Creating content"
 
 #: src/app/privacy/page.tsx
-msgid "afKQHy"
+msgctxt "afKQHy"
+msgid "Read Zoonk's privacy policy to understand how we use and protect your personal information."
 msgstr "Read Zoonk's privacy policy to understand how we use and protect your personal information."
 
 #: src/app/privacy/page.tsx
-msgid "vx0nkZ"
+msgctxt "vx0nkZ"
+msgid "Privacy Policy"
 msgstr "Privacy Policy"
 
 #: src/app/terms/page.tsx
-msgid "DaGtoz"
+msgctxt "DaGtoz"
+msgid "Read Zoonk's terms of use to understand the rules and conditions for using our platform and services"
 msgstr "Read Zoonk's terms of use to understand the rules and conditions for using our platform and services"
 
 #: src/app/terms/page.tsx
-msgid "UhkSyx"
+msgctxt "UhkSyx"
+msgid "Terms of Use"
 msgstr "Terms of Use"
 
 #: src/components/catalog/ai-warning.tsx
-msgid "FYZlTZ"
+msgctxt "FYZlTZ"
+msgid "Created with AI"
 msgstr "Created with AI"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "F0tnKc"
+msgctxt "F0tnKc"
+msgid "Thanks for your feedback"
 msgstr "Thanks for your feedback"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "IzCVhG"
+msgctxt "IzCVhG"
+msgid "More options"
 msgstr "More options"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "rTFrsw"
+msgctxt "rTFrsw"
+msgid "I liked it"
 msgstr "I liked it"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "Hqn5Uo"
+msgctxt "Hqn5Uo"
+msgid "I didn't like it"
 msgstr "I didn't like it"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "G5YSJR"
+msgctxt "G5YSJR"
+msgid "Send feedback"
 msgstr "Send feedback"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "PAKDzS"
+msgctxt "PAKDzS"
+msgid "Go to current chapter"
 msgstr "Go to current chapter"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "Js2dT3"
+msgctxt "Js2dT3"
+msgid "Go to current lesson"
 msgstr "Go to current lesson"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "izuy1D"
+msgctxt "izuy1D"
+msgid "Current item"
 msgstr "Current item"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "Gs9Kfp"
+msgctxt "Gs9Kfp"
+msgid "Back to top"
 msgstr "Back to top"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "AvySqa"
+msgctxt "AvySqa"
+msgid "{percent}% complete"
 msgstr "{percent}% complete"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "mOFG3K"
+msgctxt "mOFG3K"
+msgid "Start"
 msgstr "Start"
 
 #: src/components/catalog/continue-lesson-link.tsx
 #: src/lib/lessons.ts
-msgid "R-J5ox"
+msgctxt "R-J5ox"
+msgid "Review"
 msgstr "Review"
 
 #: src/components/feedback/contact-form.tsx
-msgid "WzCvaN"
+msgctxt "WzCvaN"
+msgid "We'll use this email to contact you."
 msgstr "We'll use this email to contact you."
 
 #: src/components/feedback/contact-form.tsx
-msgid "T7Ry38"
+msgctxt "T7Ry38"
+msgid "Message"
 msgstr "Message"
 
 #: src/components/feedback/contact-form.tsx
-msgid "M6PcEI"
+msgctxt "M6PcEI"
+msgid "How can we help you?"
 msgstr "How can we help you?"
 
 #: src/components/feedback/contact-form.tsx
-msgid "vD72E5"
+msgctxt "vD72E5"
+msgid "Message sent successfully! We'll get back to you soon."
 msgstr "Message sent successfully! We'll get back to you soon."
 
 #: src/components/feedback/contact-form.tsx
-msgid "-5vOOu"
+msgctxt "-5vOOu"
+msgid "Please provide as much detail as possible."
 msgstr "Please provide as much detail as possible."
 
 #: src/components/feedback/contact-form.tsx
-msgid "1WHPmV"
+msgctxt "1WHPmV"
+msgid "Failed to send message. Please try again or email us directly at hello@zoonk.com"
 msgstr "Failed to send message. Please try again or email us directly at hello@zoonk.com"
 
 #: src/components/feedback/contact-form.tsx
-msgid "Xx0WZV"
+msgctxt "Xx0WZV"
+msgid "Send message"
 msgstr "Send message"
 
 #: src/components/feedback/content-feedback.tsx
-msgid "BlI1_9"
+msgctxt "BlI1_9"
+msgid "Did you like this content?"
 msgstr "Did you like this content?"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "Ejhdi4"
+msgctxt "Ejhdi4"
+msgid "Feedback"
 msgstr "Feedback"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "eUzs3M"
+msgctxt "eUzs3M"
+msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "ctqXbT"
+msgctxt "ctqXbT"
+msgid "We lost the progress connection. Your content may still be generating."
 msgstr "We lost the progress connection. Your content may still be generating."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "1A8Z_l"
+msgctxt "1A8Z_l"
+msgid "Check again"
 msgstr "Check again"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "yHqv96"
+msgctxt "yHqv96"
+msgid "Connection interrupted"
 msgstr "Connection interrupted"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "JqiqNj"
+msgctxt "JqiqNj"
+msgid "Something went wrong"
 msgstr "Something went wrong"
 
 #: src/components/progress/progress-day-count-label.ts
-msgid "r9koty"
+msgctxt "r9koty"
+msgid "{count, plural, =0 {# days} one {# day} other {# days}}"
 msgstr "{count, plural, =0 {# days} one {# day} other {# days}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "tRA46q"
+msgctxt "tRA46q"
+msgid "0 min"
 msgstr "0 min"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "yMhrnF"
+msgctxt "yMhrnF"
+msgid "{seconds, plural, one {# sec} other {# sec}}"
 msgstr "{seconds, plural, one {# sec} other {# sec}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "a-oHjQ"
+msgctxt "a-oHjQ"
+msgid "{minutes, plural, one {# min} other {# min}}"
 msgstr "{minutes, plural, one {# min} other {# min}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "QqnZaw"
+msgctxt "QqnZaw"
+msgid "{hours, plural, one {# hr} other {# hr}}"
 msgstr "{hours, plural, one {# hr} other {# hr}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "Frd5VU"
+msgctxt "Frd5VU"
+msgid "{hours, plural, one {# hr} other {# hr}} {minutes, plural, one {# min} other {# min}}"
 msgstr "{hours, plural, one {# hr} other {# hr}} {minutes, plural, one {# min} other {# min}}"
 
 #: src/components/progress/total-learning-time-card.tsx
-msgid "-V74AY"
+msgctxt "-V74AY"
+msgid "Learning time"
 msgstr "Learning time"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "IS_YjO"
+msgctxt "IS_YjO"
+msgid "Upgrade to create"
 msgstr "Upgrade to create"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "ZMU6iN"
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
 msgstr "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "0h_lPM"
+msgctxt "0h_lPM"
+msgid "Upgrade"
 msgstr "Upgrade"
 
 #: src/lib/belt-colors.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 
 #: src/lib/categories/category.ts
-msgid "fFt3il"
+msgctxt "fFt3il"
+msgid "Arts"
 msgstr "Arts"
 
 #: src/lib/categories/category.ts
-msgid "w1Fanr"
+msgctxt "w1Fanr"
+msgid "Business"
 msgstr "Business"
 
 #: src/lib/categories/category.ts
-msgid "n5D_Ku"
+msgctxt "n5D_Ku"
+msgid "Communication"
 msgstr "Communication"
 
 #: src/lib/categories/category.ts
-msgid "mn6pIm"
+msgctxt "mn6pIm"
+msgid "Culture"
 msgstr "Culture"
 
 #: src/lib/categories/category.ts
-msgid "hwL7a0"
+msgctxt "hwL7a0"
+msgid "Engineering"
 msgstr "Engineering"
 
 #: src/lib/categories/category.ts
-msgid "YMDBNH"
+msgctxt "YMDBNH"
+msgid "Geography"
 msgstr "Geography"
 
 #: src/lib/categories/category.ts
-msgid "hlmkcL"
+msgctxt "hlmkcL"
+msgid "Health"
 msgstr "Health"
 
 #: src/lib/categories/category.ts
-msgid "GsBRWL"
+msgctxt "GsBRWL"
+msgid "Languages"
 msgstr "Languages"
 
 #: src/lib/categories/category.ts
-msgid "u3ovjm"
+msgctxt "u3ovjm"
+msgid "Law"
 msgstr "Law"
 
 #: src/lib/categories/category.ts
-msgid "dPgwrL"
+msgctxt "dPgwrL"
+msgid "Math"
 msgstr "Math"
 
 #: src/lib/categories/category.ts
-msgid "qydxOd"
+msgctxt "qydxOd"
+msgid "Science"
 msgstr "Science"
 
 #: src/lib/categories/category.ts
-msgid "OV_2-4"
+msgctxt "OV_2-4"
+msgid "Society"
 msgstr "Society"
 
 #: src/lib/categories/category.ts
-msgid "I1ZCPK"
+msgctxt "I1ZCPK"
+msgid "Technology"
 msgstr "Technology"
 
 #: src/lib/categories/category.ts
-msgid "XL8IWT"
+msgctxt "XL8IWT"
+msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
 msgstr "{category} courses. The best {category} online courses, interactive lessons to learn."
 
 #: src/lib/categories/category.ts
-msgid "4HKnmB"
+msgctxt "4HKnmB"
+msgid "{category} Courses"
 msgstr "{category} Courses"
 
 #: src/lib/categories/category.ts
-msgid "EMi23I"
+msgctxt "EMi23I"
+msgid "Explore all {category} courses"
 msgstr "Explore all {category} courses"
 
 #: src/lib/categories/category.ts
-msgid "Rz9oL-"
+msgctxt "Rz9oL-"
+msgid "{category} courses"
 msgstr "{category} courses"
 
 #: src/lib/lessons.ts
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alphabet"
 
 #: src/lib/lessons.ts
-msgid "4TTYDR"
+msgctxt "4TTYDR"
+msgid "Custom lesson"
 msgstr "Custom lesson"
 
 #: src/lib/lessons.ts
-msgid "E1bF_X"
+msgctxt "E1bF_X"
+msgid "Explanation"
 msgstr "Explanation"
 
 #: src/lib/lessons.ts
-msgid "QzTY8x"
+msgctxt "QzTY8x"
+msgid "Grammar"
 msgstr "Grammar"
 
 #: src/lib/lessons.ts
-msgid "1TOMnj"
+msgctxt "1TOMnj"
+msgid "Listening"
 msgstr "Listening"
 
 #: src/lib/lessons.ts
-msgid "KV-O0y"
+msgctxt "KV-O0y"
+msgid "Practice"
 msgstr "Practice"
 
 #: src/lib/lessons.ts
-msgid "OuR_Ij"
+msgctxt "OuR_Ij"
+msgid "Quiz"
 msgstr "Quiz"
 
 #: src/lib/lessons.ts
-msgid "MOK_yK"
+msgctxt "MOK_yK"
+msgid "Reading"
 msgstr "Reading"
 
 #: src/lib/lessons.ts
-msgid "_vCXIP"
+msgctxt "_vCXIP"
+msgid "Translation"
 msgstr "Translation"
 
 #: src/lib/lessons.ts
-msgid "Ox-Z-K"
+msgctxt "Ox-Z-K"
+msgid "Tutorial"
 msgstr "Tutorial"
 
 #: src/lib/lessons.ts
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Vocabulary"
 
 #: src/lib/lessons.ts
-msgid "22k1CY"
+msgctxt "22k1CY"
+msgid "Learn how letters and sounds work in this writing system."
 msgstr "Learn how letters and sounds work in this writing system."
 
 #: src/lib/lessons.ts
-msgid "LZC7R9"
+msgctxt "LZC7R9"
+msgid "Work through a lesson created for your goal."
 msgstr "Work through a lesson created for your goal."
 
 #: src/lib/lessons.ts
-msgid "fOfLbt"
+msgctxt "fOfLbt"
+msgid "Understand the key ideas using everyday language and practical examples."
 msgstr "Understand the key ideas using everyday language and practical examples."
 
 #: src/lib/lessons.ts
-msgid "dHmgw1"
+msgctxt "dHmgw1"
+msgid "Practice grammar patterns with examples and exercises."
 msgstr "Practice grammar patterns with examples and exercises."
 
 #: src/lib/lessons.ts
-msgid "AetsPy"
+msgctxt "AetsPy"
+msgid "Listen to sentences using words you recently learned."
 msgstr "Listen to sentences using words you recently learned."
 
 #: src/lib/lessons.ts
-msgid "6oNgY9"
+msgctxt "6oNgY9"
+msgid "Use what you learned in the previous lesson to solve real-world problems."
 msgstr "Use what you learned in the previous lesson to solve real-world problems."
 
 #: src/lib/lessons.ts
-msgid "vO6aLm"
+msgctxt "vO6aLm"
+msgid "Check what you understood with a short quiz."
 msgstr "Check what you understood with a short quiz."
 
 #: src/lib/lessons.ts
-msgid "OIim7M"
+msgctxt "OIim7M"
+msgid "Read sentences using words you recently learned."
 msgstr "Read sentences using words you recently learned."
 
 #: src/lib/lessons.ts
-msgid "pwrprO"
+msgctxt "pwrprO"
+msgid "Review this chapter with practice based on your mistakes."
 msgstr "Review this chapter with practice based on your mistakes."
 
 #: src/lib/lessons.ts
-msgid "IQOJhk"
+msgctxt "IQOJhk"
+msgid "Translate words from your previous vocabulary lesson."
 msgstr "Translate words from your previous vocabulary lesson."
 
 #: src/lib/lessons.ts
-msgid "9XByXq"
+msgctxt "9XByXq"
+msgid "Follow a guided step-by-step tutorial."
 msgstr "Follow a guided step-by-step tutorial."
 
 #: src/lib/lessons.ts
-msgid "IHSVS5"
+msgctxt "IHSVS5"
+msgid "Learn new words and practice using them."
 msgstr "Learn new words and practice using them."
 
 #: src/lib/lessons.ts
-msgid "OjyuQ-"
+msgctxt "OjyuQ-"
+msgid "Learn the writing system for {topic} with focused practice."
 msgstr "Learn the writing system for {topic} with focused practice."
 
 #: src/lib/lessons.ts
-msgid "pSQZ7W"
+msgctxt "pSQZ7W"
+msgid "Learn about {topic} through an interactive lesson."
 msgstr "Learn about {topic} through an interactive lesson."
 
 #: src/lib/lessons.ts
-msgid "THPcKi"
+msgctxt "THPcKi"
+msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
 msgstr "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
 
 #: src/lib/lessons.ts
-msgid "tlgfSZ"
+msgctxt "tlgfSZ"
+msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 msgstr "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 
 #: src/lib/lessons.ts
-msgid "xCvEE1"
+msgctxt "xCvEE1"
+msgid "Practice listening in {topic} by translating audio sentences."
 msgstr "Practice listening in {topic} by translating audio sentences."
 
 #: src/lib/lessons.ts
-msgid "wHBT6R"
+msgctxt "wHBT6R"
+msgid "Apply {topic} through a visual real-world problem with short decisions."
 msgstr "Apply {topic} through a visual real-world problem with short decisions."
 
 #: src/lib/lessons.ts
-msgid "h2acN8"
+msgctxt "h2acN8"
+msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 
 #: src/lib/lessons.ts
-msgid "XzxpBZ"
+msgctxt "XzxpBZ"
+msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Improve your {topic} reading comprehension by translating sentences and passages."
 
 #: src/lib/lessons.ts
-msgid "bzFQEy"
+msgctxt "bzFQEy"
+msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Review everything you learned about {topic} with a comprehensive quiz."
 
 #: src/lib/lessons.ts
-msgid "X8Gqiq"
+msgctxt "X8Gqiq"
+msgid "Practice vocabulary in {topic} by translating words you've learned."
 msgstr "Practice vocabulary in {topic} by translating words you've learned."
 
 #: src/lib/lessons.ts
-msgid "3bJDQa"
+msgctxt "3bJDQa"
+msgid "Learn {topic} with a guided step-by-step tutorial."
 msgstr "Learn {topic} with a guided step-by-step tutorial."
 
 #: src/lib/lessons.ts
-msgid "77SLH5"
+msgctxt "77SLH5"
+msgid "Learn new words in {topic} with flashcards — see each word, its translation, and pronunciation."
 msgstr "Learn new words in {topic} with flashcards — see each word, its translation, and pronunciation."
 
 #: src/lib/lessons.ts
-msgid "oCxmX9"
+msgctxt "oCxmX9"
+msgid "{chapter} {kind} {position}"
 msgstr "{chapter} {kind} {position}"
 
 #: src/lib/lessons.ts
-msgid "qHbgYB"
+msgctxt "qHbgYB"
+msgid "{lesson} - {course}"
 msgstr "{lesson} - {course}"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -4,93 +4,109 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
+msgctxt "xmcVZ0"
+msgid "Search"
 msgstr "Buscar"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
+msgctxt "PSiLeL"
+msgid "Search courses, chapters, or pages..."
 msgstr "Busca cursos, capítulos o páginas…"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
+msgctxt "I-38K2"
+msgid "My courses"
 msgstr "Mis cursos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
+msgctxt "Oj9Phc"
+msgid "Manage subscription"
 msgstr "Gestionar suscripción"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
+msgctxt "OhXwmw"
+msgid "Update language"
 msgstr "Cambiar idioma"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
+msgctxt "O7ozeo"
+msgid "Update profile"
 msgstr "Actualizar perfil"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
+msgctxt "C81_uG"
+msgid "Logout"
 msgstr "Cerrar sesión"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(progress)/_components/progress-empty-state.tsx
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
+msgctxt "AyGauy"
+msgid "Login"
 msgstr "Iniciar sesión"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
+msgctxt "y1Z3or"
+msgid "Language"
 msgstr "Idioma"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "U3l-Q9"
+msgctxt "U3l-Q9"
+msgid "Home page"
 msgstr "Página de inicio"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "jboh4c"
+msgctxt "jboh4c"
+msgid "Start a new course"
 msgstr "Empezar un curso nuevo"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "rS0suY"
+msgctxt "rS0suY"
+msgid "Speak a language"
 msgstr "Hablar un idioma"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "L6kaJv"
+msgctxt "L6kaJv"
+msgid "Learn something"
 msgstr "Aprender algo"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "3wvH7G"
+msgctxt "3wvH7G"
+msgid "Pass an exam"
 msgstr "Aprobar un examen"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
+msgctxt "CxfKLC"
+msgid "Pages"
 msgstr "Páginas"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
+msgctxt "dXSivY"
+msgid "My account"
 msgstr "Mi cuenta"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "tv5FG3"
+msgctxt "tv5FG3"
+msgid "Blog"
 msgstr "Blog"
 
 #: src/app/(catalog)/_components/command-palette.tsx
@@ -98,2184 +114,2713 @@ msgstr "Blog"
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "fFZ0Wd"
+msgctxt "fFZ0Wd"
+msgid "Feedback & Support"
 msgstr "Comentarios y ayuda"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "SENRqu"
+msgctxt "SENRqu"
+msgid "Help"
 msgstr "Ayuda"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "R85gsW"
+msgctxt "R85gsW"
+msgid "Courses"
 msgstr "Cursos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Do1Pfd"
+msgctxt "Do1Pfd"
+msgid "Chapters"
 msgstr "Capítulos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "hX5PAb"
+msgctxt "hX5PAb"
+msgid "No results found"
 msgstr "No se encontraron resultados"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "OXAZiT"
+msgctxt "OXAZiT"
+msgid "Create a course about {term}"
 msgstr "Crear un curso sobre {term}"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "onRJrc"
+msgctxt "onRJrc"
+msgid "Course page"
 msgstr "Página del curso"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "m826WB"
+msgctxt "m826WB"
+msgid "New course"
 msgstr "Curso nuevo"
 
 #: src/app/(catalog)/_components/user-avatar-menu.tsx
-msgid "6b2CRH"
+msgctxt "6b2CRH"
+msgid "User menu"
 msgstr "Menú de usuario"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/profile/page.tsx
-msgid "itPgxd"
+msgctxt "itPgxd"
+msgid "Profile"
 msgstr "Perfil"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/subscription/page.tsx
-msgid "R_6nsx"
+msgctxt "R_6nsx"
+msgid "Subscription"
 msgstr "Suscripción"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "HHFpcy"
+msgctxt "HHFpcy"
+msgid "Best day"
 msgstr "Mejor día"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/energy/energy-insights.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "auPwZG"
+msgctxt "auPwZG"
+msgid "{day} with {percentage}"
 msgstr "{day} con {percentage}"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(catalog)/(home)/score.tsx
-msgid "zml1_y"
+msgctxt "zml1_y"
+msgid "Past 3 months"
 msgstr "Últimos 3 meses"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "00_IyC"
+msgctxt "00_IyC"
+msgid "Night"
 msgstr "Noche"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "_kzk_m"
+msgctxt "_kzk_m"
+msgid "Morning"
 msgstr "Mañana"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mF-J9o"
+msgctxt "mF-J9o"
+msgid "Afternoon"
 msgstr "Tarde"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mPEpnN"
+msgctxt "mPEpnN"
+msgid "Evening"
 msgstr "Atardecer"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "dFW9lU"
+msgctxt "dFW9lU"
+msgid "Best time"
 msgstr "Mejor momento"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "r0R6ZG"
+msgctxt "r0R6ZG"
+msgid "{period} with {percentage}"
 msgstr "{period} con {percentage}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
-msgid "NubPSk"
+msgctxt "NubPSk"
+msgid "Next: {lesson}"
 msgstr "Siguiente: {lesson}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continuar"
 
 #: src/app/(catalog)/(home)/continue-learning.tsx
-msgid "0X-xfW"
+msgctxt "0X-xfW"
+msgid "Continue learning"
 msgstr "Seguir estudiando"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "soDmlG"
+msgctxt "soDmlG"
+msgid "Keep learning to increase it"
 msgstr "Sigue estudiando para aumentarla"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "WgeB0r"
+msgctxt "WgeB0r"
+msgid "Keep learning to maintain it"
 msgstr "Sigue estudiando para mantenerla"
 
 #: src/app/(catalog)/(home)/energy.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/energy/page.tsx
-msgid "cVpmV7"
+msgctxt "cVpmV7"
+msgid "Energy"
 msgstr "Energía"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "AV5XNu"
+msgctxt "AV5XNu"
+msgid "Your energy is {percentage}"
 msgstr "Tu energía es {percentage}"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
-msgid "8F6teD"
+msgctxt "8F6teD"
+msgid "Learning days"
 msgstr "Días de estudio"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
-msgid "QbNcMh"
+msgctxt "QbNcMh"
+msgid "At least one completed lesson"
 msgstr "Al menos una lección completada"
 
 #: src/app/(catalog)/(home)/learning-time.tsx
-msgid "F6B8A3"
+msgctxt "F6B8A3"
+msgid "Time spent in lessons"
 msgstr "Tiempo dedicado a las lecciones"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "pgt3eW"
+msgctxt "pgt3eW"
+msgid "Max level reached"
 msgstr "Nivel máximo alcanzado"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "8N9BRu"
+msgctxt "8N9BRu"
+msgid "{value} BP to next level"
 msgstr "{value} PM para el siguiente nivel"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/level/page.tsx
-msgid "y1Qr81"
+msgctxt "y1Qr81"
+msgid "Level"
 msgstr "Nivel"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "s0KB2i"
+msgctxt "s0KB2i"
+msgid "{belt} - Level {level}"
 msgstr "{belt} - Nivel {level}"
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "a50ZRn"
+msgctxt "a50ZRn"
+msgid "Zoonk is an AI learning platform and study app to create courses about any topic using AI. Study for your exams or learn new skills."
 msgstr "Zoonk es una plataforma de estudio con IA para crear cursos sobre cualquier tema. Estudia para tus exámenes o aprende habilidades nuevas."
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "leBFvu"
+msgctxt "leBFvu"
+msgid "Zoonk: Study App with AI"
 msgstr "Zoonk: app de estudio con IA"
 
 #: src/app/(catalog)/(home)/progress.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "sIMS7i"
+msgctxt "sIMS7i"
+msgid "Progress"
 msgstr "Progreso"
 
 #: src/app/(catalog)/(home)/score.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/score/page.tsx
-msgid "oLkLww"
+msgctxt "oLkLww"
+msgid "Score"
 msgstr "Puntuación"
 
 #: src/app/(catalog)/(home)/score.tsx
-msgid "_lCW0j"
+msgctxt "_lCW0j"
+msgid "{percentage} correct answers"
 msgstr "{percentage} respuestas correctas"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "QhvU1f"
+msgctxt "QhvU1f"
+msgid "Create this chapter"
 msgstr "Crear este capítulo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "YQGe0H"
+msgctxt "YQGe0H"
+msgid "This chapter is part of the course, but it hasn't been created yet. Create it to see all of its lessons."
 msgstr "Este capítulo forma parte del curso, pero aún no se ha creado. Créalo para ver todas sus lecciones."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "3IOFp2"
+msgctxt "3IOFp2"
+msgid "Create chapter"
 msgstr "Crear capítulo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
+msgctxt "qrEiLa"
+msgid "Back to course"
 msgstr "Volver al curso"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "Ap-oRa"
+msgctxt "Ap-oRa"
+msgid "Could not apply lesson filters. Please try again."
 msgstr "No se pudieron aplicar los filtros de lecciones. Inténtalo de nuevo."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "d6tcJn"
+msgctxt "d6tcJn"
+msgid "Filter lesson types"
 msgstr "Filtrar tipos de lección"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "kxP9GJ"
+msgctxt "kxP9GJ"
+msgid "Types"
 msgstr "Tipos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "wi5osl"
+msgctxt "wi5osl"
+msgid "Show lesson types"
 msgstr "Mostrar tipos de lección"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "OhgOkH"
+msgctxt "OhgOkH"
+msgid "Clear filter"
 msgstr "Borrar filtro"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "orGV_i"
+msgctxt "orGV_i"
+msgid "Current lesson"
 msgstr "Lección actual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "ssvp3R"
+msgctxt "ssvp3R"
+msgid "Search lessons..."
 msgstr "Buscar lecciones…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "FuT9vz"
+msgctxt "FuT9vz"
+msgid "No lessons found"
 msgstr "No se encontraron lecciones"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Completado"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "xTTP0x"
+msgctxt "xTTP0x"
+msgid "Not started"
 msgstr "Sin empezar"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "iRubpl"
+msgctxt "iRubpl"
+msgid "Current chapter"
 msgstr "Capítulo actual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "3SOcGR"
+msgctxt "3SOcGR"
+msgid "Search chapters..."
 msgstr "Buscar capítulos…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "8udPa-"
+msgctxt "8udPa-"
+msgid "No chapters found"
 msgstr "No se encontraron capítulos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "vcaAXp"
+msgctxt "vcaAXp"
+msgid "{completed, number}/{total, number} done"
 msgstr "{completed, number}/{total, number} completadas"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-curriculum-pending-notice.tsx
-msgid "Pf4uqS"
+msgctxt "Pf4uqS"
+msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "El capítulo de introducción está listo. Aún estamos creando el plan completo, así que pronto aparecerán más capítulos aquí."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "_allXG"
+msgctxt "_allXG"
+msgid "Learn {course} online with practical examples and everyday language. {description}"
 msgstr "Aprende {course} en línea con ejemplos prácticos y lenguaje cotidiano. {description}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "gyGolN"
+msgctxt "gyGolN"
+msgid "Learn {course}"
 msgstr "Aprende {course}"
 
 #: src/app/(catalog)/courses/category-pills.tsx
-msgid "tuZsq-"
+msgctxt "tuZsq-"
+msgid "Course categories"
 msgstr "Categorías de cursos"
 
 #: src/app/(catalog)/courses/category-pills.tsx
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "zQvVDJ"
+msgctxt "zQvVDJ"
+msgid "All"
 msgstr "Todo"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "Wc7aau"
+msgctxt "Wc7aau"
+msgid "No courses available yet."
 msgstr "Todavía no hay cursos disponibles."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "zJxO2f"
+msgctxt "zJxO2f"
+msgid "No courses"
 msgstr "No hay cursos"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "T0mfNV"
+msgctxt "T0mfNV"
+msgid "Loading more courses…"
 msgstr "Cargando más cursos…"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "W_5hwr"
+msgctxt "W_5hwr"
+msgid "Something went wrong. Please try again."
 msgstr "Algo salió mal. Inténtalo de nuevo."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Inténtalo de nuevo"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "WgPMAP"
+msgctxt "WgPMAP"
+msgid "Explore all Zoonk courses to learn anything using AI. Find interactive lessons to learn subjects like science, math, technology, and more."
 msgstr "Explora todos los cursos de Zoonk para aprender cualquier cosa con IA. Encuentra lecciones interactivas para aprender temas como ciencia, matemáticas, tecnología y más."
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "P5jxUC"
+msgctxt "P5jxUC"
+msgid "Online Courses using AI"
 msgstr "Cursos en línea con IA"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "s-Ncqj"
+msgctxt "s-Ncqj"
+msgid "Explore courses"
 msgstr "Explorar cursos"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "hUF3bo"
+msgctxt "hUF3bo"
+msgid "Start learning something new today"
 msgstr "Empieza a aprender algo nuevo hoy"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "riE3I5"
+msgctxt "riE3I5"
+msgid "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons."
 msgstr "Ve todos los cursos que empezaste en Zoonk. Continúa donde lo dejaste y sigue tu progreso en lecciones interactivas."
 
 #: src/app/(catalog)/my/page.tsx
-msgid "eeNr_Y"
+msgctxt "eeNr_Y"
+msgid "My Courses"
 msgstr "Mis cursos"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "Dr13kE"
+msgctxt "Dr13kE"
+msgid "Continue where you left off"
 msgstr "Continúa donde lo dejaste"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "BDHWkf"
+msgctxt "BDHWkf"
+msgid "No courses yet"
 msgstr "Aún no hay cursos"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "azX41u"
+msgctxt "azX41u"
+msgid "Start learning something new today."
 msgstr "Empieza a aprender algo nuevo hoy."
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "9m9h0p"
+msgctxt "9m9h0p"
+msgid "Start a course"
 msgstr "Empezar un curso"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "e61Jf3"
+msgctxt "e61Jf3"
+msgid "Coming soon"
 msgstr "Muy pronto"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
-msgid "dtRj3N"
+msgctxt "dtRj3N"
+msgid "Personalized courses are coming soon."
 msgstr "Los cursos personalizados estarán disponibles muy pronto."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "hJZwTS"
+msgctxt "hJZwTS"
+msgid "Email address"
 msgstr "Correo electrónico"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "OiSL94"
+msgctxt "OiSL94"
+msgid "myemail@gmail.com"
 msgstr "micorreo@gmail.com"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "45yKj9"
+msgctxt "45yKj9"
+msgid "We'll use this email to notify you when exam prep is ready."
 msgstr "Usaremos este correo para avisarte cuando la preparación para exámenes esté lista."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "Xy7a7A"
+msgctxt "Xy7a7A"
+msgid "Exam"
 msgstr "Examen"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "cDZwI_"
+msgctxt "cDZwI_"
+msgid "TOEFL, SAT, CFA, CPA..."
 msgstr "TOEFL, SAT, CFA, CPA…"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "E_0Y4u"
+msgctxt "E_0Y4u"
+msgid "Tell us the test, certification, or school exam you care about."
 msgstr "Cuéntanos qué prueba, certificación o examen escolar te interesa."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "6eV4UR"
+msgctxt "6eV4UR"
+msgid "We couldn't add you to the waitlist. Please try again."
 msgstr "No pudimos agregarte a la lista de espera. Inténtalo de nuevo."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "W78DIe"
+msgctxt "W78DIe"
+msgid "You're on the list. We'll let you know when exam prep is ready."
 msgstr "Ya estás en la lista. Te avisaremos cuando la preparación para exámenes esté lista."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "ipGe-B"
+msgctxt "ipGe-B"
+msgid "Notify me"
 msgstr "Avísame"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "gs2Dwu"
+msgctxt "gs2Dwu"
+msgid "Online AI exam prep for certifications and tests. Hands-on explanation and practice questions to help you pass your exam."
 msgstr "Preparación en línea con IA para certificaciones y exámenes. Explicaciones prácticas y preguntas de práctica para ayudarte a aprobar."
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "z8OyvL"
+msgctxt "z8OyvL"
+msgid "Online AI Exam Prep"
 msgstr "Preparación para exámenes en línea con IA"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "CzV5fE"
+msgctxt "CzV5fE"
+msgid "Exam prep is not available yet. Tell us what you're preparing for and we'll notify you when it launches."
 msgstr "La preparación para exámenes aún no está disponible. Cuéntanos para qué te estás preparando y te avisaremos cuando se lance."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "8Zy06C"
+msgctxt "8Zy06C"
+msgid "This option isn't available yet"
 msgstr "Esta opción aún no está disponible"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "TV5hlz"
+msgctxt "TV5hlz"
+msgid "Join the waitlist and we'll let you know when you can learn <strong>{title}</strong> with Zoonk."
 msgstr "Únete a la lista de espera y te avisaremos cuando puedas aprender <strong>{title}</strong> con Zoonk."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "cPhKTw"
+msgctxt "cPhKTw"
+msgid "Not available"
 msgstr "No disponible"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "5DZYgN"
+msgctxt "5DZYgN"
+msgid "We can't create this course"
 msgstr "No podemos crear este curso"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "m6ju4Q"
+msgctxt "m6ju4Q"
+msgid "Zoonk can't help with requests that involve unsafe, illegal, or harmful activity. Try a different subject instead."
 msgstr "Zoonk no puede ayudar con solicitudes que impliquen actividades inseguras, ilegales o dañinas. Prueba con otro tema."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "PDFZz6"
+msgctxt "PDFZz6"
+msgid "Try another goal"
 msgstr "Probar otro objetivo"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "hCixWc"
+msgctxt "hCixWc"
+msgid "You're on the list. We'll email you when it's available."
 msgstr "Ya estás en la lista. Te enviaremos un correo cuando esté disponible."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "UdDpuW"
+msgctxt "UdDpuW"
+msgid "Finding the best way to help"
 msgstr "Buscando la mejor forma de ayudarte"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "1A36NM"
+msgctxt "1A36NM"
+msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "Estamos revisando tu objetivo de estudio. Esto puede tardar unos segundos."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "47FYwb"
+msgctxt "47FYwb"
+msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "CaU_nf"
+msgctxt "CaU_nf"
+msgid "Discover personalized courses and resources to learn {prompt}. Zoonk uses AI to create interactive lessons tailored to you."
 msgstr "Descubre cursos y recursos personalizados para aprender {prompt}. Zoonk usa IA para crear lecciones interactivas hechas para ti."
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "X2b6pH"
+msgctxt "X2b6pH"
+msgid "Learn {prompt} with AI"
 msgstr "Aprende {prompt} con IA"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "l450Bl"
+msgctxt "l450Bl"
+msgid "Computer Science"
 msgstr "Ciencias de la computación"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ElyVN0"
+msgctxt "ElyVN0"
+msgid "Psychology"
 msgstr "Psicología"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "KOuDOE"
+msgctxt "KOuDOE"
+msgid "Economics"
 msgstr "Economía"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "cHCwbF"
+msgctxt "cHCwbF"
+msgid "Photography"
 msgstr "Fotografía"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zE1J_t"
+msgctxt "zE1J_t"
+msgid "Philosophy"
 msgstr "Filosofía"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "y68y7h"
+msgctxt "y68y7h"
+msgid "Data Science"
 msgstr "Ciencia de datos"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1qsU2j"
+msgctxt "1qsU2j"
+msgid "Creative Writing"
 msgstr "Escritura creativa"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "RGkBg_"
+msgctxt "RGkBg_"
+msgid "Biology"
 msgstr "Biología"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oiUZCZ"
+msgctxt "oiUZCZ"
+msgid "Graphic Design"
 msgstr "Diseño gráfico"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "djJp6c"
+msgctxt "djJp6c"
+msgid "History"
 msgstr "Historia"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "O9mDkA"
+msgctxt "O9mDkA"
+msgid "Marketing"
 msgstr "Marketing"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "9zLpJ_"
+msgctxt "9zLpJ_"
+msgid "What do you want to learn?"
 msgstr "¿Qué quieres aprender?"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zfDq-e"
+msgctxt "zfDq-e"
+msgid "Quantum physics"
 msgstr "Física cuántica"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oqfOwA"
+msgctxt "oqfOwA"
+msgid "Ancient philosophy"
 msgstr "Filosofía antigua"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "Osb4bp"
+msgctxt "Osb4bp"
+msgid "Machine learning"
 msgstr "Aprendizaje automático"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "OdZ_n1"
+msgctxt "OdZ_n1"
+msgid "Creative writing"
 msgstr "Escritura creativa"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "N9FWiz"
+msgctxt "N9FWiz"
+msgid "Molecular biology"
 msgstr "Biología molecular"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XFPrU4"
+msgctxt "XFPrU4"
+msgid "Behavioral economics"
 msgstr "Economía conductual"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "-0gz_i"
+msgctxt "-0gz_i"
+msgid "Organic chemistry"
 msgstr "Química orgánica"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1axOcX"
+msgctxt "1axOcX"
+msgid "UFOs"
 msgstr "Ovnis"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "e7q85h"
+msgctxt "e7q85h"
+msgid "Dinosaur extinction"
 msgstr "Extinción de los dinosaurios"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "MO2lwh"
+msgctxt "MO2lwh"
+msgid "How volcanoes work"
 msgstr "Cómo funcionan los volcanes"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ZzbdHP"
+msgctxt "ZzbdHP"
+msgid "World history"
 msgstr "Historia mundial"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XfC6Cs"
+msgctxt "XfC6Cs"
+msgid "Cognitive psychology"
 msgstr "Psicología cognitiva"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "X5XXVF"
+msgctxt "X5XXVF"
+msgid "Linear algebra"
 msgstr "Álgebra lineal"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5gOFKJ"
+msgctxt "5gOFKJ"
+msgid "Black holes"
 msgstr "Agujeros negros"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "eQHeGX"
+msgctxt "eQHeGX"
+msgid "How the internet works"
 msgstr "Cómo funciona internet"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "QOSGzc"
+msgctxt "QOSGzc"
+msgid "Roman Empire"
 msgstr "Imperio romano"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "gyEihl"
+msgctxt "gyEihl"
+msgid "Deep sea creatures"
 msgstr "Criaturas de las profundidades marinas"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "0MqSJ1"
+msgctxt "0MqSJ1"
+msgid "Solar system"
 msgstr "Sistema solar"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5qPAxv"
+msgctxt "5qPAxv"
+msgid "Artificial intelligence"
 msgstr "Inteligencia artificial"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "3WiAG4"
+msgctxt "3WiAG4"
+msgid "Harry Potter"
 msgstr "Harry Potter"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "NvSCuG"
+msgctxt "NvSCuG"
+msgid "Suggested subjects"
 msgstr "Temas sugeridos"
 
 #: src/app/(catalog)/start/learn/learn-form.tsx
-msgid "uCb1nG"
+msgctxt "uCb1nG"
+msgid "Enter a subject"
 msgstr "Escribe un tema"
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "JlJVf1"
+msgctxt "JlJVf1"
+msgid "Tell Zoonk what you want to learn and get a course created with AI. Start learning any subject with interactive lessons."
 msgstr "Dile a Zoonk qué quieres aprender y obtén un curso creado con IA. Empieza a estudiar cualquier tema con lecciones interactivas."
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "Zs1QEq"
+msgctxt "Zs1QEq"
+msgid "Learn Anything with AI"
 msgstr "Aprende cualquier cosa con IA"
 
 #: src/app/(catalog)/start/page.tsx
-msgid "UFOGo9"
+msgctxt "UFOGo9"
+msgid "Start online courses to learn languages and more on Zoonk. Practice language learning, learn English or Spanish, and create AI-powered courses for any subject."
 msgstr "Empieza cursos en línea para aprender idiomas y mucho más en Zoonk. Practica idiomas, aprende inglés o español y crea cursos con IA sobre cualquier tema."
 
 #: src/app/(catalog)/start/page.tsx
-msgid "rqpQgj"
+msgctxt "rqpQgj"
+msgid "Online Courses to Learn Languages and More"
 msgstr "Cursos en línea para aprender idiomas y mucho más"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "K4jMHW"
+msgctxt "K4jMHW"
+msgid "Online language courses with AI. Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Cursos de idiomas en línea con IA. Aprende un idioma con consejos de pronunciación, vocabulario, lectura y práctica de escucha."
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "Ht6aMH"
+msgctxt "Ht6aMH"
+msgid "Learn a language online with AI"
 msgstr "Aprende un idioma en línea con IA"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "lSAK6U"
+msgctxt "lSAK6U"
+msgid "What language do you want to learn?"
 msgstr "¿Qué idioma quieres aprender?"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "ptPPVk"
+msgctxt "ptPPVk"
+msgid "No languages found"
 msgstr "No se encontraron idiomas"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "L820yz"
+msgctxt "L820yz"
+msgid "Search languages"
 msgstr "Buscar idiomas"
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "ah2CR6"
+msgctxt "ah2CR6"
+msgid "Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Aprende un idioma con consejos de pronunciación, vocabulario, lectura y práctica de escucha."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "_E8OKF"
+msgctxt "_E8OKF"
+msgid "Turn any subject into a clear course you can follow step by step, with practical examples and no fluff."
 msgstr "Convierte cualquier tema en un curso claro que puedas seguir paso a paso, con ejemplos prácticos y sin vueltas."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "IF6NT-"
+msgctxt "IF6NT-"
+msgid "We'll prepare a study path to help you pass an entrance exam, certification, or school test."
 msgstr "Prepararemos un plan de estudio para ayudarte a aprobar un examen de ingreso, una certificación o una prueba escolar."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "AaFZIp"
+msgctxt "AaFZIp"
+msgid "What's your goal?"
 msgstr "¿Cuál es tu objetivo?"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "pev_fB"
+msgctxt "pev_fB"
+msgid "vs last month"
 msgstr "vs. el mes pasado"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "R9qHBU"
+msgctxt "R9qHBU"
+msgid "vs last 6 months"
 msgstr "vs. los últimos 6 meses"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "s-lPP3"
+msgctxt "s-lPP3"
+msgid "All time"
 msgstr "Todo el tiempo"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "YFV6dH"
+msgctxt "YFV6dH"
+msgid "vs last year"
 msgstr "vs. el año pasado"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "hCCWuZ"
+msgctxt "hCCWuZ"
+msgid "Previous period"
 msgstr "Periodo anterior"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "I2z5s_"
+msgctxt "I2z5s_"
+msgid "Next period"
 msgstr "Periodo siguiente"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "PIaUh-"
+msgctxt "PIaUh-"
+msgid "Period selection"
 msgstr "Selección de periodo"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "TBovrx"
+msgctxt "TBovrx"
+msgid "Month"
 msgstr "Mes"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "NPrFLC"
+msgctxt "NPrFLC"
+msgid "6 Months"
 msgstr "6 meses"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "IFo1oo"
+msgctxt "IFo1oo"
+msgid "Year"
 msgstr "Año"
 
 #: src/app/(progress)/_components/progress-chart-layout.tsx
-msgid "OlW5Z8"
+msgctxt "OlW5Z8"
+msgid "No data available for this period"
 msgstr "No hay datos disponibles para este periodo"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "FVh2Tr"
+msgctxt "FVh2Tr"
+msgid "Start learning to track your progress"
 msgstr "Empieza a estudiar para seguir tu progreso"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "Y1zzQt"
+msgctxt "Y1zzQt"
+msgid "Log in to track your progress"
 msgstr "Inicia sesión para seguir tu progreso"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "J3fNDZ"
+msgctxt "J3fNDZ"
+msgid "This month"
 msgstr "Este mes"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "eWUXBX"
+msgctxt "eWUXBX"
+msgid "Past 6 months"
 msgstr "Últimos 6 meses"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "lPShsT"
+msgctxt "lPShsT"
+msgid "This year"
 msgstr "Este año"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
-msgid "M-JIpD"
+msgctxt "M-JIpD"
+msgid "Energy chart"
 msgstr "Gráfico de Energía"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "rGSqvt"
+msgctxt "rGSqvt"
+msgid "Avg"
 msgstr "Promedio"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "TLPAMC"
+msgctxt "TLPAMC"
+msgid "What is Energy?"
 msgstr "¿Qué es la Energía?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "OvOWOR"
+msgctxt "OvOWOR"
+msgid "Energy is a 0% to 100% score for your recent learning consistency and accuracy."
 msgstr "La Energía es una puntuación del 0 % al 100 % que mide tu constancia y acierto recientes en el estudio."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "K3jN6p"
+msgctxt "K3jN6p"
+msgid "How do I improve Energy?"
 msgstr "¿Cómo mejoro mi Energía?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "pssms6"
+msgctxt "pssms6"
+msgid "Answer questions correctly and keep learning regularly. Correct answers raise Energy; wrong answers and days away from studying lower it."
 msgstr "Responde bien las preguntas y estudia con regularidad. Las respuestas correctas suben la Energía; las incorrectas y los días sin estudiar la bajan."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "-8Qx8X"
+msgctxt "-8Qx8X"
+msgid "Why is Energy important?"
 msgstr "¿Por qué es importante la Energía?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "UfEfhq"
+msgctxt "UfEfhq"
+msgid "Energy is like heart rate in a health app: it shows your current learning rhythm. Missing a day doesn't reset your progress; you recover as soon as you start learning again."
 msgstr "La Energía es como el ritmo cardíaco en una app de salud: muestra tu ritmo de estudio actual. Perder un día no reinicia tu progreso; te recuperas en cuanto vuelves a estudiar."
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "XxS-he"
+msgctxt "XxS-he"
+msgid "Highest energy day"
 msgstr "Día con más Energía"
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "aaiQkv"
+msgctxt "aaiQkv"
+msgid "Full energy"
 msgstr "Energía completa"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "zLCmVM"
+msgctxt "zLCmVM"
+msgid "Current Energy"
 msgstr "Energía actual"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "e9DcQa"
+msgctxt "e9DcQa"
+msgid "{percentage} average"
 msgstr "{percentage} de promedio"
 
 #: src/app/(progress)/energy/page.tsx
-msgid "AZMpf3"
+msgctxt "AZMpf3"
+msgid "Energy is a 0% to 100% score based on recent activity and accuracy."
 msgstr "La Energía es una puntuación del 0 % al 100 % basada en tu actividad y acierto recientes."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "rsIaGW"
+msgctxt "rsIaGW"
+msgid "A 0% to 100% score for recent activity and accuracy"
 msgstr "Una puntuación del 0 % al 100 % por actividad y acierto recientes"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "GA8RuL"
+msgctxt "GA8RuL"
+msgid "Brain Power chart"
 msgstr "Gráfico de Poder Mental"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "XdkaHc"
+msgctxt "XdkaHc"
+msgid "{value} BP"
 msgstr "{value} PM"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "tDbspx"
+msgctxt "tDbspx"
+msgid "Total Brain Power earned: {total}"
 msgstr "Poder Mental total ganado: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "EMy5Vs"
+msgctxt "EMy5Vs"
+msgid "What is Brain Power?"
 msgstr "¿Qué es Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "MIjvOA"
+msgctxt "MIjvOA"
+msgid "Brain Power (BP) is the total learning credit you have earned. Each completed lesson adds {brainPower} BP."
 msgstr "Poder Mental (PM) es el crédito total de estudio que has ganado. Cada lección completada suma {brainPower} PM."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "jzKXJS"
+msgctxt "jzKXJS"
+msgid "How do I increase Brain Power?"
 msgstr "¿Cómo aumento Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "Gzq1tT"
+msgctxt "Gzq1tT"
+msgid "Complete lessons. Brain Power never goes down, even when your Energy drops or you take a break."
 msgstr "Completa lecciones. Poder Mental nunca baja, incluso cuando tu Energía baja o te tomas un descanso."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "JGLOtn"
+msgctxt "JGLOtn"
+msgid "Why is Brain Power important?"
 msgstr "¿Por qué es importante Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "tC6vNz"
+msgctxt "tC6vNz"
+msgid "It is like steps in a health app: a record of how much you have learned. It also works like martial arts for your mind: build Brain Power to advance from white belt to black belt."
 msgstr "Es como los pasos en una app de salud: un registro de cuánto has aprendido. También funciona como artes marciales para tu mente: aumenta Poder Mental para avanzar de cinturón blanco a cinturón negro."
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "elq-tg"
+msgctxt "elq-tg"
+msgid "Highest BP"
 msgstr "Mayor PM"
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "BW4bMl"
+msgctxt "BW4bMl"
+msgid "{date} with {value} BP"
 msgstr "{date} con {value} PM"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "WfaE4H"
+msgctxt "WfaE4H"
+msgid "{belt}, Level {level} of 10. Maximum level achieved."
 msgstr "{belt}, nivel {level} de 10. Nivel máximo alcanzado."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "2Y-P4e"
+msgctxt "2Y-P4e"
+msgid "{belt}, Level {level} of 10. {bp} Brain Power until next level."
 msgstr "{belt}, nivel {level} de 10. Faltan {bp} de Poder Mental para el siguiente nivel."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "n_mgOm"
+msgctxt "n_mgOm"
+msgid "Belt Progression"
 msgstr "Progreso de cinturón"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "ZKbTsS"
+msgctxt "ZKbTsS"
+msgid "{current}/10"
 msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "-Sn2yd"
+msgctxt "-Sn2yd"
+msgid "{belt}: Level {current} of 10"
 msgstr "{belt}: nivel {current} de 10"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "v5yNm3"
+msgctxt "v5yNm3"
+msgid "Total Brain Power"
 msgstr "Poder Mental total"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "_Q0taG"
+msgctxt "_Q0taG"
+msgid "BP"
 msgstr "PM"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "u_oEJA"
+msgctxt "u_oEJA"
+msgid "{value} BP earned"
 msgstr "{value} PM ganados"
 
 #: src/app/(progress)/level/page.tsx
-msgid "4-USpX"
+msgctxt "4-USpX"
+msgid "Track your level progress and see how you advance."
 msgstr "Sigue tu progreso de nivel y mira cómo avanzas."
 
 #: src/app/(progress)/level/page.tsx
-msgid "L9hqMH"
+msgctxt "L9hqMH"
+msgid "Track your level progress"
 msgstr "Sigue tu progreso de nivel"
 
 #: src/app/(progress)/score/page.tsx
-msgid "qHWZBu"
+msgctxt "qHWZBu"
+msgid "Track your score over time and see your best days and times."
 msgstr "Sigue tu puntuación con el tiempo y mira tus mejores días y horas."
 
 #: src/app/(progress)/score/page.tsx
-msgid "GWkswX"
+msgctxt "GWkswX"
+msgid "Track your score and progress trends"
 msgstr "Sigue tu puntuación y tendencias de progreso"
 
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "J-05ol"
+msgctxt "J-05ol"
+msgid "Score chart"
 msgstr "Gráfico de puntuación"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "bIZaXJ"
+msgctxt "bIZaXJ"
+msgid "What is Score?"
 msgstr "¿Qué es la puntuación?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "JA-N5Z"
+msgctxt "JA-N5Z"
+msgid "Score is the percentage of questions you answered correctly during this period."
 msgstr "La puntuación es el porcentaje de preguntas que respondiste correctamente durante este período."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "z9kvhA"
+msgctxt "z9kvhA"
+msgid "How do I improve Score?"
 msgstr "¿Cómo mejoro mi puntuación?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "7_C9do"
+msgctxt "7_C9do"
+msgid "Review mistakes and retry lessons. As you answer more questions correctly, your Score goes up."
 msgstr "Repasa tus errores y vuelve a intentar las lecciones. A medida que respondas más preguntas correctamente, tu puntuación subirá."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "WqH8eP"
+msgctxt "WqH8eP"
+msgid "Why is Score important?"
 msgstr "¿Por qué es importante la puntuación?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "E0saoA"
+msgctxt "E0saoA"
+msgid "Score shows accuracy, not activity. Best day and best time help you find when you learn most effectively."
 msgstr "La puntuación muestra acierto, no actividad. Tu mejor día y tu mejor hora te ayudan a descubrir cuándo aprendes mejor."
 
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "yOFm9C"
+msgctxt "yOFm9C"
+msgid "You need to be logged in to access this page."
 msgstr "Debes iniciar sesión para acceder a esta página."
 
 #: src/app/(settings)/language/page.tsx
-msgid "2WHx14"
+msgctxt "2WHx14"
+msgid "Update your app language to learn in English, Portuguese, Spanish, French, or other supported languages."
 msgstr "Actualiza el idioma de la app para estudiar en inglés, portugués, español, francés u otros idiomas compatibles."
 
 #: src/app/(settings)/language/page.tsx
-msgid "aNLa1G"
+msgctxt "aNLa1G"
+msgid "Choose the app language you prefer for this device."
 msgstr "Elige el idioma de la app que prefieres para este dispositivo."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "dSVD13"
+msgctxt "dSVD13"
+msgid "Update your name and username on Zoonk."
 msgstr "Actualiza tu nombre y nombre de usuario en Zoonk."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "wjIStY"
+msgctxt "wjIStY"
+msgid "Your name and username as they appear to others."
 msgstr "Tu nombre y nombre de usuario tal como los ven los demás."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Comprobando…"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} está disponible"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} ya está en uso"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "De 3 a 30 caracteres. Solo letras, números y guiones bajos."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Nombre"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "yNHZ-a"
+msgctxt "yNHZ-a"
+msgid "Your profile has been updated successfully!"
 msgstr "¡Tu perfil se actualizó correctamente!"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "VT-G_7"
+msgctxt "VT-G_7"
+msgid "This name will be visible to other users."
 msgstr "Este nombre será visible para otros usuarios."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "wYCHCR"
+msgctxt "wYCHCR"
+msgid "Failed to update your profile. Please try again or contact hello@zoonk.com"
 msgstr "No se pudo actualizar tu perfil. Inténtalo de nuevo o escribe a contacto@zoonk.com"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Nombre de usuario"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "X0ha1a"
+msgctxt "X0ha1a"
+msgid "Save changes"
 msgstr "Guardar cambios"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "3iCRcP"
+msgctxt "3iCRcP"
+msgid "Manage in App Store"
 msgstr "Gestionar en App Store"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "tiFovn"
+msgctxt "tiFovn"
+msgid "Manage in Google Play"
 msgstr "Gestionar en Google Play"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "Tp4wJB"
+msgctxt "Tp4wJB"
+msgid "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
 msgstr "Esta suscripción se gestiona desde App Store. Para cambiarla o cancelarla, usa los ajustes de suscripciones de Apple."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "unNUPf"
+msgctxt "unNUPf"
+msgid "This subscription is managed through Google Play. To change or cancel it, use Google Play."
 msgstr "Esta suscripción se gestiona desde Google Play. Para cambiarla o cancelarla, usa Google Play."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "P0ZHma"
+msgctxt "P0ZHma"
+msgid "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
 msgstr "Esta suscripción la gestiona Zoonk. Contacta con soporte si necesitas ayuda para cambiarla o cancelarla."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "5CI3KH"
+msgctxt "5CI3KH"
+msgid "Contact support"
 msgstr "Contactar con soporte"
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "TKk9oj"
+msgctxt "TKk9oj"
+msgid "Compare plans and manage your Zoonk subscription. See pricing, switch plans, or update billing."
 msgstr "Compara planes y gestiona tu suscripción a Zoonk. Consulta precios, cambia de plan o actualiza la facturación."
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "NBEnVd"
+msgctxt "NBEnVd"
+msgid "Compare plans and manage your subscription."
 msgstr "Compara planes y gestiona tu suscripción."
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "PJfdJl"
+msgctxt "PJfdJl"
+msgid "Save up to {amount}"
 msgstr "Ahorra hasta {amount}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "KAb0Yr"
+msgctxt "KAb0Yr"
+msgid "Switch to {plan}"
 msgstr "Cambiar a {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0Azlrb"
+msgctxt "0Azlrb"
+msgid "Manage"
 msgstr "Gestionar"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "_gko4g"
+msgctxt "_gko4g"
+msgid "Upgrade to {plan}"
 msgstr "Mejorar a {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "wYsv4Z"
+msgctxt "wYsv4Z"
+msgid "Monthly"
 msgstr "Mensual"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "dqD39h"
+msgctxt "dqD39h"
+msgid "Yearly"
 msgstr "Anual"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "s1ZXI0"
+msgctxt "s1ZXI0"
+msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "No se pudo actualizar tu suscripción. Escríbenos a contacto@zoonk.com"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "2EsPdm"
+msgctxt "2EsPdm"
+msgid "/yr"
 msgstr "/año"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0jIMEb"
+msgctxt "0jIMEb"
+msgid "/mo"
 msgstr "/mes"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "tf1lIh"
+msgctxt "tf1lIh"
+msgid "Free"
 msgstr "Gratis"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "ZBALng"
+msgctxt "ZBALng"
+msgid "Current plan"
 msgstr "Plan actual"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "fF376U"
+msgctxt "fF376U"
+msgid "Current"
 msgstr "Actual"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "kkjl2v"
+msgctxt "kkjl2v"
+msgid "Max"
 msgstr "Max"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "lOdoIb"
+msgctxt "lOdoIb"
+msgid "Plus"
 msgstr "Plus"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "R_eOkj"
+msgctxt "R_eOkj"
+msgid "Pro"
 msgstr "Pro"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "9o8O4m"
+msgctxt "9o8O4m"
+msgid "Your subscription will end on {date}."
 msgstr "Tu suscripción terminará el {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "vaN1qz"
+msgctxt "vaN1qz"
+msgid "Current billing period ends on {date}."
 msgstr "El periodo de facturación actual termina el {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "EV_gJ6"
+msgctxt "EV_gJ6"
+msgid "First chapter included"
 msgstr "Primer capítulo incluido"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "mqHNd6"
+msgctxt "mqHNd6"
+msgid "Personalized lessons, smartest AI"
 msgstr "Lecciones personalizadas, IA más inteligente"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "SC0MFR"
+msgctxt "SC0MFR"
+msgid "Unlimited lessons"
 msgstr "Lecciones ilimitadas"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "eaOADK"
+msgctxt "eaOADK"
+msgid "Personalized lessons, fast AI"
 msgstr "Lecciones personalizadas, IA rápida"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "B5MLC7"
+msgctxt "B5MLC7"
+msgid "Share feedback, ask questions, or get help with your account and courses."
 msgstr "Comparte tu opinión, haz preguntas o recibe ayuda con tu cuenta y tus cursos."
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "cDAb4a"
+msgctxt "cDAb4a"
+msgid "GitHub Discussions"
 msgstr "GitHub Discussions"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "7h49qt"
+msgctxt "7h49qt"
+msgid "Connect with the community and get answers"
 msgstr "Conecta con la comunidad y recibe respuestas"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "YdQxfw"
+msgctxt "YdQxfw"
+msgid "Contact Support"
 msgstr "Contactar con soporte"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "dQIo6c"
+msgctxt "dQIo6c"
+msgid "Email us at hello@zoonk.com"
 msgstr "Escríbenos a contacto@zoonk.com"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "l1XTI5"
+msgctxt "l1XTI5"
+msgid "Follow us"
 msgstr "Síguenos"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "rCpmYD"
+msgctxt "rCpmYD"
+msgid "Create this lesson"
 msgstr "Crear esta lección"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "AtnLyn"
+msgctxt "AtnLyn"
+msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "Esta lección forma parte del curso, pero aún no se ha creado. Créala para empezar a estudiar."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "ZzznjM"
+msgctxt "ZzznjM"
+msgid "Create lesson"
 msgstr "Crear lección"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
-msgid "_N8rYN"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
 msgstr "Volver al capítulo"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "ZnMcrz"
+msgctxt "ZnMcrz"
+msgid "Unlock the rest of this course"
 msgstr "Desbloquea el resto de este curso"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "A_uNk-"
+msgctxt "A_uNk-"
+msgid "Create lessons before reviewing"
 msgstr "Crea lecciones antes de revisar"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "Qy4EsI"
+msgctxt "Qy4EsI"
+msgid "Nothing to review yet"
 msgstr "Aún no hay nada para repasar"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "4w9Y_P"
+msgctxt "4w9Y_P"
+msgid "Review unlocks after the earlier lessons in this chapter have been created."
 msgstr "El repaso se desbloquea cuando se hayan creado las lecciones anteriores de este capítulo."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "9AOq2-"
+msgctxt "9AOq2-"
+msgid "There are no practice questions to review yet."
 msgstr "Aún no hay preguntas de práctica para repasar."
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "txNTbP"
+msgctxt "txNTbP"
+msgid "Creating the {title} chapter"
 msgstr "Creando el capítulo {title}"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "kiZUDf"
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
 msgstr "Suele tardar cerca de un minuto"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "5c2xtK"
+msgctxt "5c2xtK"
+msgid "Taking you to your chapter..."
 msgstr "Te llevamos a tu capítulo…"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "45uo73"
+msgctxt "45uo73"
+msgid "Your lessons are ready"
 msgstr "Tus lecciones están listas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "gnxL73"
+msgctxt "gnxL73"
+msgid "Choosing lesson types"
 msgstr "Eligiendo tipos de lección"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "EKtClK"
+msgctxt "EKtClK"
+msgid "Getting started"
 msgstr "Empezando"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "SF9AtA"
+msgctxt "SF9AtA"
+msgid "Preparing lessons"
 msgstr "Preparando lecciones"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "L7nQzn"
+msgctxt "L7nQzn"
+msgid "Saving your lessons"
 msgstr "Guardando tus lecciones"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Sbsm52"
+msgctxt "Sbsm52"
+msgid "Checking how each lesson should be taught..."
 msgstr "Revisando cómo enseñar cada lección…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "0xCLwv"
+msgctxt "0xCLwv"
+msgid "Choosing type for lesson {number}..."
 msgstr "Eligiendo el tipo de la lección {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Vbn5Wz"
+msgctxt "Vbn5Wz"
+msgid "Reviewing the lesson mix..."
 msgstr "Revisando la combinación de lecciones…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5342HA"
+msgctxt "5342HA"
+msgid "Getting started..."
 msgstr "Empezando…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "nwGJ65"
+msgctxt "nwGJ65"
+msgid "Exploring your topic..."
 msgstr "Explorando tu tema…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "VKFa_t"
+msgctxt "VKFa_t"
+msgid "Mapping out the learning path..."
 msgstr "Trazando la ruta de estudio…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "zQWv1_"
+msgctxt "zQWv1_"
+msgid "Writing lesson {number}..."
 msgstr "Escribiendo la lección {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "HWSnYS"
+msgctxt "HWSnYS"
+msgid "Reviewing the flow so far..."
 msgstr "Revisando cómo va todo…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "txvxwS"
+msgctxt "txvxwS"
+msgid "Saving your progress..."
 msgstr "Guardando tu progreso…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JUr8Er"
+msgctxt "JUr8Er"
+msgid "Finishing up..."
 msgstr "Terminando…"
 
 #: src/app/generate/course/[id]/generate-course-prompt-content.tsx
-msgid "rPgekg"
+msgctxt "rPgekg"
+msgid "Back home"
 msgstr "Volver al inicio"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "15FsdE"
+msgctxt "15FsdE"
+msgid "Your course is ready"
 msgstr "Tu curso está listo"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "4Wktrz"
+msgctxt "4Wktrz"
+msgid "Your lesson is ready"
 msgstr "Tu lección está lista"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "0o41MR"
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
 msgstr "Te llevamos a tu curso…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "T2TGxR"
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
 msgstr "Te llevamos a tu lección…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "u6ROZF"
+msgctxt "u6ROZF"
+msgid "Creating the {title} course"
 msgstr "Creando el curso {title}"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "GJKrUK"
+msgctxt "GJKrUK"
+msgid "This usually takes about 2 minutes"
 msgstr "Suele tardar unos 2 minutos"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "i3JgLB"
+msgctxt "i3JgLB"
+msgid "Categorizing your course"
 msgstr "Categorizando tu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WOe-OA"
+msgctxt "WOe-OA"
+msgid "Checking for duplicates"
 msgstr "Buscando duplicados"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gjutu-"
+msgctxt "Gjutu-"
+msgid "Creating the cover image"
 msgstr "Creando la imagen de portada"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "SQFyKH"
+msgctxt "SQFyKH"
+msgid "Finding similar courses"
 msgstr "Buscando cursos similares"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WZpB8D"
+msgctxt "WZpB8D"
+msgid "Writing chapters"
 msgstr "Escribiendo capítulos"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "vEOpTk"
+msgctxt "vEOpTk"
+msgid "Planning the introduction"
 msgstr "Planificando la introducción"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "d2xrsv"
+msgctxt "d2xrsv"
+msgid "Preparing your course"
 msgstr "Preparando tu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "CFWOGF"
+msgctxt "CFWOGF"
+msgid "Saving your course"
 msgstr "Guardando tu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XPla-v"
+msgctxt "XPla-v"
+msgid "Preparing the introduction"
 msgstr "Preparando la introducción"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "HbhIvm"
+msgctxt "HbhIvm"
+msgid "Writing your course description"
 msgstr "Escribiendo la descripción de tu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Y4F0xn"
+msgctxt "Y4F0xn"
+msgid "Writing the first lesson"
 msgstr "Escribiendo la primera lección"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "e1myvm"
+msgctxt "e1myvm"
+msgid "Writing your course page"
 msgstr "Escribiendo la página de tu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "aev_pt"
+msgctxt "aev_pt"
+msgid "Figuring out the right categories..."
 msgstr "Buscando las categorías adecuadas…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "EKAN6s"
+msgctxt "EKAN6s"
+msgid "Tagging your course..."
 msgstr "Etiquetando tu curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "JJrUOR"
+msgctxt "JJrUOR"
+msgid "Comparing nearby courses..."
 msgstr "Comparando cursos parecidos…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "uw23V-"
+msgctxt "uw23V-"
+msgid "Checking whether this course already exists..."
 msgstr "Comprobando si este curso ya existe…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "qFmZfG"
+msgctxt "qFmZfG"
+msgid "Avoiding duplicate courses..."
 msgstr "Evitando cursos duplicados…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "lxBtcx"
+msgctxt "lxBtcx"
+msgid "Designing the cover..."
 msgstr "Diseñando la portada…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "W8n2i3"
+msgctxt "W8n2i3"
+msgid "Picking the right look..."
 msgstr "Eligiendo el aspecto adecuado…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "At4rk1"
+msgctxt "At4rk1"
+msgid "Adding finishing touches..."
 msgstr "Dando los últimos retoques…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "NgONb4"
+msgctxt "NgONb4"
+msgid "Searching for matching topics..."
 msgstr "Buscando temas relacionados…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Auz1tl"
+msgctxt "Auz1tl"
+msgid "Looking for alternate names..."
 msgstr "Buscando nombres alternativos…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gt_VNO"
+msgctxt "Gt_VNO"
+msgid "Expanding the course search..."
 msgstr "Ampliando la búsqueda del curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "AEG3Ol"
+msgctxt "AEG3Ol"
+msgid "Planning the course structure..."
 msgstr "Planeando la estructura del curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "OW9vMd"
+msgctxt "OW9vMd"
+msgid "Writing chapter {number}..."
 msgstr "Escribiendo el capítulo {number}…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "tXkuD8"
+msgctxt "tXkuD8"
+msgid "Reviewing the overall flow..."
 msgstr "Revisando cómo fluye todo…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "8-bhNP"
+msgctxt "8-bhNP"
+msgid "Finding the best first hook..."
 msgstr "Buscando la mejor forma de empezar…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "xrFhkn"
+msgctxt "xrFhkn"
+msgid "Writing a friendly guide to the field..."
 msgstr "Escribiendo una guía clara sobre el tema…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "c_e4hk"
+msgctxt "c_e4hk"
+msgid "Keeping the first chapter easy to start..."
 msgstr "Haciendo que el primer capítulo sea fácil de empezar…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "4LsE_n"
+msgctxt "4LsE_n"
+msgid "Creating the course shell..."
 msgstr "Creando la base del curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "3hEaI4"
+msgctxt "3hEaI4"
+msgid "Preparing the workspace..."
 msgstr "Preparando el espacio de trabajo…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "7Pw3r5"
+msgctxt "7Pw3r5"
+msgid "Saving the intro chapter..."
 msgstr "Guardando el capítulo de introducción…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "cc6_Yn"
+msgctxt "cc6_Yn"
+msgid "Preparing the first lessons..."
 msgstr "Preparando las primeras lecciones…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "a7FJJd"
+msgctxt "a7FJJd"
+msgid "Summarizing what you'll learn..."
 msgstr "Resumiendo lo que vas a aprender…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "9r_4zz"
+msgctxt "9r_4zz"
+msgid "Writing the overview..."
 msgstr "Escribiendo el resumen…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "QqKzYM"
+msgctxt "QqKzYM"
+msgid "Writing the first lesson..."
 msgstr "Escribiendo la primera lección…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XxRMuO"
+msgctxt "XxRMuO"
+msgid "Adding examples and visuals..."
 msgstr "Agregando ejemplos e imágenes…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "kmuvIN"
+msgctxt "kmuvIN"
+msgid "Getting the first lesson ready..."
 msgstr "Dejando lista la primera lección…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "chqN-J"
+msgctxt "chqN-J"
+msgid "Framing why this course is useful..."
 msgstr "Explicando por qué este curso es útil…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "twf4n2"
+msgctxt "twf4n2"
+msgid "Writing the course page..."
 msgstr "Escribiendo la página del curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "k15wFf"
+msgctxt "k15wFf"
+msgid "Shaping the starting point..."
 msgstr "Definiendo el punto de partida…"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "WihX6L"
+msgctxt "WihX6L"
+msgid "Creating the {title} lesson"
 msgstr "Creando la lección {title}"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "3vY0Zu"
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
 msgstr "Esto suele tardar 1-2 minutos"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "cVoRCh"
+msgctxt "cVoRCh"
+msgid "Preparing options..."
 msgstr "Preparando opciones…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BBwnPG"
+msgctxt "BBwnPG"
+msgid "Adding more options..."
 msgstr "Agregando más opciones…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "4wkMNX"
+msgctxt "4wkMNX"
+msgid "Getting answer options ready..."
 msgstr "Preparando las opciones de respuesta…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "WsjFV2"
+msgctxt "WsjFV2"
+msgid "Preparing the word bank..."
 msgstr "Preparando el banco de palabras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6xEJTk"
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
 msgstr "Diseñando ejercicios de práctica…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6hjA6_"
+msgctxt "6hjA6_"
+msgid "Creating examples to try..."
 msgstr "Creando ejemplos para probar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "KddvJw"
+msgctxt "KddvJw"
+msgid "Writing fill-in-the-blanks..."
 msgstr "Escribiendo ejercicios para completar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "C05-tM"
+msgctxt "C05-tM"
+msgid "Building interactive tasks..."
 msgstr "Creando actividades interactivas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JGNN92"
+msgctxt "JGNN92"
+msgid "Drawing an illustration..."
 msgstr "Dibujando una ilustración…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "a08k7g"
+msgctxt "a08k7g"
+msgid "Generating the images..."
 msgstr "Generando las imágenes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bJVUNz"
+msgctxt "bJVUNz"
+msgid "Adding some color..."
 msgstr "Agregando algo de color…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "Yoev2R"
+msgctxt "Yoev2R"
+msgid "Refining the details..."
 msgstr "Afinando los detalles…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "xBaVAH"
+msgctxt "xBaVAH"
+msgid "Finishing the artwork..."
 msgstr "Terminando la ilustración…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "W2b0tx"
+msgctxt "W2b0tx"
+msgid "Designing the lesson thumbnail..."
 msgstr "Diseñando la miniatura de la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "fRAHqN"
+msgctxt "fRAHqN"
+msgid "Creating the lesson thumbnail..."
 msgstr "Creando la miniatura de la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "elwtxf"
+msgctxt "elwtxf"
+msgid "Refining the lesson thumbnail..."
 msgstr "Afinando la miniatura de la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "uDzgwu"
+msgctxt "uDzgwu"
+msgid "Writing example sentences..."
 msgstr "Escribiendo frases de ejemplo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "SHIHyL"
+msgctxt "SHIHyL"
+msgid "Creating reading passages..."
 msgstr "Creando textos de lectura…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0Zum4g"
+msgctxt "0Zum4g"
+msgid "Putting words in context..."
 msgstr "Poniendo las palabras en contexto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "jixTNM"
+msgctxt "jixTNM"
+msgid "Building natural sentences..."
 msgstr "Creando frases naturales…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "txIcop"
+msgctxt "txIcop"
+msgid "Loading lesson data..."
 msgstr "Cargando los datos de la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "l486Kx"
+msgctxt "l486Kx"
+msgid "Checking what we need..."
 msgstr "Revisando qué necesitamos…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "EAqAX_"
+msgctxt "EAqAX_"
+msgid "Thinking about what to illustrate..."
 msgstr "Pensando en qué ilustrar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "2Tovpk"
+msgctxt "2Tovpk"
+msgid "Planning each image..."
 msgstr "Planeando cada imagen…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "sQsQbH"
+msgctxt "sQsQbH"
+msgid "Choosing the right scenes..."
 msgstr "Eligiendo las escenas adecuadas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "iUUJom"
+msgctxt "iUUJom"
+msgid "Planning the illustrations..."
 msgstr "Planeando las ilustraciones…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BszFlm"
+msgctxt "BszFlm"
+msgid "Saving your lesson..."
 msgstr "Guardando tu lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bC9979"
+msgctxt "bC9979"
+msgid "Almost done..."
 msgstr "Ya casi está…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5Jyenk"
+msgctxt "5Jyenk"
+msgid "Getting ready for the next step..."
 msgstr "Preparando el siguiente paso…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "r8xznK"
+msgctxt "r8xznK"
+msgid "Researching the topic..."
 msgstr "Investigando el tema…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "K_JznZ"
+msgctxt "K_JznZ"
+msgid "Writing the explanation..."
 msgstr "Escribiendo la explicación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "19fPwV"
+msgctxt "19fPwV"
+msgid "Making it clear..."
 msgstr "Dejándolo claro…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "65JXIy"
+msgctxt "65JXIy"
+msgid "Putting together the lesson..."
 msgstr "Armando la lección…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "nwi1Ym"
+msgctxt "nwi1Ym"
+msgid "Crafting the content..."
 msgstr "Creando el contenido…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "-QrqeN"
+msgctxt "-QrqeN"
+msgid "Writing the explanation first..."
 msgstr "Escribiendo primero la explicación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "epxxAx"
+msgctxt "epxxAx"
+msgid "Building the foundation..."
 msgstr "Creando la base…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "GyThaR"
+msgctxt "GyThaR"
+msgid "Preparing background context..."
 msgstr "Preparando el contexto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0AWsLH"
+msgctxt "0AWsLH"
+msgid "Explaining the topic..."
 msgstr "Explicando el tema…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "KL34l5"
+msgctxt "KL34l5"
+msgid "Adding romanization for grammar..."
 msgstr "Añadiendo romanización a la gramática…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "GILb0l"
+msgctxt "GILb0l"
+msgid "Converting grammar text to Latin script..."
 msgstr "Convirtiendo el texto de gramática al alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OFH7dE"
+msgctxt "OFH7dE"
+msgid "Making grammar content easier to read..."
 msgstr "Haciendo que la gramática sea más fácil de leer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VADOBa"
+msgctxt "VADOBa"
+msgid "Looking up how each word sounds..."
 msgstr "Buscando cómo suena cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "WnqJeL"
+msgctxt "WnqJeL"
+msgid "Mapping out the pronunciation..."
 msgstr "Organizando la pronunciación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "HDNFHk"
+msgctxt "HDNFHk"
+msgid "Checking how to say each word..."
 msgstr "Revisando cómo se dice cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "_Fl7bm"
+msgctxt "_Fl7bm"
+msgid "Finding the right sounds..."
 msgstr "Buscando los sonidos correctos…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "DLZ9fl"
+msgctxt "DLZ9fl"
+msgid "Converting to Latin script..."
 msgstr "Convirtiendo al alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "boocfl"
+msgctxt "boocfl"
+msgid "Adding reading aids..."
 msgstr "Añadiendo ayudas para leer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "AQMVYX"
+msgctxt "AQMVYX"
+msgid "Making it easier to read..."
 msgstr "Haciendo que sea más fácil de leer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ud2yWh"
+msgctxt "ud2yWh"
+msgid "Writing out the sounds..."
 msgstr "Escribiendo cómo suena…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "kxBeWt"
+msgctxt "kxBeWt"
+msgid "Adding romanization for vocabulary..."
 msgstr "Añadiendo romanización al vocabulario…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "Ch9BcP"
+msgctxt "Ch9BcP"
+msgid "Converting vocabulary to Latin script..."
 msgstr "Convirtiendo el vocabulario al alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1aPaHZ"
+msgctxt "1aPaHZ"
+msgid "Making vocabulary easier to read..."
 msgstr "Haciendo que el vocabulario sea más fácil de leer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "zYx0UG"
+msgctxt "zYx0UG"
+msgid "Adding pronunciation for each word..."
 msgstr "Añadiendo la pronunciación de cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VQ3-C2"
+msgctxt "VQ3-C2"
+msgid "Noting how each word sounds..."
 msgstr "Anotando cómo suena cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YWB-K_"
+msgctxt "YWB-K_"
+msgid "Detailing the word sounds..."
 msgstr "Detallando los sonidos de las palabras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "L6f1Zq"
+msgctxt "L6f1Zq"
+msgid "Recording pronunciation info..."
 msgstr "Guardando la información de pronunciación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "i-rNdh"
+msgctxt "i-rNdh"
+msgid "Picking the key vocabulary..."
 msgstr "Eligiendo el vocabulario clave…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "IdWf9_"
+msgctxt "IdWf9_"
+msgid "Choosing words to practice..."
 msgstr "Eligiendo palabras para practicar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "UFDKHM"
+msgctxt "UFDKHM"
+msgid "Finding the most useful words..."
 msgstr "Buscando las palabras más útiles…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YgG70c"
+msgctxt "YgG70c"
+msgid "Selecting important terms..."
 msgstr "Seleccionando términos importantes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "6BQo6o"
+msgctxt "6BQo6o"
+msgid "Translating individual words..."
 msgstr "Traduciendo palabras una por una…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "k0Q_Ph"
+msgctxt "k0Q_Ph"
+msgid "Looking up each term..."
 msgstr "Buscando cada término…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "hZLCkp"
+msgctxt "hZLCkp"
+msgid "Finding word meanings..."
 msgstr "Buscando significados de palabras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "SC0o7J"
+msgctxt "SC0o7J"
+msgid "Building the vocabulary guide..."
 msgstr "Creando la guía de vocabulario…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "5InW8H"
+msgctxt "5InW8H"
+msgid "Recording the audio..."
 msgstr "Grabando el audio…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "4xvh9e"
+msgctxt "4xvh9e"
+msgid "Getting the pronunciation right..."
 msgstr "Afinando la pronunciación…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "oB01Wc"
+msgctxt "oB01Wc"
+msgid "Preparing the voice..."
 msgstr "Preparando la voz…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ScA7Xm"
+msgctxt "ScA7Xm"
+msgid "Making it sound natural..."
 msgstr "Haciendo que suene natural…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1vO-bV"
+msgctxt "1vO-bV"
+msgid "Recording vocabulary audio..."
 msgstr "Grabando el audio del vocabulario…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "jV2zI1"
+msgctxt "jV2zI1"
+msgid "Getting the sound for each word..."
 msgstr "Preparando el sonido de cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "FahI7K"
+msgctxt "FahI7K"
+msgid "Preparing vocabulary audio..."
 msgstr "Preparando el audio del vocabulario…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "JfNFGM"
+msgctxt "JfNFGM"
+msgid "Making words listenable..."
 msgstr "Dejando las palabras listas para escuchar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "muXaEm"
+msgctxt "muXaEm"
+msgid "Recording pronunciation for each word..."
 msgstr "Grabando la pronunciación de cada palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "QDv0wS"
+msgctxt "QDv0wS"
+msgid "Getting the audio for each term..."
 msgstr "Preparando el audio de cada término…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OJkDgV"
+msgctxt "OJkDgV"
+msgid "Preparing word-by-word audio..."
 msgstr "Preparando audio palabra por palabra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "C2ELVi"
+msgctxt "C2ELVi"
+msgid "Making each word listenable..."
 msgstr "Dejando cada palabra lista para escuchar…"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "58heST"
+msgctxt "58heST"
+msgid "Adding grammar romanization"
 msgstr "Añadiendo romanización de gramática"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "TlrPFF"
+msgctxt "TlrPFF"
+msgid "Adding pronunciation"
 msgstr "Añadiendo pronunciación"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "V0mPLK"
+msgctxt "V0mPLK"
+msgid "Adding romanization"
 msgstr "Añadiendo romanización"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "HXMA75"
+msgctxt "HXMA75"
+msgid "Adding vocabulary romanization"
 msgstr "Añadiendo romanización del vocabulario"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "4OjRPB"
+msgctxt "4OjRPB"
+msgid "Adding word pronunciation"
 msgstr "Añadiendo pronunciación de palabras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "RXfSEl"
+msgctxt "RXfSEl"
+msgid "Building word list"
 msgstr "Creando la lista de palabras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "viluaR"
+msgctxt "viluaR"
+msgid "Preparing options"
 msgstr "Preparando opciones"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "c7xJGQ"
+msgctxt "c7xJGQ"
+msgid "Creating exercises"
 msgstr "Creando ejercicios"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "aKNA_b"
+msgctxt "aKNA_b"
+msgid "Creating images"
 msgstr "Creando imágenes"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "WI2yui"
+msgctxt "WI2yui"
+msgid "Creating lesson thumbnail"
 msgstr "Creando la miniatura de la lección"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "mIpv67"
+msgctxt "mIpv67"
+msgid "Creating sentences"
 msgstr "Creando frases"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "0zeST_"
+msgctxt "0zeST_"
+msgid "Looking up words"
 msgstr "Buscando palabras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v7HGj3"
+msgctxt "v7HGj3"
+msgid "Planning the images"
 msgstr "Planificando las imágenes"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "T00GEW"
+msgctxt "T00GEW"
+msgid "Recording audio"
 msgstr "Grabando audio"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v2DAdY"
+msgctxt "v2DAdY"
+msgid "Recording vocabulary audio"
 msgstr "Grabando audio del vocabulario"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "j-pO55"
+msgctxt "j-pO55"
+msgid "Recording word audio"
 msgstr "Grabando audio de palabras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "2ZPUqg"
+msgctxt "2ZPUqg"
+msgid "Saving your lesson"
 msgstr "Guardando tu lección"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v4iFHN"
+msgctxt "v4iFHN"
+msgid "Writing the content"
 msgstr "Escribiendo el contenido"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "ZA0_P-"
+msgctxt "ZA0_P-"
+msgid "Writing the explanation"
 msgstr "Escribiendo la explicación"
 
 #: src/app/generate/layout.tsx
-msgid "_tq5fR"
+msgctxt "_tq5fR"
+msgid "Creating content"
 msgstr "Creando contenido"
 
 #: src/app/privacy/page.tsx
-msgid "afKQHy"
+msgctxt "afKQHy"
+msgid "Read Zoonk's privacy policy to understand how we use and protect your personal information."
 msgstr "Lee la política de privacidad de Zoonk para entender cómo usamos y protegemos tu información personal."
 
 #: src/app/privacy/page.tsx
-msgid "vx0nkZ"
+msgctxt "vx0nkZ"
+msgid "Privacy Policy"
 msgstr "Política de privacidad"
 
 #: src/app/terms/page.tsx
-msgid "DaGtoz"
+msgctxt "DaGtoz"
+msgid "Read Zoonk's terms of use to understand the rules and conditions for using our platform and services"
 msgstr "Lee los términos de uso de Zoonk para entender las reglas y condiciones para usar nuestra plataforma y servicios"
 
 #: src/app/terms/page.tsx
-msgid "UhkSyx"
+msgctxt "UhkSyx"
+msgid "Terms of Use"
 msgstr "Términos de uso"
 
 #: src/components/catalog/ai-warning.tsx
-msgid "FYZlTZ"
+msgctxt "FYZlTZ"
+msgid "Created with AI"
 msgstr "Creado con IA"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "F0tnKc"
+msgctxt "F0tnKc"
+msgid "Thanks for your feedback"
 msgstr "Gracias por tus comentarios"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "IzCVhG"
+msgctxt "IzCVhG"
+msgid "More options"
 msgstr "Más opciones"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "rTFrsw"
+msgctxt "rTFrsw"
+msgid "I liked it"
 msgstr "Me gustó"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "Hqn5Uo"
+msgctxt "Hqn5Uo"
+msgid "I didn't like it"
 msgstr "No me gustó"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "G5YSJR"
+msgctxt "G5YSJR"
+msgid "Send feedback"
 msgstr "Enviar comentarios"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "PAKDzS"
+msgctxt "PAKDzS"
+msgid "Go to current chapter"
 msgstr "Ir al capítulo actual"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "Js2dT3"
+msgctxt "Js2dT3"
+msgid "Go to current lesson"
 msgstr "Ir a la lección actual"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "izuy1D"
+msgctxt "izuy1D"
+msgid "Current item"
 msgstr "Elemento actual"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "Gs9Kfp"
+msgctxt "Gs9Kfp"
+msgid "Back to top"
 msgstr "Volver arriba"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "AvySqa"
+msgctxt "AvySqa"
+msgid "{percent}% complete"
 msgstr "{percent}% completado"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "mOFG3K"
+msgctxt "mOFG3K"
+msgid "Start"
 msgstr "Empezar"
 
 #: src/components/catalog/continue-lesson-link.tsx
 #: src/lib/lessons.ts
-msgid "R-J5ox"
+msgctxt "R-J5ox"
+msgid "Review"
 msgstr "Repasar"
 
 #: src/components/feedback/contact-form.tsx
-msgid "WzCvaN"
+msgctxt "WzCvaN"
+msgid "We'll use this email to contact you."
 msgstr "Usaremos este correo para contactarte."
 
 #: src/components/feedback/contact-form.tsx
-msgid "T7Ry38"
+msgctxt "T7Ry38"
+msgid "Message"
 msgstr "Mensaje"
 
 #: src/components/feedback/contact-form.tsx
-msgid "M6PcEI"
+msgctxt "M6PcEI"
+msgid "How can we help you?"
 msgstr "¿Cómo podemos ayudarte?"
 
 #: src/components/feedback/contact-form.tsx
-msgid "vD72E5"
+msgctxt "vD72E5"
+msgid "Message sent successfully! We'll get back to you soon."
 msgstr "¡Mensaje enviado correctamente! Te responderemos pronto."
 
 #: src/components/feedback/contact-form.tsx
-msgid "-5vOOu"
+msgctxt "-5vOOu"
+msgid "Please provide as much detail as possible."
 msgstr "Cuéntanos todos los detalles que puedas."
 
 #: src/components/feedback/contact-form.tsx
-msgid "1WHPmV"
+msgctxt "1WHPmV"
+msgid "Failed to send message. Please try again or email us directly at hello@zoonk.com"
 msgstr "No se pudo enviar el mensaje. Inténtalo de nuevo o escríbenos directamente a contacto@zoonk.com"
 
 #: src/components/feedback/contact-form.tsx
-msgid "Xx0WZV"
+msgctxt "Xx0WZV"
+msgid "Send message"
 msgstr "Enviar mensaje"
 
 #: src/components/feedback/content-feedback.tsx
-msgid "BlI1_9"
+msgctxt "BlI1_9"
+msgid "Did you like this content?"
 msgstr "¿Te gustó este contenido?"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "Ejhdi4"
+msgctxt "Ejhdi4"
+msgid "Feedback"
 msgstr "Comentarios"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "eUzs3M"
+msgctxt "eUzs3M"
+msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envíanos comentarios, preguntas o sugerencias. Completa el formulario de abajo o escríbenos directamente a contacto@zoonk.com."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "ctqXbT"
+msgctxt "ctqXbT"
+msgid "We lost the progress connection. Your content may still be generating."
 msgstr "Se perdió la conexión de progreso. Es posible que tu contenido se siga generando."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "1A8Z_l"
+msgctxt "1A8Z_l"
+msgid "Check again"
 msgstr "Revisar de nuevo"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "yHqv96"
+msgctxt "yHqv96"
+msgid "Connection interrupted"
 msgstr "Conexión interrumpida"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "JqiqNj"
+msgctxt "JqiqNj"
+msgid "Something went wrong"
 msgstr "Algo salió mal"
 
 #: src/components/progress/progress-day-count-label.ts
-msgid "r9koty"
+msgctxt "r9koty"
+msgid "{count, plural, =0 {# days} one {# day} other {# days}}"
 msgstr "{count, plural, =0 {# días} one {# día} other {# días}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "tRA46q"
+msgctxt "tRA46q"
+msgid "0 min"
 msgstr "0 min"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "yMhrnF"
+msgctxt "yMhrnF"
+msgid "{seconds, plural, one {# sec} other {# sec}}"
 msgstr "{seconds, plural, one {# s} other {# s}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "a-oHjQ"
+msgctxt "a-oHjQ"
+msgid "{minutes, plural, one {# min} other {# min}}"
 msgstr "{minutes, plural, one {# min} other {# min}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "QqnZaw"
+msgctxt "QqnZaw"
+msgid "{hours, plural, one {# hr} other {# hr}}"
 msgstr "{hours, plural, one {# h} other {# h}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "Frd5VU"
+msgctxt "Frd5VU"
+msgid "{hours, plural, one {# hr} other {# hr}} {minutes, plural, one {# min} other {# min}}"
 msgstr "{hours, plural, one {# h} other {# h}} {minutes, plural, one {# min} other {# min}}"
 
 #: src/components/progress/total-learning-time-card.tsx
-msgid "-V74AY"
+msgctxt "-V74AY"
+msgid "Learning time"
 msgstr "Tiempo de estudio"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "IS_YjO"
+msgctxt "IS_YjO"
+msgid "Upgrade to create"
 msgstr "Mejora tu plan para crear"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "ZMU6iN"
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
 msgstr "Llegaste al límite de lecciones gratis. Mejora tu plan para tener lecciones ilimitadas"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "0h_lPM"
+msgctxt "0h_lPM"
+msgid "Upgrade"
 msgstr "Mejorar plan"
 
 #: src/lib/belt-colors.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {Cinturón blanco} yellow {Cinturón amarillo} orange {Cinturón naranja} green {Cinturón verde} blue {Cinturón azul} purple {Cinturón morado} brown {Cinturón marrón} red {Cinturón rojo} gray {Cinturón gris} black {Cinturón negro} other {Cinturón}}"
 
 #: src/lib/categories/category.ts
-msgid "fFt3il"
+msgctxt "fFt3il"
+msgid "Arts"
 msgstr "Arte"
 
 #: src/lib/categories/category.ts
-msgid "w1Fanr"
+msgctxt "w1Fanr"
+msgid "Business"
 msgstr "Negocios"
 
 #: src/lib/categories/category.ts
-msgid "n5D_Ku"
+msgctxt "n5D_Ku"
+msgid "Communication"
 msgstr "Comunicación"
 
 #: src/lib/categories/category.ts
-msgid "mn6pIm"
+msgctxt "mn6pIm"
+msgid "Culture"
 msgstr "Cultura"
 
 #: src/lib/categories/category.ts
-msgid "hwL7a0"
+msgctxt "hwL7a0"
+msgid "Engineering"
 msgstr "Ingeniería"
 
 #: src/lib/categories/category.ts
-msgid "YMDBNH"
+msgctxt "YMDBNH"
+msgid "Geography"
 msgstr "Geografía"
 
 #: src/lib/categories/category.ts
-msgid "hlmkcL"
+msgctxt "hlmkcL"
+msgid "Health"
 msgstr "Salud"
 
 #: src/lib/categories/category.ts
-msgid "GsBRWL"
+msgctxt "GsBRWL"
+msgid "Languages"
 msgstr "Idiomas"
 
 #: src/lib/categories/category.ts
-msgid "u3ovjm"
+msgctxt "u3ovjm"
+msgid "Law"
 msgstr "Derecho"
 
 #: src/lib/categories/category.ts
-msgid "dPgwrL"
+msgctxt "dPgwrL"
+msgid "Math"
 msgstr "Matemáticas"
 
 #: src/lib/categories/category.ts
-msgid "qydxOd"
+msgctxt "qydxOd"
+msgid "Science"
 msgstr "Ciencia"
 
 #: src/lib/categories/category.ts
-msgid "OV_2-4"
+msgctxt "OV_2-4"
+msgid "Society"
 msgstr "Sociedad"
 
 #: src/lib/categories/category.ts
-msgid "I1ZCPK"
+msgctxt "I1ZCPK"
+msgid "Technology"
 msgstr "Tecnología"
 
 #: src/lib/categories/category.ts
-msgid "XL8IWT"
+msgctxt "XL8IWT"
+msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
 msgstr "Cursos de {category}. Los mejores cursos en línea de {category}, con lecciones interactivas para aprender."
 
 #: src/lib/categories/category.ts
-msgid "4HKnmB"
+msgctxt "4HKnmB"
+msgid "{category} Courses"
 msgstr "Cursos de {category}"
 
 #: src/lib/categories/category.ts
-msgid "EMi23I"
+msgctxt "EMi23I"
+msgid "Explore all {category} courses"
 msgstr "Explora todos los cursos de {category}"
 
 #: src/lib/categories/category.ts
-msgid "Rz9oL-"
+msgctxt "Rz9oL-"
+msgid "{category} courses"
 msgstr "Cursos de {category}"
 
 #: src/lib/lessons.ts
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alfabeto"
 
 #: src/lib/lessons.ts
-msgid "4TTYDR"
+msgctxt "4TTYDR"
+msgid "Custom lesson"
 msgstr "Lección personalizada"
 
 #: src/lib/lessons.ts
-msgid "E1bF_X"
+msgctxt "E1bF_X"
+msgid "Explanation"
 msgstr "Explicación"
 
 #: src/lib/lessons.ts
-msgid "QzTY8x"
+msgctxt "QzTY8x"
+msgid "Grammar"
 msgstr "Gramática"
 
 #: src/lib/lessons.ts
-msgid "1TOMnj"
+msgctxt "1TOMnj"
+msgid "Listening"
 msgstr "Escucha"
 
 #: src/lib/lessons.ts
-msgid "KV-O0y"
+msgctxt "KV-O0y"
+msgid "Practice"
 msgstr "Práctica"
 
 #: src/lib/lessons.ts
-msgid "OuR_Ij"
+msgctxt "OuR_Ij"
+msgid "Quiz"
 msgstr "Quiz"
 
 #: src/lib/lessons.ts
-msgid "MOK_yK"
+msgctxt "MOK_yK"
+msgid "Reading"
 msgstr "Lectura"
 
 #: src/lib/lessons.ts
-msgid "_vCXIP"
+msgctxt "_vCXIP"
+msgid "Translation"
 msgstr "Traducción"
 
 #: src/lib/lessons.ts
-msgid "Ox-Z-K"
+msgctxt "Ox-Z-K"
+msgid "Tutorial"
 msgstr "Tutorial"
 
 #: src/lib/lessons.ts
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Vocabulario"
 
 #: src/lib/lessons.ts
-msgid "22k1CY"
+msgctxt "22k1CY"
+msgid "Learn how letters and sounds work in this writing system."
 msgstr "Aprende cómo funcionan las letras y los sonidos en este sistema de escritura."
 
 #: src/lib/lessons.ts
-msgid "LZC7R9"
+msgctxt "LZC7R9"
+msgid "Work through a lesson created for your goal."
 msgstr "Avanza en una lección creada para tu objetivo."
 
 #: src/lib/lessons.ts
-msgid "fOfLbt"
+msgctxt "fOfLbt"
+msgid "Understand the key ideas using everyday language and practical examples."
 msgstr "Entiende las ideas clave con palabras sencillas y ejemplos prácticos."
 
 #: src/lib/lessons.ts
-msgid "dHmgw1"
+msgctxt "dHmgw1"
+msgid "Practice grammar patterns with examples and exercises."
 msgstr "Practica patrones gramaticales con ejemplos y ejercicios."
 
 #: src/lib/lessons.ts
-msgid "AetsPy"
+msgctxt "AetsPy"
+msgid "Listen to sentences using words you recently learned."
 msgstr "Escucha oraciones con palabras que aprendiste hace poco."
 
 #: src/lib/lessons.ts
-msgid "6oNgY9"
+msgctxt "6oNgY9"
+msgid "Use what you learned in the previous lesson to solve real-world problems."
 msgstr "Usa lo que aprendiste en la lección anterior para resolver problemas reales."
 
 #: src/lib/lessons.ts
-msgid "vO6aLm"
+msgctxt "vO6aLm"
+msgid "Check what you understood with a short quiz."
 msgstr "Comprueba lo que entendiste con un quiz corto."
 
 #: src/lib/lessons.ts
-msgid "OIim7M"
+msgctxt "OIim7M"
+msgid "Read sentences using words you recently learned."
 msgstr "Lee oraciones con palabras que aprendiste hace poco."
 
 #: src/lib/lessons.ts
-msgid "pwrprO"
+msgctxt "pwrprO"
+msgid "Review this chapter with practice based on your mistakes."
 msgstr "Repasa este capítulo con práctica basada en tus errores."
 
 #: src/lib/lessons.ts
-msgid "IQOJhk"
+msgctxt "IQOJhk"
+msgid "Translate words from your previous vocabulary lesson."
 msgstr "Traduce palabras de tu lección anterior de vocabulario."
 
 #: src/lib/lessons.ts
-msgid "9XByXq"
+msgctxt "9XByXq"
+msgid "Follow a guided step-by-step tutorial."
 msgstr "Sigue un tutorial guiado paso a paso."
 
 #: src/lib/lessons.ts
-msgid "IHSVS5"
+msgctxt "IHSVS5"
+msgid "Learn new words and practice using them."
 msgstr "Aprende palabras nuevas y practica cómo usarlas."
 
 #: src/lib/lessons.ts
-msgid "OjyuQ-"
+msgctxt "OjyuQ-"
+msgid "Learn the writing system for {topic} with focused practice."
 msgstr "Aprende el sistema de escritura de {topic} con práctica enfocada."
 
 #: src/lib/lessons.ts
-msgid "pSQZ7W"
+msgctxt "pSQZ7W"
+msgid "Learn about {topic} through an interactive lesson."
 msgstr "Aprende sobre {topic} con una lección interactiva."
 
 #: src/lib/lessons.ts
-msgid "THPcKi"
+msgctxt "THPcKi"
+msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
 msgstr "Entiende qué es {topic}: conceptos clave y definiciones explicados con metáforas y analogías claras."
 
 #: src/lib/lessons.ts
-msgid "tlgfSZ"
+msgctxt "tlgfSZ"
+msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 msgstr "Practica las reglas gramaticales de {topic} con ejercicios pensados para ayudarte a recordarlas y usarlas."
 
 #: src/lib/lessons.ts
-msgid "xCvEE1"
+msgctxt "xCvEE1"
+msgid "Practice listening in {topic} by translating audio sentences."
 msgstr "Practica la escucha en {topic} traduciendo oraciones de audio."
 
 #: src/lib/lessons.ts
-msgid "wHBT6R"
+msgctxt "wHBT6R"
+msgid "Apply {topic} through a visual real-world problem with short decisions."
 msgstr "Aplica {topic} con un problema visual de la vida real y decisiones cortas."
 
 #: src/lib/lessons.ts
-msgid "h2acN8"
+msgctxt "h2acN8"
+msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Pon a prueba cuánto entiendes de {topic} con preguntas que comprueban si de verdad entendiste, no solo si memorizaste."
 
 #: src/lib/lessons.ts
-msgid "XzxpBZ"
+msgctxt "XzxpBZ"
+msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Mejora tu comprensión lectora de {topic} traduciendo oraciones y fragmentos."
 
 #: src/lib/lessons.ts
-msgid "bzFQEy"
+msgctxt "bzFQEy"
+msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Repasa todo lo que aprendiste sobre {topic} con un cuestionario completo."
 
 #: src/lib/lessons.ts
-msgid "X8Gqiq"
+msgctxt "X8Gqiq"
+msgid "Practice vocabulary in {topic} by translating words you've learned."
 msgstr "Practica el vocabulario de {topic} traduciendo palabras que ya aprendiste."
 
 #: src/lib/lessons.ts
-msgid "3bJDQa"
+msgctxt "3bJDQa"
+msgid "Learn {topic} with a guided step-by-step tutorial."
 msgstr "Aprende {topic} con un tutorial guiado paso a paso."
 
 #: src/lib/lessons.ts
-msgid "77SLH5"
+msgctxt "77SLH5"
+msgid "Learn new words in {topic} with flashcards — see each word, its translation, and pronunciation."
 msgstr "Aprende palabras nuevas de {topic} con tarjetas: ve cada palabra, su traducción y su pronunciación."
 
 #: src/lib/lessons.ts
-msgid "oCxmX9"
+msgctxt "oCxmX9"
+msgid "{chapter} {kind} {position}"
 msgstr "{kind} {chapter} {position}"
 
 #: src/lib/lessons.ts
-msgid "qHbgYB"
+msgctxt "qHbgYB"
+msgid "{lesson} - {course}"
 msgstr "{lesson} - {course}"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -4,93 +4,109 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
+msgctxt "xmcVZ0"
+msgid "Search"
 msgstr "Rechercher"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
+msgctxt "PSiLeL"
+msgid "Search courses, chapters, or pages..."
 msgstr "Rechercher des cours, chapitres ou pages…"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
+msgctxt "I-38K2"
+msgid "My courses"
 msgstr "Mes cours"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
+msgctxt "Oj9Phc"
+msgid "Manage subscription"
 msgstr "Gérer l’abonnement"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
+msgctxt "OhXwmw"
+msgid "Update language"
 msgstr "Changer la langue"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
+msgctxt "O7ozeo"
+msgid "Update profile"
 msgstr "Modifier le profil"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
+msgctxt "C81_uG"
+msgid "Logout"
 msgstr "Se déconnecter"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(progress)/_components/progress-empty-state.tsx
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
+msgctxt "AyGauy"
+msgid "Login"
 msgstr "Se connecter"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
+msgctxt "y1Z3or"
+msgid "Language"
 msgstr "Langue"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "U3l-Q9"
+msgctxt "U3l-Q9"
+msgid "Home page"
 msgstr "Page d’accueil"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "jboh4c"
+msgctxt "jboh4c"
+msgid "Start a new course"
 msgstr "Commencer un nouveau cours"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "rS0suY"
+msgctxt "rS0suY"
+msgid "Speak a language"
 msgstr "Parler une langue"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "L6kaJv"
+msgctxt "L6kaJv"
+msgid "Learn something"
 msgstr "Apprendre quelque chose"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "3wvH7G"
+msgctxt "3wvH7G"
+msgid "Pass an exam"
 msgstr "Réussir un examen"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
+msgctxt "CxfKLC"
+msgid "Pages"
 msgstr "Pages"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
+msgctxt "dXSivY"
+msgid "My account"
 msgstr "Mon compte"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "tv5FG3"
+msgctxt "tv5FG3"
+msgid "Blog"
 msgstr "Blog"
 
 #: src/app/(catalog)/_components/command-palette.tsx
@@ -98,2184 +114,2713 @@ msgstr "Blog"
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "fFZ0Wd"
+msgctxt "fFZ0Wd"
+msgid "Feedback & Support"
 msgstr "Avis et aide"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "SENRqu"
+msgctxt "SENRqu"
+msgid "Help"
 msgstr "Aide"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "R85gsW"
+msgctxt "R85gsW"
+msgid "Courses"
 msgstr "Cours"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Do1Pfd"
+msgctxt "Do1Pfd"
+msgid "Chapters"
 msgstr "Chapitres"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "hX5PAb"
+msgctxt "hX5PAb"
+msgid "No results found"
 msgstr "Aucun résultat trouvé"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "OXAZiT"
+msgctxt "OXAZiT"
+msgid "Create a course about {term}"
 msgstr "Créer un cours sur {term}"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "onRJrc"
+msgctxt "onRJrc"
+msgid "Course page"
 msgstr "Page du cours"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "m826WB"
+msgctxt "m826WB"
+msgid "New course"
 msgstr "Nouveau cours"
 
 #: src/app/(catalog)/_components/user-avatar-menu.tsx
-msgid "6b2CRH"
+msgctxt "6b2CRH"
+msgid "User menu"
 msgstr "Menu utilisateur"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/profile/page.tsx
-msgid "itPgxd"
+msgctxt "itPgxd"
+msgid "Profile"
 msgstr "Profil"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/subscription/page.tsx
-msgid "R_6nsx"
+msgctxt "R_6nsx"
+msgid "Subscription"
 msgstr "Abonnement"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "HHFpcy"
+msgctxt "HHFpcy"
+msgid "Best day"
 msgstr "Meilleur jour"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/energy/energy-insights.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "auPwZG"
+msgctxt "auPwZG"
+msgid "{day} with {percentage}"
 msgstr "{day} avec {percentage}"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(catalog)/(home)/score.tsx
-msgid "zml1_y"
+msgctxt "zml1_y"
+msgid "Past 3 months"
 msgstr "3 derniers mois"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "00_IyC"
+msgctxt "00_IyC"
+msgid "Night"
 msgstr "Nuit"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "_kzk_m"
+msgctxt "_kzk_m"
+msgid "Morning"
 msgstr "Matin"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mF-J9o"
+msgctxt "mF-J9o"
+msgid "Afternoon"
 msgstr "Après-midi"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mPEpnN"
+msgctxt "mPEpnN"
+msgid "Evening"
 msgstr "Soir"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "dFW9lU"
+msgctxt "dFW9lU"
+msgid "Best time"
 msgstr "Meilleur moment"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "r0R6ZG"
+msgctxt "r0R6ZG"
+msgid "{period} with {percentage}"
 msgstr "{period} avec {percentage}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
-msgid "NubPSk"
+msgctxt "NubPSk"
+msgid "Next: {lesson}"
 msgstr "Ensuite : {lesson}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continuer"
 
 #: src/app/(catalog)/(home)/continue-learning.tsx
-msgid "0X-xfW"
+msgctxt "0X-xfW"
+msgid "Continue learning"
 msgstr "Continuer à apprendre"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "soDmlG"
+msgctxt "soDmlG"
+msgid "Keep learning to increase it"
 msgstr "Continue à apprendre pour l’augmenter"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "WgeB0r"
+msgctxt "WgeB0r"
+msgid "Keep learning to maintain it"
 msgstr "Continue à apprendre pour la maintenir"
 
 #: src/app/(catalog)/(home)/energy.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/energy/page.tsx
-msgid "cVpmV7"
+msgctxt "cVpmV7"
+msgid "Energy"
 msgstr "Énergie"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "AV5XNu"
+msgctxt "AV5XNu"
+msgid "Your energy is {percentage}"
 msgstr "Ton énergie est à {percentage}"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
-msgid "8F6teD"
+msgctxt "8F6teD"
+msgid "Learning days"
 msgstr "Jours d’apprentissage"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
-msgid "QbNcMh"
+msgctxt "QbNcMh"
+msgid "At least one completed lesson"
 msgstr "Au moins une leçon terminée"
 
 #: src/app/(catalog)/(home)/learning-time.tsx
-msgid "F6B8A3"
+msgctxt "F6B8A3"
+msgid "Time spent in lessons"
 msgstr "Temps passé en leçon"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "pgt3eW"
+msgctxt "pgt3eW"
+msgid "Max level reached"
 msgstr "Niveau maximal atteint"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "8N9BRu"
+msgctxt "8N9BRu"
+msgid "{value} BP to next level"
 msgstr "{value} PM jusqu’au prochain niveau"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/level/page.tsx
-msgid "y1Qr81"
+msgctxt "y1Qr81"
+msgid "Level"
 msgstr "Niveau"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "s0KB2i"
+msgctxt "s0KB2i"
+msgid "{belt} - Level {level}"
 msgstr "{belt} - Niveau {level}"
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "a50ZRn"
+msgctxt "a50ZRn"
+msgid "Zoonk is an AI learning platform and study app to create courses about any topic using AI. Study for your exams or learn new skills."
 msgstr "Zoonk est une plateforme d’apprentissage et une appli d’étude avec IA pour créer des cours sur n’importe quel sujet. Révise pour tes examens ou apprends de nouvelles compétences."
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "leBFvu"
+msgctxt "leBFvu"
+msgid "Zoonk: Study App with AI"
 msgstr "Zoonk : appli d’étude avec IA"
 
 #: src/app/(catalog)/(home)/progress.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "sIMS7i"
+msgctxt "sIMS7i"
+msgid "Progress"
 msgstr "Progression"
 
 #: src/app/(catalog)/(home)/score.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/score/page.tsx
-msgid "oLkLww"
+msgctxt "oLkLww"
+msgid "Score"
 msgstr "Score"
 
 #: src/app/(catalog)/(home)/score.tsx
-msgid "_lCW0j"
+msgctxt "_lCW0j"
+msgid "{percentage} correct answers"
 msgstr "{percentage} de bonnes réponses"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "QhvU1f"
+msgctxt "QhvU1f"
+msgid "Create this chapter"
 msgstr "Créer ce chapitre"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "YQGe0H"
+msgctxt "YQGe0H"
+msgid "This chapter is part of the course, but it hasn't been created yet. Create it to see all of its lessons."
 msgstr "Ce chapitre fait partie du cours, mais il n’a pas encore été créé. Crée-le pour voir toutes ses leçons."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "3IOFp2"
+msgctxt "3IOFp2"
+msgid "Create chapter"
 msgstr "Créer le chapitre"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
+msgctxt "qrEiLa"
+msgid "Back to course"
 msgstr "Retour au cours"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "Ap-oRa"
+msgctxt "Ap-oRa"
+msgid "Could not apply lesson filters. Please try again."
 msgstr "Impossible d’appliquer les filtres des leçons. Réessaie."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "d6tcJn"
+msgctxt "d6tcJn"
+msgid "Filter lesson types"
 msgstr "Filtrer les types de leçons"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "kxP9GJ"
+msgctxt "kxP9GJ"
+msgid "Types"
 msgstr "Types"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "wi5osl"
+msgctxt "wi5osl"
+msgid "Show lesson types"
 msgstr "Afficher les types de leçons"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "OhgOkH"
+msgctxt "OhgOkH"
+msgid "Clear filter"
 msgstr "Effacer le filtre"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "orGV_i"
+msgctxt "orGV_i"
+msgid "Current lesson"
 msgstr "Leçon actuelle"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "ssvp3R"
+msgctxt "ssvp3R"
+msgid "Search lessons..."
 msgstr "Rechercher des leçons…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "FuT9vz"
+msgctxt "FuT9vz"
+msgid "No lessons found"
 msgstr "Aucune leçon trouvée"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Terminé"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "xTTP0x"
+msgctxt "xTTP0x"
+msgid "Not started"
 msgstr "Pas commencé"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "iRubpl"
+msgctxt "iRubpl"
+msgid "Current chapter"
 msgstr "Chapitre actuel"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "3SOcGR"
+msgctxt "3SOcGR"
+msgid "Search chapters..."
 msgstr "Rechercher des chapitres…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "8udPa-"
+msgctxt "8udPa-"
+msgid "No chapters found"
 msgstr "Aucun chapitre trouvé"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "vcaAXp"
+msgctxt "vcaAXp"
+msgid "{completed, number}/{total, number} done"
 msgstr "{completed, number}/{total, number} terminés"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-curriculum-pending-notice.tsx
-msgid "Pf4uqS"
+msgctxt "Pf4uqS"
+msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "Le chapitre d’introduction est prêt. Nous créons encore le programme complet, donc d’autres chapitres apparaîtront bientôt ici."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "_allXG"
+msgctxt "_allXG"
+msgid "Learn {course} online with practical examples and everyday language. {description}"
 msgstr "Apprends {course} en ligne avec des exemples pratiques et un langage du quotidien. {description}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "gyGolN"
+msgctxt "gyGolN"
+msgid "Learn {course}"
 msgstr "Apprends {course}"
 
 #: src/app/(catalog)/courses/category-pills.tsx
-msgid "tuZsq-"
+msgctxt "tuZsq-"
+msgid "Course categories"
 msgstr "Catégories de cours"
 
 #: src/app/(catalog)/courses/category-pills.tsx
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "zQvVDJ"
+msgctxt "zQvVDJ"
+msgid "All"
 msgstr "Tout"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "Wc7aau"
+msgctxt "Wc7aau"
+msgid "No courses available yet."
 msgstr "Aucun cours disponible pour le moment."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "zJxO2f"
+msgctxt "zJxO2f"
+msgid "No courses"
 msgstr "Aucun cours"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "T0mfNV"
+msgctxt "T0mfNV"
+msgid "Loading more courses…"
 msgstr "Chargement d'autres cours…"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "W_5hwr"
+msgctxt "W_5hwr"
+msgid "Something went wrong. Please try again."
 msgstr "Une erreur est survenue. Réessaie."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Réessayer"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "WgPMAP"
+msgctxt "WgPMAP"
+msgid "Explore all Zoonk courses to learn anything using AI. Find interactive lessons to learn subjects like science, math, technology, and more."
 msgstr "Explore tous les cours Zoonk pour tout apprendre avec l'IA. Trouve des leçons interactives pour apprendre les sciences, les maths, la technologie et plus encore."
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "P5jxUC"
+msgctxt "P5jxUC"
+msgid "Online Courses using AI"
 msgstr "Cours en ligne avec l'IA"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "s-Ncqj"
+msgctxt "s-Ncqj"
+msgid "Explore courses"
 msgstr "Explorer les cours"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "hUF3bo"
+msgctxt "hUF3bo"
+msgid "Start learning something new today"
 msgstr "Commence à apprendre quelque chose de nouveau aujourd'hui"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "riE3I5"
+msgctxt "riE3I5"
+msgid "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons."
 msgstr "Vois tous les cours que tu as commencés sur Zoonk. Reprends là où tu t'es arrêté et suis ta progression dans les leçons interactives."
 
 #: src/app/(catalog)/my/page.tsx
-msgid "eeNr_Y"
+msgctxt "eeNr_Y"
+msgid "My Courses"
 msgstr "Mes cours"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "Dr13kE"
+msgctxt "Dr13kE"
+msgid "Continue where you left off"
 msgstr "Reprends là où tu t'es arrêté"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "BDHWkf"
+msgctxt "BDHWkf"
+msgid "No courses yet"
 msgstr "Aucun cours pour l'instant"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "azX41u"
+msgctxt "azX41u"
+msgid "Start learning something new today."
 msgstr "Commence à apprendre quelque chose de nouveau aujourd'hui."
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "9m9h0p"
+msgctxt "9m9h0p"
+msgid "Start a course"
 msgstr "Commencer un cours"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "e61Jf3"
+msgctxt "e61Jf3"
+msgid "Coming soon"
 msgstr "Bientôt disponible"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
-msgid "dtRj3N"
+msgctxt "dtRj3N"
+msgid "Personalized courses are coming soon."
 msgstr "Les cours personnalisés arrivent bientôt."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "hJZwTS"
+msgctxt "hJZwTS"
+msgid "Email address"
 msgstr "Adresse e-mail"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "OiSL94"
+msgctxt "OiSL94"
+msgid "myemail@gmail.com"
 msgstr "myemail@gmail.com"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "45yKj9"
+msgctxt "45yKj9"
+msgid "We'll use this email to notify you when exam prep is ready."
 msgstr "Nous utiliserons cet e-mail pour te prévenir quand la préparation aux examens sera prête."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "Xy7a7A"
+msgctxt "Xy7a7A"
+msgid "Exam"
 msgstr "Examen"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "cDZwI_"
+msgctxt "cDZwI_"
+msgid "TOEFL, SAT, CFA, CPA..."
 msgstr "TOEFL, SAT, CFA, CPA…"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "E_0Y4u"
+msgctxt "E_0Y4u"
+msgid "Tell us the test, certification, or school exam you care about."
 msgstr "Dis-nous le test, la certification ou l'examen scolaire qui t'intéresse."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "6eV4UR"
+msgctxt "6eV4UR"
+msgid "We couldn't add you to the waitlist. Please try again."
 msgstr "Nous n'avons pas pu t'ajouter à la liste d'attente. Réessaie."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "W78DIe"
+msgctxt "W78DIe"
+msgid "You're on the list. We'll let you know when exam prep is ready."
 msgstr "Tu es sur la liste. Nous te préviendrons quand la préparation aux examens sera prête."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "ipGe-B"
+msgctxt "ipGe-B"
+msgid "Notify me"
 msgstr "Me prévenir"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "gs2Dwu"
+msgctxt "gs2Dwu"
+msgid "Online AI exam prep for certifications and tests. Hands-on explanation and practice questions to help you pass your exam."
 msgstr "Préparation aux examens en ligne avec l'IA pour les certifications et les tests. Des explications pratiques et des questions d'entraînement pour t'aider à réussir ton examen."
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "z8OyvL"
+msgctxt "z8OyvL"
+msgid "Online AI Exam Prep"
 msgstr "Préparation aux examens en ligne avec l'IA"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "CzV5fE"
+msgctxt "CzV5fE"
+msgid "Exam prep is not available yet. Tell us what you're preparing for and we'll notify you when it launches."
 msgstr "La préparation aux examens n'est pas encore disponible. Dis-nous ce que tu prépares et nous te préviendrons au lancement."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "8Zy06C"
+msgctxt "8Zy06C"
+msgid "This option isn't available yet"
 msgstr "Cette option n'est pas encore disponible"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "TV5hlz"
+msgctxt "TV5hlz"
+msgid "Join the waitlist and we'll let you know when you can learn <strong>{title}</strong> with Zoonk."
 msgstr "Rejoins la liste d'attente et nous te préviendrons quand tu pourras apprendre <strong>{title}</strong> avec Zoonk."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "cPhKTw"
+msgctxt "cPhKTw"
+msgid "Not available"
 msgstr "Non disponible"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "5DZYgN"
+msgctxt "5DZYgN"
+msgid "We can't create this course"
 msgstr "Nous ne pouvons pas créer ce cours"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "m6ju4Q"
+msgctxt "m6ju4Q"
+msgid "Zoonk can't help with requests that involve unsafe, illegal, or harmful activity. Try a different subject instead."
 msgstr "Zoonk ne peut pas aider avec les demandes liées à une activité dangereuse, illégale ou nuisible. Essaie plutôt un autre sujet."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "PDFZz6"
+msgctxt "PDFZz6"
+msgid "Try another goal"
 msgstr "Essayer un autre objectif"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "hCixWc"
+msgctxt "hCixWc"
+msgid "You're on the list. We'll email you when it's available."
 msgstr "Tu es sur la liste. Nous t'enverrons un e-mail quand ce sera disponible."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "UdDpuW"
+msgctxt "UdDpuW"
+msgid "Finding the best way to help"
 msgstr "Nous cherchons la meilleure façon de t'aider"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "1A36NM"
+msgctxt "1A36NM"
+msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "Nous vérifions ton objectif d'apprentissage. Cela peut prendre quelques secondes."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "47FYwb"
+msgctxt "47FYwb"
+msgid "Cancel"
 msgstr "Annuler"
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "CaU_nf"
+msgctxt "CaU_nf"
+msgid "Discover personalized courses and resources to learn {prompt}. Zoonk uses AI to create interactive lessons tailored to you."
 msgstr "Découvre des cours personnalisés et des ressources pour apprendre {prompt}. Zoonk utilise l'IA pour créer des leçons interactives adaptées à toi."
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "X2b6pH"
+msgctxt "X2b6pH"
+msgid "Learn {prompt} with AI"
 msgstr "Apprends {prompt} avec l'IA"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "l450Bl"
+msgctxt "l450Bl"
+msgid "Computer Science"
 msgstr "Informatique"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ElyVN0"
+msgctxt "ElyVN0"
+msgid "Psychology"
 msgstr "Psychologie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "KOuDOE"
+msgctxt "KOuDOE"
+msgid "Economics"
 msgstr "Économie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "cHCwbF"
+msgctxt "cHCwbF"
+msgid "Photography"
 msgstr "Photographie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zE1J_t"
+msgctxt "zE1J_t"
+msgid "Philosophy"
 msgstr "Philosophie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "y68y7h"
+msgctxt "y68y7h"
+msgid "Data Science"
 msgstr "Science des données"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1qsU2j"
+msgctxt "1qsU2j"
+msgid "Creative Writing"
 msgstr "Écriture créative"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "RGkBg_"
+msgctxt "RGkBg_"
+msgid "Biology"
 msgstr "Biologie"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oiUZCZ"
+msgctxt "oiUZCZ"
+msgid "Graphic Design"
 msgstr "Design graphique"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "djJp6c"
+msgctxt "djJp6c"
+msgid "History"
 msgstr "Histoire"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "O9mDkA"
+msgctxt "O9mDkA"
+msgid "Marketing"
 msgstr "Marketing"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "9zLpJ_"
+msgctxt "9zLpJ_"
+msgid "What do you want to learn?"
 msgstr "Qu'est-ce que tu veux apprendre ?"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zfDq-e"
+msgctxt "zfDq-e"
+msgid "Quantum physics"
 msgstr "Physique quantique"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oqfOwA"
+msgctxt "oqfOwA"
+msgid "Ancient philosophy"
 msgstr "Philosophie antique"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "Osb4bp"
+msgctxt "Osb4bp"
+msgid "Machine learning"
 msgstr "Apprentissage automatique"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "OdZ_n1"
+msgctxt "OdZ_n1"
+msgid "Creative writing"
 msgstr "Écriture créative"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "N9FWiz"
+msgctxt "N9FWiz"
+msgid "Molecular biology"
 msgstr "Biologie moléculaire"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XFPrU4"
+msgctxt "XFPrU4"
+msgid "Behavioral economics"
 msgstr "Économie comportementale"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "-0gz_i"
+msgctxt "-0gz_i"
+msgid "Organic chemistry"
 msgstr "Chimie organique"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1axOcX"
+msgctxt "1axOcX"
+msgid "UFOs"
 msgstr "Ovnis"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "e7q85h"
+msgctxt "e7q85h"
+msgid "Dinosaur extinction"
 msgstr "Extinction des dinosaures"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "MO2lwh"
+msgctxt "MO2lwh"
+msgid "How volcanoes work"
 msgstr "Comment fonctionnent les volcans"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ZzbdHP"
+msgctxt "ZzbdHP"
+msgid "World history"
 msgstr "Histoire mondiale"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XfC6Cs"
+msgctxt "XfC6Cs"
+msgid "Cognitive psychology"
 msgstr "Psychologie cognitive"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "X5XXVF"
+msgctxt "X5XXVF"
+msgid "Linear algebra"
 msgstr "Algèbre linéaire"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5gOFKJ"
+msgctxt "5gOFKJ"
+msgid "Black holes"
 msgstr "Trous noirs"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "eQHeGX"
+msgctxt "eQHeGX"
+msgid "How the internet works"
 msgstr "Comment fonctionne Internet"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "QOSGzc"
+msgctxt "QOSGzc"
+msgid "Roman Empire"
 msgstr "Empire romain"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "gyEihl"
+msgctxt "gyEihl"
+msgid "Deep sea creatures"
 msgstr "Créatures des grands fonds"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "0MqSJ1"
+msgctxt "0MqSJ1"
+msgid "Solar system"
 msgstr "Système solaire"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5qPAxv"
+msgctxt "5qPAxv"
+msgid "Artificial intelligence"
 msgstr "Intelligence artificielle"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "3WiAG4"
+msgctxt "3WiAG4"
+msgid "Harry Potter"
 msgstr "Harry Potter"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "NvSCuG"
+msgctxt "NvSCuG"
+msgid "Suggested subjects"
 msgstr "Sujets suggérés"
 
 #: src/app/(catalog)/start/learn/learn-form.tsx
-msgid "uCb1nG"
+msgctxt "uCb1nG"
+msgid "Enter a subject"
 msgstr "Saisis un sujet"
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "JlJVf1"
+msgctxt "JlJVf1"
+msgid "Tell Zoonk what you want to learn and get a course created with AI. Start learning any subject with interactive lessons."
 msgstr "Dis à Zoonk ce que tu veux apprendre et obtiens un cours créé avec l’IA. Commence à apprendre n’importe quel sujet avec des leçons interactives."
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "Zs1QEq"
+msgctxt "Zs1QEq"
+msgid "Learn Anything with AI"
 msgstr "Apprends tout avec l’IA"
 
 #: src/app/(catalog)/start/page.tsx
-msgid "UFOGo9"
+msgctxt "UFOGo9"
+msgid "Start online courses to learn languages and more on Zoonk. Practice language learning, learn English or Spanish, and create AI-powered courses for any subject."
 msgstr "Commence des cours en ligne pour apprendre des langues et plus encore sur Zoonk. Pratique une langue, apprends l’anglais ou l’espagnol, et crée des cours avec l’IA sur n’importe quel sujet."
 
 #: src/app/(catalog)/start/page.tsx
-msgid "rqpQgj"
+msgctxt "rqpQgj"
+msgid "Online Courses to Learn Languages and More"
 msgstr "Cours en ligne pour apprendre des langues et plus encore"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "K4jMHW"
+msgctxt "K4jMHW"
+msgid "Online language courses with AI. Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Cours de langue en ligne avec l’IA. Apprends une langue avec des conseils de prononciation, du vocabulaire, de la lecture et de l’écoute."
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "Ht6aMH"
+msgctxt "Ht6aMH"
+msgid "Learn a language online with AI"
 msgstr "Apprends une langue en ligne avec l’IA"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "lSAK6U"
+msgctxt "lSAK6U"
+msgid "What language do you want to learn?"
 msgstr "Quelle langue veux-tu apprendre ?"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "ptPPVk"
+msgctxt "ptPPVk"
+msgid "No languages found"
 msgstr "Aucune langue trouvée"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "L820yz"
+msgctxt "L820yz"
+msgid "Search languages"
 msgstr "Rechercher des langues"
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "ah2CR6"
+msgctxt "ah2CR6"
+msgid "Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Apprends une langue avec des conseils de prononciation, du vocabulaire, de la lecture et de l’écoute."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "_E8OKF"
+msgctxt "_E8OKF"
+msgid "Turn any subject into a clear course you can follow step by step, with practical examples and no fluff."
 msgstr "Transforme n’importe quel sujet en cours clair, à suivre étape par étape, avec des exemples pratiques et sans blabla."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "IF6NT-"
+msgctxt "IF6NT-"
+msgid "We'll prepare a study path to help you pass an entrance exam, certification, or school test."
 msgstr "Nous préparerons un parcours d’étude pour t’aider à réussir un concours d’entrée, une certification ou un examen scolaire."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "AaFZIp"
+msgctxt "AaFZIp"
+msgid "What's your goal?"
 msgstr "Quel est ton objectif ?"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "pev_fB"
+msgctxt "pev_fB"
+msgid "vs last month"
 msgstr "par rapport au mois dernier"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "R9qHBU"
+msgctxt "R9qHBU"
+msgid "vs last 6 months"
 msgstr "par rapport aux 6 derniers mois"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "s-lPP3"
+msgctxt "s-lPP3"
+msgid "All time"
 msgstr "Depuis le début"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "YFV6dH"
+msgctxt "YFV6dH"
+msgid "vs last year"
 msgstr "par rapport à l’année dernière"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "hCCWuZ"
+msgctxt "hCCWuZ"
+msgid "Previous period"
 msgstr "Période précédente"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "I2z5s_"
+msgctxt "I2z5s_"
+msgid "Next period"
 msgstr "Période suivante"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "PIaUh-"
+msgctxt "PIaUh-"
+msgid "Period selection"
 msgstr "Choix de la période"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "TBovrx"
+msgctxt "TBovrx"
+msgid "Month"
 msgstr "Mois"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "NPrFLC"
+msgctxt "NPrFLC"
+msgid "6 Months"
 msgstr "6 mois"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "IFo1oo"
+msgctxt "IFo1oo"
+msgid "Year"
 msgstr "Année"
 
 #: src/app/(progress)/_components/progress-chart-layout.tsx
-msgid "OlW5Z8"
+msgctxt "OlW5Z8"
+msgid "No data available for this period"
 msgstr "Aucune donnée disponible pour cette période"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "FVh2Tr"
+msgctxt "FVh2Tr"
+msgid "Start learning to track your progress"
 msgstr "Commence à apprendre pour suivre ta progression"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "Y1zzQt"
+msgctxt "Y1zzQt"
+msgid "Log in to track your progress"
 msgstr "Connecte-toi pour suivre ta progression"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "J3fNDZ"
+msgctxt "J3fNDZ"
+msgid "This month"
 msgstr "Ce mois-ci"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "eWUXBX"
+msgctxt "eWUXBX"
+msgid "Past 6 months"
 msgstr "6 derniers mois"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "lPShsT"
+msgctxt "lPShsT"
+msgid "This year"
 msgstr "Cette année"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
-msgid "M-JIpD"
+msgctxt "M-JIpD"
+msgid "Energy chart"
 msgstr "Graphique d'Énergie"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "rGSqvt"
+msgctxt "rGSqvt"
+msgid "Avg"
 msgstr "Moy."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "TLPAMC"
+msgctxt "TLPAMC"
+msgid "What is Energy?"
 msgstr "Qu'est-ce que l'Énergie ?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "OvOWOR"
+msgctxt "OvOWOR"
+msgid "Energy is a 0% to 100% score for your recent learning consistency and accuracy."
 msgstr "L'Énergie est un score de 0 % à 100 % qui reflète ta régularité et ta précision récentes dans l'apprentissage."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "K3jN6p"
+msgctxt "K3jN6p"
+msgid "How do I improve Energy?"
 msgstr "Comment améliorer mon Énergie ?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "pssms6"
+msgctxt "pssms6"
+msgid "Answer questions correctly and keep learning regularly. Correct answers raise Energy; wrong answers and days away from studying lower it."
 msgstr "Réponds correctement aux questions et continue d'apprendre régulièrement. Les bonnes réponses augmentent l'Énergie ; les mauvaises réponses et les jours sans étudier la font baisser."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "-8Qx8X"
+msgctxt "-8Qx8X"
+msgid "Why is Energy important?"
 msgstr "Pourquoi l'Énergie est-elle importante ?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "UfEfhq"
+msgctxt "UfEfhq"
+msgid "Energy is like heart rate in a health app: it shows your current learning rhythm. Missing a day doesn't reset your progress; you recover as soon as you start learning again."
 msgstr "L'Énergie, c'est comme le rythme cardiaque dans une appli santé : elle montre ton rythme d'apprentissage actuel. Rater une journée ne remet pas tes progrès à zéro ; tu récupères dès que tu recommences à apprendre."
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "XxS-he"
+msgctxt "XxS-he"
+msgid "Highest energy day"
 msgstr "Jour avec le plus d'énergie"
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "aaiQkv"
+msgctxt "aaiQkv"
+msgid "Full energy"
 msgstr "Énergie au maximum"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "zLCmVM"
+msgctxt "zLCmVM"
+msgid "Current Energy"
 msgstr "Énergie actuelle"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "e9DcQa"
+msgctxt "e9DcQa"
+msgid "{percentage} average"
 msgstr "{percentage} de moyenne"
 
 #: src/app/(progress)/energy/page.tsx
-msgid "AZMpf3"
+msgctxt "AZMpf3"
+msgid "Energy is a 0% to 100% score based on recent activity and accuracy."
 msgstr "L'Énergie est un score de 0 % à 100 % basé sur ton activité récente et ta précision."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "rsIaGW"
+msgctxt "rsIaGW"
+msgid "A 0% to 100% score for recent activity and accuracy"
 msgstr "Un score de 0 % à 100 % pour l'activité récente et la précision"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "GA8RuL"
+msgctxt "GA8RuL"
+msgid "Brain Power chart"
 msgstr "Graphique de Puissance Mentale"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "XdkaHc"
+msgctxt "XdkaHc"
+msgid "{value} BP"
 msgstr "{value} PM"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "tDbspx"
+msgctxt "tDbspx"
+msgid "Total Brain Power earned: {total}"
 msgstr "Puissance Mentale totale gagnée : {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "EMy5Vs"
+msgctxt "EMy5Vs"
+msgid "What is Brain Power?"
 msgstr "Qu'est-ce que Puissance Mentale ?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "MIjvOA"
+msgctxt "MIjvOA"
+msgid "Brain Power (BP) is the total learning credit you have earned. Each completed lesson adds {brainPower} BP."
 msgstr "Puissance Mentale (PM) est le total de crédits d'apprentissage que tu as gagnés. Chaque leçon terminée ajoute {brainPower} PM."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "jzKXJS"
+msgctxt "jzKXJS"
+msgid "How do I increase Brain Power?"
 msgstr "Comment augmenter Puissance Mentale ?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "Gzq1tT"
+msgctxt "Gzq1tT"
+msgid "Complete lessons. Brain Power never goes down, even when your Energy drops or you take a break."
 msgstr "Termine des leçons. Puissance Mentale ne baisse jamais, même quand ton Énergie diminue ou que tu fais une pause."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "JGLOtn"
+msgctxt "JGLOtn"
+msgid "Why is Brain Power important?"
 msgstr "Pourquoi Puissance Mentale est-elle importante ?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "tC6vNz"
+msgctxt "tC6vNz"
+msgid "It is like steps in a health app: a record of how much you have learned. It also works like martial arts for your mind: build Brain Power to advance from white belt to black belt."
 msgstr "C'est comme les pas dans une appli santé : un suivi de tout ce que tu as appris. Ça marche aussi comme les arts martiaux pour ton esprit : développe ta Puissance Mentale pour passer de la ceinture blanche à la ceinture noire."
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "elq-tg"
+msgctxt "elq-tg"
+msgid "Highest BP"
 msgstr "PM le plus élevé"
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "BW4bMl"
+msgctxt "BW4bMl"
+msgid "{date} with {value} BP"
 msgstr "{date} avec {value} PM"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "WfaE4H"
+msgctxt "WfaE4H"
+msgid "{belt}, Level {level} of 10. Maximum level achieved."
 msgstr "{belt}, niveau {level} sur 10. Niveau maximum atteint."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "2Y-P4e"
+msgctxt "2Y-P4e"
+msgid "{belt}, Level {level} of 10. {bp} Brain Power until next level."
 msgstr "{belt}, niveau {level} sur 10. {bp} de Puissance Mentale avant le niveau suivant."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "n_mgOm"
+msgctxt "n_mgOm"
+msgid "Belt Progression"
 msgstr "Progression des ceintures"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "ZKbTsS"
+msgctxt "ZKbTsS"
+msgid "{current}/10"
 msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "-Sn2yd"
+msgctxt "-Sn2yd"
+msgid "{belt}: Level {current} of 10"
 msgstr "{belt} : niveau {current} sur 10"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "v5yNm3"
+msgctxt "v5yNm3"
+msgid "Total Brain Power"
 msgstr "Puissance Mentale totale"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "_Q0taG"
+msgctxt "_Q0taG"
+msgid "BP"
 msgstr "PM"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "u_oEJA"
+msgctxt "u_oEJA"
+msgid "{value} BP earned"
 msgstr "{value} PM gagnés"
 
 #: src/app/(progress)/level/page.tsx
-msgid "4-USpX"
+msgctxt "4-USpX"
+msgid "Track your level progress and see how you advance."
 msgstr "Suis ta progression de niveau et vois comment tu avances."
 
 #: src/app/(progress)/level/page.tsx
-msgid "L9hqMH"
+msgctxt "L9hqMH"
+msgid "Track your level progress"
 msgstr "Suis ta progression de niveau"
 
 #: src/app/(progress)/score/page.tsx
-msgid "qHWZBu"
+msgctxt "qHWZBu"
+msgid "Track your score over time and see your best days and times."
 msgstr "Suis ton score au fil du temps et découvre tes meilleurs jours et moments."
 
 #: src/app/(progress)/score/page.tsx
-msgid "GWkswX"
+msgctxt "GWkswX"
+msgid "Track your score and progress trends"
 msgstr "Suis ton score et tes tendances de progression"
 
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "J-05ol"
+msgctxt "J-05ol"
+msgid "Score chart"
 msgstr "Graphique du score"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "bIZaXJ"
+msgctxt "bIZaXJ"
+msgid "What is Score?"
 msgstr "Qu'est-ce que le score ?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "JA-N5Z"
+msgctxt "JA-N5Z"
+msgid "Score is the percentage of questions you answered correctly during this period."
 msgstr "Le score est le pourcentage de questions auxquelles tu as répondu correctement pendant cette période."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "z9kvhA"
+msgctxt "z9kvhA"
+msgid "How do I improve Score?"
 msgstr "Comment améliorer mon score ?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "7_C9do"
+msgctxt "7_C9do"
+msgid "Review mistakes and retry lessons. As you answer more questions correctly, your Score goes up."
 msgstr "Revois tes erreurs et réessaie les leçons. Plus tu réponds correctement aux questions, plus ton score augmente."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "WqH8eP"
+msgctxt "WqH8eP"
+msgid "Why is Score important?"
 msgstr "Pourquoi le score est-il important ?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "E0saoA"
+msgctxt "E0saoA"
+msgid "Score shows accuracy, not activity. Best day and best time help you find when you learn most effectively."
 msgstr "Le score montre ta précision, pas ton activité. Le meilleur jour et le meilleur moment t'aident à savoir quand tu apprends le plus efficacement."
 
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "yOFm9C"
+msgctxt "yOFm9C"
+msgid "You need to be logged in to access this page."
 msgstr "Tu dois être connecté pour accéder à cette page."
 
 #: src/app/(settings)/language/page.tsx
-msgid "2WHx14"
+msgctxt "2WHx14"
+msgid "Update your app language to learn in English, Portuguese, Spanish, French, or other supported languages."
 msgstr "Mets à jour la langue de l'appli pour apprendre en anglais, portugais, espagnol, français ou dans une autre langue prise en charge."
 
 #: src/app/(settings)/language/page.tsx
-msgid "aNLa1G"
+msgctxt "aNLa1G"
+msgid "Choose the app language you prefer for this device."
 msgstr "Choisis la langue de l'appli que tu préfères pour cet appareil."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "dSVD13"
+msgctxt "dSVD13"
+msgid "Update your name and username on Zoonk."
 msgstr "Mets à jour ton nom et ton nom d'utilisateur sur Zoonk."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "wjIStY"
+msgctxt "wjIStY"
+msgid "Your name and username as they appear to others."
 msgstr "Ton nom et ton nom d'utilisateur tels qu'ils apparaissent aux autres."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Vérification…"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} est disponible"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} est déjà pris"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "3 à 30 caractères. Lettres, chiffres et traits de soulignement uniquement."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Nom"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "yNHZ-a"
+msgctxt "yNHZ-a"
+msgid "Your profile has been updated successfully!"
 msgstr "Ton profil a bien été mis à jour !"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "VT-G_7"
+msgctxt "VT-G_7"
+msgid "This name will be visible to other users."
 msgstr "Ce nom sera visible par les autres utilisateurs."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "wYCHCR"
+msgctxt "wYCHCR"
+msgid "Failed to update your profile. Please try again or contact hello@zoonk.com"
 msgstr "Impossible de mettre ton profil à jour. Réessaie ou contacte hello@zoonk.com"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Nom d’utilisateur"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "X0ha1a"
+msgctxt "X0ha1a"
+msgid "Save changes"
 msgstr "Enregistrer les changements"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "3iCRcP"
+msgctxt "3iCRcP"
+msgid "Manage in App Store"
 msgstr "Gérer dans l’App Store"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "tiFovn"
+msgctxt "tiFovn"
+msgid "Manage in Google Play"
 msgstr "Gérer dans Google Play"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "Tp4wJB"
+msgctxt "Tp4wJB"
+msgid "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
 msgstr "Cet abonnement est géré dans l’App Store. Pour le modifier ou l’annuler, utilise les réglages d’abonnement Apple."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "unNUPf"
+msgctxt "unNUPf"
+msgid "This subscription is managed through Google Play. To change or cancel it, use Google Play."
 msgstr "Cet abonnement est géré dans Google Play. Pour le modifier ou l’annuler, utilise Google Play."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "P0ZHma"
+msgctxt "P0ZHma"
+msgid "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
 msgstr "Cet abonnement est géré par Zoonk. Contacte l’assistance si tu as besoin d’aide pour le modifier ou l’annuler."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "5CI3KH"
+msgctxt "5CI3KH"
+msgid "Contact support"
 msgstr "Contacter l’assistance"
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "TKk9oj"
+msgctxt "TKk9oj"
+msgid "Compare plans and manage your Zoonk subscription. See pricing, switch plans, or update billing."
 msgstr "Compare les offres et gère ton abonnement Zoonk. Consulte les prix, change d’offre ou mets à jour la facturation."
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "NBEnVd"
+msgctxt "NBEnVd"
+msgid "Compare plans and manage your subscription."
 msgstr "Compare les offres et gère ton abonnement."
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "PJfdJl"
+msgctxt "PJfdJl"
+msgid "Save up to {amount}"
 msgstr "Économise jusqu’à {amount}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "KAb0Yr"
+msgctxt "KAb0Yr"
+msgid "Switch to {plan}"
 msgstr "Passer à {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0Azlrb"
+msgctxt "0Azlrb"
+msgid "Manage"
 msgstr "Gérer"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "_gko4g"
+msgctxt "_gko4g"
+msgid "Upgrade to {plan}"
 msgstr "Passer à {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "wYsv4Z"
+msgctxt "wYsv4Z"
+msgid "Monthly"
 msgstr "Mensuel"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "dqD39h"
+msgctxt "dqD39h"
+msgid "Yearly"
 msgstr "Annuel"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "s1ZXI0"
+msgctxt "s1ZXI0"
+msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "Impossible de mettre ton abonnement à jour. Contacte-nous à hello@zoonk.com"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "2EsPdm"
+msgctxt "2EsPdm"
+msgid "/yr"
 msgstr "/an"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0jIMEb"
+msgctxt "0jIMEb"
+msgid "/mo"
 msgstr "/mois"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "tf1lIh"
+msgctxt "tf1lIh"
+msgid "Free"
 msgstr "Gratuit"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "ZBALng"
+msgctxt "ZBALng"
+msgid "Current plan"
 msgstr "Offre actuelle"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "fF376U"
+msgctxt "fF376U"
+msgid "Current"
 msgstr "Actuel"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "kkjl2v"
+msgctxt "kkjl2v"
+msgid "Max"
 msgstr "Max"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "lOdoIb"
+msgctxt "lOdoIb"
+msgid "Plus"
 msgstr "Plus"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "R_eOkj"
+msgctxt "R_eOkj"
+msgid "Pro"
 msgstr "Pro"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "9o8O4m"
+msgctxt "9o8O4m"
+msgid "Your subscription will end on {date}."
 msgstr "Ton abonnement prendra fin le {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "vaN1qz"
+msgctxt "vaN1qz"
+msgid "Current billing period ends on {date}."
 msgstr "La période de facturation en cours se termine le {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "EV_gJ6"
+msgctxt "EV_gJ6"
+msgid "First chapter included"
 msgstr "Premier chapitre inclus"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "mqHNd6"
+msgctxt "mqHNd6"
+msgid "Personalized lessons, smartest AI"
 msgstr "Leçons personnalisées, IA la plus avancée"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "SC0MFR"
+msgctxt "SC0MFR"
+msgid "Unlimited lessons"
 msgstr "Leçons illimitées"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "eaOADK"
+msgctxt "eaOADK"
+msgid "Personalized lessons, fast AI"
 msgstr "Leçons personnalisées, IA rapide"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "B5MLC7"
+msgctxt "B5MLC7"
+msgid "Share feedback, ask questions, or get help with your account and courses."
 msgstr "Partage tes retours, pose tes questions ou obtiens de l’aide pour ton compte et tes cours."
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "cDAb4a"
+msgctxt "cDAb4a"
+msgid "GitHub Discussions"
 msgstr "Discussions GitHub"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "7h49qt"
+msgctxt "7h49qt"
+msgid "Connect with the community and get answers"
 msgstr "Échange avec la communauté et obtiens des réponses"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "YdQxfw"
+msgctxt "YdQxfw"
+msgid "Contact Support"
 msgstr "Contacter l’assistance"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "dQIo6c"
+msgctxt "dQIo6c"
+msgid "Email us at hello@zoonk.com"
 msgstr "Écris-nous à hello@zoonk.com"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "l1XTI5"
+msgctxt "l1XTI5"
+msgid "Follow us"
 msgstr "Suis-nous"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "rCpmYD"
+msgctxt "rCpmYD"
+msgid "Create this lesson"
 msgstr "Créer cette leçon"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "AtnLyn"
+msgctxt "AtnLyn"
+msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "Cette leçon fait partie du cours, mais elle n’a pas encore été créée. Crée-la pour commencer à apprendre."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "ZzznjM"
+msgctxt "ZzznjM"
+msgid "Create lesson"
 msgstr "Créer la leçon"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
-msgid "_N8rYN"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
 msgstr "Retour au chapitre"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "ZnMcrz"
+msgctxt "ZnMcrz"
+msgid "Unlock the rest of this course"
 msgstr "Déverrouiller le reste de ce cours"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "A_uNk-"
+msgctxt "A_uNk-"
+msgid "Create lessons before reviewing"
 msgstr "Crée les leçons avant de les réviser"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "Qy4EsI"
+msgctxt "Qy4EsI"
+msgid "Nothing to review yet"
 msgstr "Rien à réviser pour l’instant"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "4w9Y_P"
+msgctxt "4w9Y_P"
+msgid "Review unlocks after the earlier lessons in this chapter have been created."
 msgstr "La révision se débloque une fois que les leçons précédentes de ce chapitre ont été créées."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "9AOq2-"
+msgctxt "9AOq2-"
+msgid "There are no practice questions to review yet."
 msgstr "Il n’y a pas encore de questions d’entraînement à réviser."
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "txNTbP"
+msgctxt "txNTbP"
+msgid "Creating the {title} chapter"
 msgstr "Création du chapitre {title}"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "kiZUDf"
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
 msgstr "Ça prend généralement environ une minute"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "5c2xtK"
+msgctxt "5c2xtK"
+msgid "Taking you to your chapter..."
 msgstr "On t’emmène vers ton chapitre…"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "45uo73"
+msgctxt "45uo73"
+msgid "Your lessons are ready"
 msgstr "Tes leçons sont prêtes"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "gnxL73"
+msgctxt "gnxL73"
+msgid "Choosing lesson types"
 msgstr "Choix des types de leçons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "EKtClK"
+msgctxt "EKtClK"
+msgid "Getting started"
 msgstr "Démarrage"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "SF9AtA"
+msgctxt "SF9AtA"
+msgid "Preparing lessons"
 msgstr "Préparation des leçons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "L7nQzn"
+msgctxt "L7nQzn"
+msgid "Saving your lessons"
 msgstr "Enregistrement de tes leçons"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Sbsm52"
+msgctxt "Sbsm52"
+msgid "Checking how each lesson should be taught..."
 msgstr "On vérifie comment enseigner chaque leçon…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "0xCLwv"
+msgctxt "0xCLwv"
+msgid "Choosing type for lesson {number}..."
 msgstr "Choix du type de la leçon {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Vbn5Wz"
+msgctxt "Vbn5Wz"
+msgid "Reviewing the lesson mix..."
 msgstr "Vérification de l’ensemble des leçons…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5342HA"
+msgctxt "5342HA"
+msgid "Getting started..."
 msgstr "Démarrage…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "nwGJ65"
+msgctxt "nwGJ65"
+msgid "Exploring your topic..."
 msgstr "Exploration de ton sujet…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "VKFa_t"
+msgctxt "VKFa_t"
+msgid "Mapping out the learning path..."
 msgstr "Préparation du parcours d’apprentissage…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "zQWv1_"
+msgctxt "zQWv1_"
+msgid "Writing lesson {number}..."
 msgstr "Rédaction de la leçon {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "HWSnYS"
+msgctxt "HWSnYS"
+msgid "Reviewing the flow so far..."
 msgstr "Vérification du parcours jusqu’ici…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "txvxwS"
+msgctxt "txvxwS"
+msgid "Saving your progress..."
 msgstr "Enregistrement de ta progression…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JUr8Er"
+msgctxt "JUr8Er"
+msgid "Finishing up..."
 msgstr "Dernières finitions…"
 
 #: src/app/generate/course/[id]/generate-course-prompt-content.tsx
-msgid "rPgekg"
+msgctxt "rPgekg"
+msgid "Back home"
 msgstr "Retour à l’accueil"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "15FsdE"
+msgctxt "15FsdE"
+msgid "Your course is ready"
 msgstr "Ton cours est prêt"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "4Wktrz"
+msgctxt "4Wktrz"
+msgid "Your lesson is ready"
 msgstr "Ta leçon est prête"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "0o41MR"
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
 msgstr "On t’emmène vers ton cours…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "T2TGxR"
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
 msgstr "On t’emmène vers ta leçon…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "u6ROZF"
+msgctxt "u6ROZF"
+msgid "Creating the {title} course"
 msgstr "Création du cours {title}"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "GJKrUK"
+msgctxt "GJKrUK"
+msgid "This usually takes about 2 minutes"
 msgstr "Ça prend généralement environ 2 minutes"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "i3JgLB"
+msgctxt "i3JgLB"
+msgid "Categorizing your course"
 msgstr "Classement de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WOe-OA"
+msgctxt "WOe-OA"
+msgid "Checking for duplicates"
 msgstr "Recherche de doublons"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gjutu-"
+msgctxt "Gjutu-"
+msgid "Creating the cover image"
 msgstr "Création de l’image de couverture"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "SQFyKH"
+msgctxt "SQFyKH"
+msgid "Finding similar courses"
 msgstr "Recherche de cours similaires"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WZpB8D"
+msgctxt "WZpB8D"
+msgid "Writing chapters"
 msgstr "Rédaction des chapitres"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "vEOpTk"
+msgctxt "vEOpTk"
+msgid "Planning the introduction"
 msgstr "Préparation de l’introduction"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "d2xrsv"
+msgctxt "d2xrsv"
+msgid "Preparing your course"
 msgstr "Préparation de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "CFWOGF"
+msgctxt "CFWOGF"
+msgid "Saving your course"
 msgstr "Enregistrement de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XPla-v"
+msgctxt "XPla-v"
+msgid "Preparing the introduction"
 msgstr "Préparation de l’introduction"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "HbhIvm"
+msgctxt "HbhIvm"
+msgid "Writing your course description"
 msgstr "Rédaction de la description de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Y4F0xn"
+msgctxt "Y4F0xn"
+msgid "Writing the first lesson"
 msgstr "Rédaction de la première leçon"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "e1myvm"
+msgctxt "e1myvm"
+msgid "Writing your course page"
 msgstr "Rédaction de la page de ton cours"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "aev_pt"
+msgctxt "aev_pt"
+msgid "Figuring out the right categories..."
 msgstr "Recherche des bonnes catégories…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "EKAN6s"
+msgctxt "EKAN6s"
+msgid "Tagging your course..."
 msgstr "Ajout de tags à ton cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "JJrUOR"
+msgctxt "JJrUOR"
+msgid "Comparing nearby courses..."
 msgstr "Comparaison avec des cours proches…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "uw23V-"
+msgctxt "uw23V-"
+msgid "Checking whether this course already exists..."
 msgstr "Vérification de l’existence de ce cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "qFmZfG"
+msgctxt "qFmZfG"
+msgid "Avoiding duplicate courses..."
 msgstr "Évitement des cours en double…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "lxBtcx"
+msgctxt "lxBtcx"
+msgid "Designing the cover..."
 msgstr "Création de la couverture…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "W8n2i3"
+msgctxt "W8n2i3"
+msgid "Picking the right look..."
 msgstr "Choix du bon style…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "At4rk1"
+msgctxt "At4rk1"
+msgid "Adding finishing touches..."
 msgstr "Ajout des dernières touches…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "NgONb4"
+msgctxt "NgONb4"
+msgid "Searching for matching topics..."
 msgstr "Recherche de sujets correspondants…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Auz1tl"
+msgctxt "Auz1tl"
+msgid "Looking for alternate names..."
 msgstr "Recherche d’autres noms…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gt_VNO"
+msgctxt "Gt_VNO"
+msgid "Expanding the course search..."
 msgstr "On élargit la recherche de cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "AEG3Ol"
+msgctxt "AEG3Ol"
+msgid "Planning the course structure..."
 msgstr "On prépare la structure du cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "OW9vMd"
+msgctxt "OW9vMd"
+msgid "Writing chapter {number}..."
 msgstr "On écrit le chapitre {number}…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "tXkuD8"
+msgctxt "tXkuD8"
+msgid "Reviewing the overall flow..."
 msgstr "On vérifie l’enchaînement global…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "8-bhNP"
+msgctxt "8-bhNP"
+msgid "Finding the best first hook..."
 msgstr "On cherche la meilleure accroche pour commencer…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "xrFhkn"
+msgctxt "xrFhkn"
+msgid "Writing a friendly guide to the field..."
 msgstr "On écrit un guide simple pour découvrir le sujet…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "c_e4hk"
+msgctxt "c_e4hk"
+msgid "Keeping the first chapter easy to start..."
 msgstr "On rend le premier chapitre facile à commencer…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "4LsE_n"
+msgctxt "4LsE_n"
+msgid "Creating the course shell..."
 msgstr "On crée la structure de base du cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "3hEaI4"
+msgctxt "3hEaI4"
+msgid "Preparing the workspace..."
 msgstr "On prépare l’espace de travail…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "7Pw3r5"
+msgctxt "7Pw3r5"
+msgid "Saving the intro chapter..."
 msgstr "On enregistre le chapitre d’introduction…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "cc6_Yn"
+msgctxt "cc6_Yn"
+msgid "Preparing the first lessons..."
 msgstr "On prépare les premières leçons…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "a7FJJd"
+msgctxt "a7FJJd"
+msgid "Summarizing what you'll learn..."
 msgstr "On résume ce que tu vas apprendre…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "9r_4zz"
+msgctxt "9r_4zz"
+msgid "Writing the overview..."
 msgstr "On écrit l’aperçu…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "QqKzYM"
+msgctxt "QqKzYM"
+msgid "Writing the first lesson..."
 msgstr "On écrit la première leçon…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XxRMuO"
+msgctxt "XxRMuO"
+msgid "Adding examples and visuals..."
 msgstr "On ajoute des exemples et des images…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "kmuvIN"
+msgctxt "kmuvIN"
+msgid "Getting the first lesson ready..."
 msgstr "On prépare la première leçon…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "chqN-J"
+msgctxt "chqN-J"
+msgid "Framing why this course is useful..."
 msgstr "On explique pourquoi ce cours est utile…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "twf4n2"
+msgctxt "twf4n2"
+msgid "Writing the course page..."
 msgstr "On écrit la page du cours…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "k15wFf"
+msgctxt "k15wFf"
+msgid "Shaping the starting point..."
 msgstr "On prépare le point de départ…"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "WihX6L"
+msgctxt "WihX6L"
+msgid "Creating the {title} lesson"
 msgstr "Création de la leçon {title}"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "3vY0Zu"
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
 msgstr "Cela prend généralement 1 à 2 minutes"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "cVoRCh"
+msgctxt "cVoRCh"
+msgid "Preparing options..."
 msgstr "On prépare les options…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BBwnPG"
+msgctxt "BBwnPG"
+msgid "Adding more options..."
 msgstr "On ajoute plus d’options…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "4wkMNX"
+msgctxt "4wkMNX"
+msgid "Getting answer options ready..."
 msgstr "On prépare les choix de réponse…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "WsjFV2"
+msgctxt "WsjFV2"
+msgid "Preparing the word bank..."
 msgstr "On prépare la banque de mots…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6xEJTk"
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
 msgstr "On crée des exercices d’entraînement…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6hjA6_"
+msgctxt "6hjA6_"
+msgid "Creating examples to try..."
 msgstr "On crée des exemples à essayer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "KddvJw"
+msgctxt "KddvJw"
+msgid "Writing fill-in-the-blanks..."
 msgstr "On écrit des textes à trous…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "C05-tM"
+msgctxt "C05-tM"
+msgid "Building interactive tasks..."
 msgstr "On crée des activités interactives…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JGNN92"
+msgctxt "JGNN92"
+msgid "Drawing an illustration..."
 msgstr "On dessine une illustration…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "a08k7g"
+msgctxt "a08k7g"
+msgid "Generating the images..."
 msgstr "On génère les images…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bJVUNz"
+msgctxt "bJVUNz"
+msgid "Adding some color..."
 msgstr "On ajoute un peu de couleur…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "Yoev2R"
+msgctxt "Yoev2R"
+msgid "Refining the details..."
 msgstr "On affine les détails…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "xBaVAH"
+msgctxt "xBaVAH"
+msgid "Finishing the artwork..."
 msgstr "On termine l’illustration…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "W2b0tx"
+msgctxt "W2b0tx"
+msgid "Designing the lesson thumbnail..."
 msgstr "On conçoit la vignette de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "fRAHqN"
+msgctxt "fRAHqN"
+msgid "Creating the lesson thumbnail..."
 msgstr "On crée la vignette de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "elwtxf"
+msgctxt "elwtxf"
+msgid "Refining the lesson thumbnail..."
 msgstr "On affine la vignette de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "uDzgwu"
+msgctxt "uDzgwu"
+msgid "Writing example sentences..."
 msgstr "On écrit des phrases d’exemple…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "SHIHyL"
+msgctxt "SHIHyL"
+msgid "Creating reading passages..."
 msgstr "On crée des textes à lire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0Zum4g"
+msgctxt "0Zum4g"
+msgid "Putting words in context..."
 msgstr "On met les mots en contexte…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "jixTNM"
+msgctxt "jixTNM"
+msgid "Building natural sentences..."
 msgstr "On construit des phrases naturelles…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "txIcop"
+msgctxt "txIcop"
+msgid "Loading lesson data..."
 msgstr "On charge les données de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "l486Kx"
+msgctxt "l486Kx"
+msgid "Checking what we need..."
 msgstr "On vérifie ce dont on a besoin…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "EAqAX_"
+msgctxt "EAqAX_"
+msgid "Thinking about what to illustrate..."
 msgstr "On réfléchit à ce qu’il faut illustrer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "2Tovpk"
+msgctxt "2Tovpk"
+msgid "Planning each image..."
 msgstr "On prépare chaque image…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "sQsQbH"
+msgctxt "sQsQbH"
+msgid "Choosing the right scenes..."
 msgstr "On choisit les bonnes scènes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "iUUJom"
+msgctxt "iUUJom"
+msgid "Planning the illustrations..."
 msgstr "On prépare les illustrations…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BszFlm"
+msgctxt "BszFlm"
+msgid "Saving your lesson..."
 msgstr "On enregistre ta leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bC9979"
+msgctxt "bC9979"
+msgid "Almost done..."
 msgstr "C’est presque fini…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5Jyenk"
+msgctxt "5Jyenk"
+msgid "Getting ready for the next step..."
 msgstr "On se prépare pour la prochaine étape…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "r8xznK"
+msgctxt "r8xznK"
+msgid "Researching the topic..."
 msgstr "Recherche sur le sujet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "K_JznZ"
+msgctxt "K_JznZ"
+msgid "Writing the explanation..."
 msgstr "Rédaction de l’explication…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "19fPwV"
+msgctxt "19fPwV"
+msgid "Making it clear..."
 msgstr "Clarification en cours…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "65JXIy"
+msgctxt "65JXIy"
+msgid "Putting together the lesson..."
 msgstr "Préparation de la leçon…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "nwi1Ym"
+msgctxt "nwi1Ym"
+msgid "Crafting the content..."
 msgstr "Création du contenu…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "-QrqeN"
+msgctxt "-QrqeN"
+msgid "Writing the explanation first..."
 msgstr "Rédaction de l’explication d’abord…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "epxxAx"
+msgctxt "epxxAx"
+msgid "Building the foundation..."
 msgstr "Mise en place des bases…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "GyThaR"
+msgctxt "GyThaR"
+msgid "Preparing background context..."
 msgstr "Préparation du contexte…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0AWsLH"
+msgctxt "0AWsLH"
+msgid "Explaining the topic..."
 msgstr "Explication du sujet…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "KL34l5"
+msgctxt "KL34l5"
+msgid "Adding romanization for grammar..."
 msgstr "Ajout de la romanisation pour la grammaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "GILb0l"
+msgctxt "GILb0l"
+msgid "Converting grammar text to Latin script..."
 msgstr "Conversion du texte de grammaire en alphabet latin…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OFH7dE"
+msgctxt "OFH7dE"
+msgid "Making grammar content easier to read..."
 msgstr "Simplification de la lecture de la grammaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VADOBa"
+msgctxt "VADOBa"
+msgid "Looking up how each word sounds..."
 msgstr "Recherche du son de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "WnqJeL"
+msgctxt "WnqJeL"
+msgid "Mapping out the pronunciation..."
 msgstr "Préparation de la prononciation…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "HDNFHk"
+msgctxt "HDNFHk"
+msgid "Checking how to say each word..."
 msgstr "Vérification de la prononciation de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "_Fl7bm"
+msgctxt "_Fl7bm"
+msgid "Finding the right sounds..."
 msgstr "Recherche des bons sons…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "DLZ9fl"
+msgctxt "DLZ9fl"
+msgid "Converting to Latin script..."
 msgstr "Conversion en alphabet latin…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "boocfl"
+msgctxt "boocfl"
+msgid "Adding reading aids..."
 msgstr "Ajout d’aides à la lecture…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "AQMVYX"
+msgctxt "AQMVYX"
+msgid "Making it easier to read..."
 msgstr "Simplification de la lecture…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ud2yWh"
+msgctxt "ud2yWh"
+msgid "Writing out the sounds..."
 msgstr "Transcription des sons…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "kxBeWt"
+msgctxt "kxBeWt"
+msgid "Adding romanization for vocabulary..."
 msgstr "Ajout de la romanisation pour le vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "Ch9BcP"
+msgctxt "Ch9BcP"
+msgid "Converting vocabulary to Latin script..."
 msgstr "Conversion du vocabulaire en alphabet latin…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1aPaHZ"
+msgctxt "1aPaHZ"
+msgid "Making vocabulary easier to read..."
 msgstr "Simplification de la lecture du vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "zYx0UG"
+msgctxt "zYx0UG"
+msgid "Adding pronunciation for each word..."
 msgstr "Ajout de la prononciation pour chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VQ3-C2"
+msgctxt "VQ3-C2"
+msgid "Noting how each word sounds..."
 msgstr "Notation du son de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YWB-K_"
+msgctxt "YWB-K_"
+msgid "Detailing the word sounds..."
 msgstr "Détail des sons des mots…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "L6f1Zq"
+msgctxt "L6f1Zq"
+msgid "Recording pronunciation info..."
 msgstr "Enregistrement des infos de prononciation…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "i-rNdh"
+msgctxt "i-rNdh"
+msgid "Picking the key vocabulary..."
 msgstr "Choix du vocabulaire clé…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "IdWf9_"
+msgctxt "IdWf9_"
+msgid "Choosing words to practice..."
 msgstr "Choix des mots à pratiquer…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "UFDKHM"
+msgctxt "UFDKHM"
+msgid "Finding the most useful words..."
 msgstr "Recherche des mots les plus utiles…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YgG70c"
+msgctxt "YgG70c"
+msgid "Selecting important terms..."
 msgstr "Sélection des termes importants…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "6BQo6o"
+msgctxt "6BQo6o"
+msgid "Translating individual words..."
 msgstr "Traduction des mots un par un…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "k0Q_Ph"
+msgctxt "k0Q_Ph"
+msgid "Looking up each term..."
 msgstr "Recherche de chaque terme…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "hZLCkp"
+msgctxt "hZLCkp"
+msgid "Finding word meanings..."
 msgstr "Recherche du sens des mots…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "SC0o7J"
+msgctxt "SC0o7J"
+msgid "Building the vocabulary guide..."
 msgstr "Création du guide de vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "5InW8H"
+msgctxt "5InW8H"
+msgid "Recording the audio..."
 msgstr "Enregistrement de l’audio…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "4xvh9e"
+msgctxt "4xvh9e"
+msgid "Getting the pronunciation right..."
 msgstr "Ajustement de la prononciation…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "oB01Wc"
+msgctxt "oB01Wc"
+msgid "Preparing the voice..."
 msgstr "Préparation de la voix…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ScA7Xm"
+msgctxt "ScA7Xm"
+msgid "Making it sound natural..."
 msgstr "Création d’un son naturel…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1vO-bV"
+msgctxt "1vO-bV"
+msgid "Recording vocabulary audio..."
 msgstr "Enregistrement de l’audio du vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "jV2zI1"
+msgctxt "jV2zI1"
+msgid "Getting the sound for each word..."
 msgstr "Préparation du son de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "FahI7K"
+msgctxt "FahI7K"
+msgid "Preparing vocabulary audio..."
 msgstr "Préparation de l’audio du vocabulaire…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "JfNFGM"
+msgctxt "JfNFGM"
+msgid "Making words listenable..."
 msgstr "Préparation des mots à écouter…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "muXaEm"
+msgctxt "muXaEm"
+msgid "Recording pronunciation for each word..."
 msgstr "Enregistrement de la prononciation de chaque mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "QDv0wS"
+msgctxt "QDv0wS"
+msgid "Getting the audio for each term..."
 msgstr "Préparation de l’audio de chaque terme…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OJkDgV"
+msgctxt "OJkDgV"
+msgid "Preparing word-by-word audio..."
 msgstr "Préparation de l’audio mot par mot…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "C2ELVi"
+msgctxt "C2ELVi"
+msgid "Making each word listenable..."
 msgstr "Préparation de chaque mot à écouter…"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "58heST"
+msgctxt "58heST"
+msgid "Adding grammar romanization"
 msgstr "Ajout de la romanisation de la grammaire"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "TlrPFF"
+msgctxt "TlrPFF"
+msgid "Adding pronunciation"
 msgstr "Ajout de la prononciation"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "V0mPLK"
+msgctxt "V0mPLK"
+msgid "Adding romanization"
 msgstr "Ajout de la romanisation"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "HXMA75"
+msgctxt "HXMA75"
+msgid "Adding vocabulary romanization"
 msgstr "Ajout de la romanisation du vocabulaire"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "4OjRPB"
+msgctxt "4OjRPB"
+msgid "Adding word pronunciation"
 msgstr "Ajout de la prononciation des mots"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "RXfSEl"
+msgctxt "RXfSEl"
+msgid "Building word list"
 msgstr "Création de la liste de mots"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "viluaR"
+msgctxt "viluaR"
+msgid "Preparing options"
 msgstr "Préparation des options"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "c7xJGQ"
+msgctxt "c7xJGQ"
+msgid "Creating exercises"
 msgstr "Création des exercices"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "aKNA_b"
+msgctxt "aKNA_b"
+msgid "Creating images"
 msgstr "Création des images"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "WI2yui"
+msgctxt "WI2yui"
+msgid "Creating lesson thumbnail"
 msgstr "Création de la vignette de la leçon"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "mIpv67"
+msgctxt "mIpv67"
+msgid "Creating sentences"
 msgstr "Création des phrases"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "0zeST_"
+msgctxt "0zeST_"
+msgid "Looking up words"
 msgstr "Recherche de mots"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v7HGj3"
+msgctxt "v7HGj3"
+msgid "Planning the images"
 msgstr "Planification des images"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "T00GEW"
+msgctxt "T00GEW"
+msgid "Recording audio"
 msgstr "Enregistrement de l’audio"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v2DAdY"
+msgctxt "v2DAdY"
+msgid "Recording vocabulary audio"
 msgstr "Enregistrement de l’audio du vocabulaire"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "j-pO55"
+msgctxt "j-pO55"
+msgid "Recording word audio"
 msgstr "Enregistrement de l’audio du mot"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "2ZPUqg"
+msgctxt "2ZPUqg"
+msgid "Saving your lesson"
 msgstr "Enregistrement de ta leçon"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v4iFHN"
+msgctxt "v4iFHN"
+msgid "Writing the content"
 msgstr "Rédaction du contenu"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "ZA0_P-"
+msgctxt "ZA0_P-"
+msgid "Writing the explanation"
 msgstr "Rédaction de l’explication"
 
 #: src/app/generate/layout.tsx
-msgid "_tq5fR"
+msgctxt "_tq5fR"
+msgid "Creating content"
 msgstr "Création du contenu"
 
 #: src/app/privacy/page.tsx
-msgid "afKQHy"
+msgctxt "afKQHy"
+msgid "Read Zoonk's privacy policy to understand how we use and protect your personal information."
 msgstr "Lis la politique de confidentialité de Zoonk pour comprendre comment nous utilisons et protégeons tes informations personnelles."
 
 #: src/app/privacy/page.tsx
-msgid "vx0nkZ"
+msgctxt "vx0nkZ"
+msgid "Privacy Policy"
 msgstr "Politique de confidentialité"
 
 #: src/app/terms/page.tsx
-msgid "DaGtoz"
+msgctxt "DaGtoz"
+msgid "Read Zoonk's terms of use to understand the rules and conditions for using our platform and services"
 msgstr "Lis les conditions d’utilisation de Zoonk pour comprendre les règles et conditions liées à l’utilisation de notre plateforme et de nos services"
 
 #: src/app/terms/page.tsx
-msgid "UhkSyx"
+msgctxt "UhkSyx"
+msgid "Terms of Use"
 msgstr "Conditions d’utilisation"
 
 #: src/components/catalog/ai-warning.tsx
-msgid "FYZlTZ"
+msgctxt "FYZlTZ"
+msgid "Created with AI"
 msgstr "Créé avec l’IA"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "F0tnKc"
+msgctxt "F0tnKc"
+msgid "Thanks for your feedback"
 msgstr "Merci pour ton avis"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "IzCVhG"
+msgctxt "IzCVhG"
+msgid "More options"
 msgstr "Plus d’options"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "rTFrsw"
+msgctxt "rTFrsw"
+msgid "I liked it"
 msgstr "J’ai aimé"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "Hqn5Uo"
+msgctxt "Hqn5Uo"
+msgid "I didn't like it"
 msgstr "Je n’ai pas aimé"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "G5YSJR"
+msgctxt "G5YSJR"
+msgid "Send feedback"
 msgstr "Envoyer un avis"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "PAKDzS"
+msgctxt "PAKDzS"
+msgid "Go to current chapter"
 msgstr "Aller au chapitre actuel"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "Js2dT3"
+msgctxt "Js2dT3"
+msgid "Go to current lesson"
 msgstr "Aller à la leçon actuelle"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "izuy1D"
+msgctxt "izuy1D"
+msgid "Current item"
 msgstr "Élément actuel"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "Gs9Kfp"
+msgctxt "Gs9Kfp"
+msgid "Back to top"
 msgstr "Retour en haut"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "AvySqa"
+msgctxt "AvySqa"
+msgid "{percent}% complete"
 msgstr "{percent} % terminé"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "mOFG3K"
+msgctxt "mOFG3K"
+msgid "Start"
 msgstr "Commencer"
 
 #: src/components/catalog/continue-lesson-link.tsx
 #: src/lib/lessons.ts
-msgid "R-J5ox"
+msgctxt "R-J5ox"
+msgid "Review"
 msgstr "Réviser"
 
 #: src/components/feedback/contact-form.tsx
-msgid "WzCvaN"
+msgctxt "WzCvaN"
+msgid "We'll use this email to contact you."
 msgstr "Nous utiliserons cet e-mail pour te contacter."
 
 #: src/components/feedback/contact-form.tsx
-msgid "T7Ry38"
+msgctxt "T7Ry38"
+msgid "Message"
 msgstr "Message"
 
 #: src/components/feedback/contact-form.tsx
-msgid "M6PcEI"
+msgctxt "M6PcEI"
+msgid "How can we help you?"
 msgstr "Comment pouvons-nous t’aider ?"
 
 #: src/components/feedback/contact-form.tsx
-msgid "vD72E5"
+msgctxt "vD72E5"
+msgid "Message sent successfully! We'll get back to you soon."
 msgstr "Message envoyé ! Nous te répondrons bientôt."
 
 #: src/components/feedback/contact-form.tsx
-msgid "-5vOOu"
+msgctxt "-5vOOu"
+msgid "Please provide as much detail as possible."
 msgstr "Donne autant de détails que possible."
 
 #: src/components/feedback/contact-form.tsx
-msgid "1WHPmV"
+msgctxt "1WHPmV"
+msgid "Failed to send message. Please try again or email us directly at hello@zoonk.com"
 msgstr "Impossible d’envoyer le message. Réessaie ou écris-nous directement à hello@zoonk.com"
 
 #: src/components/feedback/contact-form.tsx
-msgid "Xx0WZV"
+msgctxt "Xx0WZV"
+msgid "Send message"
 msgstr "Envoyer le message"
 
 #: src/components/feedback/content-feedback.tsx
-msgid "BlI1_9"
+msgctxt "BlI1_9"
+msgid "Did you like this content?"
 msgstr "As-tu aimé ce contenu ?"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "Ejhdi4"
+msgctxt "Ejhdi4"
+msgid "Feedback"
 msgstr "Avis"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "eUzs3M"
+msgctxt "eUzs3M"
+msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envoie-nous tes avis, questions ou suggestions. Remplis le formulaire ci-dessous ou écris-nous directement à hello@zoonk.com."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "ctqXbT"
+msgctxt "ctqXbT"
+msgid "We lost the progress connection. Your content may still be generating."
 msgstr "La connexion au suivi de progression a été perdue. Ton contenu est peut-être encore en cours de création."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "1A8Z_l"
+msgctxt "1A8Z_l"
+msgid "Check again"
 msgstr "Vérifier à nouveau"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "yHqv96"
+msgctxt "yHqv96"
+msgid "Connection interrupted"
 msgstr "Connexion interrompue"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "JqiqNj"
+msgctxt "JqiqNj"
+msgid "Something went wrong"
 msgstr "Un problème est survenu"
 
 #: src/components/progress/progress-day-count-label.ts
-msgid "r9koty"
+msgctxt "r9koty"
+msgid "{count, plural, =0 {# days} one {# day} other {# days}}"
 msgstr "{count, plural, =0 {# jour} one {# jour} other {# jours}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "tRA46q"
+msgctxt "tRA46q"
+msgid "0 min"
 msgstr "0 min"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "yMhrnF"
+msgctxt "yMhrnF"
+msgid "{seconds, plural, one {# sec} other {# sec}}"
 msgstr "{seconds, plural, one {# s} other {# s}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "a-oHjQ"
+msgctxt "a-oHjQ"
+msgid "{minutes, plural, one {# min} other {# min}}"
 msgstr "{minutes, plural, one {# min} other {# min}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "QqnZaw"
+msgctxt "QqnZaw"
+msgid "{hours, plural, one {# hr} other {# hr}}"
 msgstr "{hours, plural, one {# h} other {# h}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "Frd5VU"
+msgctxt "Frd5VU"
+msgid "{hours, plural, one {# hr} other {# hr}} {minutes, plural, one {# min} other {# min}}"
 msgstr "{hours, plural, one {# h} other {# h}} {minutes, plural, one {# min} other {# min}}"
 
 #: src/components/progress/total-learning-time-card.tsx
-msgid "-V74AY"
+msgctxt "-V74AY"
+msgid "Learning time"
 msgstr "Temps d’apprentissage"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "IS_YjO"
+msgctxt "IS_YjO"
+msgid "Upgrade to create"
 msgstr "Passe à l’offre supérieure pour créer"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "ZMU6iN"
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
 msgstr "Tu as atteint ta limite de leçons gratuites. Passe à l’offre supérieure pour des leçons illimitées"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "0h_lPM"
+msgctxt "0h_lPM"
+msgid "Upgrade"
 msgstr "Passer à l’offre supérieure"
 
 #: src/lib/belt-colors.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {Ceinture Blanche} yellow {Ceinture Jaune} orange {Ceinture Orange} green {Ceinture Verte} blue {Ceinture Bleue} purple {Ceinture Violette} brown {Ceinture Marron} red {Ceinture Rouge} gray {Ceinture Grise} black {Ceinture Noire} other {Ceinture}}"
 
 #: src/lib/categories/category.ts
-msgid "fFt3il"
+msgctxt "fFt3il"
+msgid "Arts"
 msgstr "Arts"
 
 #: src/lib/categories/category.ts
-msgid "w1Fanr"
+msgctxt "w1Fanr"
+msgid "Business"
 msgstr "Business"
 
 #: src/lib/categories/category.ts
-msgid "n5D_Ku"
+msgctxt "n5D_Ku"
+msgid "Communication"
 msgstr "Communication"
 
 #: src/lib/categories/category.ts
-msgid "mn6pIm"
+msgctxt "mn6pIm"
+msgid "Culture"
 msgstr "Culture"
 
 #: src/lib/categories/category.ts
-msgid "hwL7a0"
+msgctxt "hwL7a0"
+msgid "Engineering"
 msgstr "Ingénierie"
 
 #: src/lib/categories/category.ts
-msgid "YMDBNH"
+msgctxt "YMDBNH"
+msgid "Geography"
 msgstr "Géographie"
 
 #: src/lib/categories/category.ts
-msgid "hlmkcL"
+msgctxt "hlmkcL"
+msgid "Health"
 msgstr "Santé"
 
 #: src/lib/categories/category.ts
-msgid "GsBRWL"
+msgctxt "GsBRWL"
+msgid "Languages"
 msgstr "Langues"
 
 #: src/lib/categories/category.ts
-msgid "u3ovjm"
+msgctxt "u3ovjm"
+msgid "Law"
 msgstr "Droit"
 
 #: src/lib/categories/category.ts
-msgid "dPgwrL"
+msgctxt "dPgwrL"
+msgid "Math"
 msgstr "Maths"
 
 #: src/lib/categories/category.ts
-msgid "qydxOd"
+msgctxt "qydxOd"
+msgid "Science"
 msgstr "Sciences"
 
 #: src/lib/categories/category.ts
-msgid "OV_2-4"
+msgctxt "OV_2-4"
+msgid "Society"
 msgstr "Société"
 
 #: src/lib/categories/category.ts
-msgid "I1ZCPK"
+msgctxt "I1ZCPK"
+msgid "Technology"
 msgstr "Technologie"
 
 #: src/lib/categories/category.ts
-msgid "XL8IWT"
+msgctxt "XL8IWT"
+msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
 msgstr "Cours de {category}. Les meilleurs cours en ligne de {category}, avec des leçons interactives pour apprendre."
 
 #: src/lib/categories/category.ts
-msgid "4HKnmB"
+msgctxt "4HKnmB"
+msgid "{category} Courses"
 msgstr "Cours de {category}"
 
 #: src/lib/categories/category.ts
-msgid "EMi23I"
+msgctxt "EMi23I"
+msgid "Explore all {category} courses"
 msgstr "Explorer tous les cours de {category}"
 
 #: src/lib/categories/category.ts
-msgid "Rz9oL-"
+msgctxt "Rz9oL-"
+msgid "{category} courses"
 msgstr "Cours de {category}"
 
 #: src/lib/lessons.ts
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alphabet"
 
 #: src/lib/lessons.ts
-msgid "4TTYDR"
+msgctxt "4TTYDR"
+msgid "Custom lesson"
 msgstr "Leçon personnalisée"
 
 #: src/lib/lessons.ts
-msgid "E1bF_X"
+msgctxt "E1bF_X"
+msgid "Explanation"
 msgstr "Explication"
 
 #: src/lib/lessons.ts
-msgid "QzTY8x"
+msgctxt "QzTY8x"
+msgid "Grammar"
 msgstr "Grammaire"
 
 #: src/lib/lessons.ts
-msgid "1TOMnj"
+msgctxt "1TOMnj"
+msgid "Listening"
 msgstr "Écoute"
 
 #: src/lib/lessons.ts
-msgid "KV-O0y"
+msgctxt "KV-O0y"
+msgid "Practice"
 msgstr "Entraînement"
 
 #: src/lib/lessons.ts
-msgid "OuR_Ij"
+msgctxt "OuR_Ij"
+msgid "Quiz"
 msgstr "Quiz"
 
 #: src/lib/lessons.ts
-msgid "MOK_yK"
+msgctxt "MOK_yK"
+msgid "Reading"
 msgstr "Lecture"
 
 #: src/lib/lessons.ts
-msgid "_vCXIP"
+msgctxt "_vCXIP"
+msgid "Translation"
 msgstr "Traduction"
 
 #: src/lib/lessons.ts
-msgid "Ox-Z-K"
+msgctxt "Ox-Z-K"
+msgid "Tutorial"
 msgstr "Tutoriel"
 
 #: src/lib/lessons.ts
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Vocabulaire"
 
 #: src/lib/lessons.ts
-msgid "22k1CY"
+msgctxt "22k1CY"
+msgid "Learn how letters and sounds work in this writing system."
 msgstr "Découvre comment les lettres et les sons fonctionnent dans ce système d’écriture."
 
 #: src/lib/lessons.ts
-msgid "LZC7R9"
+msgctxt "LZC7R9"
+msgid "Work through a lesson created for your goal."
 msgstr "Suis une leçon créée pour ton objectif."
 
 #: src/lib/lessons.ts
-msgid "fOfLbt"
+msgctxt "fOfLbt"
+msgid "Understand the key ideas using everyday language and practical examples."
 msgstr "Comprends les idées clés avec des mots simples et des exemples pratiques."
 
 #: src/lib/lessons.ts
-msgid "dHmgw1"
+msgctxt "dHmgw1"
+msgid "Practice grammar patterns with examples and exercises."
 msgstr "Entraîne-toi aux structures grammaticales avec des exemples et des exercices."
 
 #: src/lib/lessons.ts
-msgid "AetsPy"
+msgctxt "AetsPy"
+msgid "Listen to sentences using words you recently learned."
 msgstr "Écoute des phrases avec des mots que tu as appris récemment."
 
 #: src/lib/lessons.ts
-msgid "6oNgY9"
+msgctxt "6oNgY9"
+msgid "Use what you learned in the previous lesson to solve real-world problems."
 msgstr "Utilise ce que tu as appris dans la leçon précédente pour résoudre des problèmes concrets."
 
 #: src/lib/lessons.ts
-msgid "vO6aLm"
+msgctxt "vO6aLm"
+msgid "Check what you understood with a short quiz."
 msgstr "Vérifie ce que tu as compris avec un petit quiz."
 
 #: src/lib/lessons.ts
-msgid "OIim7M"
+msgctxt "OIim7M"
+msgid "Read sentences using words you recently learned."
 msgstr "Lis des phrases avec des mots que tu as appris récemment."
 
 #: src/lib/lessons.ts
-msgid "pwrprO"
+msgctxt "pwrprO"
+msgid "Review this chapter with practice based on your mistakes."
 msgstr "Révise ce chapitre avec des exercices basés sur tes erreurs."
 
 #: src/lib/lessons.ts
-msgid "IQOJhk"
+msgctxt "IQOJhk"
+msgid "Translate words from your previous vocabulary lesson."
 msgstr "Traduis les mots de ta leçon de vocabulaire précédente."
 
 #: src/lib/lessons.ts
-msgid "9XByXq"
+msgctxt "9XByXq"
+msgid "Follow a guided step-by-step tutorial."
 msgstr "Suis un tutoriel guidé étape par étape."
 
 #: src/lib/lessons.ts
-msgid "IHSVS5"
+msgctxt "IHSVS5"
+msgid "Learn new words and practice using them."
 msgstr "Apprends de nouveaux mots et entraîne-toi à les utiliser."
 
 #: src/lib/lessons.ts
-msgid "OjyuQ-"
+msgctxt "OjyuQ-"
+msgid "Learn the writing system for {topic} with focused practice."
 msgstr "Apprends le système d’écriture de {topic} avec un entraînement ciblé."
 
 #: src/lib/lessons.ts
-msgid "pSQZ7W"
+msgctxt "pSQZ7W"
+msgid "Learn about {topic} through an interactive lesson."
 msgstr "Découvre {topic} avec une leçon interactive."
 
 #: src/lib/lessons.ts
-msgid "THPcKi"
+msgctxt "THPcKi"
+msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
 msgstr "Comprends ce qu’est {topic} : les concepts clés et les définitions sont expliqués avec des métaphores et des analogies claires."
 
 #: src/lib/lessons.ts
-msgid "tlgfSZ"
+msgctxt "tlgfSZ"
+msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 msgstr "Entraîne-toi aux règles de grammaire de {topic} avec des exercices conçus pour t’aider à les retenir et à les appliquer."
 
 #: src/lib/lessons.ts
-msgid "xCvEE1"
+msgctxt "xCvEE1"
+msgid "Practice listening in {topic} by translating audio sentences."
 msgstr "Entraîne ton écoute en {topic} en traduisant des phrases audio."
 
 #: src/lib/lessons.ts
-msgid "wHBT6R"
+msgctxt "wHBT6R"
+msgid "Apply {topic} through a visual real-world problem with short decisions."
 msgstr "Mets {topic} en pratique avec un problème visuel concret et de courtes décisions."
 
 #: src/lib/lessons.ts
-msgid "h2acN8"
+msgctxt "h2acN8"
+msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Teste ta compréhension de {topic} avec des questions faites pour vérifier si tu as vraiment compris, pas juste mémorisé."
 
 #: src/lib/lessons.ts
-msgid "XzxpBZ"
+msgctxt "XzxpBZ"
+msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Améliore ta compréhension écrite de {topic} en traduisant des phrases et des passages."
 
 #: src/lib/lessons.ts
-msgid "bzFQEy"
+msgctxt "bzFQEy"
+msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Révise tout ce que tu as appris sur {topic} avec un quiz complet."
 
 #: src/lib/lessons.ts
-msgid "X8Gqiq"
+msgctxt "X8Gqiq"
+msgid "Practice vocabulary in {topic} by translating words you've learned."
 msgstr "Entraîne-toi au vocabulaire de {topic} en traduisant les mots que tu as appris."
 
 #: src/lib/lessons.ts
-msgid "3bJDQa"
+msgctxt "3bJDQa"
+msgid "Learn {topic} with a guided step-by-step tutorial."
 msgstr "Apprends {topic} avec un tutoriel guidé, étape par étape."
 
 #: src/lib/lessons.ts
-msgid "77SLH5"
+msgctxt "77SLH5"
+msgid "Learn new words in {topic} with flashcards — see each word, its translation, and pronunciation."
 msgstr "Apprends de nouveaux mots en {topic} avec des cartes mémoire — vois chaque mot, sa traduction et sa prononciation."
 
 #: src/lib/lessons.ts
-msgid "oCxmX9"
+msgctxt "oCxmX9"
+msgid "{chapter} {kind} {position}"
 msgstr "{chapter} {kind} {position}"
 
 #: src/lib/lessons.ts
-msgid "qHbgYB"
+msgctxt "qHbgYB"
+msgid "{lesson} - {course}"
 msgstr "{lesson} - {course}"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -4,93 +4,109 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "xmcVZ0"
+msgctxt "xmcVZ0"
+msgid "Search"
 msgstr "Pesquisar"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "PSiLeL"
+msgctxt "PSiLeL"
+msgid "Search courses, chapters, or pages..."
 msgstr "Busque cursos, capítulos ou páginas…"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "I-38K2"
+msgctxt "I-38K2"
+msgid "My courses"
 msgstr "Meus cursos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Oj9Phc"
+msgctxt "Oj9Phc"
+msgid "Manage subscription"
 msgstr "Gerenciar assinatura"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "OhXwmw"
+msgctxt "OhXwmw"
+msgid "Update language"
 msgstr "Alterar idioma"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "O7ozeo"
+msgctxt "O7ozeo"
+msgid "Update profile"
 msgstr "Atualizar perfil"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "C81_uG"
+msgctxt "C81_uG"
+msgid "Logout"
 msgstr "Sair"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/logout-dropdown-item.tsx
 #: src/app/(progress)/_components/progress-empty-state.tsx
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "AyGauy"
+msgctxt "AyGauy"
+msgid "Login"
 msgstr "Entrar"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(settings)/_components/locale-switcher.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/language/page.tsx
-msgid "y1Z3or"
+msgctxt "y1Z3or"
+msgid "Language"
 msgstr "Idioma"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/navbar-links.tsx
 #: src/app/(progress)/_components/progress-navbar.tsx
 #: src/app/(settings)/_components/settings-navbar.tsx
-msgid "U3l-Q9"
+msgctxt "U3l-Q9"
+msgid "Home page"
 msgstr "Página inicial"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "jboh4c"
+msgctxt "jboh4c"
+msgid "Start a new course"
 msgstr "Começar um novo curso"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "rS0suY"
+msgctxt "rS0suY"
+msgid "Speak a language"
 msgstr "Falar um idioma"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "L6kaJv"
+msgctxt "L6kaJv"
+msgid "Learn something"
 msgstr "Aprender algo"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "3wvH7G"
+msgctxt "3wvH7G"
+msgid "Pass an exam"
 msgstr "Passar em uma prova"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "CxfKLC"
+msgctxt "CxfKLC"
+msgid "Pages"
 msgstr "Páginas"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "dXSivY"
+msgctxt "dXSivY"
+msgid "My account"
 msgstr "Minha conta"
 
 #: src/app/(catalog)/_components/command-palette.tsx
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
-msgid "tv5FG3"
+msgctxt "tv5FG3"
+msgid "Blog"
 msgstr "Blog"
 
 #: src/app/(catalog)/_components/command-palette.tsx
@@ -98,2184 +114,2713 @@ msgstr "Blog"
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "fFZ0Wd"
+msgctxt "fFZ0Wd"
+msgid "Feedback & Support"
 msgstr "Sugestões e Suporte"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "SENRqu"
+msgctxt "SENRqu"
+msgid "Help"
 msgstr "Ajuda"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "R85gsW"
+msgctxt "R85gsW"
+msgid "Courses"
 msgstr "Cursos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "Do1Pfd"
+msgctxt "Do1Pfd"
+msgid "Chapters"
 msgstr "Capítulos"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "hX5PAb"
+msgctxt "hX5PAb"
+msgid "No results found"
 msgstr "Nenhum resultado encontrado"
 
 #: src/app/(catalog)/_components/command-palette.tsx
-msgid "OXAZiT"
+msgctxt "OXAZiT"
+msgid "Create a course about {term}"
 msgstr "Criar curso sobre {term}"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "onRJrc"
+msgctxt "onRJrc"
+msgid "Course page"
 msgstr "Página do curso"
 
 #: src/app/(catalog)/_components/navbar-links.tsx
-msgid "m826WB"
+msgctxt "m826WB"
+msgid "New course"
 msgstr "Novo curso"
 
 #: src/app/(catalog)/_components/user-avatar-menu.tsx
-msgid "6b2CRH"
+msgctxt "6b2CRH"
+msgid "User menu"
 msgstr "Menu do usuário"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/profile/page.tsx
-msgid "itPgxd"
+msgctxt "itPgxd"
+msgid "Profile"
 msgstr "Perfil"
 
 #: src/app/(catalog)/_components/user-dropdown-menu.tsx
 #: src/app/(settings)/_components/settings-pills.tsx
 #: src/app/(settings)/subscription/page.tsx
-msgid "R_6nsx"
+msgctxt "R_6nsx"
+msgid "Subscription"
 msgstr "Assinatura"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "HHFpcy"
+msgctxt "HHFpcy"
+msgid "Best day"
 msgstr "Melhor dia"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(progress)/energy/energy-insights.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "auPwZG"
+msgctxt "auPwZG"
+msgid "{day} with {percentage}"
 msgstr "{day} com {percentage}"
 
 #: src/app/(catalog)/(home)/best-day.tsx
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(catalog)/(home)/score.tsx
-msgid "zml1_y"
+msgctxt "zml1_y"
+msgid "Past 3 months"
 msgstr "Últimos 3 meses"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "00_IyC"
+msgctxt "00_IyC"
+msgid "Night"
 msgstr "Madrugada"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "_kzk_m"
+msgctxt "_kzk_m"
+msgid "Morning"
 msgstr "Manhã"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mF-J9o"
+msgctxt "mF-J9o"
+msgid "Afternoon"
 msgstr "Tarde"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "mPEpnN"
+msgctxt "mPEpnN"
+msgid "Evening"
 msgstr "Noite"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "dFW9lU"
+msgctxt "dFW9lU"
+msgid "Best time"
 msgstr "Melhor horário"
 
 #: src/app/(catalog)/(home)/best-time.tsx
 #: src/app/(progress)/score/score-insights.tsx
-msgid "r0R6ZG"
+msgctxt "r0R6ZG"
+msgid "{period} with {percentage}"
 msgstr "{period} com {percentage}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
-msgid "NubPSk"
+msgctxt "NubPSk"
+msgid "Next: {lesson}"
 msgstr "Próxima: {lesson}"
 
 #: src/app/(catalog)/(home)/continue-learning-card.tsx
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continuar"
 
 #: src/app/(catalog)/(home)/continue-learning.tsx
-msgid "0X-xfW"
+msgctxt "0X-xfW"
+msgid "Continue learning"
 msgstr "Continuar estudando"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "soDmlG"
+msgctxt "soDmlG"
+msgid "Keep learning to increase it"
 msgstr "Continue estudando para aumentar sua energia"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "WgeB0r"
+msgctxt "WgeB0r"
+msgid "Keep learning to maintain it"
 msgstr "Continue estudando para manter sua energia"
 
 #: src/app/(catalog)/(home)/energy.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/energy/page.tsx
-msgid "cVpmV7"
+msgctxt "cVpmV7"
+msgid "Energy"
 msgstr "Energia"
 
 #: src/app/(catalog)/(home)/energy.tsx
-msgid "AV5XNu"
+msgctxt "AV5XNu"
+msgid "Your energy is {percentage}"
 msgstr "Sua energia está em {percentage}"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
 #: src/app/(progress)/level/level-insights.tsx
-msgid "8F6teD"
+msgctxt "8F6teD"
+msgid "Learning days"
 msgstr "Dias de estudo"
 
 #: src/app/(catalog)/(home)/learning-days.tsx
-msgid "QbNcMh"
+msgctxt "QbNcMh"
+msgid "At least one completed lesson"
 msgstr "Pelo menos uma aula completa"
 
 #: src/app/(catalog)/(home)/learning-time.tsx
-msgid "F6B8A3"
+msgctxt "F6B8A3"
+msgid "Time spent in lessons"
 msgstr "Tempo dedicado às aulas"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "pgt3eW"
+msgctxt "pgt3eW"
+msgid "Max level reached"
 msgstr "Nível máximo alcançado"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "8N9BRu"
+msgctxt "8N9BRu"
+msgid "{value} BP to next level"
 msgstr "Faltam {value} PM para o próximo nível"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/level/page.tsx
-msgid "y1Qr81"
+msgctxt "y1Qr81"
+msgid "Level"
 msgstr "Nível"
 
 #: src/app/(catalog)/(home)/level.tsx
 #: src/app/(progress)/level/level-stats.tsx
-msgid "s0KB2i"
+msgctxt "s0KB2i"
+msgid "{belt} - Level {level}"
 msgstr "{belt} - Nível {level}"
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "a50ZRn"
+msgctxt "a50ZRn"
+msgid "Zoonk is an AI learning platform and study app to create courses about any topic using AI. Study for your exams or learn new skills."
 msgstr "Plataforma de estudos para estudar com IA. App de estudos para passar em provas, concursos, aprender idiomas e qualquer assunto."
 
 #: src/app/(catalog)/(home)/page.tsx
-msgid "leBFvu"
+msgctxt "leBFvu"
+msgid "Zoonk: Study App with AI"
 msgstr "Zoonk: IA para Estudos"
 
 #: src/app/(catalog)/(home)/progress.tsx
 #: src/app/generate/ch/[id]/generation-client.tsx
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "sIMS7i"
+msgctxt "sIMS7i"
+msgid "Progress"
 msgstr "Progresso"
 
 #: src/app/(catalog)/(home)/score.tsx
 #: src/app/(progress)/_components/metric-pills.tsx
 #: src/app/(progress)/score/page.tsx
-msgid "oLkLww"
+msgctxt "oLkLww"
+msgid "Score"
 msgstr "Pontuação"
 
 #: src/app/(catalog)/(home)/score.tsx
-msgid "_lCW0j"
+msgctxt "_lCW0j"
+msgid "{percentage} correct answers"
 msgstr "{percentage} de acertos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "QhvU1f"
+msgctxt "QhvU1f"
+msgid "Create this chapter"
 msgstr "Criar este capítulo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "YQGe0H"
+msgctxt "YQGe0H"
+msgid "This chapter is part of the course, but it hasn't been created yet. Create it to see all of its lessons."
 msgstr "Este capítulo faz parte do curso, mas ainda não foi criado. Crie ele para ver todas as aulas."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
-msgid "3IOFp2"
+msgctxt "3IOFp2"
+msgid "Create chapter"
 msgstr "Criar capítulo"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/generate/ch/[id]/generate-chapter-content.tsx
-msgid "qrEiLa"
+msgctxt "qrEiLa"
+msgid "Back to course"
 msgstr "Voltar para o curso"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "Ap-oRa"
+msgctxt "Ap-oRa"
+msgid "Could not apply lesson filters. Please try again."
 msgstr "Não foi possível aplicar os filtros de aulas. Tente de novo."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "d6tcJn"
+msgctxt "d6tcJn"
+msgid "Filter lesson types"
 msgstr "Filtrar tipos de aula"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "kxP9GJ"
+msgctxt "kxP9GJ"
+msgid "Types"
 msgstr "Tipos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "wi5osl"
+msgctxt "wi5osl"
+msgid "Show lesson types"
 msgstr "Mostrar tipos de aula"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list-filters.tsx
-msgid "OhgOkH"
+msgctxt "OhgOkH"
+msgid "Clear filter"
 msgstr "Limpar filtro"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "orGV_i"
+msgctxt "orGV_i"
+msgid "Current lesson"
 msgstr "Aula atual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "ssvp3R"
+msgctxt "ssvp3R"
+msgid "Search lessons..."
 msgstr "Buscar aulas…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
-msgid "FuT9vz"
+msgctxt "FuT9vz"
+msgid "No lessons found"
 msgstr "Nenhuma aula encontrada"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Completou"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/lesson-list.tsx
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "xTTP0x"
+msgctxt "xTTP0x"
+msgid "Not started"
 msgstr "Não começou"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "iRubpl"
+msgctxt "iRubpl"
+msgid "Current chapter"
 msgstr "Capítulo atual"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "3SOcGR"
+msgctxt "3SOcGR"
+msgid "Search chapters..."
 msgstr "Buscar capítulos…"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "8udPa-"
+msgctxt "8udPa-"
+msgid "No chapters found"
 msgstr "Nenhum capítulo encontrado"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
-msgid "vcaAXp"
+msgctxt "vcaAXp"
+msgid "{completed, number}/{total, number} done"
 msgstr "{completed, number}/{total, number} concluídos"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/course-curriculum-pending-notice.tsx
-msgid "Pf4uqS"
+msgctxt "Pf4uqS"
+msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "O capítulo de introdução está pronto. A gente ainda está criando o currículo completo, então mais capítulos vão aparecer aqui em breve."
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "_allXG"
+msgctxt "_allXG"
+msgid "Learn {course} online with practical examples and everyday language. {description}"
 msgstr "Aprenda {course} online com exemplos práticos e linguagem do dia a dia. {description}"
 
 #: src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
-msgid "gyGolN"
+msgctxt "gyGolN"
+msgid "Learn {course}"
 msgstr "Aprenda {course}"
 
 #: src/app/(catalog)/courses/category-pills.tsx
-msgid "tuZsq-"
+msgctxt "tuZsq-"
+msgid "Course categories"
 msgstr "Categorias de cursos"
 
 #: src/app/(catalog)/courses/category-pills.tsx
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "zQvVDJ"
+msgctxt "zQvVDJ"
+msgid "All"
 msgstr "Todos"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "Wc7aau"
+msgctxt "Wc7aau"
+msgid "No courses available yet."
 msgstr "Ainda não há cursos disponíveis."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "zJxO2f"
+msgctxt "zJxO2f"
+msgid "No courses"
 msgstr "Nenhum curso"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
-msgid "T0mfNV"
+msgctxt "T0mfNV"
+msgid "Loading more courses…"
 msgstr "Carregando mais cursos…"
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "W_5hwr"
+msgctxt "W_5hwr"
+msgid "Something went wrong. Please try again."
 msgstr "Algo deu errado. Tente de novo."
 
 #: src/app/(catalog)/courses/course-list-client.tsx
 #: src/components/generation/workflow-generation-error.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Tentar de novo"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "WgPMAP"
+msgctxt "WgPMAP"
+msgid "Explore all Zoonk courses to learn anything using AI. Find interactive lessons to learn subjects like science, math, technology, and more."
 msgstr "Explore todos os cursos do Zoonk para aprender qualquer coisa com IA. Encontre aulas interativas para aprender temas como ciências, matemática, tecnologia e muito mais."
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "P5jxUC"
+msgctxt "P5jxUC"
+msgid "Online Courses using AI"
 msgstr "Cursos online com IA"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "s-Ncqj"
+msgctxt "s-Ncqj"
+msgid "Explore courses"
 msgstr "Explorar cursos"
 
 #: src/app/(catalog)/courses/page.tsx
-msgid "hUF3bo"
+msgctxt "hUF3bo"
+msgid "Start learning something new today"
 msgstr "Comece a aprender algo novo hoje"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "riE3I5"
+msgctxt "riE3I5"
+msgid "View all the courses you started on Zoonk. Continue where you left off and track your progress across interactive lessons."
 msgstr "Veja todos os cursos que você começou no Zoonk. Continue de onde parou e acompanhe seu progresso nas aulas interativas."
 
 #: src/app/(catalog)/my/page.tsx
-msgid "eeNr_Y"
+msgctxt "eeNr_Y"
+msgid "My Courses"
 msgstr "Meus cursos"
 
 #: src/app/(catalog)/my/page.tsx
-msgid "Dr13kE"
+msgctxt "Dr13kE"
+msgid "Continue where you left off"
 msgstr "Continue de onde parou"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "BDHWkf"
+msgctxt "BDHWkf"
+msgid "No courses yet"
 msgstr "Nenhum curso ainda"
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "azX41u"
+msgctxt "azX41u"
+msgid "Start learning something new today."
 msgstr "Comece a aprender algo novo hoje."
 
 #: src/app/(catalog)/my/user-course-list.tsx
-msgid "9m9h0p"
+msgctxt "9m9h0p"
+msgid "Start a course"
 msgstr "Começar um curso"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
 #: src/app/(catalog)/start/exam/page.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
 #: src/app/(catalog)/start/start-content.tsx
-msgid "e61Jf3"
+msgctxt "e61Jf3"
+msgid "Coming soon"
 msgstr "Em breve"
 
 #: src/app/(catalog)/p/[courseId]/page.tsx
-msgid "dtRj3N"
+msgctxt "dtRj3N"
+msgid "Personalized courses are coming soon."
 msgstr "Cursos personalizados chegam em breve."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "hJZwTS"
+msgctxt "hJZwTS"
+msgid "Email address"
 msgstr "Email"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
 #: src/components/feedback/contact-form.tsx
-msgid "OiSL94"
+msgctxt "OiSL94"
+msgid "myemail@gmail.com"
 msgstr "meuemail@gmail.com"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "45yKj9"
+msgctxt "45yKj9"
+msgid "We'll use this email to notify you when exam prep is ready."
 msgstr "A gente vai usar este email para te avisar quando a preparação para provas estiver pronta."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "Xy7a7A"
+msgctxt "Xy7a7A"
+msgid "Exam"
 msgstr "Prova"
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "cDZwI_"
+msgctxt "cDZwI_"
+msgid "TOEFL, SAT, CFA, CPA..."
 msgstr "TOEFL, ENEM, OAB, concurso..."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "E_0Y4u"
+msgctxt "E_0Y4u"
+msgid "Tell us the test, certification, or school exam you care about."
 msgstr "Conte qual prova, certificação ou exame escolar importa para você."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "6eV4UR"
+msgctxt "6eV4UR"
+msgid "We couldn't add you to the waitlist. Please try again."
 msgstr "Não conseguimos te colocar na lista de espera. Tente de novo."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
-msgid "W78DIe"
+msgctxt "W78DIe"
+msgid "You're on the list. We'll let you know when exam prep is ready."
 msgstr "Você entrou na lista. A gente te avisa quando a preparação para provas estiver pronta."
 
 #: src/app/(catalog)/start/exam/exam-waitlist-form.tsx
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "ipGe-B"
+msgctxt "ipGe-B"
+msgid "Notify me"
 msgstr "Me avise"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "gs2Dwu"
+msgctxt "gs2Dwu"
+msgid "Online AI exam prep for certifications and tests. Hands-on explanation and practice questions to help you pass your exam."
 msgstr "Estudar online com IA para ENEM, concursos, certificações e provas. Explicações práticas e com quiz interativo para ajudar você a passar em qualquer prova."
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "z8OyvL"
+msgctxt "z8OyvL"
+msgid "Online AI Exam Prep"
 msgstr "Estudar para concursos e provas com IA"
 
 #: src/app/(catalog)/start/exam/page.tsx
-msgid "CzV5fE"
+msgctxt "CzV5fE"
+msgid "Exam prep is not available yet. Tell us what you're preparing for and we'll notify you when it launches."
 msgstr "A preparação para provas ainda não está disponível. Conte para qual prova está estudando e a gente te avisa quando for lançada."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "8Zy06C"
+msgctxt "8Zy06C"
+msgid "This option isn't available yet"
 msgstr "Esta opção ainda não está disponível"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "TV5hlz"
+msgctxt "TV5hlz"
+msgid "Join the waitlist and we'll let you know when you can learn <strong>{title}</strong> with Zoonk."
 msgstr "Entre na lista de espera e a gente te avisa quando você puder aprender <strong>{title}</strong> com o Zoonk."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "cPhKTw"
+msgctxt "cPhKTw"
+msgid "Not available"
 msgstr "Indisponível"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "5DZYgN"
+msgctxt "5DZYgN"
+msgid "We can't create this course"
 msgstr "Não podemos criar este curso"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "m6ju4Q"
+msgctxt "m6ju4Q"
+msgid "Zoonk can't help with requests that involve unsafe, illegal, or harmful activity. Try a different subject instead."
 msgstr "O Zoonk não pode ajudar com pedidos que envolvem atividades inseguras, ilegais ou prejudiciais. Tente outro assunto."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
-msgid "PDFZz6"
+msgctxt "PDFZz6"
+msgid "Try another goal"
 msgstr "Tentar outra meta"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-prompt-waitlist-form.tsx
-msgid "hCixWc"
+msgctxt "hCixWc"
+msgid "You're on the list. We'll email you when it's available."
 msgstr "Você entrou na lista. A gente te envia um email quando estiver disponível."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "UdDpuW"
+msgctxt "UdDpuW"
+msgid "Finding the best way to help"
 msgstr "Buscando a melhor forma de ajudar"
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgid "1A36NM"
+msgctxt "1A36NM"
+msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "A gente está analisando sua meta de estudo. Isso pode levar alguns segundos."
 
 #: src/app/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "47FYwb"
+msgctxt "47FYwb"
+msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "CaU_nf"
+msgctxt "CaU_nf"
+msgid "Discover personalized courses and resources to learn {prompt}. Zoonk uses AI to create interactive lessons tailored to you."
 msgstr "Descubra cursos e recursos personalizados para aprender {prompt}. O Zoonk usa IA para criar aulas interativas sob medida para você."
 
 #: src/app/(catalog)/start/learn/[prompt]/page.tsx
-msgid "X2b6pH"
+msgctxt "X2b6pH"
+msgid "Learn {prompt} with AI"
 msgstr "Aprenda {prompt} com IA"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "l450Bl"
+msgctxt "l450Bl"
+msgid "Computer Science"
 msgstr "Ciência da Computação"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ElyVN0"
+msgctxt "ElyVN0"
+msgid "Psychology"
 msgstr "Psicologia"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "KOuDOE"
+msgctxt "KOuDOE"
+msgid "Economics"
 msgstr "Economia"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "cHCwbF"
+msgctxt "cHCwbF"
+msgid "Photography"
 msgstr "Fotografia"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zE1J_t"
+msgctxt "zE1J_t"
+msgid "Philosophy"
 msgstr "Filosofia"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "y68y7h"
+msgctxt "y68y7h"
+msgid "Data Science"
 msgstr "Ciência de Dados"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1qsU2j"
+msgctxt "1qsU2j"
+msgid "Creative Writing"
 msgstr "Escrita Criativa"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "RGkBg_"
+msgctxt "RGkBg_"
+msgid "Biology"
 msgstr "Biologia"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oiUZCZ"
+msgctxt "oiUZCZ"
+msgid "Graphic Design"
 msgstr "Design Gráfico"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
 #: src/lib/categories/category.ts
-msgid "djJp6c"
+msgctxt "djJp6c"
+msgid "History"
 msgstr "História"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "O9mDkA"
+msgctxt "O9mDkA"
+msgid "Marketing"
 msgstr "Marketing"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "9zLpJ_"
+msgctxt "9zLpJ_"
+msgid "What do you want to learn?"
 msgstr "O que você quer aprender?"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "zfDq-e"
+msgctxt "zfDq-e"
+msgid "Quantum physics"
 msgstr "Física quântica"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "oqfOwA"
+msgctxt "oqfOwA"
+msgid "Ancient philosophy"
 msgstr "Filosofia antiga"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "Osb4bp"
+msgctxt "Osb4bp"
+msgid "Machine learning"
 msgstr "Aprendizado de máquina"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "OdZ_n1"
+msgctxt "OdZ_n1"
+msgid "Creative writing"
 msgstr "Escrita criativa"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "N9FWiz"
+msgctxt "N9FWiz"
+msgid "Molecular biology"
 msgstr "Biologia molecular"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XFPrU4"
+msgctxt "XFPrU4"
+msgid "Behavioral economics"
 msgstr "Economia comportamental"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "-0gz_i"
+msgctxt "-0gz_i"
+msgid "Organic chemistry"
 msgstr "Química orgânica"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "1axOcX"
+msgctxt "1axOcX"
+msgid "UFOs"
 msgstr "OVNIs"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "e7q85h"
+msgctxt "e7q85h"
+msgid "Dinosaur extinction"
 msgstr "Extinção dos dinossauros"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "MO2lwh"
+msgctxt "MO2lwh"
+msgid "How volcanoes work"
 msgstr "Como os vulcões funcionam"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "ZzbdHP"
+msgctxt "ZzbdHP"
+msgid "World history"
 msgstr "História mundial"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "XfC6Cs"
+msgctxt "XfC6Cs"
+msgid "Cognitive psychology"
 msgstr "Psicologia cognitiva"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "X5XXVF"
+msgctxt "X5XXVF"
+msgid "Linear algebra"
 msgstr "Álgebra linear"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5gOFKJ"
+msgctxt "5gOFKJ"
+msgid "Black holes"
 msgstr "Buracos negros"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "eQHeGX"
+msgctxt "eQHeGX"
+msgid "How the internet works"
 msgstr "Como a internet funciona"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "QOSGzc"
+msgctxt "QOSGzc"
+msgid "Roman Empire"
 msgstr "Império Romano"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "gyEihl"
+msgctxt "gyEihl"
+msgid "Deep sea creatures"
 msgstr "Animais do fundo do mar"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "0MqSJ1"
+msgctxt "0MqSJ1"
+msgid "Solar system"
 msgstr "Sistema solar"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "5qPAxv"
+msgctxt "5qPAxv"
+msgid "Artificial intelligence"
 msgstr "Inteligência artificial"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "3WiAG4"
+msgctxt "3WiAG4"
+msgid "Harry Potter"
 msgstr "Harry Potter"
 
 #: src/app/(catalog)/start/learn/learn-content.tsx
-msgid "NvSCuG"
+msgctxt "NvSCuG"
+msgid "Suggested subjects"
 msgstr "Assuntos sugeridos"
 
 #: src/app/(catalog)/start/learn/learn-form.tsx
-msgid "uCb1nG"
+msgctxt "uCb1nG"
+msgid "Enter a subject"
 msgstr "Digite um assunto"
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "JlJVf1"
+msgctxt "JlJVf1"
+msgid "Tell Zoonk what you want to learn and get a course created with AI. Start learning any subject with interactive lessons."
 msgstr "Diga ao Zoonk o que você quer aprender e receba um curso criado com IA. Comece a estudar qualquer assunto com aulas interativas."
 
 #: src/app/(catalog)/start/learn/page.tsx
-msgid "Zs1QEq"
+msgctxt "Zs1QEq"
+msgid "Learn Anything with AI"
 msgstr "Aprenda qualquer coisa com IA"
 
 #: src/app/(catalog)/start/page.tsx
-msgid "UFOGo9"
+msgctxt "UFOGo9"
+msgid "Start online courses to learn languages and more on Zoonk. Practice language learning, learn English or Spanish, and create AI-powered courses for any subject."
 msgstr "Comece cursos online com IA para aprender idiomas no Zoonk. Aprenda inglês, espanhol ou qualquer assunto com aulas interativas."
 
 #: src/app/(catalog)/start/page.tsx
-msgid "rqpQgj"
+msgctxt "rqpQgj"
+msgid "Online Courses to Learn Languages and More"
 msgstr "Cursos online com IA para aprender idiomas"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "K4jMHW"
+msgctxt "K4jMHW"
+msgid "Online language courses with AI. Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Cursos online de idiomas com IA. Aprender idiomas com dicas de pronúncia, vocabulário, leitura e prática de escuta."
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "Ht6aMH"
+msgctxt "Ht6aMH"
+msgid "Learn a language online with AI"
 msgstr "Aprender idiomas online com IA"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "lSAK6U"
+msgctxt "lSAK6U"
+msgid "What language do you want to learn?"
 msgstr "Qual idioma você quer aprender?"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "ptPPVk"
+msgctxt "ptPPVk"
+msgid "No languages found"
 msgstr "Nenhum idioma encontrado"
 
 #: src/app/(catalog)/start/speak/page.tsx
-msgid "L820yz"
+msgctxt "L820yz"
+msgid "Search languages"
 msgstr "Pesquisar idiomas"
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "ah2CR6"
+msgctxt "ah2CR6"
+msgid "Learn a language with pronunciation tips, vocabulary, reading, and listening practice."
 msgstr "Aprenda um idioma com dicas de pronúncia, vocabulário, leitura e escuta."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "_E8OKF"
+msgctxt "_E8OKF"
+msgid "Turn any subject into a clear course you can follow step by step, with practical examples and no fluff."
 msgstr "Transforme qualquer assunto em um curso claro com exemplos práticos e sem enrolação."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "IF6NT-"
+msgctxt "IF6NT-"
+msgid "We'll prepare a study path to help you pass an entrance exam, certification, or school test."
 msgstr "Preparamos uma trilha para você passar em um concurso, ENEM, certificação ou prova escolar."
 
 #: src/app/(catalog)/start/start-content.tsx
-msgid "AaFZIp"
+msgctxt "AaFZIp"
+msgid "What's your goal?"
 msgstr "Qual é seu objetivo?"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "pev_fB"
+msgctxt "pev_fB"
+msgid "vs last month"
 msgstr "vs mês passado"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "R9qHBU"
+msgctxt "R9qHBU"
+msgid "vs last 6 months"
 msgstr "vs últimos 6 meses"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "s-lPP3"
+msgctxt "s-lPP3"
+msgid "All time"
 msgstr "Todo o período"
 
 #: src/app/(progress)/_components/metric-comparison.tsx
-msgid "YFV6dH"
+msgctxt "YFV6dH"
+msgid "vs last year"
 msgstr "vs ano passado"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "hCCWuZ"
+msgctxt "hCCWuZ"
+msgid "Previous period"
 msgstr "Período anterior"
 
 #: src/app/(progress)/_components/period-navigation.tsx
-msgid "I2z5s_"
+msgctxt "I2z5s_"
+msgid "Next period"
 msgstr "Próximo período"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "PIaUh-"
+msgctxt "PIaUh-"
+msgid "Period selection"
 msgstr "Seleção de período"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "TBovrx"
+msgctxt "TBovrx"
+msgid "Month"
 msgstr "Mês"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "NPrFLC"
+msgctxt "NPrFLC"
+msgid "6 Months"
 msgstr "6 meses"
 
 #: src/app/(progress)/_components/period-tabs.tsx
-msgid "IFo1oo"
+msgctxt "IFo1oo"
+msgid "Year"
 msgstr "Ano"
 
 #: src/app/(progress)/_components/progress-chart-layout.tsx
-msgid "OlW5Z8"
+msgctxt "OlW5Z8"
+msgid "No data available for this period"
 msgstr "Nenhum dado disponível neste período"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "FVh2Tr"
+msgctxt "FVh2Tr"
+msgid "Start learning to track your progress"
 msgstr "Comece a estudar para acompanhar seu progresso"
 
 #: src/app/(progress)/_components/progress-empty-state.tsx
-msgid "Y1zzQt"
+msgctxt "Y1zzQt"
+msgid "Log in to track your progress"
 msgstr "Entre para acompanhar seu progresso"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "J3fNDZ"
+msgctxt "J3fNDZ"
+msgid "This month"
 msgstr "Este mês"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "eWUXBX"
+msgctxt "eWUXBX"
+msgid "Past 6 months"
 msgstr "Últimos 6 meses"
 
 #: src/app/(progress)/_components/progress-insight-period-label.ts
-msgid "lPShsT"
+msgctxt "lPShsT"
+msgid "This year"
 msgstr "Este ano"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
-msgid "M-JIpD"
+msgctxt "M-JIpD"
+msgid "Energy chart"
 msgstr "Gráfico de Energia"
 
 #: src/app/(progress)/energy/energy-chart-client.tsx
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "rGSqvt"
+msgctxt "rGSqvt"
+msgid "Avg"
 msgstr "Média"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "TLPAMC"
+msgctxt "TLPAMC"
+msgid "What is Energy?"
 msgstr "O que é Energia?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "OvOWOR"
+msgctxt "OvOWOR"
+msgid "Energy is a 0% to 100% score for your recent learning consistency and accuracy."
 msgstr "Energia é uma nota de 0% a 100% para sua constância e precisão nos estudos recentes."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "K3jN6p"
+msgctxt "K3jN6p"
+msgid "How do I improve Energy?"
 msgstr "Como melhoro a Energia?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "pssms6"
+msgctxt "pssms6"
+msgid "Answer questions correctly and keep learning regularly. Correct answers raise Energy; wrong answers and days away from studying lower it."
 msgstr "Responda às perguntas corretamente e continue estudando com frequência. Respostas certas aumentam a Energia; respostas erradas e dias sem estudar diminuem ela."
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "-8Qx8X"
+msgctxt "-8Qx8X"
+msgid "Why is Energy important?"
 msgstr "Por que a Energia é importante?"
 
 #: src/app/(progress)/energy/energy-explanation.tsx
-msgid "UfEfhq"
+msgctxt "UfEfhq"
+msgid "Energy is like heart rate in a health app: it shows your current learning rhythm. Missing a day doesn't reset your progress; you recover as soon as you start learning again."
 msgstr "Energia é como os batimentos cardíacos em um app de saúde: mostra seu ritmo de estudo atual. Perder um dia não zera seu progresso; você se recupera assim que volta a estudar."
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "XxS-he"
+msgctxt "XxS-he"
+msgid "Highest energy day"
 msgstr "Dia com mais energia"
 
 #: src/app/(progress)/energy/energy-insights.tsx
-msgid "aaiQkv"
+msgctxt "aaiQkv"
+msgid "Full energy"
 msgstr "Energia máxima"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "zLCmVM"
+msgctxt "zLCmVM"
+msgid "Current Energy"
 msgstr "Energia atual"
 
 #: src/app/(progress)/energy/energy-stats.tsx
-msgid "e9DcQa"
+msgctxt "e9DcQa"
+msgid "{percentage} average"
 msgstr "{percentage} em média"
 
 #: src/app/(progress)/energy/page.tsx
-msgid "AZMpf3"
+msgctxt "AZMpf3"
+msgid "Energy is a 0% to 100% score based on recent activity and accuracy."
 msgstr "Energia é uma nota de 0% a 100% com base na atividade e precisão recentes."
 
 #: src/app/(progress)/energy/page.tsx
-msgid "rsIaGW"
+msgctxt "rsIaGW"
+msgid "A 0% to 100% score for recent activity and accuracy"
 msgstr "Uma nota de 0% a 100% para atividade e precisão recentes"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "GA8RuL"
+msgctxt "GA8RuL"
+msgid "Brain Power chart"
 msgstr "Gráfico de Poder Mental"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "XdkaHc"
+msgctxt "XdkaHc"
+msgid "{value} BP"
 msgstr "{value} PM"
 
 #: src/app/(progress)/level/level-chart-client.tsx
-msgid "tDbspx"
+msgctxt "tDbspx"
+msgid "Total Brain Power earned: {total}"
 msgstr "Poder Mental total ganho: {total}"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "EMy5Vs"
+msgctxt "EMy5Vs"
+msgid "What is Brain Power?"
 msgstr "O que é Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "MIjvOA"
+msgctxt "MIjvOA"
+msgid "Brain Power (BP) is the total learning credit you have earned. Each completed lesson adds {brainPower} BP."
 msgstr "Poder Mental (PM) é o total de aprendizado que você acumulou. Cada aula concluída adiciona {brainPower} PM."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "jzKXJS"
+msgctxt "jzKXJS"
+msgid "How do I increase Brain Power?"
 msgstr "Como aumento o Poder Mental?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "Gzq1tT"
+msgctxt "Gzq1tT"
+msgid "Complete lessons. Brain Power never goes down, even when your Energy drops or you take a break."
 msgstr "Complete aulas. O Poder Mental nunca diminui, mesmo quando sua Energia cai ou você faz uma pausa."
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "JGLOtn"
+msgctxt "JGLOtn"
+msgid "Why is Brain Power important?"
 msgstr "Por que o Poder Mental é importante?"
 
 #: src/app/(progress)/level/level-explanation.tsx
-msgid "tC6vNz"
+msgctxt "tC6vNz"
+msgid "It is like steps in a health app: a record of how much you have learned. It also works like martial arts for your mind: build Brain Power to advance from white belt to black belt."
 msgstr "É como passos em um app de saúde: um registro de quanto você aprendeu. Também funciona como artes marciais para a sua mente: ganhe Poder Mental para avançar da faixa branca até a faixa preta."
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "elq-tg"
+msgctxt "elq-tg"
+msgid "Highest BP"
 msgstr "Maior PM"
 
 #: src/app/(progress)/level/level-insights.tsx
-msgid "BW4bMl"
+msgctxt "BW4bMl"
+msgid "{date} with {value} BP"
 msgstr "{date} com {value} PM"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "WfaE4H"
+msgctxt "WfaE4H"
+msgid "{belt}, Level {level} of 10. Maximum level achieved."
 msgstr "{belt}, Nível {level} de 10. Nível máximo alcançado."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "2Y-P4e"
+msgctxt "2Y-P4e"
+msgid "{belt}, Level {level} of 10. {bp} Brain Power until next level."
 msgstr "{belt}, Nível {level} de 10. Faltam {bp} de Poder Mental para o próximo nível."
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "n_mgOm"
+msgctxt "n_mgOm"
+msgid "Belt Progression"
 msgstr "Progressão de faixas"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "ZKbTsS"
+msgctxt "ZKbTsS"
+msgid "{current}/10"
 msgstr "{current}/10"
 
 #: src/app/(progress)/level/level-progression.tsx
-msgid "-Sn2yd"
+msgctxt "-Sn2yd"
+msgid "{belt}: Level {current} of 10"
 msgstr "{belt}: Nível {current} de 10"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "v5yNm3"
+msgctxt "v5yNm3"
+msgid "Total Brain Power"
 msgstr "Poder Mental total"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "_Q0taG"
+msgctxt "_Q0taG"
+msgid "BP"
 msgstr "PM"
 
 #: src/app/(progress)/level/level-stats.tsx
-msgid "u_oEJA"
+msgctxt "u_oEJA"
+msgid "{value} BP earned"
 msgstr "{value} PM ganhos"
 
 #: src/app/(progress)/level/page.tsx
-msgid "4-USpX"
+msgctxt "4-USpX"
+msgid "Track your level progress and see how you advance."
 msgstr "Acompanhe seu progresso de nível e veja como você avança."
 
 #: src/app/(progress)/level/page.tsx
-msgid "L9hqMH"
+msgctxt "L9hqMH"
+msgid "Track your level progress"
 msgstr "Acompanhe seu progresso de nível"
 
 #: src/app/(progress)/score/page.tsx
-msgid "qHWZBu"
+msgctxt "qHWZBu"
+msgid "Track your score over time and see your best days and times."
 msgstr "Acompanhe sua pontuação ao longo do tempo e veja seus melhores dias e horários."
 
 #: src/app/(progress)/score/page.tsx
-msgid "GWkswX"
+msgctxt "GWkswX"
+msgid "Track your score and progress trends"
 msgstr "Acompanhe sua pontuação e tendências de progresso"
 
 #: src/app/(progress)/score/score-chart-client.tsx
-msgid "J-05ol"
+msgctxt "J-05ol"
+msgid "Score chart"
 msgstr "Gráfico de pontuação"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "bIZaXJ"
+msgctxt "bIZaXJ"
+msgid "What is Score?"
 msgstr "O que é Pontuação?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "JA-N5Z"
+msgctxt "JA-N5Z"
+msgid "Score is the percentage of questions you answered correctly during this period."
 msgstr "Pontuação é a porcentagem de perguntas que você respondeu corretamente neste período."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "z9kvhA"
+msgctxt "z9kvhA"
+msgid "How do I improve Score?"
 msgstr "Como melhoro a Pontuação?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "7_C9do"
+msgctxt "7_C9do"
+msgid "Review mistakes and retry lessons. As you answer more questions correctly, your Score goes up."
 msgstr "Revise erros e refaça aulas. Conforme você responde mais perguntas corretamente, sua Pontuação aumenta."
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "WqH8eP"
+msgctxt "WqH8eP"
+msgid "Why is Score important?"
 msgstr "Por que a Pontuação é importante?"
 
 #: src/app/(progress)/score/score-explanation.tsx
-msgid "E0saoA"
+msgctxt "E0saoA"
+msgid "Score shows accuracy, not activity. Best day and best time help you find when you learn most effectively."
 msgstr "A Pontuação mostra precisão, não atividade. Melhor dia e melhor horário te ajudam a descobrir quando você aprende melhor."
 
 #: src/app/(settings)/_components/protected-section.tsx
-msgid "yOFm9C"
+msgctxt "yOFm9C"
+msgid "You need to be logged in to access this page."
 msgstr "Você precisa estar logado para acessar esta página."
 
 #: src/app/(settings)/language/page.tsx
-msgid "2WHx14"
+msgctxt "2WHx14"
+msgid "Update your app language to learn in English, Portuguese, Spanish, French, or other supported languages."
 msgstr "Atualize o idioma do app para aprender em inglês, português, espanhol, francês ou outros idiomas disponíveis."
 
 #: src/app/(settings)/language/page.tsx
-msgid "aNLa1G"
+msgctxt "aNLa1G"
+msgid "Choose the app language you prefer for this device."
 msgstr "Escolha o idioma do app que você prefere neste dispositivo."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "dSVD13"
+msgctxt "dSVD13"
+msgid "Update your name and username on Zoonk."
 msgstr "Atualize seu nome e nome de usuário no Zoonk."
 
 #: src/app/(settings)/profile/page.tsx
-msgid "wjIStY"
+msgctxt "wjIStY"
+msgid "Your name and username as they appear to others."
 msgstr "Seu nome e nome de usuário como aparecem para outras pessoas."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "1SvspN"
+msgctxt "1SvspN"
+msgid "Checking..."
 msgstr "Verificando…"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "9N4_rz"
+msgctxt "9N4_rz"
+msgid "{username} is available"
 msgstr "{username} está disponível"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "R76cpj"
+msgctxt "R76cpj"
+msgid "{username} is already taken"
 msgstr "{username} já está em uso"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "vLl7z0"
+msgctxt "vLl7z0"
+msgid "3-30 characters. Letters, numbers, and underscores only."
 msgstr "De 3 a 30 caracteres. Só letras, números e sublinhados."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "HAlOn1"
+msgctxt "HAlOn1"
+msgid "Name"
 msgstr "Nome"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "yNHZ-a"
+msgctxt "yNHZ-a"
+msgid "Your profile has been updated successfully!"
 msgstr "Seu perfil foi atualizado com sucesso!"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "VT-G_7"
+msgctxt "VT-G_7"
+msgid "This name will be visible to other users."
 msgstr "Este nome vai ficar visível para outros usuários."
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "wYCHCR"
+msgctxt "wYCHCR"
+msgid "Failed to update your profile. Please try again or contact hello@zoonk.com"
 msgstr "Não foi possível atualizar seu perfil. Tente de novo ou fale com contato@zoonk.com"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "JCIgkj"
+msgctxt "JCIgkj"
+msgid "Username"
 msgstr "Nome de usuário"
 
 #: src/app/(settings)/profile/profile-form.tsx
-msgid "X0ha1a"
+msgctxt "X0ha1a"
+msgid "Save changes"
 msgstr "Salvar alterações"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "3iCRcP"
+msgctxt "3iCRcP"
+msgid "Manage in App Store"
 msgstr "Gerenciar na App Store"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "tiFovn"
+msgctxt "tiFovn"
+msgid "Manage in Google Play"
 msgstr "Gerenciar no Google Play"
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "Tp4wJB"
+msgctxt "Tp4wJB"
+msgid "This subscription is managed through the App Store. To change or cancel it, use Apple's subscription settings."
 msgstr "Esta assinatura é gerenciada pela App Store. Para mudar ou cancelar, use os ajustes de assinatura da Apple."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "unNUPf"
+msgctxt "unNUPf"
+msgid "This subscription is managed through Google Play. To change or cancel it, use Google Play."
 msgstr "Esta assinatura é gerenciada pelo Google Play. Para mudar ou cancelar, use o Google Play."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "P0ZHma"
+msgctxt "P0ZHma"
+msgid "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
 msgstr "Esta assinatura é gerenciada pelo Zoonk. Fale com o suporte se precisar de ajuda para mudar ou cancelar."
 
 #: src/app/(settings)/subscription/managed-subscription.tsx
-msgid "5CI3KH"
+msgctxt "5CI3KH"
+msgid "Contact support"
 msgstr "Falar com o suporte"
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "TKk9oj"
+msgctxt "TKk9oj"
+msgid "Compare plans and manage your Zoonk subscription. See pricing, switch plans, or update billing."
 msgstr "Compare planos e gerencie sua assinatura do Zoonk. Veja preços, troque de plano ou atualize a cobrança."
 
 #: src/app/(settings)/subscription/page.tsx
-msgid "NBEnVd"
+msgctxt "NBEnVd"
+msgid "Compare plans and manage your subscription."
 msgstr "Compare planos e gerencie sua assinatura."
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "PJfdJl"
+msgctxt "PJfdJl"
+msgid "Save up to {amount}"
 msgstr "Economize até {amount}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "KAb0Yr"
+msgctxt "KAb0Yr"
+msgid "Switch to {plan}"
 msgstr "Mudar para {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0Azlrb"
+msgctxt "0Azlrb"
+msgid "Manage"
 msgstr "Gerenciar"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "_gko4g"
+msgctxt "_gko4g"
+msgid "Upgrade to {plan}"
 msgstr "Assinar o plano {plan}"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "wYsv4Z"
+msgctxt "wYsv4Z"
+msgid "Monthly"
 msgstr "Mensal"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "dqD39h"
+msgctxt "dqD39h"
+msgid "Yearly"
 msgstr "Anual"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "s1ZXI0"
+msgctxt "s1ZXI0"
+msgid "Unable to update your subscription. Contact us at hello@zoonk.com"
 msgstr "Não foi possível atualizar sua assinatura. Fale com a gente em contato@zoonk.com"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "2EsPdm"
+msgctxt "2EsPdm"
+msgid "/yr"
 msgstr "/ano"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "0jIMEb"
+msgctxt "0jIMEb"
+msgid "/mo"
 msgstr "/mês"
 
 #: src/app/(settings)/subscription/plan-list.tsx
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "tf1lIh"
+msgctxt "tf1lIh"
+msgid "Free"
 msgstr "Grátis"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "ZBALng"
+msgctxt "ZBALng"
+msgid "Current plan"
 msgstr "Plano atual"
 
 #: src/app/(settings)/subscription/plan-list.tsx
-msgid "fF376U"
+msgctxt "fF376U"
+msgid "Current"
 msgstr "Atual"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "kkjl2v"
+msgctxt "kkjl2v"
+msgid "Max"
 msgstr "Max"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "lOdoIb"
+msgctxt "lOdoIb"
+msgid "Plus"
 msgstr "Plus"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "R_eOkj"
+msgctxt "R_eOkj"
+msgid "Pro"
 msgstr "Pro"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "9o8O4m"
+msgctxt "9o8O4m"
+msgid "Your subscription will end on {date}."
 msgstr "Sua assinatura termina em {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "vaN1qz"
+msgctxt "vaN1qz"
+msgid "Current billing period ends on {date}."
 msgstr "O período de cobrança atual termina em {date}."
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "EV_gJ6"
+msgctxt "EV_gJ6"
+msgid "First chapter included"
 msgstr "Primeiro capítulo incluído"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "mqHNd6"
+msgctxt "mqHNd6"
+msgid "Personalized lessons, smartest AI"
 msgstr "Aulas personalizadas, IA mais inteligente"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "SC0MFR"
+msgctxt "SC0MFR"
+msgid "Unlimited lessons"
 msgstr "Aulas ilimitadas"
 
 #: src/app/(settings)/subscription/subscription-plans.tsx
-msgid "eaOADK"
+msgctxt "eaOADK"
+msgid "Personalized lessons, fast AI"
 msgstr "Aulas personalizadas, IA rápida"
 
 #: src/app/(settings)/support/page.tsx
 #: src/app/(settings)/support/support-content.tsx
-msgid "B5MLC7"
+msgctxt "B5MLC7"
+msgid "Share feedback, ask questions, or get help with your account and courses."
 msgstr "Envie feedback, faça perguntas ou receba ajuda com sua conta e cursos."
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "cDAb4a"
+msgctxt "cDAb4a"
+msgid "GitHub Discussions"
 msgstr "GitHub Discussions"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "7h49qt"
+msgctxt "7h49qt"
+msgid "Connect with the community and get answers"
 msgstr "Converse com a comunidade e receba respostas"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "YdQxfw"
+msgctxt "YdQxfw"
+msgid "Contact Support"
 msgstr "Falar com o suporte"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "dQIo6c"
+msgctxt "dQIo6c"
+msgid "Email us at hello@zoonk.com"
 msgstr "Envie um email para contato@zoonk.com"
 
 #: src/app/(settings)/support/support-content.tsx
-msgid "l1XTI5"
+msgctxt "l1XTI5"
+msgid "Follow us"
 msgstr "Siga a gente"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "rCpmYD"
+msgctxt "rCpmYD"
+msgid "Create this lesson"
 msgstr "Criar esta aula"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgid "AtnLyn"
+msgctxt "AtnLyn"
+msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "Esta aula faz parte do curso, mas ainda não foi criada. Crie ela para começar a estudar."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "ZzznjM"
+msgctxt "ZzznjM"
+msgid "Create lesson"
 msgstr "Criar aula"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/generate/l/[id]/generate-lesson-content.tsx
-msgid "_N8rYN"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
 msgstr "Voltar ao capítulo"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgid "ZnMcrz"
+msgctxt "ZnMcrz"
+msgid "Unlock the rest of this course"
 msgstr "Desbloquear o resto deste curso"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "A_uNk-"
+msgctxt "A_uNk-"
+msgid "Create lessons before reviewing"
 msgstr "Crie as aulas antes de revisar"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "Qy4EsI"
+msgctxt "Qy4EsI"
+msgid "Nothing to review yet"
 msgstr "Nada para revisar ainda"
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "4w9Y_P"
+msgctxt "4w9Y_P"
+msgid "Review unlocks after the earlier lessons in this chapter have been created."
 msgstr "A revisão fica disponível depois que as aulas anteriores deste capítulo forem criadas."
 
 #: src/app/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgid "9AOq2-"
+msgctxt "9AOq2-"
+msgid "There are no practice questions to review yet."
 msgstr "Ainda não há perguntas práticas para revisar."
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "txNTbP"
+msgctxt "txNTbP"
+msgid "Creating the {title} chapter"
 msgstr "Criando o capítulo {title}"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "kiZUDf"
+msgctxt "kiZUDf"
+msgid "This usually takes about a minute"
 msgstr "Isso costuma levar cerca de um minuto"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "5c2xtK"
+msgctxt "5c2xtK"
+msgid "Taking you to your chapter..."
 msgstr "Te levando para o seu capítulo…"
 
 #: src/app/generate/ch/[id]/generation-client.tsx
-msgid "45uo73"
+msgctxt "45uo73"
+msgid "Your lessons are ready"
 msgstr "Suas aulas estão prontas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "gnxL73"
+msgctxt "gnxL73"
+msgid "Choosing lesson types"
 msgstr "Escolhendo os tipos de aula"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "EKtClK"
+msgctxt "EKtClK"
+msgid "Getting started"
 msgstr "Começando"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "SF9AtA"
+msgctxt "SF9AtA"
+msgid "Preparing lessons"
 msgstr "Preparando as aulas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "L7nQzn"
+msgctxt "L7nQzn"
+msgid "Saving your lessons"
 msgstr "Salvando suas aulas"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Sbsm52"
+msgctxt "Sbsm52"
+msgid "Checking how each lesson should be taught..."
 msgstr "Conferindo como cada aula deve ser ensinada…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "0xCLwv"
+msgctxt "0xCLwv"
+msgid "Choosing type for lesson {number}..."
 msgstr "Escolhendo o tipo da aula {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "Vbn5Wz"
+msgctxt "Vbn5Wz"
+msgid "Reviewing the lesson mix..."
 msgstr "Revisando a mistura de aulas…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5342HA"
+msgctxt "5342HA"
+msgid "Getting started..."
 msgstr "Começando…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "nwGJ65"
+msgctxt "nwGJ65"
+msgid "Exploring your topic..."
 msgstr "Explorando seu tema…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "VKFa_t"
+msgctxt "VKFa_t"
+msgid "Mapping out the learning path..."
 msgstr "Montando a trilha de estudo…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "zQWv1_"
+msgctxt "zQWv1_"
+msgid "Writing lesson {number}..."
 msgstr "Escrevendo a aula {number}…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
-msgid "HWSnYS"
+msgctxt "HWSnYS"
+msgid "Reviewing the flow so far..."
 msgstr "Revisando o fluxo até aqui…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "txvxwS"
+msgctxt "txvxwS"
+msgid "Saving your progress..."
 msgstr "Salvando seu progresso…"
 
 #: src/app/generate/ch/[id]/use-generation-phases.ts
 #: src/app/generate/course/[id]/use-generation-phases.ts
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JUr8Er"
+msgctxt "JUr8Er"
+msgid "Finishing up..."
 msgstr "Finalizando…"
 
 #: src/app/generate/course/[id]/generate-course-prompt-content.tsx
-msgid "rPgekg"
+msgctxt "rPgekg"
+msgid "Back home"
 msgstr "Voltar para o início"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "15FsdE"
+msgctxt "15FsdE"
+msgid "Your course is ready"
 msgstr "Seu curso está pronto"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "4Wktrz"
+msgctxt "4Wktrz"
+msgid "Your lesson is ready"
 msgstr "Sua aula está pronta"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "0o41MR"
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
 msgstr "Te levando para o seu curso…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "T2TGxR"
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
 msgstr "Te levando para a sua aula…"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "u6ROZF"
+msgctxt "u6ROZF"
+msgid "Creating the {title} course"
 msgstr "Criando o curso {title}"
 
 #: src/app/generate/course/[id]/generation-client.tsx
-msgid "GJKrUK"
+msgctxt "GJKrUK"
+msgid "This usually takes about 2 minutes"
 msgstr "Isso costuma levar cerca de 2 minutos"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "i3JgLB"
+msgctxt "i3JgLB"
+msgid "Categorizing your course"
 msgstr "Categorizando seu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WOe-OA"
+msgctxt "WOe-OA"
+msgid "Checking for duplicates"
 msgstr "Conferindo duplicatas"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gjutu-"
+msgctxt "Gjutu-"
+msgid "Creating the cover image"
 msgstr "Criando a imagem de capa"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "SQFyKH"
+msgctxt "SQFyKH"
+msgid "Finding similar courses"
 msgstr "Encontrando cursos parecidos"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "WZpB8D"
+msgctxt "WZpB8D"
+msgid "Writing chapters"
 msgstr "Escrevendo os capítulos"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "vEOpTk"
+msgctxt "vEOpTk"
+msgid "Planning the introduction"
 msgstr "Planejando a introdução"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "d2xrsv"
+msgctxt "d2xrsv"
+msgid "Preparing your course"
 msgstr "Preparando seu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "CFWOGF"
+msgctxt "CFWOGF"
+msgid "Saving your course"
 msgstr "Salvando seu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XPla-v"
+msgctxt "XPla-v"
+msgid "Preparing the introduction"
 msgstr "Preparando a introdução"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "HbhIvm"
+msgctxt "HbhIvm"
+msgid "Writing your course description"
 msgstr "Escrevendo a descrição do seu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Y4F0xn"
+msgctxt "Y4F0xn"
+msgid "Writing the first lesson"
 msgstr "Escrevendo a primeira aula"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "e1myvm"
+msgctxt "e1myvm"
+msgid "Writing your course page"
 msgstr "Escrevendo a página do seu curso"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "aev_pt"
+msgctxt "aev_pt"
+msgid "Figuring out the right categories..."
 msgstr "Descobrindo as categorias certas…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "EKAN6s"
+msgctxt "EKAN6s"
+msgid "Tagging your course..."
 msgstr "Adicionando tags ao seu curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "JJrUOR"
+msgctxt "JJrUOR"
+msgid "Comparing nearby courses..."
 msgstr "Comparando cursos parecidos…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "uw23V-"
+msgctxt "uw23V-"
+msgid "Checking whether this course already exists..."
 msgstr "Conferindo se este curso já existe…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "qFmZfG"
+msgctxt "qFmZfG"
+msgid "Avoiding duplicate courses..."
 msgstr "Evitando cursos duplicados…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "lxBtcx"
+msgctxt "lxBtcx"
+msgid "Designing the cover..."
 msgstr "Criando a capa…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "W8n2i3"
+msgctxt "W8n2i3"
+msgid "Picking the right look..."
 msgstr "Escolhendo o visual certo…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "At4rk1"
+msgctxt "At4rk1"
+msgid "Adding finishing touches..."
 msgstr "Dando os toques finais…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "NgONb4"
+msgctxt "NgONb4"
+msgid "Searching for matching topics..."
 msgstr "Buscando temas relacionados…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Auz1tl"
+msgctxt "Auz1tl"
+msgid "Looking for alternate names..."
 msgstr "Procurando nomes alternativos…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "Gt_VNO"
+msgctxt "Gt_VNO"
+msgid "Expanding the course search..."
 msgstr "Ampliando a busca do curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "AEG3Ol"
+msgctxt "AEG3Ol"
+msgid "Planning the course structure..."
 msgstr "Planejando a estrutura do curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "OW9vMd"
+msgctxt "OW9vMd"
+msgid "Writing chapter {number}..."
 msgstr "Escrevendo o capítulo {number}…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "tXkuD8"
+msgctxt "tXkuD8"
+msgid "Reviewing the overall flow..."
 msgstr "Revisando o fluxo geral…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "8-bhNP"
+msgctxt "8-bhNP"
+msgid "Finding the best first hook..."
 msgstr "Encontrando o melhor começo…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "xrFhkn"
+msgctxt "xrFhkn"
+msgid "Writing a friendly guide to the field..."
 msgstr "Escrevendo um guia amigável sobre o tema…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "c_e4hk"
+msgctxt "c_e4hk"
+msgid "Keeping the first chapter easy to start..."
 msgstr "Deixando o primeiro capítulo fácil de começar…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "4LsE_n"
+msgctxt "4LsE_n"
+msgid "Creating the course shell..."
 msgstr "Criando a base do curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "3hEaI4"
+msgctxt "3hEaI4"
+msgid "Preparing the workspace..."
 msgstr "Preparando o espaço de trabalho…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "7Pw3r5"
+msgctxt "7Pw3r5"
+msgid "Saving the intro chapter..."
 msgstr "Salvando o capítulo de introdução…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "cc6_Yn"
+msgctxt "cc6_Yn"
+msgid "Preparing the first lessons..."
 msgstr "Preparando as primeiras aulas…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "a7FJJd"
+msgctxt "a7FJJd"
+msgid "Summarizing what you'll learn..."
 msgstr "Resumindo o que você vai aprender…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "9r_4zz"
+msgctxt "9r_4zz"
+msgid "Writing the overview..."
 msgstr "Escrevendo a visão geral…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "QqKzYM"
+msgctxt "QqKzYM"
+msgid "Writing the first lesson..."
 msgstr "Escrevendo a primeira aula…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "XxRMuO"
+msgctxt "XxRMuO"
+msgid "Adding examples and visuals..."
 msgstr "Adicionando exemplos e imagens…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "kmuvIN"
+msgctxt "kmuvIN"
+msgid "Getting the first lesson ready..."
 msgstr "Preparando a primeira aula…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "chqN-J"
+msgctxt "chqN-J"
+msgid "Framing why this course is useful..."
 msgstr "Mostrando por que este curso é útil…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "twf4n2"
+msgctxt "twf4n2"
+msgid "Writing the course page..."
 msgstr "Escrevendo a página do curso…"
 
 #: src/app/generate/course/[id]/use-generation-phases.ts
-msgid "k15wFf"
+msgctxt "k15wFf"
+msgid "Shaping the starting point..."
 msgstr "Definindo o ponto de partida…"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "WihX6L"
+msgctxt "WihX6L"
+msgid "Creating the {title} lesson"
 msgstr "Criando a aula {title}"
 
 #: src/app/generate/l/[id]/generation-client.tsx
-msgid "3vY0Zu"
+msgctxt "3vY0Zu"
+msgid "This usually takes 1-2 minutes"
 msgstr "Isso costuma levar de 1 a 2 minutos"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "cVoRCh"
+msgctxt "cVoRCh"
+msgid "Preparing options..."
 msgstr "Preparando alternativas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BBwnPG"
+msgctxt "BBwnPG"
+msgid "Adding more options..."
 msgstr "Adicionando mais alternativas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "4wkMNX"
+msgctxt "4wkMNX"
+msgid "Getting answer options ready..."
 msgstr "Preparando as alternativas de resposta…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "WsjFV2"
+msgctxt "WsjFV2"
+msgid "Preparing the word bank..."
 msgstr "Preparando o banco de palavras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6xEJTk"
+msgctxt "6xEJTk"
+msgid "Designing practice exercises..."
 msgstr "Criando exercícios práticos…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "6hjA6_"
+msgctxt "6hjA6_"
+msgid "Creating examples to try..."
 msgstr "Criando exemplos para praticar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "KddvJw"
+msgctxt "KddvJw"
+msgid "Writing fill-in-the-blanks..."
 msgstr "Criando lacunas para preencher…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "C05-tM"
+msgctxt "C05-tM"
+msgid "Building interactive tasks..."
 msgstr "Criando atividades interativas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "JGNN92"
+msgctxt "JGNN92"
+msgid "Drawing an illustration..."
 msgstr "Desenhando uma ilustração…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "a08k7g"
+msgctxt "a08k7g"
+msgid "Generating the images..."
 msgstr "Gerando as imagens…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bJVUNz"
+msgctxt "bJVUNz"
+msgid "Adding some color..."
 msgstr "Adicionando um pouco de cor…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "Yoev2R"
+msgctxt "Yoev2R"
+msgid "Refining the details..."
 msgstr "Ajustando os detalhes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "xBaVAH"
+msgctxt "xBaVAH"
+msgid "Finishing the artwork..."
 msgstr "Finalizando a arte…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "W2b0tx"
+msgctxt "W2b0tx"
+msgid "Designing the lesson thumbnail..."
 msgstr "Planejando a capa da aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "fRAHqN"
+msgctxt "fRAHqN"
+msgid "Creating the lesson thumbnail..."
 msgstr "Criando a capa da aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "elwtxf"
+msgctxt "elwtxf"
+msgid "Refining the lesson thumbnail..."
 msgstr "Ajustando a capa da aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "uDzgwu"
+msgctxt "uDzgwu"
+msgid "Writing example sentences..."
 msgstr "Escrevendo frases de exemplo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "SHIHyL"
+msgctxt "SHIHyL"
+msgid "Creating reading passages..."
 msgstr "Criando textos de leitura…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0Zum4g"
+msgctxt "0Zum4g"
+msgid "Putting words in context..."
 msgstr "Colocando as palavras em contexto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "jixTNM"
+msgctxt "jixTNM"
+msgid "Building natural sentences..."
 msgstr "Criando frases naturais…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "txIcop"
+msgctxt "txIcop"
+msgid "Loading lesson data..."
 msgstr "Carregando os dados da aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "l486Kx"
+msgctxt "l486Kx"
+msgid "Checking what we need..."
 msgstr "Vendo o que a gente precisa…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "EAqAX_"
+msgctxt "EAqAX_"
+msgid "Thinking about what to illustrate..."
 msgstr "Pensando no que ilustrar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "2Tovpk"
+msgctxt "2Tovpk"
+msgid "Planning each image..."
 msgstr "Planejando cada imagem…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "sQsQbH"
+msgctxt "sQsQbH"
+msgid "Choosing the right scenes..."
 msgstr "Escolhendo as cenas certas…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "iUUJom"
+msgctxt "iUUJom"
+msgid "Planning the illustrations..."
 msgstr "Planejando as ilustrações…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "BszFlm"
+msgctxt "BszFlm"
+msgid "Saving your lesson..."
 msgstr "Salvando sua aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "bC9979"
+msgctxt "bC9979"
+msgid "Almost done..."
 msgstr "Quase pronto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "5Jyenk"
+msgctxt "5Jyenk"
+msgid "Getting ready for the next step..."
 msgstr "Preparando o próximo passo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "r8xznK"
+msgctxt "r8xznK"
+msgid "Researching the topic..."
 msgstr "Pesquisando o tema…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "K_JznZ"
+msgctxt "K_JznZ"
+msgid "Writing the explanation..."
 msgstr "Escrevendo a explicação…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "19fPwV"
+msgctxt "19fPwV"
+msgid "Making it clear..."
 msgstr "Deixando tudo claro…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "65JXIy"
+msgctxt "65JXIy"
+msgid "Putting together the lesson..."
 msgstr "Montando a aula…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "nwi1Ym"
+msgctxt "nwi1Ym"
+msgid "Crafting the content..."
 msgstr "Criando o conteúdo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "-QrqeN"
+msgctxt "-QrqeN"
+msgid "Writing the explanation first..."
 msgstr "Escrevendo a explicação primeiro…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "epxxAx"
+msgctxt "epxxAx"
+msgid "Building the foundation..."
 msgstr "Criando a base…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "GyThaR"
+msgctxt "GyThaR"
+msgid "Preparing background context..."
 msgstr "Preparando o contexto…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/content.ts
-msgid "0AWsLH"
+msgctxt "0AWsLH"
+msgid "Explaining the topic..."
 msgstr "Explicando o tema…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "KL34l5"
+msgctxt "KL34l5"
+msgid "Adding romanization for grammar..."
 msgstr "Adicionando romanização da gramática…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "GILb0l"
+msgctxt "GILb0l"
+msgid "Converting grammar text to Latin script..."
 msgstr "Convertendo o texto de gramática para o alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OFH7dE"
+msgctxt "OFH7dE"
+msgid "Making grammar content easier to read..."
 msgstr "Deixando o conteúdo de gramática mais fácil de ler…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VADOBa"
+msgctxt "VADOBa"
+msgid "Looking up how each word sounds..."
 msgstr "Buscando como cada palavra soa…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "WnqJeL"
+msgctxt "WnqJeL"
+msgid "Mapping out the pronunciation..."
 msgstr "Mapeando a pronúncia…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "HDNFHk"
+msgctxt "HDNFHk"
+msgid "Checking how to say each word..."
 msgstr "Verificando como dizer cada palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "_Fl7bm"
+msgctxt "_Fl7bm"
+msgid "Finding the right sounds..."
 msgstr "Encontrando os sons certos…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "DLZ9fl"
+msgctxt "DLZ9fl"
+msgid "Converting to Latin script..."
 msgstr "Convertendo para o alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "boocfl"
+msgctxt "boocfl"
+msgid "Adding reading aids..."
 msgstr "Adicionando ajuda de leitura…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "AQMVYX"
+msgctxt "AQMVYX"
+msgid "Making it easier to read..."
 msgstr "Deixando mais fácil de ler…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ud2yWh"
+msgctxt "ud2yWh"
+msgid "Writing out the sounds..."
 msgstr "Escrevendo os sons…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "kxBeWt"
+msgctxt "kxBeWt"
+msgid "Adding romanization for vocabulary..."
 msgstr "Adicionando romanização do vocabulário…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "Ch9BcP"
+msgctxt "Ch9BcP"
+msgid "Converting vocabulary to Latin script..."
 msgstr "Convertendo o vocabulário para o alfabeto latino…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1aPaHZ"
+msgctxt "1aPaHZ"
+msgid "Making vocabulary easier to read..."
 msgstr "Deixando o vocabulário mais fácil de ler…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "zYx0UG"
+msgctxt "zYx0UG"
+msgid "Adding pronunciation for each word..."
 msgstr "Adicionando pronúncia de cada palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "VQ3-C2"
+msgctxt "VQ3-C2"
+msgid "Noting how each word sounds..."
 msgstr "Anotando como cada palavra soa…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YWB-K_"
+msgctxt "YWB-K_"
+msgid "Detailing the word sounds..."
 msgstr "Detalhando os sons das palavras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "L6f1Zq"
+msgctxt "L6f1Zq"
+msgid "Recording pronunciation info..."
 msgstr "Registrando informações de pronúncia…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "i-rNdh"
+msgctxt "i-rNdh"
+msgid "Picking the key vocabulary..."
 msgstr "Escolhendo o vocabulário principal…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "IdWf9_"
+msgctxt "IdWf9_"
+msgid "Choosing words to practice..."
 msgstr "Escolhendo palavras para praticar…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "UFDKHM"
+msgctxt "UFDKHM"
+msgid "Finding the most useful words..."
 msgstr "Encontrando as palavras mais úteis…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "YgG70c"
+msgctxt "YgG70c"
+msgid "Selecting important terms..."
 msgstr "Selecionando termos importantes…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "6BQo6o"
+msgctxt "6BQo6o"
+msgid "Translating individual words..."
 msgstr "Traduzindo palavras individuais…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "k0Q_Ph"
+msgctxt "k0Q_Ph"
+msgid "Looking up each term..."
 msgstr "Buscando cada termo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "hZLCkp"
+msgctxt "hZLCkp"
+msgid "Finding word meanings..."
 msgstr "Encontrando significados das palavras…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "SC0o7J"
+msgctxt "SC0o7J"
+msgid "Building the vocabulary guide..."
 msgstr "Criando o guia de vocabulário…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "5InW8H"
+msgctxt "5InW8H"
+msgid "Recording the audio..."
 msgstr "Gravando o áudio…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "4xvh9e"
+msgctxt "4xvh9e"
+msgid "Getting the pronunciation right..."
 msgstr "Acertando a pronúncia…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "oB01Wc"
+msgctxt "oB01Wc"
+msgid "Preparing the voice..."
 msgstr "Preparando a voz…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "ScA7Xm"
+msgctxt "ScA7Xm"
+msgid "Making it sound natural..."
 msgstr "Deixando o som natural…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "1vO-bV"
+msgctxt "1vO-bV"
+msgid "Recording vocabulary audio..."
 msgstr "Gravando o áudio do vocabulário…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "jV2zI1"
+msgctxt "jV2zI1"
+msgid "Getting the sound for each word..."
 msgstr "Criando o som de cada palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "FahI7K"
+msgctxt "FahI7K"
+msgid "Preparing vocabulary audio..."
 msgstr "Preparando o áudio do vocabulário…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "JfNFGM"
+msgctxt "JfNFGM"
+msgid "Making words listenable..."
 msgstr "Deixando as palavras prontas para ouvir…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "muXaEm"
+msgctxt "muXaEm"
+msgid "Recording pronunciation for each word..."
 msgstr "Gravando a pronúncia de cada palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "QDv0wS"
+msgctxt "QDv0wS"
+msgid "Getting the audio for each term..."
 msgstr "Criando o áudio de cada termo…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "OJkDgV"
+msgctxt "OJkDgV"
+msgid "Preparing word-by-word audio..."
 msgstr "Preparando áudio palavra por palavra…"
 
 #: src/app/generate/l/[id]/phase-thinking-generators/language.ts
-msgid "C2ELVi"
+msgctxt "C2ELVi"
+msgid "Making each word listenable..."
 msgstr "Deixando cada palavra pronta para ouvir…"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "58heST"
+msgctxt "58heST"
+msgid "Adding grammar romanization"
 msgstr "Adicionando romanização da gramática"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "TlrPFF"
+msgctxt "TlrPFF"
+msgid "Adding pronunciation"
 msgstr "Adicionando pronúncia"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "V0mPLK"
+msgctxt "V0mPLK"
+msgid "Adding romanization"
 msgstr "Adicionando romanização"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "HXMA75"
+msgctxt "HXMA75"
+msgid "Adding vocabulary romanization"
 msgstr "Adicionando romanização do vocabulário"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "4OjRPB"
+msgctxt "4OjRPB"
+msgid "Adding word pronunciation"
 msgstr "Adicionando pronúncia das palavras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "RXfSEl"
+msgctxt "RXfSEl"
+msgid "Building word list"
 msgstr "Montando lista de palavras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "viluaR"
+msgctxt "viluaR"
+msgid "Preparing options"
 msgstr "Preparando alternativas"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "c7xJGQ"
+msgctxt "c7xJGQ"
+msgid "Creating exercises"
 msgstr "Criando exercícios"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "aKNA_b"
+msgctxt "aKNA_b"
+msgid "Creating images"
 msgstr "Criando imagens"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "WI2yui"
+msgctxt "WI2yui"
+msgid "Creating lesson thumbnail"
 msgstr "Criando miniatura da aula"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "mIpv67"
+msgctxt "mIpv67"
+msgid "Creating sentences"
 msgstr "Criando frases"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "0zeST_"
+msgctxt "0zeST_"
+msgid "Looking up words"
 msgstr "Buscando palavras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v7HGj3"
+msgctxt "v7HGj3"
+msgid "Planning the images"
 msgstr "Planejando imagens"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "T00GEW"
+msgctxt "T00GEW"
+msgid "Recording audio"
 msgstr "Gravando áudio"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v2DAdY"
+msgctxt "v2DAdY"
+msgid "Recording vocabulary audio"
 msgstr "Gravando áudio do vocabulário"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "j-pO55"
+msgctxt "j-pO55"
+msgid "Recording word audio"
 msgstr "Gravando áudio das palavras"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "2ZPUqg"
+msgctxt "2ZPUqg"
+msgid "Saving your lesson"
 msgstr "Salvando sua aula"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "v4iFHN"
+msgctxt "v4iFHN"
+msgid "Writing the content"
 msgstr "Escrevendo o conteúdo"
 
 #: src/app/generate/l/[id]/use-phase-labels.ts
-msgid "ZA0_P-"
+msgctxt "ZA0_P-"
+msgid "Writing the explanation"
 msgstr "Escrevendo a explicação"
 
 #: src/app/generate/layout.tsx
-msgid "_tq5fR"
+msgctxt "_tq5fR"
+msgid "Creating content"
 msgstr "Criando conteúdo"
 
 #: src/app/privacy/page.tsx
-msgid "afKQHy"
+msgctxt "afKQHy"
+msgid "Read Zoonk's privacy policy to understand how we use and protect your personal information."
 msgstr "Leia a política de privacidade do Zoonk para entender como a gente usa e protege suas informações pessoais."
 
 #: src/app/privacy/page.tsx
-msgid "vx0nkZ"
+msgctxt "vx0nkZ"
+msgid "Privacy Policy"
 msgstr "Política de privacidade"
 
 #: src/app/terms/page.tsx
-msgid "DaGtoz"
+msgctxt "DaGtoz"
+msgid "Read Zoonk's terms of use to understand the rules and conditions for using our platform and services"
 msgstr "Leia os termos de uso do Zoonk para entender as regras e condições para usar nossa plataforma e serviços"
 
 #: src/app/terms/page.tsx
-msgid "UhkSyx"
+msgctxt "UhkSyx"
+msgid "Terms of Use"
 msgstr "Termos de uso"
 
 #: src/components/catalog/ai-warning.tsx
-msgid "FYZlTZ"
+msgctxt "FYZlTZ"
+msgid "Created with AI"
 msgstr "Criado com IA"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "F0tnKc"
+msgctxt "F0tnKc"
+msgid "Thanks for your feedback"
 msgstr "Valeu pelo feedback"
 
 #: src/components/catalog/catalog-actions.tsx
-msgid "IzCVhG"
+msgctxt "IzCVhG"
+msgid "More options"
 msgstr "Mais opções"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "rTFrsw"
+msgctxt "rTFrsw"
+msgid "I liked it"
 msgstr "Gostei"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "Hqn5Uo"
+msgctxt "Hqn5Uo"
+msgid "I didn't like it"
 msgstr "Não gostei"
 
 #: src/components/catalog/catalog-actions.tsx
 #: src/components/feedback/content-feedback.tsx
-msgid "G5YSJR"
+msgctxt "G5YSJR"
+msgid "Send feedback"
 msgstr "Enviar feedback"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "PAKDzS"
+msgctxt "PAKDzS"
+msgid "Go to current chapter"
 msgstr "Ir para o capítulo atual"
 
 #: src/components/catalog/catalog-active-shortcut-link.tsx
-msgid "Js2dT3"
+msgctxt "Js2dT3"
+msgid "Go to current lesson"
 msgstr "Ir para a aula atual"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "izuy1D"
+msgctxt "izuy1D"
+msgid "Current item"
 msgstr "Item atual"
 
 #: src/components/catalog/catalog-grid-back-to-top.tsx
-msgid "Gs9Kfp"
+msgctxt "Gs9Kfp"
+msgid "Back to top"
 msgstr "Voltar ao topo"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "AvySqa"
+msgctxt "AvySqa"
+msgid "{percent}% complete"
 msgstr "{percent}% completo"
 
 #: src/components/catalog/continue-lesson-link.tsx
-msgid "mOFG3K"
+msgctxt "mOFG3K"
+msgid "Start"
 msgstr "Começar"
 
 #: src/components/catalog/continue-lesson-link.tsx
 #: src/lib/lessons.ts
-msgid "R-J5ox"
+msgctxt "R-J5ox"
+msgid "Review"
 msgstr "Revisar"
 
 #: src/components/feedback/contact-form.tsx
-msgid "WzCvaN"
+msgctxt "WzCvaN"
+msgid "We'll use this email to contact you."
 msgstr "A gente vai usar este email para falar com você."
 
 #: src/components/feedback/contact-form.tsx
-msgid "T7Ry38"
+msgctxt "T7Ry38"
+msgid "Message"
 msgstr "Mensagem"
 
 #: src/components/feedback/contact-form.tsx
-msgid "M6PcEI"
+msgctxt "M6PcEI"
+msgid "How can we help you?"
 msgstr "Como a gente pode te ajudar?"
 
 #: src/components/feedback/contact-form.tsx
-msgid "vD72E5"
+msgctxt "vD72E5"
+msgid "Message sent successfully! We'll get back to you soon."
 msgstr "Mensagem enviada! A gente vai responder em breve."
 
 #: src/components/feedback/contact-form.tsx
-msgid "-5vOOu"
+msgctxt "-5vOOu"
+msgid "Please provide as much detail as possible."
 msgstr "Dê o máximo de detalhes que puder."
 
 #: src/components/feedback/contact-form.tsx
-msgid "1WHPmV"
+msgctxt "1WHPmV"
+msgid "Failed to send message. Please try again or email us directly at hello@zoonk.com"
 msgstr "Não foi possível enviar a mensagem. Tente de novo ou fale com a gente direto pelo email contato@zoonk.com"
 
 #: src/components/feedback/contact-form.tsx
-msgid "Xx0WZV"
+msgctxt "Xx0WZV"
+msgid "Send message"
 msgstr "Enviar mensagem"
 
 #: src/components/feedback/content-feedback.tsx
-msgid "BlI1_9"
+msgctxt "BlI1_9"
+msgid "Did you like this content?"
 msgstr "Você gostou deste conteúdo?"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "Ejhdi4"
+msgctxt "Ejhdi4"
+msgid "Feedback"
 msgstr "Feedback"
 
 #: src/components/feedback/feedback-dialog.tsx
-msgid "eUzs3M"
+msgctxt "eUzs3M"
+msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envie feedback, perguntas ou sugestões. Preencha o formulário abaixo ou fale com a gente direto pelo email contato@zoonk.com."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "ctqXbT"
+msgctxt "ctqXbT"
+msgid "We lost the progress connection. Your content may still be generating."
 msgstr "A conexão do progresso caiu. Seu conteúdo ainda pode estar sendo gerado."
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "1A8Z_l"
+msgctxt "1A8Z_l"
+msgid "Check again"
 msgstr "Verificar de novo"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "yHqv96"
+msgctxt "yHqv96"
+msgid "Connection interrupted"
 msgstr "Conexão interrompida"
 
 #: src/components/generation/workflow-generation-error.tsx
-msgid "JqiqNj"
+msgctxt "JqiqNj"
+msgid "Something went wrong"
 msgstr "Algo deu errado"
 
 #: src/components/progress/progress-day-count-label.ts
-msgid "r9koty"
+msgctxt "r9koty"
+msgid "{count, plural, =0 {# days} one {# day} other {# days}}"
 msgstr "{count, plural, =0 {# dias} one {# dia} other {# dias}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "tRA46q"
+msgctxt "tRA46q"
+msgid "0 min"
 msgstr "0 min"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "yMhrnF"
+msgctxt "yMhrnF"
+msgid "{seconds, plural, one {# sec} other {# sec}}"
 msgstr "{seconds, plural, one {# s} other {# s}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "a-oHjQ"
+msgctxt "a-oHjQ"
+msgid "{minutes, plural, one {# min} other {# min}}"
 msgstr "{minutes, plural, one {# min} other {# min}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "QqnZaw"
+msgctxt "QqnZaw"
+msgid "{hours, plural, one {# hr} other {# hr}}"
 msgstr "{hours, plural, one {# h} other {# h}}"
 
 #: src/components/progress/progress-learning-time-label.ts
-msgid "Frd5VU"
+msgctxt "Frd5VU"
+msgid "{hours, plural, one {# hr} other {# hr}} {minutes, plural, one {# min} other {# min}}"
 msgstr "{hours, plural, one {# h} other {# h}} {minutes, plural, one {# min} other {# min}}"
 
 #: src/components/progress/total-learning-time-card.tsx
-msgid "-V74AY"
+msgctxt "-V74AY"
+msgid "Learning time"
 msgstr "Tempo de estudo"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "IS_YjO"
+msgctxt "IS_YjO"
+msgid "Upgrade to create"
 msgstr "Faça upgrade para criar"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "ZMU6iN"
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
 msgstr "Você atingiu o limite de aulas grátis. Faça upgrade para ter aulas ilimitadas"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgid "0h_lPM"
+msgctxt "0h_lPM"
+msgid "Upgrade"
 msgstr "Fazer upgrade"
 
 #: src/lib/belt-colors.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {Faixa Branca} yellow {Faixa Amarela} orange {Faixa Laranja} green {Faixa Verde} blue {Faixa Azul} purple {Faixa Roxa} brown {Faixa Marrom} red {Faixa Vermelha} gray {Faixa Cinza} black {Faixa Preta} other {Faixa}}"
 
 #: src/lib/categories/category.ts
-msgid "fFt3il"
+msgctxt "fFt3il"
+msgid "Arts"
 msgstr "Artes"
 
 #: src/lib/categories/category.ts
-msgid "w1Fanr"
+msgctxt "w1Fanr"
+msgid "Business"
 msgstr "Negócios"
 
 #: src/lib/categories/category.ts
-msgid "n5D_Ku"
+msgctxt "n5D_Ku"
+msgid "Communication"
 msgstr "Comunicação"
 
 #: src/lib/categories/category.ts
-msgid "mn6pIm"
+msgctxt "mn6pIm"
+msgid "Culture"
 msgstr "Cultura"
 
 #: src/lib/categories/category.ts
-msgid "hwL7a0"
+msgctxt "hwL7a0"
+msgid "Engineering"
 msgstr "Engenharia"
 
 #: src/lib/categories/category.ts
-msgid "YMDBNH"
+msgctxt "YMDBNH"
+msgid "Geography"
 msgstr "Geografia"
 
 #: src/lib/categories/category.ts
-msgid "hlmkcL"
+msgctxt "hlmkcL"
+msgid "Health"
 msgstr "Saúde"
 
 #: src/lib/categories/category.ts
-msgid "GsBRWL"
+msgctxt "GsBRWL"
+msgid "Languages"
 msgstr "Idiomas"
 
 #: src/lib/categories/category.ts
-msgid "u3ovjm"
+msgctxt "u3ovjm"
+msgid "Law"
 msgstr "Direito"
 
 #: src/lib/categories/category.ts
-msgid "dPgwrL"
+msgctxt "dPgwrL"
+msgid "Math"
 msgstr "Matemática"
 
 #: src/lib/categories/category.ts
-msgid "qydxOd"
+msgctxt "qydxOd"
+msgid "Science"
 msgstr "Ciências"
 
 #: src/lib/categories/category.ts
-msgid "OV_2-4"
+msgctxt "OV_2-4"
+msgid "Society"
 msgstr "Sociedade"
 
 #: src/lib/categories/category.ts
-msgid "I1ZCPK"
+msgctxt "I1ZCPK"
+msgid "Technology"
 msgstr "Tecnologia"
 
 #: src/lib/categories/category.ts
-msgid "XL8IWT"
+msgctxt "XL8IWT"
+msgid "{category} courses. The best {category} online courses, interactive lessons to learn."
 msgstr "Cursos de {category}. Os melhores cursos online de {category}, com aulas interativas para aprender."
 
 #: src/lib/categories/category.ts
-msgid "4HKnmB"
+msgctxt "4HKnmB"
+msgid "{category} Courses"
 msgstr "Cursos de {category}"
 
 #: src/lib/categories/category.ts
-msgid "EMi23I"
+msgctxt "EMi23I"
+msgid "Explore all {category} courses"
 msgstr "Explore todos os cursos de {category}"
 
 #: src/lib/categories/category.ts
-msgid "Rz9oL-"
+msgctxt "Rz9oL-"
+msgid "{category} courses"
 msgstr "Cursos de {category}"
 
 #: src/lib/lessons.ts
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alfabeto"
 
 #: src/lib/lessons.ts
-msgid "4TTYDR"
+msgctxt "4TTYDR"
+msgid "Custom lesson"
 msgstr "Aula personalizada"
 
 #: src/lib/lessons.ts
-msgid "E1bF_X"
+msgctxt "E1bF_X"
+msgid "Explanation"
 msgstr "Explicação"
 
 #: src/lib/lessons.ts
-msgid "QzTY8x"
+msgctxt "QzTY8x"
+msgid "Grammar"
 msgstr "Gramática"
 
 #: src/lib/lessons.ts
-msgid "1TOMnj"
+msgctxt "1TOMnj"
+msgid "Listening"
 msgstr "Escuta"
 
 #: src/lib/lessons.ts
-msgid "KV-O0y"
+msgctxt "KV-O0y"
+msgid "Practice"
 msgstr "Prática"
 
 #: src/lib/lessons.ts
-msgid "OuR_Ij"
+msgctxt "OuR_Ij"
+msgid "Quiz"
 msgstr "Quiz"
 
 #: src/lib/lessons.ts
-msgid "MOK_yK"
+msgctxt "MOK_yK"
+msgid "Reading"
 msgstr "Leitura"
 
 #: src/lib/lessons.ts
-msgid "_vCXIP"
+msgctxt "_vCXIP"
+msgid "Translation"
 msgstr "Tradução"
 
 #: src/lib/lessons.ts
-msgid "Ox-Z-K"
+msgctxt "Ox-Z-K"
+msgid "Tutorial"
 msgstr "Tutorial"
 
 #: src/lib/lessons.ts
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Vocabulário"
 
 #: src/lib/lessons.ts
-msgid "22k1CY"
+msgctxt "22k1CY"
+msgid "Learn how letters and sounds work in this writing system."
 msgstr "Aprenda como as letras e sons funcionam neste sistema de escrita."
 
 #: src/lib/lessons.ts
-msgid "LZC7R9"
+msgctxt "LZC7R9"
+msgid "Work through a lesson created for your goal."
 msgstr "Faça uma aula criada para o seu objetivo."
 
 #: src/lib/lessons.ts
-msgid "fOfLbt"
+msgctxt "fOfLbt"
+msgid "Understand the key ideas using everyday language and practical examples."
 msgstr "Entenda as ideias principais com linguagem simples e exemplos práticos."
 
 #: src/lib/lessons.ts
-msgid "dHmgw1"
+msgctxt "dHmgw1"
+msgid "Practice grammar patterns with examples and exercises."
 msgstr "Pratique padrões de gramática com exemplos e exercícios."
 
 #: src/lib/lessons.ts
-msgid "AetsPy"
+msgctxt "AetsPy"
+msgid "Listen to sentences using words you recently learned."
 msgstr "Escute frases com palavras que você aprendeu recentemente."
 
 #: src/lib/lessons.ts
-msgid "6oNgY9"
+msgctxt "6oNgY9"
+msgid "Use what you learned in the previous lesson to solve real-world problems."
 msgstr "Use o que você aprendeu na aula anterior para resolver problemas do mundo real."
 
 #: src/lib/lessons.ts
-msgid "vO6aLm"
+msgctxt "vO6aLm"
+msgid "Check what you understood with a short quiz."
 msgstr "Confira o que você entendeu com um quiz curto."
 
 #: src/lib/lessons.ts
-msgid "OIim7M"
+msgctxt "OIim7M"
+msgid "Read sentences using words you recently learned."
 msgstr "Leia frases com palavras que você aprendeu recentemente."
 
 #: src/lib/lessons.ts
-msgid "pwrprO"
+msgctxt "pwrprO"
+msgid "Review this chapter with practice based on your mistakes."
 msgstr "Revise este capítulo com prática baseada nos seus erros."
 
 #: src/lib/lessons.ts
-msgid "IQOJhk"
+msgctxt "IQOJhk"
+msgid "Translate words from your previous vocabulary lesson."
 msgstr "Traduza palavras da sua aula de vocabulário anterior."
 
 #: src/lib/lessons.ts
-msgid "9XByXq"
+msgctxt "9XByXq"
+msgid "Follow a guided step-by-step tutorial."
 msgstr "Siga um tutorial guiado passo a passo."
 
 #: src/lib/lessons.ts
-msgid "IHSVS5"
+msgctxt "IHSVS5"
+msgid "Learn new words and practice using them."
 msgstr "Aprenda palavras novas e pratique usando elas."
 
 #: src/lib/lessons.ts
-msgid "OjyuQ-"
+msgctxt "OjyuQ-"
+msgid "Learn the writing system for {topic} with focused practice."
 msgstr "Aprenda o sistema de escrita de {topic} com prática focada."
 
 #: src/lib/lessons.ts
-msgid "pSQZ7W"
+msgctxt "pSQZ7W"
+msgid "Learn about {topic} through an interactive lesson."
 msgstr "Aprenda sobre {topic} com uma aula interativa."
 
 #: src/lib/lessons.ts
-msgid "THPcKi"
+msgctxt "THPcKi"
+msgid "Understand what {topic} is — core concepts and definitions explained with clear metaphors and analogies."
 msgstr "Entenda o que é {topic}: conceitos principais e definições explicados com metáforas e analogias claras."
 
 #: src/lib/lessons.ts
-msgid "tlgfSZ"
+msgctxt "tlgfSZ"
+msgid "Practice {topic} grammar rules with exercises designed to help you remember and apply them."
 msgstr "Pratique as regras de gramática de {topic} com exercícios feitos para te ajudar a lembrar e usar elas."
 
 #: src/lib/lessons.ts
-msgid "xCvEE1"
+msgctxt "xCvEE1"
+msgid "Practice listening in {topic} by translating audio sentences."
 msgstr "Pratique escuta em {topic} traduzindo frases em áudio."
 
 #: src/lib/lessons.ts
-msgid "wHBT6R"
+msgctxt "wHBT6R"
+msgid "Apply {topic} through a visual real-world problem with short decisions."
 msgstr "Aplique {topic} em um problema visual do mundo real com decisões curtas."
 
 #: src/lib/lessons.ts
-msgid "h2acN8"
+msgctxt "h2acN8"
+msgid "Test your understanding of {topic} with questions designed to check real comprehension, not just memorization."
 msgstr "Teste seu entendimento sobre {topic} com perguntas feitas para checar se você entendeu de verdade, não só memorizou."
 
 #: src/lib/lessons.ts
-msgid "XzxpBZ"
+msgctxt "XzxpBZ"
+msgid "Improve your {topic} reading comprehension by translating sentences and passages."
 msgstr "Melhore sua compreensão de leitura em {topic} traduzindo frases e trechos."
 
 #: src/lib/lessons.ts
-msgid "bzFQEy"
+msgctxt "bzFQEy"
+msgid "Review everything you learned about {topic} with a comprehensive quiz."
 msgstr "Revise tudo que você aprendeu sobre {topic} com um quiz completo."
 
 #: src/lib/lessons.ts
-msgid "X8Gqiq"
+msgctxt "X8Gqiq"
+msgid "Practice vocabulary in {topic} by translating words you've learned."
 msgstr "Pratique vocabulário em {topic} traduzindo palavras que você aprendeu."
 
 #: src/lib/lessons.ts
-msgid "3bJDQa"
+msgctxt "3bJDQa"
+msgid "Learn {topic} with a guided step-by-step tutorial."
 msgstr "Aprenda {topic} com um tutorial guiado passo a passo."
 
 #: src/lib/lessons.ts
-msgid "77SLH5"
+msgctxt "77SLH5"
+msgid "Learn new words in {topic} with flashcards — see each word, its translation, and pronunciation."
 msgstr "Aprenda palavras novas em {topic} com flashcards — veja cada palavra, a tradução e a pronúncia."
 
 #: src/lib/lessons.ts
-msgid "oCxmX9"
+msgctxt "oCxmX9"
+msgid "{chapter} {kind} {position}"
 msgstr "{kind} {chapter} {position}"
 
 #: src/lib/lessons.ts
-msgid "qHbgYB"
+msgctxt "qHbgYB"
+msgid "{lesson} - {course}"
 msgstr "{lesson} - {course}"

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -1,5 +1,6 @@
 import createMDX from "@next/mdx";
 import { withSentryConfig } from "@sentry/nextjs";
+import { NEXT_INTL_PO_FORMAT } from "@zoonk/i18n/next-intl/po-format";
 import { getPublicAppSecurityHeaders } from "@zoonk/next/security/headers";
 import { withBotId } from "botid/next/config";
 import { type NextConfig } from "next";
@@ -61,7 +62,7 @@ const withNextIntl = createNextIntlPlugin({
   experimental: {
     extract: { path: "./messages" },
     messages: {
-      format: "po",
+      format: NEXT_INTL_PO_FORMAT,
       locales: "infer",
       path: ["./messages", "../../packages/player/messages"],
       precompile: true,

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -3,17 +3,24 @@
   "private": true,
   "type": "module",
   "exports": {
-    "./define-eloqnt-config": "./src/define-eloqnt-config.ts"
+    "./define-eloqnt-config": "./src/define-eloqnt-config.ts",
+    "./next-intl/po-format": "./src/next-intl/po-format.ts"
   },
   "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@eloqnt/cli": "catalog:",
-    "ai-sdk-provider-codex-cli": "1.2.2"
+    "ai-sdk-provider-codex-cli": "1.2.2",
+    "next-intl": "catalog:",
+    "po-parser": "2.1.1"
   },
   "devDependencies": {
+    "@types/node": "catalog:",
     "@typescript/native": "catalog:",
-    "@zoonk/tsconfig": "workspace:*"
+    "@zoonk/tsconfig": "workspace:*",
+    "vitest": "catalog:"
   }
 }

--- a/packages/i18n/src/define-eloqnt-config.ts
+++ b/packages/i18n/src/define-eloqnt-config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "@eloqnt/cli";
 import { codexCli } from "ai-sdk-provider-codex-cli";
+import { NEXT_INTL_PO_FORMAT } from "./next-intl/po-format";
 
 // Can be extended as necessary
 type EloqntProjectOptions = { srcPath?: string | string[] };
@@ -19,7 +20,12 @@ function getCodexPath() {
  */
 export default function defineEloqntConfig(options: EloqntProjectOptions = {}) {
   return defineConfig({
-    messages: { format: "po", locales: "infer", path: "./messages", sourceLocale: "en" },
+    messages: {
+      format: NEXT_INTL_PO_FORMAT,
+      locales: "infer",
+      path: "./messages",
+      sourceLocale: "en",
+    },
     model: codexCli("gpt-5.6-sol", { codexPath: getCodexPath() }),
     srcPath: options.srcPath ?? "./src",
   });

--- a/packages/i18n/src/next-intl/po-codec.test.ts
+++ b/packages/i18n/src/next-intl/po-codec.test.ts
@@ -1,0 +1,77 @@
+import POParser from "po-parser";
+import { describe, expect, it } from "vitest";
+import createPoCodec from "./po-codec";
+
+const legacyCatalog = `msgid ""
+msgstr ""
+"Language: pt\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"X-Generator: next-intl\\n"
+"X-Crowdin-SourceKey: msgstr\\n"
+
+#: src/search.tsx
+msgid "xmcVZ0"
+msgstr "Pesquisar"
+`;
+
+describe("PO codec", () => {
+  it("migrates legacy IDs without losing translations", () => {
+    const codec = createPoCodec();
+    const decodedMessages = codec.decode(legacyCatalog, { locale: "pt" });
+
+    const sourceMessage = {
+      description: [],
+      id: "xmcVZ0",
+      message: "Search",
+      references: [{ path: "src/search.tsx" }],
+    };
+
+    const migratedCatalog = codec.encode(decodedMessages, {
+      locale: "pt",
+      sourceMessagesById: new Map([[sourceMessage.id, sourceMessage]]),
+    });
+
+    const parsedCatalog = POParser.parse(migratedCatalog);
+
+    expect(
+      parsedCatalog.messages?.map(({ msgctxt, msgid, msgstr, references }) => ({
+        msgctxt,
+        msgid,
+        msgstr,
+        references,
+      })),
+    ).toStrictEqual([
+      {
+        msgctxt: "xmcVZ0",
+        msgid: "Search",
+        msgstr: "Pesquisar",
+        references: [{ path: "src/search.tsx" }],
+      },
+    ]);
+
+    expect(parsedCatalog.meta).toStrictEqual({
+      "Content-Transfer-Encoding": "8bit",
+      "Content-Type": "text/plain; charset=utf-8",
+      Language: "pt",
+      "X-Generator": "next-intl",
+    });
+  });
+
+  it("uses the generated ID as the runtime message key", () => {
+    const codec = createPoCodec();
+
+    const source = `msgid ""
+msgstr ""
+"Language: pt\\n"
+
+msgctxt "settings.search"
+msgid "Search"
+msgstr "Pesquisar"
+`;
+
+    expect(codec.toJSONString(source, { locale: "pt" })).toBe(
+      JSON.stringify({ settings: { search: "Pesquisar" } }),
+    );
+  });
+});

--- a/packages/i18n/src/next-intl/po-codec.ts
+++ b/packages/i18n/src/next-intl/po-codec.ts
@@ -1,0 +1,252 @@
+import { defineCodec } from "next-intl/extractor";
+import POParser, { type Entry } from "po-parser";
+
+const BUILT_IN_SOURCE_KEY = "X-Crowdin-SourceKey";
+const FORBIDDEN_OBJECT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+// oxlint-disable-next-line sort-keys -- Preserve the conventional gettext header order.
+const DEFAULT_METADATA = {
+  "Content-Type": "text/plain; charset=utf-8",
+  "Content-Transfer-Encoding": "8bit",
+  "X-Generator": "next-intl",
+};
+
+type Codec = ReturnType<ReturnType<typeof defineCodec>>;
+type DecodeContext = Parameters<Codec["decode"]>[1];
+type EncodeContext = Parameters<Codec["encode"]>[1];
+type ExtractedMessage = ReturnType<Codec["decode"]>[number];
+
+/**
+ * Identifies catalogs written by next-intl's built-in PO codec so the first
+ * extraction can migrate their IDs without losing existing translations.
+ */
+function usesBuiltInCodec(metadata: Record<string, string> | undefined) {
+  return metadata?.[BUILT_IN_SOURCE_KEY] === "msgstr";
+}
+
+/**
+ * Removes metadata that told Crowdin to treat msgstr as the source key. This
+ * codec writes the source message to msgid, so keeping that header would make
+ * external PO tools read the translated value as the source text.
+ */
+function getRetainedMetadata(metadata: Record<string, string> | undefined) {
+  return Object.fromEntries(
+    Object.entries(metadata ?? {}).filter(([key]) => key !== BUILT_IN_SOURCE_KEY),
+  );
+}
+
+/**
+ * Restores the runtime ID from either the new codec shape or the built-in PO
+ * shape used before this migration. Built-in catalogs use msgctxt as a
+ * namespace, while this codec stores the complete generated ID there.
+ */
+function getMessageId({ entry, isBuiltInCatalog }: { entry: Entry; isBuiltInCatalog: boolean }) {
+  if (isBuiltInCatalog) {
+    return entry.msgctxt ? `${entry.msgctxt}.${entry.msgid}` : entry.msgid;
+  }
+
+  if (!entry.msgctxt) {
+    throw new Error(`msgctxt is required for msgid "${entry.msgid}".`);
+  }
+
+  return entry.msgctxt;
+}
+
+/**
+ * Converts a PO entry into next-intl's extractor shape while retaining flags,
+ * comments, and references needed when the catalog is written again.
+ */
+function decodeEntry({ entry, isBuiltInCatalog }: { entry: Entry; isBuiltInCatalog: boolean }) {
+  const {
+    extractedComments,
+    msgctxt: _msgctxt,
+    msgid: _msgid,
+    msgstr,
+    references,
+    ...rest
+  } = entry;
+
+  return {
+    ...rest,
+    description: extractedComments ?? [],
+    id: getMessageId({ entry, isBuiltInCatalog }),
+    message: msgstr,
+    references: references ?? [],
+  } satisfies ExtractedMessage;
+}
+
+/**
+ * Sorts entries by their first source reference so extraction produces stable
+ * catalogs that follow the same order as next-intl's built-in codecs.
+ */
+function compareMessages({
+  messageA,
+  messageB,
+}: {
+  messageA: ExtractedMessage;
+  messageB: ExtractedMessage;
+}) {
+  const referenceA = messageA.references[0];
+  const referenceB = messageB.references[0];
+
+  if (!referenceA || !referenceB) {
+    return 0;
+  }
+
+  const pathComparison = referenceA.path.localeCompare(referenceB.path, "en");
+  return pathComparison || (referenceA.line ?? 0) - (referenceB.line ?? 0);
+}
+
+/**
+ * Keeps one path-only reference per source file because line numbers change
+ * frequently and create noisy catalog diffs.
+ */
+function getPathOnlyReferences(
+  references: ExtractedMessage["references"],
+): NonNullable<Entry["references"]> {
+  return [...new Set(references.map((reference) => reference.path))].map((path) => ({ path }));
+}
+
+/**
+ * Writes source text to msgid while retaining the generated runtime ID in
+ * msgctxt and the existing locale value in msgstr.
+ */
+function encodeMessage({
+  context,
+  message,
+}: {
+  context: EncodeContext;
+  message: ExtractedMessage;
+}): Entry {
+  const sourceMessage = context.sourceMessagesById.get(message.id)?.message;
+
+  if (sourceMessage === undefined) {
+    throw new Error(
+      `Source message not found for id "${message.id}" in locale "${context.locale}".`,
+    );
+  }
+
+  const { description, id, message: translation, references, ...rest } = message;
+  const pathOnlyReferences = getPathOnlyReferences(references);
+
+  return {
+    ...rest,
+    ...(description.length > 0 && { extractedComments: description }),
+    ...(pathOnlyReferences.length > 0 && { references: pathOnlyReferences }),
+    msgctxt: id,
+    msgid: sourceMessage,
+    msgstr: translation,
+  };
+}
+
+/**
+ * Checks message ID segments before they become object keys so a catalog
+ * cannot modify an object's prototype when next-intl loads it as JSON.
+ */
+function assertSafeKey(key: string) {
+  if (FORBIDDEN_OBJECT_KEYS.has(key)) {
+    throw new Error(`Invalid message id segment: ${key}`);
+  }
+}
+
+/** Checks whether an existing message branch can receive another nested key. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Adds one dotted runtime ID to the local catalog object. Keeping the mutation
+ * inside this builder avoids repeatedly copying the whole catalog while still
+ * preventing unsafe object keys.
+ */
+function setNestedProperty({
+  index = 0,
+  keyPath,
+  object,
+  value,
+}: {
+  index?: number;
+  keyPath: string[];
+  object: Record<string, unknown>;
+  value: string;
+}) {
+  const key = keyPath[index];
+
+  if (!key) {
+    return;
+  }
+
+  assertSafeKey(key);
+
+  if (index === keyPath.length - 1) {
+    object[key] = value;
+    return;
+  }
+
+  const existingValue = object[key];
+  const nestedObject = isRecord(existingValue) ? existingValue : {};
+
+  object[key] = nestedObject;
+  setNestedProperty({ index: index + 1, keyPath, object: nestedObject, value });
+}
+
+/**
+ * Builds the nested JSON catalog so each generated ID remains the runtime
+ * lookup key even though PO tools display its source message as msgid.
+ */
+function getMessagesObject(messages: ExtractedMessage[]): Record<string, unknown> {
+  const messagesObject: Record<string, unknown> = {};
+
+  for (const message of messages) {
+    setNestedProperty({
+      keyPath: message.id.split("."),
+      object: messagesObject,
+      value: message.message,
+    });
+  }
+
+  return messagesObject;
+}
+
+/**
+ * Creates an isolated codec instance so metadata is retained per locale while
+ * next-intl reads and writes a set of catalogs during one extraction run.
+ */
+function createPoCodec(): Codec {
+  const metadataByLocale = new Map<string, Record<string, string>>();
+
+  /** Reads both legacy built-in catalogs and catalogs already written by this codec. */
+  function decode(content: string, context: DecodeContext) {
+    const catalog = POParser.parse(content);
+    const isBuiltInCatalog = usesBuiltInCodec(catalog.meta);
+
+    metadataByLocale.set(context.locale, getRetainedMetadata(catalog.meta));
+
+    return (catalog.messages ?? []).map((entry) => decodeEntry({ entry, isBuiltInCatalog }));
+  }
+
+  /** Writes the standard PO source/translation shape while preserving runtime IDs. */
+  function encode(messages: ExtractedMessage[], context: EncodeContext) {
+    const sortedMessages = messages.toSorted((messageA, messageB) =>
+      compareMessages({ messageA, messageB }),
+    );
+
+    return POParser.serialize({
+      messages: sortedMessages.map((message) => encodeMessage({ context, message })),
+      meta: {
+        Language: context.locale,
+        ...DEFAULT_METADATA,
+        ...metadataByLocale.get(context.locale),
+      },
+    });
+  }
+
+  /** Converts PO content into the nested JSON shape consumed by next-intl at runtime. */
+  function toJSONString(content: string, context: DecodeContext) {
+    return JSON.stringify(getMessagesObject(decode(content, context)));
+  }
+
+  return { decode, encode, toJSONString };
+}
+
+export default defineCodec(createPoCodec);

--- a/packages/i18n/src/next-intl/po-format.ts
+++ b/packages/i18n/src/next-intl/po-format.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+
+/**
+ * Gives every next-intl consumer the same absolute codec path because custom
+ * codec paths are otherwise resolved relative to each app's project root.
+ */
+export const NEXT_INTL_PO_FORMAT = {
+  codec: fileURLToPath(new URL("po-codec.ts", import.meta.url)),
+  extension: ".po",
+} as const;

--- a/packages/player/extract-messages.ts
+++ b/packages/player/extract-messages.ts
@@ -1,6 +1,12 @@
+import { NEXT_INTL_PO_FORMAT } from "@zoonk/i18n/next-intl/po-format";
 import { unstable_extractMessages } from "next-intl/extractor";
 
 await unstable_extractMessages({
-  messages: { format: "po", locales: "infer", path: "./messages", sourceLocale: "en" },
+  messages: {
+    format: NEXT_INTL_PO_FORMAT,
+    locales: "infer",
+    path: "./messages",
+    sourceLocale: "en",
+  },
   srcPath: "./src",
 });

--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -4,370 +4,457 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/components/alphabet-step.tsx
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alphabet"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "6NoIUl"
+msgctxt "6NoIUl"
+msgid "Correct"
 msgstr "Richtig"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "Ypr9T5"
+msgctxt "Ypr9T5"
+msgid "Incorrect"
 msgstr "Falsch"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/sort-order-step.tsx
-msgid "hFFOe-"
+msgctxt "hFFOe-"
+msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "vPyO9S"
+msgctxt "vPyO9S"
+msgid "Position {position}: {item}. Tap to remove."
 msgstr "Position {position}: {item}. Tippe, um zu entfernen."
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/select-image-step.tsx
-msgid "1nJY2_"
+msgctxt "1nJY2_"
+msgid "Your answer"
 msgstr "Deine Antwort"
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "7R_rOB"
+msgctxt "7R_rOB"
+msgid "Tap words to build your answer"
 msgstr "Tippe Wörter an, um deine Antwort zu bilden"
 
 #: src/components/arrange-words.tsx
 #: src/components/fill-blank-word-bank.tsx
-msgid "e7WNdK"
+msgctxt "e7WNdK"
+msgid "Word bank"
 msgstr "Wortschatz"
 
 #: src/components/completion-auth-branch.tsx
-msgid "E2sGaF"
+msgctxt "E2sGaF"
+msgid "Exit"
 msgstr "Beenden"
 
 #: src/components/completion-auth-branch.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Erneut versuchen"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
-msgid "9-Ddtu"
+msgctxt "9-Ddtu"
+msgid "Next"
 msgstr "Weiter"
 
 #: src/components/completion-auth-branch.tsx
-msgid "odXlk8"
+msgctxt "odXlk8"
+msgid "Log in"
 msgstr "Anmelden"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "fS3hB9"
+msgctxt "fS3hB9"
+msgid "New daily best"
 msgstr "Neuer Tagesrekord"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "VaM8Q9"
+msgctxt "VaM8Q9"
+msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
 msgstr "Du hast heute {brainPower} BP erreicht, deine höchste Brain Power an einem Tag. Lern jeden Tag weiter, um einen neuen Rekord zu setzen."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "m2WzLQ"
+msgctxt "m2WzLQ"
+msgid "Max Energy!"
 msgstr "Maximale Energie!"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "Fo6YtA"
+msgctxt "Fo6YtA"
+msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
 msgstr "Glückwunsch! Du hast maximale Energie erreicht. Übe jeden Tag, um deine Energie bei 100% zu halten."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "J89SkG"
+msgctxt "J89SkG"
+msgid "{percentage} Energy"
 msgstr "{percentage} Energie"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "3Jd-mJ"
+msgctxt "3Jd-mJ"
+msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
 msgstr "Dein Einsatz zahlt sich aus. Schließe jeden Tag Lektionen ab, um deine Energie zu steigern."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "5YVYKd"
+msgctxt "5YVYKd"
+msgid "1 year of max Energy"
 msgstr "1 Jahr volle Energie"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "1WNk4i"
+msgctxt "1WNk4i"
+msgid "{days} days of max Energy"
 msgstr "{days} Tage volle Energie"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "cIxpmv"
+msgctxt "cIxpmv"
+msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
 msgstr "Wow, was für eine unglaubliche Ausdauer! Lern weiter jeden Tag, damit deine Energie bei 100% bleibt."
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "SIXtG5"
+msgctxt "SIXtG5"
+msgid "{days} learning days"
 msgstr "{days} Lerntage"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "hjXoGI"
+msgctxt "hjXoGI"
+msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
 msgstr "Du hast an {days} verschiedenen Tagen Lektionen abgeschlossen. Wenn du oft übst, kannst du dir das Gelernte besser merken."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "dZvEPp"
+msgctxt "dZvEPp"
+msgid "{minutes} minutes of learning"
 msgstr "{minutes} Minuten lernen"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "kw1W3C"
+msgctxt "kw1W3C"
+msgid "1 full day of learning"
 msgstr "1 voller Lerntag"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "BlVoPr"
+msgctxt "BlVoPr"
+msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# Stunde gelernt} other {# Stunden gelernt}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "WcAhMT"
+msgctxt "WcAhMT"
+msgid "You can learn a lot by practicing for a few minutes a day."
 msgstr "Du kannst viel lernen, wenn du täglich ein paar Minuten übst."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "LzEQnT"
+msgctxt "LzEQnT"
+msgid "That's a full day of focused practice."
 msgstr "Das ist ein ganzer Tag konzentriertes Üben."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "PpK3hX"
+msgctxt "PpK3hX"
+msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
 msgstr "Das sind mehr als {days, plural, one {# voller Tag} other {# volle Tage}} konzentriertes Üben."
 
 #: src/components/completion-level-milestone.tsx
-msgid "155cHi"
+msgctxt "155cHi"
+msgid "Level achieved"
 msgstr "Level erreicht"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Ar7dNY"
+msgctxt "Ar7dNY"
+msgid "You reached a new level: {belt}, level {level}. Congrats!"
 msgstr "Du hast ein neues Level erreicht: {belt}, Level {level}. Glückwunsch!"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Bk6B6r"
+msgctxt "Bk6B6r"
+msgid "Almost there"
 msgstr "Fast geschafft"
 
 #: src/components/completion-level-milestone.tsx
-msgid "b7ZoLo"
+msgctxt "b7ZoLo"
+msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
 msgstr "Dein Wissen wächst. Schließe {count, plural, one {noch # Lektion} other {noch # Lektionen}} ab, um {belt}, Level {level}, zu erreichen."
 
 #: src/components/completion-milestone-actions.tsx
-msgid "DiIkZH"
+msgctxt "DiIkZH"
+msgid "Next Chapter"
 msgstr "Nächstes Kapitel"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "w0D7HC"
+msgctxt "w0D7HC"
+msgid "Review Course"
 msgstr "Kurs wiederholen"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "wm_M34"
+msgctxt "wm_M34"
+msgid "Review Chapter"
 msgstr "Kapitel wiederholen"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "iSioEh"
+msgctxt "iSioEh"
+msgid "Learn about Energy"
 msgstr "Mehr über Energie erfahren"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "DC0WoT"
+msgctxt "DC0WoT"
+msgid "Learn about Score"
 msgstr "Mehr über Score"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "Q0R3MU"
+msgctxt "Q0R3MU"
+msgid "Learn about levels"
 msgstr "Mehr über Levels erfahren"
 
 #: src/components/completion-progress-milestone-screen.tsx
 #: src/components/step-action-button.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Fortfahren"
 
 #: src/components/completion-score-milestone.tsx
-msgid "e6_3Ke"
+msgctxt "e6_3Ke"
+msgid "{day} is your best day"
 msgstr "{day} ist dein bester Tag"
 
 #: src/components/completion-score-milestone.tsx
-msgid "PTQ0ah"
+msgctxt "PTQ0ah"
+msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
 msgstr "An {day} hast du normalerweise {percentage} der Antworten richtig – dein bester Durchschnitt in dieser Woche."
 
 #: src/components/completion-screen.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Abgeschlossen"
 
 #: src/components/completion-screen.tsx
-msgid "2wDWd0"
+msgctxt "2wDWd0"
+msgid "Course Complete"
 msgstr "Kurs abgeschlossen"
 
 #: src/components/completion-screen.tsx
-msgid "t2VOpl"
+msgctxt "t2VOpl"
+msgid "Chapter Complete"
 msgstr "Kapitel abgeschlossen"
 
 #: src/components/completion-screen.tsx
 #: src/components/in-play-sticky-header.tsx
-msgid "qXzoF7"
+msgctxt "qXzoF7"
+msgid "Lesson {current} of {total}"
 msgstr "Lektion {current} von {total}"
 
 #: src/components/completion-screen.tsx
-msgid "9wxMoj"
+msgctxt "9wxMoj"
+msgid "Chapter progress"
 msgstr "Kapitel-Fortschritt"
 
 #: src/components/completion-screen.tsx
-msgid "P768k7"
+msgctxt "P768k7"
+msgid "correct"
 msgstr "richtig"
 
 #: src/components/feedback-answer-blocks.tsx
-msgid "3nOd8f"
+msgctxt "3nOd8f"
+msgid "Your answer:"
 msgstr "Deine Antwort:"
 
 #: src/components/feedback-answer-blocks.tsx
 #: src/components/inline-feedback.tsx
-msgid "QAJ_Tl"
+msgctxt "QAJ_Tl"
+msgid "Correct answer:"
 msgstr "Richtige Antwort:"
 
 #: src/components/feedback-screen.tsx
-msgid "kgOBET"
+msgctxt "kgOBET"
+msgid "Question"
 msgstr "Frage"
 
 #: src/components/feedback-screen.tsx
-msgid "fpO9TK"
+msgctxt "fpO9TK"
+msgid "Translate:"
 msgstr "Übersetze:"
 
 #: src/components/fill-blank-step.tsx
-msgid "SL2Bob"
+msgctxt "SL2Bob"
+msgid "Blank {position}: {item}. {result}."
 msgstr "Lücke {position}: {item}. {result}."
 
 #: src/components/fill-blank-step.tsx
-msgid "wUEGVH"
+msgctxt "wUEGVH"
+msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Lücke {position}: {item}. Tippe, um zu entfernen."
 
 #: src/components/fill-blank-step.tsx
-msgid "FmmJ_j"
+msgctxt "FmmJ_j"
+msgid "Blank {position}"
 msgstr "Lücke {position}"
 
 #: src/components/inline-feedback.tsx
-msgid "HvLGEN"
+msgctxt "HvLGEN"
+msgid "Answer feedback"
 msgstr "Feedback zur Antwort"
 
 #: src/components/lesson-info-popover.tsx
-msgid "RwePAQ"
+msgctxt "RwePAQ"
+msgid "Lesson info"
 msgstr "Lektionsinfo"
 
 #: src/components/listening-step.tsx
-msgid "aAmWaS"
+msgctxt "aAmWaS"
+msgid "What do you hear?"
 msgstr "Was hörst du?"
 
 #: src/components/listening-step.tsx
 #: src/components/reading-step.tsx
-msgid "19nXyC"
+msgctxt "19nXyC"
+msgid "Translate this sentence:"
 msgstr "Übersetze diesen Satz:"
 
 #: src/components/match-columns-step.tsx
-msgid "fV1MzK"
+msgctxt "fV1MzK"
+msgid "Match the pairs."
 msgstr "Ordne die Paare zu."
 
 #: src/components/match-columns-step.tsx
-msgid "ja1JDt"
+msgctxt "ja1JDt"
+msgid "All pairs matched. Press Check to continue."
 msgstr "Alle Paare zugeordnet. Drücke Prüfen, um fortzufahren."
 
 #: src/components/play-audio-button.tsx
-msgid "WGft2H"
+msgctxt "WGft2H"
+msgid "Pause pronunciation"
 msgstr "Aussprache pausieren"
 
 #: src/components/play-audio-button.tsx
-msgid "lYWSeP"
+msgctxt "lYWSeP"
+msgid "Play pronunciation"
 msgstr "Aussprache abspielen"
 
 #: src/components/player-choice-scene.tsx
-msgid "akd-cv"
+msgctxt "akd-cv"
+msgid "Answer options"
 msgstr "Antwortoptionen"
 
 #: src/components/player-header.tsx
-msgid "rbrahO"
+msgctxt "rbrahO"
+msgid "Close"
 msgstr "Schließen"
 
 #: src/components/player-progress-bar.tsx
-msgid "dYp90P"
+msgctxt "dYp90P"
+msgid "Lesson progress"
 msgstr "Lektionsfortschritt"
 
 #: src/components/player-shell.tsx
-msgid "ZHEKO0"
+msgctxt "ZHEKO0"
+msgid "Lesson content"
 msgstr "Lektionsinhalt"
 
 #: src/components/player-shell.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "41rDiT"
+msgctxt "41rDiT"
+msgid "Lesson controls"
 msgstr "Lektionssteuerung"
 
 #: src/components/select-image-step.tsx
-msgid "mhiTW7"
+msgctxt "mhiTW7"
+msgid "Correct answer"
 msgstr "Richtige Antwort"
 
 #: src/components/select-image-step.tsx
-msgid "NA6C_-"
+msgctxt "NA6C_-"
+msgid "Image options"
 msgstr "Bildoptionen"
 
 #: src/components/sort-order-step.tsx
-msgid "p5llOK"
+msgctxt "p5llOK"
+msgid "Sort items"
 msgstr "Elemente sortieren"
 
 #: src/components/sort-order-step.tsx
-msgid "VA8c_A"
+msgctxt "VA8c_A"
+msgid "Correct order:"
 msgstr "Richtige Reihenfolge:"
 
 #: src/components/sort-order-step.tsx
-msgid "9lc1oV"
+msgctxt "9lc1oV"
+msgid "Drag items into the correct order"
 msgstr "Ziehe die Elemente in die richtige Reihenfolge"
 
 #: src/components/step-action-button.tsx
-msgid "RDZVQL"
+msgctxt "RDZVQL"
+msgid "Check"
 msgstr "Prüfen"
 
 #: src/components/step-navigation-button-group.tsx
-msgid "JJNc3c"
+msgctxt "JJNc3c"
+msgid "Previous"
 msgstr "Zurück"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "aNzy1T"
+msgctxt "aNzy1T"
+msgid "Previous step"
 msgstr "Vorheriger Schritt"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "d-qgix"
+msgctxt "d-qgix"
+msgid "Next step"
 msgstr "Nächster Schritt"
 
 #: src/components/translation-step.tsx
-msgid "MxLxkr"
+msgctxt "MxLxkr"
+msgid "Translate this word:"
 msgstr "Übersetze dieses Wort:"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "czygLT"
+msgctxt "czygLT"
+msgid "Log in to save progress"
 msgstr "Melde dich an, um den Fortschritt zu speichern"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "yBJVJw"
+msgctxt "yBJVJw"
+msgid "Continue without saving"
 msgstr "Ohne Speichern fortfahren"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "O781mu"
+msgctxt "O781mu"
+msgid "Progress won't be saved"
 msgstr "Fortschritt wird nicht gespeichert"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "JDumQX"
+msgctxt "JDumQX"
+msgid "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
 msgstr "Du kannst diese Lektion ohne Konto ausprobieren, aber deine Punktzahl, Kursfortschritt, Levels und Energie werden nicht gespeichert."
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "rxdOwg"
+msgctxt "rxdOwg"
+msgid "This lesson wasn't saved"
 msgstr "Diese Lektion wurde nicht gespeichert"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "Wamgyz"
+msgctxt "Wamgyz"
+msgid "Log in before your next lesson to keep future progress, scores, levels, and Energy."
 msgstr "Melde dich vor deiner nächsten Lektion an, damit künftige Fortschritte, Punktzahlen, Levels und Energie gespeichert werden."
 
 #: src/components/verdict-label.tsx
-msgid "xmF49T"
+msgctxt "xmF49T"
+msgid "Correct!"
 msgstr "Richtig!"
 
 #: src/components/verdict-label.tsx
-msgid "--l7ni"
+msgctxt "--l7ni"
+msgid "Not quite"
 msgstr "Nicht ganz"
 
 #: src/components/vocabulary-step.tsx
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Wortschatz"
 
 #: src/use-belt-label.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {Weißer Gürtel} yellow {Gelber Gürtel} orange {Orangefarbener Gürtel} green {Grüner Gürtel} blue {Blauer Gürtel} purple {Lilafarbener Gürtel} brown {Brauner Gürtel} red {Roter Gürtel} gray {Grauer Gürtel} black {Schwarzer Gürtel} other {Gürtel}}"

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -4,370 +4,457 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/components/alphabet-step.tsx
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alphabet"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "6NoIUl"
+msgctxt "6NoIUl"
+msgid "Correct"
 msgstr "Correct"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "Ypr9T5"
+msgctxt "Ypr9T5"
+msgid "Incorrect"
 msgstr "Incorrect"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/sort-order-step.tsx
-msgid "hFFOe-"
+msgctxt "hFFOe-"
+msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "vPyO9S"
+msgctxt "vPyO9S"
+msgid "Position {position}: {item}. Tap to remove."
 msgstr "Position {position}: {item}. Tap to remove."
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/select-image-step.tsx
-msgid "1nJY2_"
+msgctxt "1nJY2_"
+msgid "Your answer"
 msgstr "Your answer"
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "7R_rOB"
+msgctxt "7R_rOB"
+msgid "Tap words to build your answer"
 msgstr "Tap words to build your answer"
 
 #: src/components/arrange-words.tsx
 #: src/components/fill-blank-word-bank.tsx
-msgid "e7WNdK"
+msgctxt "e7WNdK"
+msgid "Word bank"
 msgstr "Word bank"
 
 #: src/components/completion-auth-branch.tsx
-msgid "E2sGaF"
+msgctxt "E2sGaF"
+msgid "Exit"
 msgstr "Exit"
 
 #: src/components/completion-auth-branch.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Try again"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
-msgid "9-Ddtu"
+msgctxt "9-Ddtu"
+msgid "Next"
 msgstr "Next"
 
 #: src/components/completion-auth-branch.tsx
-msgid "odXlk8"
+msgctxt "odXlk8"
+msgid "Log in"
 msgstr "Log in"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "fS3hB9"
+msgctxt "fS3hB9"
+msgid "New daily best"
 msgstr "New daily best"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "VaM8Q9"
+msgctxt "VaM8Q9"
+msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
 msgstr "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "m2WzLQ"
+msgctxt "m2WzLQ"
+msgid "Max Energy!"
 msgstr "Max Energy!"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "Fo6YtA"
+msgctxt "Fo6YtA"
+msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
 msgstr "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "J89SkG"
+msgctxt "J89SkG"
+msgid "{percentage} Energy"
 msgstr "{percentage} Energy"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "3Jd-mJ"
+msgctxt "3Jd-mJ"
+msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
 msgstr "Your effort is paying off. Complete lessons every day to increase your Energy."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "5YVYKd"
+msgctxt "5YVYKd"
+msgid "1 year of max Energy"
 msgstr "1 year of max Energy"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "1WNk4i"
+msgctxt "1WNk4i"
+msgid "{days} days of max Energy"
 msgstr "{days} days of max Energy"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "cIxpmv"
+msgctxt "cIxpmv"
+msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
 msgstr "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "SIXtG5"
+msgctxt "SIXtG5"
+msgid "{days} learning days"
 msgstr "{days} learning days"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "hjXoGI"
+msgctxt "hjXoGI"
+msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
 msgstr "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "dZvEPp"
+msgctxt "dZvEPp"
+msgid "{minutes} minutes of learning"
 msgstr "{minutes} minutes of learning"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "kw1W3C"
+msgctxt "kw1W3C"
+msgid "1 full day of learning"
 msgstr "1 full day of learning"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "BlVoPr"
+msgctxt "BlVoPr"
+msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "WcAhMT"
+msgctxt "WcAhMT"
+msgid "You can learn a lot by practicing for a few minutes a day."
 msgstr "You can learn a lot by practicing for a few minutes a day."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "LzEQnT"
+msgctxt "LzEQnT"
+msgid "That's a full day of focused practice."
 msgstr "That's a full day of focused practice."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "PpK3hX"
+msgctxt "PpK3hX"
+msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
 msgstr "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
 
 #: src/components/completion-level-milestone.tsx
-msgid "155cHi"
+msgctxt "155cHi"
+msgid "Level achieved"
 msgstr "Level achieved"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Ar7dNY"
+msgctxt "Ar7dNY"
+msgid "You reached a new level: {belt}, level {level}. Congrats!"
 msgstr "You reached a new level: {belt}, level {level}. Congrats!"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Bk6B6r"
+msgctxt "Bk6B6r"
+msgid "Almost there"
 msgstr "Almost there"
 
 #: src/components/completion-level-milestone.tsx
-msgid "b7ZoLo"
+msgctxt "b7ZoLo"
+msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
 msgstr "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
 
 #: src/components/completion-milestone-actions.tsx
-msgid "DiIkZH"
+msgctxt "DiIkZH"
+msgid "Next Chapter"
 msgstr "Next Chapter"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "w0D7HC"
+msgctxt "w0D7HC"
+msgid "Review Course"
 msgstr "Review Course"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "wm_M34"
+msgctxt "wm_M34"
+msgid "Review Chapter"
 msgstr "Review Chapter"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "iSioEh"
+msgctxt "iSioEh"
+msgid "Learn about Energy"
 msgstr "Learn about Energy"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "DC0WoT"
+msgctxt "DC0WoT"
+msgid "Learn about Score"
 msgstr "Learn about Score"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "Q0R3MU"
+msgctxt "Q0R3MU"
+msgid "Learn about levels"
 msgstr "Learn about levels"
 
 #: src/components/completion-progress-milestone-screen.tsx
 #: src/components/step-action-button.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continue"
 
 #: src/components/completion-score-milestone.tsx
-msgid "e6_3Ke"
+msgctxt "e6_3Ke"
+msgid "{day} is your best day"
 msgstr "{day} is your best day"
 
 #: src/components/completion-score-milestone.tsx
-msgid "PTQ0ah"
+msgctxt "PTQ0ah"
+msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
 msgstr "You usually get {percentage} of answers right on {day}, your highest average of the week."
 
 #: src/components/completion-screen.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Completed"
 
 #: src/components/completion-screen.tsx
-msgid "2wDWd0"
+msgctxt "2wDWd0"
+msgid "Course Complete"
 msgstr "Course Complete"
 
 #: src/components/completion-screen.tsx
-msgid "t2VOpl"
+msgctxt "t2VOpl"
+msgid "Chapter Complete"
 msgstr "Chapter Complete"
 
 #: src/components/completion-screen.tsx
 #: src/components/in-play-sticky-header.tsx
-msgid "qXzoF7"
+msgctxt "qXzoF7"
+msgid "Lesson {current} of {total}"
 msgstr "Lesson {current} of {total}"
 
 #: src/components/completion-screen.tsx
-msgid "9wxMoj"
+msgctxt "9wxMoj"
+msgid "Chapter progress"
 msgstr "Chapter progress"
 
 #: src/components/completion-screen.tsx
-msgid "P768k7"
+msgctxt "P768k7"
+msgid "correct"
 msgstr "correct"
 
 #: src/components/feedback-answer-blocks.tsx
-msgid "3nOd8f"
+msgctxt "3nOd8f"
+msgid "Your answer:"
 msgstr "Your answer:"
 
 #: src/components/feedback-answer-blocks.tsx
 #: src/components/inline-feedback.tsx
-msgid "QAJ_Tl"
+msgctxt "QAJ_Tl"
+msgid "Correct answer:"
 msgstr "Correct answer:"
 
 #: src/components/feedback-screen.tsx
-msgid "kgOBET"
+msgctxt "kgOBET"
+msgid "Question"
 msgstr "Question"
 
 #: src/components/feedback-screen.tsx
-msgid "fpO9TK"
+msgctxt "fpO9TK"
+msgid "Translate:"
 msgstr "Translate:"
 
 #: src/components/fill-blank-step.tsx
-msgid "SL2Bob"
+msgctxt "SL2Bob"
+msgid "Blank {position}: {item}. {result}."
 msgstr "Blank {position}: {item}. {result}."
 
 #: src/components/fill-blank-step.tsx
-msgid "wUEGVH"
+msgctxt "wUEGVH"
+msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Blank {position}: {item}. Tap to remove."
 
 #: src/components/fill-blank-step.tsx
-msgid "FmmJ_j"
+msgctxt "FmmJ_j"
+msgid "Blank {position}"
 msgstr "Blank {position}"
 
 #: src/components/inline-feedback.tsx
-msgid "HvLGEN"
+msgctxt "HvLGEN"
+msgid "Answer feedback"
 msgstr "Answer feedback"
 
 #: src/components/lesson-info-popover.tsx
-msgid "RwePAQ"
+msgctxt "RwePAQ"
+msgid "Lesson info"
 msgstr "Lesson info"
 
 #: src/components/listening-step.tsx
-msgid "aAmWaS"
+msgctxt "aAmWaS"
+msgid "What do you hear?"
 msgstr "What do you hear?"
 
 #: src/components/listening-step.tsx
 #: src/components/reading-step.tsx
-msgid "19nXyC"
+msgctxt "19nXyC"
+msgid "Translate this sentence:"
 msgstr "Translate this sentence:"
 
 #: src/components/match-columns-step.tsx
-msgid "fV1MzK"
+msgctxt "fV1MzK"
+msgid "Match the pairs."
 msgstr "Match the pairs."
 
 #: src/components/match-columns-step.tsx
-msgid "ja1JDt"
+msgctxt "ja1JDt"
+msgid "All pairs matched. Press Check to continue."
 msgstr "All pairs matched. Press Check to continue."
 
 #: src/components/play-audio-button.tsx
-msgid "WGft2H"
+msgctxt "WGft2H"
+msgid "Pause pronunciation"
 msgstr "Pause pronunciation"
 
 #: src/components/play-audio-button.tsx
-msgid "lYWSeP"
+msgctxt "lYWSeP"
+msgid "Play pronunciation"
 msgstr "Play pronunciation"
 
 #: src/components/player-choice-scene.tsx
-msgid "akd-cv"
+msgctxt "akd-cv"
+msgid "Answer options"
 msgstr "Answer options"
 
 #: src/components/player-header.tsx
-msgid "rbrahO"
+msgctxt "rbrahO"
+msgid "Close"
 msgstr "Close"
 
 #: src/components/player-progress-bar.tsx
-msgid "dYp90P"
+msgctxt "dYp90P"
+msgid "Lesson progress"
 msgstr "Lesson progress"
 
 #: src/components/player-shell.tsx
-msgid "ZHEKO0"
+msgctxt "ZHEKO0"
+msgid "Lesson content"
 msgstr "Lesson content"
 
 #: src/components/player-shell.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "41rDiT"
+msgctxt "41rDiT"
+msgid "Lesson controls"
 msgstr "Lesson controls"
 
 #: src/components/select-image-step.tsx
-msgid "mhiTW7"
+msgctxt "mhiTW7"
+msgid "Correct answer"
 msgstr "Correct answer"
 
 #: src/components/select-image-step.tsx
-msgid "NA6C_-"
+msgctxt "NA6C_-"
+msgid "Image options"
 msgstr "Image options"
 
 #: src/components/sort-order-step.tsx
-msgid "p5llOK"
+msgctxt "p5llOK"
+msgid "Sort items"
 msgstr "Sort items"
 
 #: src/components/sort-order-step.tsx
-msgid "VA8c_A"
+msgctxt "VA8c_A"
+msgid "Correct order:"
 msgstr "Correct order:"
 
 #: src/components/sort-order-step.tsx
-msgid "9lc1oV"
+msgctxt "9lc1oV"
+msgid "Drag items into the correct order"
 msgstr "Drag items into the correct order"
 
 #: src/components/step-action-button.tsx
-msgid "RDZVQL"
+msgctxt "RDZVQL"
+msgid "Check"
 msgstr "Check"
 
 #: src/components/step-navigation-button-group.tsx
-msgid "JJNc3c"
+msgctxt "JJNc3c"
+msgid "Previous"
 msgstr "Previous"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "aNzy1T"
+msgctxt "aNzy1T"
+msgid "Previous step"
 msgstr "Previous step"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "d-qgix"
+msgctxt "d-qgix"
+msgid "Next step"
 msgstr "Next step"
 
 #: src/components/translation-step.tsx
-msgid "MxLxkr"
+msgctxt "MxLxkr"
+msgid "Translate this word:"
 msgstr "Translate this word:"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "czygLT"
+msgctxt "czygLT"
+msgid "Log in to save progress"
 msgstr "Log in to save progress"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "yBJVJw"
+msgctxt "yBJVJw"
+msgid "Continue without saving"
 msgstr "Continue without saving"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "O781mu"
+msgctxt "O781mu"
+msgid "Progress won't be saved"
 msgstr "Progress won't be saved"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "JDumQX"
+msgctxt "JDumQX"
+msgid "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
 msgstr "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "rxdOwg"
+msgctxt "rxdOwg"
+msgid "This lesson wasn't saved"
 msgstr "This lesson wasn't saved"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "Wamgyz"
+msgctxt "Wamgyz"
+msgid "Log in before your next lesson to keep future progress, scores, levels, and Energy."
 msgstr "Log in before your next lesson to keep future progress, scores, levels, and Energy."
 
 #: src/components/verdict-label.tsx
-msgid "xmF49T"
+msgctxt "xmF49T"
+msgid "Correct!"
 msgstr "Correct!"
 
 #: src/components/verdict-label.tsx
-msgid "--l7ni"
+msgctxt "--l7ni"
+msgid "Not quite"
 msgstr "Not quite"
 
 #: src/components/vocabulary-step.tsx
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Vocabulary"
 
 #: src/use-belt-label.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -4,370 +4,457 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/components/alphabet-step.tsx
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alfabeto"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "6NoIUl"
+msgctxt "6NoIUl"
+msgid "Correct"
 msgstr "Correcto"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "Ypr9T5"
+msgctxt "Ypr9T5"
+msgid "Incorrect"
 msgstr "Incorrecto"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/sort-order-step.tsx
-msgid "hFFOe-"
+msgctxt "hFFOe-"
+msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "vPyO9S"
+msgctxt "vPyO9S"
+msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posición {position}: {item}. Toca para quitar."
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/select-image-step.tsx
-msgid "1nJY2_"
+msgctxt "1nJY2_"
+msgid "Your answer"
 msgstr "Tu respuesta"
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "7R_rOB"
+msgctxt "7R_rOB"
+msgid "Tap words to build your answer"
 msgstr "Toca las palabras para formar tu respuesta"
 
 #: src/components/arrange-words.tsx
 #: src/components/fill-blank-word-bank.tsx
-msgid "e7WNdK"
+msgctxt "e7WNdK"
+msgid "Word bank"
 msgstr "Banco de palabras"
 
 #: src/components/completion-auth-branch.tsx
-msgid "E2sGaF"
+msgctxt "E2sGaF"
+msgid "Exit"
 msgstr "Salir"
 
 #: src/components/completion-auth-branch.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Inténtalo de nuevo"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
-msgid "9-Ddtu"
+msgctxt "9-Ddtu"
+msgid "Next"
 msgstr "Siguiente"
 
 #: src/components/completion-auth-branch.tsx
-msgid "odXlk8"
+msgctxt "odXlk8"
+msgid "Log in"
 msgstr "Iniciar sesión"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "fS3hB9"
+msgctxt "fS3hB9"
+msgid "New daily best"
 msgstr "Nuevo récord diario"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "VaM8Q9"
+msgctxt "VaM8Q9"
+msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
 msgstr "Hoy alcanzaste {brainPower} PM, tu mayor Poder Mental en un solo día. Sigue estudiando cada día para marcar un nuevo récord."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "m2WzLQ"
+msgctxt "m2WzLQ"
+msgid "Max Energy!"
 msgstr "¡Energía al máximo!"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "Fo6YtA"
+msgctxt "Fo6YtA"
+msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
 msgstr "¡Felicidades! Alcanzaste el máximo de Energía. Sigue practicando cada día para mantener tu Energía al 100 %."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "J89SkG"
+msgctxt "J89SkG"
+msgid "{percentage} Energy"
 msgstr "{percentage} de Energía"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "3Jd-mJ"
+msgctxt "3Jd-mJ"
+msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
 msgstr "Tu esfuerzo está dando resultado. Completa lecciones cada día para aumentar tu Energía."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "5YVYKd"
+msgctxt "5YVYKd"
+msgid "1 year of max Energy"
 msgstr "1 año de Energía al máximo"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "1WNk4i"
+msgctxt "1WNk4i"
+msgid "{days} days of max Energy"
 msgstr "{days} días de Energía al máximo"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "cIxpmv"
+msgctxt "cIxpmv"
+msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
 msgstr "¡Guau, qué constancia tan increíble! Sigue estudiando cada día para mantener tu Energía al 100 %."
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "SIXtG5"
+msgctxt "SIXtG5"
+msgid "{days} learning days"
 msgstr "{days} días de estudio"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "hjXoGI"
+msgctxt "hjXoGI"
+msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
 msgstr "Completaste lecciones en {days} días diferentes. Practicar a menudo te ayuda a recordar lo que aprendes."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "dZvEPp"
+msgctxt "dZvEPp"
+msgid "{minutes} minutes of learning"
 msgstr "{minutes} minutos de estudio"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "kw1W3C"
+msgctxt "kw1W3C"
+msgid "1 full day of learning"
 msgstr "1 día completo de estudio"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "BlVoPr"
+msgctxt "BlVoPr"
+msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# hora de estudio} other {# horas de estudio}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "WcAhMT"
+msgctxt "WcAhMT"
+msgid "You can learn a lot by practicing for a few minutes a day."
 msgstr "Puedes aprender mucho practicando unos minutos al día."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "LzEQnT"
+msgctxt "LzEQnT"
+msgid "That's a full day of focused practice."
 msgstr "Eso es un día completo de práctica concentrada."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "PpK3hX"
+msgctxt "PpK3hX"
+msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
 msgstr "Eso es más de {days, plural, one {# día completo} other {# días completos}} de práctica concentrada."
 
 #: src/components/completion-level-milestone.tsx
-msgid "155cHi"
+msgctxt "155cHi"
+msgid "Level achieved"
 msgstr "Nivel alcanzado"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Ar7dNY"
+msgctxt "Ar7dNY"
+msgid "You reached a new level: {belt}, level {level}. Congrats!"
 msgstr "Alcanzaste un nuevo nivel: {belt}, nivel {level}. ¡Felicidades!"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Bk6B6r"
+msgctxt "Bk6B6r"
+msgid "Almost there"
 msgstr "Ya casi"
 
 #: src/components/completion-level-milestone.tsx
-msgid "b7ZoLo"
+msgctxt "b7ZoLo"
+msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
 msgstr "Tu conocimiento está creciendo. Completa {count, plural, one {# lección más} other {# lecciones más}} para llegar a {belt}, nivel {level}."
 
 #: src/components/completion-milestone-actions.tsx
-msgid "DiIkZH"
+msgctxt "DiIkZH"
+msgid "Next Chapter"
 msgstr "Capítulo siguiente"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "w0D7HC"
+msgctxt "w0D7HC"
+msgid "Review Course"
 msgstr "Repasar curso"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "wm_M34"
+msgctxt "wm_M34"
+msgid "Review Chapter"
 msgstr "Repasar capítulo"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "iSioEh"
+msgctxt "iSioEh"
+msgid "Learn about Energy"
 msgstr "Aprende sobre Energía"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "DC0WoT"
+msgctxt "DC0WoT"
+msgid "Learn about Score"
 msgstr "Aprende sobre la puntuación"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "Q0R3MU"
+msgctxt "Q0R3MU"
+msgid "Learn about levels"
 msgstr "Aprende sobre los niveles"
 
 #: src/components/completion-progress-milestone-screen.tsx
 #: src/components/step-action-button.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continuar"
 
 #: src/components/completion-score-milestone.tsx
-msgid "e6_3Ke"
+msgctxt "e6_3Ke"
+msgid "{day} is your best day"
 msgstr "{day} es tu mejor día"
 
 #: src/components/completion-score-milestone.tsx
-msgid "PTQ0ah"
+msgctxt "PTQ0ah"
+msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
 msgstr "Sueles acertar el {percentage} de las respuestas los {day}, tu promedio más alto de la semana."
 
 #: src/components/completion-screen.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Completada"
 
 #: src/components/completion-screen.tsx
-msgid "2wDWd0"
+msgctxt "2wDWd0"
+msgid "Course Complete"
 msgstr "Curso completado"
 
 #: src/components/completion-screen.tsx
-msgid "t2VOpl"
+msgctxt "t2VOpl"
+msgid "Chapter Complete"
 msgstr "Capítulo completado"
 
 #: src/components/completion-screen.tsx
 #: src/components/in-play-sticky-header.tsx
-msgid "qXzoF7"
+msgctxt "qXzoF7"
+msgid "Lesson {current} of {total}"
 msgstr "Lección {current} de {total}"
 
 #: src/components/completion-screen.tsx
-msgid "9wxMoj"
+msgctxt "9wxMoj"
+msgid "Chapter progress"
 msgstr "Progreso del capítulo"
 
 #: src/components/completion-screen.tsx
-msgid "P768k7"
+msgctxt "P768k7"
+msgid "correct"
 msgstr "correctas"
 
 #: src/components/feedback-answer-blocks.tsx
-msgid "3nOd8f"
+msgctxt "3nOd8f"
+msgid "Your answer:"
 msgstr "Tu respuesta:"
 
 #: src/components/feedback-answer-blocks.tsx
 #: src/components/inline-feedback.tsx
-msgid "QAJ_Tl"
+msgctxt "QAJ_Tl"
+msgid "Correct answer:"
 msgstr "Respuesta correcta:"
 
 #: src/components/feedback-screen.tsx
-msgid "kgOBET"
+msgctxt "kgOBET"
+msgid "Question"
 msgstr "Pregunta"
 
 #: src/components/feedback-screen.tsx
-msgid "fpO9TK"
+msgctxt "fpO9TK"
+msgid "Translate:"
 msgstr "Traduce:"
 
 #: src/components/fill-blank-step.tsx
-msgid "SL2Bob"
+msgctxt "SL2Bob"
+msgid "Blank {position}: {item}. {result}."
 msgstr "Espacio {position}: {item}. {result}."
 
 #: src/components/fill-blank-step.tsx
-msgid "wUEGVH"
+msgctxt "wUEGVH"
+msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Espacio {position}: {item}. Toca para quitar."
 
 #: src/components/fill-blank-step.tsx
-msgid "FmmJ_j"
+msgctxt "FmmJ_j"
+msgid "Blank {position}"
 msgstr "Espacio {position}"
 
 #: src/components/inline-feedback.tsx
-msgid "HvLGEN"
+msgctxt "HvLGEN"
+msgid "Answer feedback"
 msgstr "Comentarios sobre la respuesta"
 
 #: src/components/lesson-info-popover.tsx
-msgid "RwePAQ"
+msgctxt "RwePAQ"
+msgid "Lesson info"
 msgstr "Información de la lección"
 
 #: src/components/listening-step.tsx
-msgid "aAmWaS"
+msgctxt "aAmWaS"
+msgid "What do you hear?"
 msgstr "¿Qué escuchas?"
 
 #: src/components/listening-step.tsx
 #: src/components/reading-step.tsx
-msgid "19nXyC"
+msgctxt "19nXyC"
+msgid "Translate this sentence:"
 msgstr "Traduce esta oración:"
 
 #: src/components/match-columns-step.tsx
-msgid "fV1MzK"
+msgctxt "fV1MzK"
+msgid "Match the pairs."
 msgstr "Une las parejas."
 
 #: src/components/match-columns-step.tsx
-msgid "ja1JDt"
+msgctxt "ja1JDt"
+msgid "All pairs matched. Press Check to continue."
 msgstr "Todas las parejas están unidas. Pulsa Revisar para continuar."
 
 #: src/components/play-audio-button.tsx
-msgid "WGft2H"
+msgctxt "WGft2H"
+msgid "Pause pronunciation"
 msgstr "Pausar pronunciación"
 
 #: src/components/play-audio-button.tsx
-msgid "lYWSeP"
+msgctxt "lYWSeP"
+msgid "Play pronunciation"
 msgstr "Reproducir pronunciación"
 
 #: src/components/player-choice-scene.tsx
-msgid "akd-cv"
+msgctxt "akd-cv"
+msgid "Answer options"
 msgstr "Opciones de respuesta"
 
 #: src/components/player-header.tsx
-msgid "rbrahO"
+msgctxt "rbrahO"
+msgid "Close"
 msgstr "Cerrar"
 
 #: src/components/player-progress-bar.tsx
-msgid "dYp90P"
+msgctxt "dYp90P"
+msgid "Lesson progress"
 msgstr "Progreso de la lección"
 
 #: src/components/player-shell.tsx
-msgid "ZHEKO0"
+msgctxt "ZHEKO0"
+msgid "Lesson content"
 msgstr "Contenido de la lección"
 
 #: src/components/player-shell.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "41rDiT"
+msgctxt "41rDiT"
+msgid "Lesson controls"
 msgstr "Controles de la lección"
 
 #: src/components/select-image-step.tsx
-msgid "mhiTW7"
+msgctxt "mhiTW7"
+msgid "Correct answer"
 msgstr "Respuesta correcta"
 
 #: src/components/select-image-step.tsx
-msgid "NA6C_-"
+msgctxt "NA6C_-"
+msgid "Image options"
 msgstr "Opciones de imagen"
 
 #: src/components/sort-order-step.tsx
-msgid "p5llOK"
+msgctxt "p5llOK"
+msgid "Sort items"
 msgstr "Ordenar elementos"
 
 #: src/components/sort-order-step.tsx
-msgid "VA8c_A"
+msgctxt "VA8c_A"
+msgid "Correct order:"
 msgstr "Orden correcto:"
 
 #: src/components/sort-order-step.tsx
-msgid "9lc1oV"
+msgctxt "9lc1oV"
+msgid "Drag items into the correct order"
 msgstr "Arrastra los elementos al orden correcto"
 
 #: src/components/step-action-button.tsx
-msgid "RDZVQL"
+msgctxt "RDZVQL"
+msgid "Check"
 msgstr "Revisar"
 
 #: src/components/step-navigation-button-group.tsx
-msgid "JJNc3c"
+msgctxt "JJNc3c"
+msgid "Previous"
 msgstr "Anterior"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "aNzy1T"
+msgctxt "aNzy1T"
+msgid "Previous step"
 msgstr "Paso anterior"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "d-qgix"
+msgctxt "d-qgix"
+msgid "Next step"
 msgstr "Siguiente paso"
 
 #: src/components/translation-step.tsx
-msgid "MxLxkr"
+msgctxt "MxLxkr"
+msgid "Translate this word:"
 msgstr "Traduce esta palabra:"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "czygLT"
+msgctxt "czygLT"
+msgid "Log in to save progress"
 msgstr "Inicia sesión para guardar tu progreso"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "yBJVJw"
+msgctxt "yBJVJw"
+msgid "Continue without saving"
 msgstr "Continuar sin guardar"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "O781mu"
+msgctxt "O781mu"
+msgid "Progress won't be saved"
 msgstr "No se guardará el progreso"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "JDumQX"
+msgctxt "JDumQX"
+msgid "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
 msgstr "Puedes probar esta lección sin una cuenta, pero no se guardarán tu puntuación, el progreso del curso, los niveles ni la Energía."
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "rxdOwg"
+msgctxt "rxdOwg"
+msgid "This lesson wasn't saved"
 msgstr "Esta lección no se guardó"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "Wamgyz"
+msgctxt "Wamgyz"
+msgid "Log in before your next lesson to keep future progress, scores, levels, and Energy."
 msgstr "Inicia sesión antes de tu próxima lección para conservar tu progreso, puntuaciones, niveles y Energía en el futuro."
 
 #: src/components/verdict-label.tsx
-msgid "xmF49T"
+msgctxt "xmF49T"
+msgid "Correct!"
 msgstr "¡Correcto!"
 
 #: src/components/verdict-label.tsx
-msgid "--l7ni"
+msgctxt "--l7ni"
+msgid "Not quite"
 msgstr "Casi"
 
 #: src/components/vocabulary-step.tsx
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Vocabulario"
 
 #: src/use-belt-label.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {Cinturón blanco} yellow {Cinturón amarillo} orange {Cinturón naranja} green {Cinturón verde} blue {Cinturón azul} purple {Cinturón morado} brown {Cinturón marrón} red {Cinturón rojo} gray {Cinturón gris} black {Cinturón negro} other {Cinturón}}"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -4,370 +4,457 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/components/alphabet-step.tsx
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alphabet"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "6NoIUl"
+msgctxt "6NoIUl"
+msgid "Correct"
 msgstr "Correct"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "Ypr9T5"
+msgctxt "Ypr9T5"
+msgid "Incorrect"
 msgstr "Incorrect"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/sort-order-step.tsx
-msgid "hFFOe-"
+msgctxt "hFFOe-"
+msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "vPyO9S"
+msgctxt "vPyO9S"
+msgid "Position {position}: {item}. Tap to remove."
 msgstr "Position {position} : {item}. Appuie pour retirer."
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/select-image-step.tsx
-msgid "1nJY2_"
+msgctxt "1nJY2_"
+msgid "Your answer"
 msgstr "Ta réponse"
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "7R_rOB"
+msgctxt "7R_rOB"
+msgid "Tap words to build your answer"
 msgstr "Appuie sur les mots pour construire ta réponse"
 
 #: src/components/arrange-words.tsx
 #: src/components/fill-blank-word-bank.tsx
-msgid "e7WNdK"
+msgctxt "e7WNdK"
+msgid "Word bank"
 msgstr "Banque de mots"
 
 #: src/components/completion-auth-branch.tsx
-msgid "E2sGaF"
+msgctxt "E2sGaF"
+msgid "Exit"
 msgstr "Quitter"
 
 #: src/components/completion-auth-branch.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Réessayer"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
-msgid "9-Ddtu"
+msgctxt "9-Ddtu"
+msgid "Next"
 msgstr "Suivant"
 
 #: src/components/completion-auth-branch.tsx
-msgid "odXlk8"
+msgctxt "odXlk8"
+msgid "Log in"
 msgstr "Se connecter"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "fS3hB9"
+msgctxt "fS3hB9"
+msgid "New daily best"
 msgstr "Nouveau record du jour"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "VaM8Q9"
+msgctxt "VaM8Q9"
+msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
 msgstr "Tu as atteint {brainPower} PM aujourd’hui, ta plus grande Puissance Mentale en une seule journée. Continue à apprendre chaque jour pour battre ton record."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "m2WzLQ"
+msgctxt "m2WzLQ"
+msgid "Max Energy!"
 msgstr "Énergie au max !"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "Fo6YtA"
+msgctxt "Fo6YtA"
+msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
 msgstr "Bravo ! Tu as atteint le maximum d’Énergie. Continue à t’entraîner chaque jour pour garder ton Énergie à 100 %."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "J89SkG"
+msgctxt "J89SkG"
+msgid "{percentage} Energy"
 msgstr "{percentage} Énergie"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "3Jd-mJ"
+msgctxt "3Jd-mJ"
+msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
 msgstr "Tes efforts paient. Termine des leçons chaque jour pour augmenter ton Énergie."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "5YVYKd"
+msgctxt "5YVYKd"
+msgid "1 year of max Energy"
 msgstr "1 an d’Énergie au max"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "1WNk4i"
+msgctxt "1WNk4i"
+msgid "{days} days of max Energy"
 msgstr "{days} jours d’Énergie au max"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "cIxpmv"
+msgctxt "cIxpmv"
+msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
 msgstr "Waouh, quelle régularité incroyable ! Continue à étudier chaque jour pour garder ton Énergie à 100 %."
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "SIXtG5"
+msgctxt "SIXtG5"
+msgid "{days} learning days"
 msgstr "{days} jours d’apprentissage"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "hjXoGI"
+msgctxt "hjXoGI"
+msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
 msgstr "Tu as terminé des leçons sur {days} jours différents. T’entraîner souvent t’aide à retenir ce que tu apprends."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "dZvEPp"
+msgctxt "dZvEPp"
+msgid "{minutes} minutes of learning"
 msgstr "{minutes} minutes d’apprentissage"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "kw1W3C"
+msgctxt "kw1W3C"
+msgid "1 full day of learning"
 msgstr "1 journée complète d’apprentissage"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "BlVoPr"
+msgctxt "BlVoPr"
+msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# heure d’apprentissage} other {# heures d’apprentissage}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "WcAhMT"
+msgctxt "WcAhMT"
+msgid "You can learn a lot by practicing for a few minutes a day."
 msgstr "Tu peux apprendre beaucoup en t’entraînant quelques minutes par jour."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "LzEQnT"
+msgctxt "LzEQnT"
+msgid "That's a full day of focused practice."
 msgstr "C’est une journée complète d’entraînement concentré."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "PpK3hX"
+msgctxt "PpK3hX"
+msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
 msgstr "C’est plus de {days, plural, one {# journée complète} other {# journées complètes}} d’entraînement concentré."
 
 #: src/components/completion-level-milestone.tsx
-msgid "155cHi"
+msgctxt "155cHi"
+msgid "Level achieved"
 msgstr "Niveau atteint"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Ar7dNY"
+msgctxt "Ar7dNY"
+msgid "You reached a new level: {belt}, level {level}. Congrats!"
 msgstr "Tu as atteint un nouveau niveau : {belt}, niveau {level}. Bravo !"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Bk6B6r"
+msgctxt "Bk6B6r"
+msgid "Almost there"
 msgstr "Presque"
 
 #: src/components/completion-level-milestone.tsx
-msgid "b7ZoLo"
+msgctxt "b7ZoLo"
+msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
 msgstr "Tes connaissances progressent. Termine encore {count, plural, one {# leçon} other {# leçons}} pour atteindre {belt}, niveau {level}."
 
 #: src/components/completion-milestone-actions.tsx
-msgid "DiIkZH"
+msgctxt "DiIkZH"
+msgid "Next Chapter"
 msgstr "Chapitre suivant"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "w0D7HC"
+msgctxt "w0D7HC"
+msgid "Review Course"
 msgstr "Réviser le cours"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "wm_M34"
+msgctxt "wm_M34"
+msgid "Review Chapter"
 msgstr "Réviser le chapitre"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "iSioEh"
+msgctxt "iSioEh"
+msgid "Learn about Energy"
 msgstr "Découvrir l’Énergie"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "DC0WoT"
+msgctxt "DC0WoT"
+msgid "Learn about Score"
 msgstr "Découvrir le score"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "Q0R3MU"
+msgctxt "Q0R3MU"
+msgid "Learn about levels"
 msgstr "Découvrir les niveaux"
 
 #: src/components/completion-progress-milestone-screen.tsx
 #: src/components/step-action-button.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continuer"
 
 #: src/components/completion-score-milestone.tsx
-msgid "e6_3Ke"
+msgctxt "e6_3Ke"
+msgid "{day} is your best day"
 msgstr "{day} est ton meilleur jour"
 
 #: src/components/completion-score-milestone.tsx
-msgid "PTQ0ah"
+msgctxt "PTQ0ah"
+msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
 msgstr "Tu obtiens généralement {percentage} de bonnes réponses le {day}, ta meilleure moyenne de la semaine."
 
 #: src/components/completion-screen.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Terminé"
 
 #: src/components/completion-screen.tsx
-msgid "2wDWd0"
+msgctxt "2wDWd0"
+msgid "Course Complete"
 msgstr "Cours terminé"
 
 #: src/components/completion-screen.tsx
-msgid "t2VOpl"
+msgctxt "t2VOpl"
+msgid "Chapter Complete"
 msgstr "Chapitre terminé"
 
 #: src/components/completion-screen.tsx
 #: src/components/in-play-sticky-header.tsx
-msgid "qXzoF7"
+msgctxt "qXzoF7"
+msgid "Lesson {current} of {total}"
 msgstr "Leçon {current} sur {total}"
 
 #: src/components/completion-screen.tsx
-msgid "9wxMoj"
+msgctxt "9wxMoj"
+msgid "Chapter progress"
 msgstr "Progression du chapitre"
 
 #: src/components/completion-screen.tsx
-msgid "P768k7"
+msgctxt "P768k7"
+msgid "correct"
 msgstr "correctes"
 
 #: src/components/feedback-answer-blocks.tsx
-msgid "3nOd8f"
+msgctxt "3nOd8f"
+msgid "Your answer:"
 msgstr "Ta réponse :"
 
 #: src/components/feedback-answer-blocks.tsx
 #: src/components/inline-feedback.tsx
-msgid "QAJ_Tl"
+msgctxt "QAJ_Tl"
+msgid "Correct answer:"
 msgstr "Bonne réponse :"
 
 #: src/components/feedback-screen.tsx
-msgid "kgOBET"
+msgctxt "kgOBET"
+msgid "Question"
 msgstr "Question"
 
 #: src/components/feedback-screen.tsx
-msgid "fpO9TK"
+msgctxt "fpO9TK"
+msgid "Translate:"
 msgstr "Traduis :"
 
 #: src/components/fill-blank-step.tsx
-msgid "SL2Bob"
+msgctxt "SL2Bob"
+msgid "Blank {position}: {item}. {result}."
 msgstr "Case {position} : {item}. {result}."
 
 #: src/components/fill-blank-step.tsx
-msgid "wUEGVH"
+msgctxt "wUEGVH"
+msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Case {position} : {item}. Appuie pour retirer."
 
 #: src/components/fill-blank-step.tsx
-msgid "FmmJ_j"
+msgctxt "FmmJ_j"
+msgid "Blank {position}"
 msgstr "Case {position}"
 
 #: src/components/inline-feedback.tsx
-msgid "HvLGEN"
+msgctxt "HvLGEN"
+msgid "Answer feedback"
 msgstr "Retour sur la réponse"
 
 #: src/components/lesson-info-popover.tsx
-msgid "RwePAQ"
+msgctxt "RwePAQ"
+msgid "Lesson info"
 msgstr "Infos sur la leçon"
 
 #: src/components/listening-step.tsx
-msgid "aAmWaS"
+msgctxt "aAmWaS"
+msgid "What do you hear?"
 msgstr "Qu’est-ce que tu entends ?"
 
 #: src/components/listening-step.tsx
 #: src/components/reading-step.tsx
-msgid "19nXyC"
+msgctxt "19nXyC"
+msgid "Translate this sentence:"
 msgstr "Traduis cette phrase :"
 
 #: src/components/match-columns-step.tsx
-msgid "fV1MzK"
+msgctxt "fV1MzK"
+msgid "Match the pairs."
 msgstr "Associe les paires."
 
 #: src/components/match-columns-step.tsx
-msgid "ja1JDt"
+msgctxt "ja1JDt"
+msgid "All pairs matched. Press Check to continue."
 msgstr "Toutes les paires sont associées. Appuie sur Vérifier pour continuer."
 
 #: src/components/play-audio-button.tsx
-msgid "WGft2H"
+msgctxt "WGft2H"
+msgid "Pause pronunciation"
 msgstr "Mettre la prononciation en pause"
 
 #: src/components/play-audio-button.tsx
-msgid "lYWSeP"
+msgctxt "lYWSeP"
+msgid "Play pronunciation"
 msgstr "Écouter la prononciation"
 
 #: src/components/player-choice-scene.tsx
-msgid "akd-cv"
+msgctxt "akd-cv"
+msgid "Answer options"
 msgstr "Choix de réponse"
 
 #: src/components/player-header.tsx
-msgid "rbrahO"
+msgctxt "rbrahO"
+msgid "Close"
 msgstr "Fermer"
 
 #: src/components/player-progress-bar.tsx
-msgid "dYp90P"
+msgctxt "dYp90P"
+msgid "Lesson progress"
 msgstr "Progression de la leçon"
 
 #: src/components/player-shell.tsx
-msgid "ZHEKO0"
+msgctxt "ZHEKO0"
+msgid "Lesson content"
 msgstr "Contenu de la leçon"
 
 #: src/components/player-shell.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "41rDiT"
+msgctxt "41rDiT"
+msgid "Lesson controls"
 msgstr "Commandes de la leçon"
 
 #: src/components/select-image-step.tsx
-msgid "mhiTW7"
+msgctxt "mhiTW7"
+msgid "Correct answer"
 msgstr "Bonne réponse"
 
 #: src/components/select-image-step.tsx
-msgid "NA6C_-"
+msgctxt "NA6C_-"
+msgid "Image options"
 msgstr "Choix d’images"
 
 #: src/components/sort-order-step.tsx
-msgid "p5llOK"
+msgctxt "p5llOK"
+msgid "Sort items"
 msgstr "Trier les éléments"
 
 #: src/components/sort-order-step.tsx
-msgid "VA8c_A"
+msgctxt "VA8c_A"
+msgid "Correct order:"
 msgstr "Bon ordre :"
 
 #: src/components/sort-order-step.tsx
-msgid "9lc1oV"
+msgctxt "9lc1oV"
+msgid "Drag items into the correct order"
 msgstr "Fais glisser les éléments dans le bon ordre"
 
 #: src/components/step-action-button.tsx
-msgid "RDZVQL"
+msgctxt "RDZVQL"
+msgid "Check"
 msgstr "Vérifier"
 
 #: src/components/step-navigation-button-group.tsx
-msgid "JJNc3c"
+msgctxt "JJNc3c"
+msgid "Previous"
 msgstr "Précédent"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "aNzy1T"
+msgctxt "aNzy1T"
+msgid "Previous step"
 msgstr "Étape précédente"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "d-qgix"
+msgctxt "d-qgix"
+msgid "Next step"
 msgstr "Étape suivante"
 
 #: src/components/translation-step.tsx
-msgid "MxLxkr"
+msgctxt "MxLxkr"
+msgid "Translate this word:"
 msgstr "Traduis ce mot :"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "czygLT"
+msgctxt "czygLT"
+msgid "Log in to save progress"
 msgstr "Connecte-toi pour sauvegarder ta progression"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "yBJVJw"
+msgctxt "yBJVJw"
+msgid "Continue without saving"
 msgstr "Continuer sans sauvegarder"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "O781mu"
+msgctxt "O781mu"
+msgid "Progress won't be saved"
 msgstr "La progression ne sera pas sauvegardée"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "JDumQX"
+msgctxt "JDumQX"
+msgid "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
 msgstr "Tu peux essayer cette leçon sans compte, mais ton score, ta progression dans le cours, tes niveaux et ton Énergie ne seront pas sauvegardés."
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "rxdOwg"
+msgctxt "rxdOwg"
+msgid "This lesson wasn't saved"
 msgstr "Cette leçon n’a pas été sauvegardée"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "Wamgyz"
+msgctxt "Wamgyz"
+msgid "Log in before your next lesson to keep future progress, scores, levels, and Energy."
 msgstr "Connecte-toi avant ta prochaine leçon pour garder tes futures progressions, tes scores, tes niveaux et ton Énergie."
 
 #: src/components/verdict-label.tsx
-msgid "xmF49T"
+msgctxt "xmF49T"
+msgid "Correct!"
 msgstr "Correct !"
 
 #: src/components/verdict-label.tsx
-msgid "--l7ni"
+msgctxt "--l7ni"
+msgid "Not quite"
 msgstr "Pas tout à fait"
 
 #: src/components/vocabulary-step.tsx
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Vocabulaire"
 
 #: src/use-belt-label.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {Ceinture Blanche} yellow {Ceinture Jaune} orange {Ceinture Orange} green {Ceinture Verte} blue {Ceinture Bleue} purple {Ceinture Violette} brown {Ceinture Marron} red {Ceinture Rouge} gray {Ceinture Grise} black {Ceinture Noire} other {Ceinture}}"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -4,370 +4,457 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: next-intl\n"
-"X-Crowdin-SourceKey: msgstr\n"
 
 #: src/components/alphabet-step.tsx
-msgid "w0J_gv"
+msgctxt "w0J_gv"
+msgid "Alphabet"
 msgstr "Alfabeto"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "6NoIUl"
+msgctxt "6NoIUl"
+msgid "Correct"
 msgstr "Correto"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/fill-blank-step.tsx
 #: src/components/sort-order-step.tsx
-msgid "Ypr9T5"
+msgctxt "Ypr9T5"
+msgid "Incorrect"
 msgstr "Incorreto"
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/sort-order-step.tsx
-msgid "hFFOe-"
+msgctxt "hFFOe-"
+msgid "{item}. {result}."
 msgstr "{item}. {result}."
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "vPyO9S"
+msgctxt "vPyO9S"
+msgid "Position {position}: {item}. Tap to remove."
 msgstr "Posição {position}: {item}. Toque para remover."
 
 #: src/components/arrange-words-answer-area.tsx
 #: src/components/select-image-step.tsx
-msgid "1nJY2_"
+msgctxt "1nJY2_"
+msgid "Your answer"
 msgstr "Sua resposta"
 
 #: src/components/arrange-words-answer-area.tsx
-msgid "7R_rOB"
+msgctxt "7R_rOB"
+msgid "Tap words to build your answer"
 msgstr "Toque nas palavras para montar sua resposta"
 
 #: src/components/arrange-words.tsx
 #: src/components/fill-blank-word-bank.tsx
-msgid "e7WNdK"
+msgctxt "e7WNdK"
+msgid "Word bank"
 msgstr "Banco de palavras"
 
 #: src/components/completion-auth-branch.tsx
-msgid "E2sGaF"
+msgctxt "E2sGaF"
+msgid "Exit"
 msgstr "Sair"
 
 #: src/components/completion-auth-branch.tsx
-msgid "FazwRl"
+msgctxt "FazwRl"
+msgid "Try again"
 msgstr "Tentar de novo"
 
 #: src/components/completion-auth-branch.tsx
 #: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
-msgid "9-Ddtu"
+msgctxt "9-Ddtu"
+msgid "Next"
 msgstr "Próxima"
 
 #: src/components/completion-auth-branch.tsx
-msgid "odXlk8"
+msgctxt "odXlk8"
+msgid "Log in"
 msgstr "Entrar"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "fS3hB9"
+msgctxt "fS3hB9"
+msgid "New daily best"
 msgstr "Novo recorde diário"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgid "VaM8Q9"
+msgctxt "VaM8Q9"
+msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
 msgstr "Você chegou a {brainPower} PM hoje, seu maior Poder Mental em um só dia. Continue estudando todos os dias para bater esse recorde."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "m2WzLQ"
+msgctxt "m2WzLQ"
+msgid "Max Energy!"
 msgstr "Energia máxima!"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "Fo6YtA"
+msgctxt "Fo6YtA"
+msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
 msgstr "Parabéns! Você chegou à Energia máxima. Continue praticando todos os dias para manter sua Energia em 100%."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "J89SkG"
+msgctxt "J89SkG"
+msgid "{percentage} Energy"
 msgstr "{percentage} de Energia"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "3Jd-mJ"
+msgctxt "3Jd-mJ"
+msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
 msgstr "Seu esforço está dando resultado. Complete aulas todos os dias para aumentar sua Energia."
 
 #: src/components/completion-energy-milestone.tsx
-msgid "5YVYKd"
+msgctxt "5YVYKd"
+msgid "1 year of max Energy"
 msgstr "1 ano de Energia máxima"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "1WNk4i"
+msgctxt "1WNk4i"
+msgid "{days} days of max Energy"
 msgstr "{days} dias de Energia máxima"
 
 #: src/components/completion-energy-milestone.tsx
-msgid "cIxpmv"
+msgctxt "cIxpmv"
+msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
 msgstr "Uau, que consistência incrível! Continue estudando todos os dias para manter sua Energia em 100%."
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "SIXtG5"
+msgctxt "SIXtG5"
+msgid "{days} learning days"
 msgstr "{days} dias de estudo"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgid "hjXoGI"
+msgctxt "hjXoGI"
+msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
 msgstr "Você completou aulas em {days} dias diferentes. Praticar com frequência te ajuda a lembrar o que você aprende."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "dZvEPp"
+msgctxt "dZvEPp"
+msgid "{minutes} minutes of learning"
 msgstr "{minutes} minutos de estudo"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "kw1W3C"
+msgctxt "kw1W3C"
+msgid "1 full day of learning"
 msgstr "1 dia inteiro de estudo"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "BlVoPr"
+msgctxt "BlVoPr"
+msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# hora de estudo} other {# horas de estudo}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "WcAhMT"
+msgctxt "WcAhMT"
+msgid "You can learn a lot by practicing for a few minutes a day."
 msgstr "Você pode aprender muito praticando por alguns minutos por dia."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "LzEQnT"
+msgctxt "LzEQnT"
+msgid "That's a full day of focused practice."
 msgstr "Isso é um dia inteiro de prática focada."
 
 #: src/components/completion-learning-time-milestone.tsx
-msgid "PpK3hX"
+msgctxt "PpK3hX"
+msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
 msgstr "Isso é mais de {days, plural, one {# dia inteiro} other {# dias inteiros}} de prática focada."
 
 #: src/components/completion-level-milestone.tsx
-msgid "155cHi"
+msgctxt "155cHi"
+msgid "Level achieved"
 msgstr "Nível alcançado"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Ar7dNY"
+msgctxt "Ar7dNY"
+msgid "You reached a new level: {belt}, level {level}. Congrats!"
 msgstr "Você chegou a um novo nível: {belt}, nível {level}. Parabéns!"
 
 #: src/components/completion-level-milestone.tsx
-msgid "Bk6B6r"
+msgctxt "Bk6B6r"
+msgid "Almost there"
 msgstr "Quase lá"
 
 #: src/components/completion-level-milestone.tsx
-msgid "b7ZoLo"
+msgctxt "b7ZoLo"
+msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
 msgstr "Seu conhecimento está crescendo. Complete {count, plural, one {mais # aula} other {mais # aulas}} para chegar a {belt}, nível {level}."
 
 #: src/components/completion-milestone-actions.tsx
-msgid "DiIkZH"
+msgctxt "DiIkZH"
+msgid "Next Chapter"
 msgstr "Próximo capítulo"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "w0D7HC"
+msgctxt "w0D7HC"
+msgid "Review Course"
 msgstr "Revisar curso"
 
 #: src/components/completion-milestone-actions.tsx
-msgid "wm_M34"
+msgctxt "wm_M34"
+msgid "Review Chapter"
 msgstr "Revisar capítulo"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "iSioEh"
+msgctxt "iSioEh"
+msgid "Learn about Energy"
 msgstr "Saiba mais sobre Energia"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "DC0WoT"
+msgctxt "DC0WoT"
+msgid "Learn about Score"
 msgstr "Saiba mais sobre a pontuação"
 
 #: src/components/completion-progress-milestone-screen.tsx
-msgid "Q0R3MU"
+msgctxt "Q0R3MU"
+msgid "Learn about levels"
 msgstr "Saiba mais sobre níveis"
 
 #: src/components/completion-progress-milestone-screen.tsx
 #: src/components/step-action-button.tsx
-msgid "acrOoz"
+msgctxt "acrOoz"
+msgid "Continue"
 msgstr "Continuar"
 
 #: src/components/completion-score-milestone.tsx
-msgid "e6_3Ke"
+msgctxt "e6_3Ke"
+msgid "{day} is your best day"
 msgstr "{day} é seu melhor dia"
 
 #: src/components/completion-score-milestone.tsx
-msgid "PTQ0ah"
+msgctxt "PTQ0ah"
+msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
 msgstr "Você costuma acertar {percentage} das respostas em {day}, sua maior média da semana."
 
 #: src/components/completion-screen.tsx
-msgid "95stPq"
+msgctxt "95stPq"
+msgid "Completed"
 msgstr "Concluída"
 
 #: src/components/completion-screen.tsx
-msgid "2wDWd0"
+msgctxt "2wDWd0"
+msgid "Course Complete"
 msgstr "Curso concluído"
 
 #: src/components/completion-screen.tsx
-msgid "t2VOpl"
+msgctxt "t2VOpl"
+msgid "Chapter Complete"
 msgstr "Capítulo concluído"
 
 #: src/components/completion-screen.tsx
 #: src/components/in-play-sticky-header.tsx
-msgid "qXzoF7"
+msgctxt "qXzoF7"
+msgid "Lesson {current} of {total}"
 msgstr "Aula {current} de {total}"
 
 #: src/components/completion-screen.tsx
-msgid "9wxMoj"
+msgctxt "9wxMoj"
+msgid "Chapter progress"
 msgstr "Progresso do capítulo"
 
 #: src/components/completion-screen.tsx
-msgid "P768k7"
+msgctxt "P768k7"
+msgid "correct"
 msgstr "corretas"
 
 #: src/components/feedback-answer-blocks.tsx
-msgid "3nOd8f"
+msgctxt "3nOd8f"
+msgid "Your answer:"
 msgstr "Sua resposta:"
 
 #: src/components/feedback-answer-blocks.tsx
 #: src/components/inline-feedback.tsx
-msgid "QAJ_Tl"
+msgctxt "QAJ_Tl"
+msgid "Correct answer:"
 msgstr "Resposta correta:"
 
 #: src/components/feedback-screen.tsx
-msgid "kgOBET"
+msgctxt "kgOBET"
+msgid "Question"
 msgstr "Pergunta"
 
 #: src/components/feedback-screen.tsx
-msgid "fpO9TK"
+msgctxt "fpO9TK"
+msgid "Translate:"
 msgstr "Traduza:"
 
 #: src/components/fill-blank-step.tsx
-msgid "SL2Bob"
+msgctxt "SL2Bob"
+msgid "Blank {position}: {item}. {result}."
 msgstr "Lacuna {position}: {item}. {result}."
 
 #: src/components/fill-blank-step.tsx
-msgid "wUEGVH"
+msgctxt "wUEGVH"
+msgid "Blank {position}: {item}. Tap to remove."
 msgstr "Lacuna {position}: {item}. Toque para remover."
 
 #: src/components/fill-blank-step.tsx
-msgid "FmmJ_j"
+msgctxt "FmmJ_j"
+msgid "Blank {position}"
 msgstr "Lacuna {position}"
 
 #: src/components/inline-feedback.tsx
-msgid "HvLGEN"
+msgctxt "HvLGEN"
+msgid "Answer feedback"
 msgstr "Comentário sobre a resposta"
 
 #: src/components/lesson-info-popover.tsx
-msgid "RwePAQ"
+msgctxt "RwePAQ"
+msgid "Lesson info"
 msgstr "Informações da aula"
 
 #: src/components/listening-step.tsx
-msgid "aAmWaS"
+msgctxt "aAmWaS"
+msgid "What do you hear?"
 msgstr "O que você ouve?"
 
 #: src/components/listening-step.tsx
 #: src/components/reading-step.tsx
-msgid "19nXyC"
+msgctxt "19nXyC"
+msgid "Translate this sentence:"
 msgstr "Traduza esta frase:"
 
 #: src/components/match-columns-step.tsx
-msgid "fV1MzK"
+msgctxt "fV1MzK"
+msgid "Match the pairs."
 msgstr "Combine os pares."
 
 #: src/components/match-columns-step.tsx
-msgid "ja1JDt"
+msgctxt "ja1JDt"
+msgid "All pairs matched. Press Check to continue."
 msgstr "Todos os pares foram combinados. Toque em Conferir para continuar."
 
 #: src/components/play-audio-button.tsx
-msgid "WGft2H"
+msgctxt "WGft2H"
+msgid "Pause pronunciation"
 msgstr "Pausar pronúncia"
 
 #: src/components/play-audio-button.tsx
-msgid "lYWSeP"
+msgctxt "lYWSeP"
+msgid "Play pronunciation"
 msgstr "Ouvir pronúncia"
 
 #: src/components/player-choice-scene.tsx
-msgid "akd-cv"
+msgctxt "akd-cv"
+msgid "Answer options"
 msgstr "Alternativas de resposta"
 
 #: src/components/player-header.tsx
-msgid "rbrahO"
+msgctxt "rbrahO"
+msgid "Close"
 msgstr "Fechar"
 
 #: src/components/player-progress-bar.tsx
-msgid "dYp90P"
+msgctxt "dYp90P"
+msgid "Lesson progress"
 msgstr "Progresso da aula"
 
 #: src/components/player-shell.tsx
-msgid "ZHEKO0"
+msgctxt "ZHEKO0"
+msgid "Lesson content"
 msgstr "Conteúdo da aula"
 
 #: src/components/player-shell.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "41rDiT"
+msgctxt "41rDiT"
+msgid "Lesson controls"
 msgstr "Controles da aula"
 
 #: src/components/select-image-step.tsx
-msgid "mhiTW7"
+msgctxt "mhiTW7"
+msgid "Correct answer"
 msgstr "Resposta correta"
 
 #: src/components/select-image-step.tsx
-msgid "NA6C_-"
+msgctxt "NA6C_-"
+msgid "Image options"
 msgstr "Alternativas de imagem"
 
 #: src/components/sort-order-step.tsx
-msgid "p5llOK"
+msgctxt "p5llOK"
+msgid "Sort items"
 msgstr "Ordenar itens"
 
 #: src/components/sort-order-step.tsx
-msgid "VA8c_A"
+msgctxt "VA8c_A"
+msgid "Correct order:"
 msgstr "Ordem correta:"
 
 #: src/components/sort-order-step.tsx
-msgid "9lc1oV"
+msgctxt "9lc1oV"
+msgid "Drag items into the correct order"
 msgstr "Arraste os itens para a ordem correta"
 
 #: src/components/step-action-button.tsx
-msgid "RDZVQL"
+msgctxt "RDZVQL"
+msgid "Check"
 msgstr "Conferir"
 
 #: src/components/step-navigation-button-group.tsx
-msgid "JJNc3c"
+msgctxt "JJNc3c"
+msgid "Previous"
 msgstr "Anterior"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "aNzy1T"
+msgctxt "aNzy1T"
+msgid "Previous step"
 msgstr "Etapa anterior"
 
 #: src/components/swipe-navigable-step-layout.tsx
-msgid "d-qgix"
+msgctxt "d-qgix"
+msgid "Next step"
 msgstr "Próxima etapa"
 
 #: src/components/translation-step.tsx
-msgid "MxLxkr"
+msgctxt "MxLxkr"
+msgid "Translate this word:"
 msgstr "Traduza esta palavra:"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "czygLT"
+msgctxt "czygLT"
+msgid "Log in to save progress"
 msgstr "Entre para salvar seu progresso"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "yBJVJw"
+msgctxt "yBJVJw"
+msgid "Continue without saving"
 msgstr "Continuar sem salvar"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "O781mu"
+msgctxt "O781mu"
+msgid "Progress won't be saved"
 msgstr "O progresso não será salvo"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "JDumQX"
+msgctxt "JDumQX"
+msgid "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
 msgstr "Você pode testar esta aula sem uma conta, mas sua pontuação, progresso no curso, níveis e Energia não serão salvos."
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "rxdOwg"
+msgctxt "rxdOwg"
+msgid "This lesson wasn't saved"
 msgstr "Esta aula não foi salva"
 
 #: src/components/unauthenticated-progress-prompt.tsx
-msgid "Wamgyz"
+msgctxt "Wamgyz"
+msgid "Log in before your next lesson to keep future progress, scores, levels, and Energy."
 msgstr "Entre antes da próxima aula para salvar seu progresso, pontuações, níveis e Energia daqui para frente."
 
 #: src/components/verdict-label.tsx
-msgid "xmF49T"
+msgctxt "xmF49T"
+msgid "Correct!"
 msgstr "Correto!"
 
 #: src/components/verdict-label.tsx
-msgid "--l7ni"
+msgctxt "--l7ni"
+msgid "Not quite"
 msgstr "Quase"
 
 #: src/components/vocabulary-step.tsx
-msgid "lqtP-R"
+msgctxt "lqtP-R"
+msgid "Vocabulary"
 msgstr "Vocabulário"
 
 #: src/use-belt-label.ts
-msgid "znY9eW"
+msgctxt "znY9eW"
+msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"
 msgstr "{color, select, white {Faixa Branca} yellow {Faixa Amarela} orange {Faixa Laranja} green {Faixa Verde} blue {Faixa Azul} purple {Faixa Roxa} brown {Faixa Marrom} red {Faixa Vermelha} gray {Faixa Cinza} black {Faixa Preta} other {Faixa}}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -785,13 +785,25 @@ importers:
       ai-sdk-provider-codex-cli:
         specifier: 1.2.2
         version: 1.2.2(zod@4.4.3)
+      next-intl:
+        specifier: 'catalog:'
+        version: 4.13.0(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
+      po-parser:
+        specifier: 2.1.1
+        version: 2.1.1
     devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
       '@typescript/native':
         specifier: 'catalog:'
         version: typescript@7.0.2
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.8)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/mailer:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches all `.po` catalogs to use the source text as `msgid` via a custom `next-intl` codec that auto‑migrates existing files without losing translations. The shared `NEXT_INTL_PO_FORMAT` from `@zoonk/i18n` is now used across apps and the player.

- **New Features**
  - Custom PO codec uses source text as IDs and preserves old hash IDs in `msgctxt`.
  - Shared format helper `NEXT_INTL_PO_FORMAT` added in `@zoonk/i18n`; wired into `apps/main`, `apps/api`, and the player extractor.
  - Tests added for migration; `po-parser` included for PO handling.

- **Migration**
  - No manual steps. Run message extraction (dev/build or the player script) to rewrite `.po` files and commit the updated catalogs.

<sup>Written for commit 63df891468d859ecf71b2f6ad621ba78ca869b33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

