### PR TITLE
fix(ai): retry silent audio and convert to mp3

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -49,8 +49,10 @@
     "@ai-sdk/gateway": "4.0.16",
     "@ai-sdk/google": "4.0.12",
     "@ai-sdk/openai": "4.0.11",
+    "@audio/decode-wav": "1.4.2",
     "@zoonk/utils": "workspace:*",
-    "ai": "catalog:"
+    "ai": "catalog:",
+    "wasm-media-encoders": "0.7.0"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/ai/src/tasks/audio/convert-wav-to-mp3.test.ts
+++ b/packages/ai/src/tasks/audio/convert-wav-to-mp3.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { convertWavToMp3 } from "./convert-wav-to-mp3";
+
+const SAMPLE_RATE = 24_000;
+const BITS_PER_SAMPLE = 16;
+const BYTES_PER_SAMPLE = BITS_PER_SAMPLE / 8;
+const WAV_HEADER_BYTES = 44;
+
+/**
+ * Builds mono PCM WAV fixtures so these tests exercise the real provider WAV
+ * decoder, audibility check, and WASM MP3 encoder as one conversion boundary.
+ */
+function createWavAudio({
+  amplitude,
+  durationSeconds,
+}: {
+  amplitude: number;
+  durationSeconds: number;
+}): Uint8Array {
+  const samples = SAMPLE_RATE * durationSeconds;
+  const dataBytes = samples * BYTES_PER_SAMPLE;
+  const audio = new Uint8Array(WAV_HEADER_BYTES + dataBytes);
+  const dataView = new DataView(audio.buffer);
+
+  audio.set(new TextEncoder().encode("RIFF"), 0);
+  dataView.setUint32(4, audio.byteLength - 8, true);
+  audio.set(new TextEncoder().encode("WAVEfmt "), 8);
+  dataView.setUint32(16, 16, true);
+  dataView.setUint16(20, 1, true);
+  dataView.setUint16(22, 1, true);
+  dataView.setUint32(24, SAMPLE_RATE, true);
+  dataView.setUint32(28, SAMPLE_RATE * BYTES_PER_SAMPLE, true);
+  dataView.setUint16(32, BYTES_PER_SAMPLE, true);
+  dataView.setUint16(34, BITS_PER_SAMPLE, true);
+  audio.set(new TextEncoder().encode("data"), 36);
+  dataView.setUint32(40, dataBytes, true);
+
+  const sampleData = Int16Array.from({ length: samples }, () => amplitude);
+  audio.set(new Uint8Array(sampleData.buffer), WAV_HEADER_BYTES);
+
+  return audio;
+}
+
+describe(convertWavToMp3, () => {
+  it("encodes audible WAV into a smaller MP3", async () => {
+    const wavAudio = createWavAudio({ amplitude: 1000, durationSeconds: 1 });
+
+    const mp3Audio = await convertWavToMp3({
+      audio: wavAudio,
+      model: "google/gemini-2.5-flash-preview-tts",
+    });
+
+    expect(mp3Audio.byteLength).toBeLessThan(wavAudio.byteLength);
+    expect(mp3Audio[0]).toBe(255);
+    expect(mp3Audio[1]).toBeGreaterThanOrEqual(224);
+  });
+
+  it("rejects silent WAV before encoding", async () => {
+    const wavAudio = createWavAudio({ amplitude: 0, durationSeconds: 1 });
+
+    await expect(
+      convertWavToMp3({ audio: wavAudio, model: "google/gemini-2.5-flash-preview-tts" }),
+    ).rejects.toThrow("returned silent audio");
+  });
+
+  it("rejects malformed WAV", async () => {
+    await expect(
+      convertWavToMp3({
+        audio: new Uint8Array([1, 2, 3]),
+        model: "google/gemini-2.5-flash-preview-tts",
+      }),
+    ).rejects.toThrow("returned invalid WAV audio");
+  });
+});

--- a/packages/ai/src/tasks/audio/convert-wav-to-mp3.ts
+++ b/packages/ai/src/tasks/audio/convert-wav-to-mp3.ts
@@ -1,0 +1,109 @@
+import decodeWav from "@audio/decode-wav";
+import { createMp3Encoder } from "wasm-media-encoders";
+import { type SpeechModelName } from "./speech-models";
+import { type DecodedAudio, assertAudibleAudioSignal } from "./validate-audio-signal";
+
+const MP3_BITRATE_KBPS = 48;
+const MP3_SAMPLE_RATE = 24_000;
+
+type EncodableAudio = DecodedAudio & { channelCount: 1 | 2 };
+
+/**
+ * Rejects empty or unsupported provider WAV shapes before they reach the
+ * encoder. TTS responses should be mono, but accepting stereo keeps this
+ * boundary safe if a provider changes its channel layout without changing the
+ * WAV contract.
+ */
+function getChannelCount({
+  channelData,
+  model,
+}: {
+  channelData: Float32Array[];
+  model: SpeechModelName;
+}): 1 | 2 {
+  const channelCount = channelData.length;
+
+  if (channelCount === 1 || channelCount === 2) {
+    return channelCount;
+  }
+
+  throw new Error(`${model} returned invalid WAV audio`);
+}
+
+/**
+ * Decodes provider WAV into normalized samples and verifies that every channel
+ * represents the same non-empty timeline. Wrapping parser errors here gives
+ * the retry layer one stable provider failure regardless of the malformed WAV.
+ */
+async function decodeWavAudio({
+  audio,
+  model,
+}: {
+  audio: Uint8Array;
+  model: SpeechModelName;
+}): Promise<EncodableAudio> {
+  try {
+    const decodedAudio = await decodeWav(audio);
+    const channelCount = getChannelCount({ channelData: decodedAudio.channelData, model });
+    const samplesDecoded = decodedAudio.channelData[0]?.length ?? 0;
+
+    const channelsHaveMatchingLengths = decodedAudio.channelData.every(
+      (channel) => channel.length === samplesDecoded,
+    );
+
+    if (decodedAudio.sampleRate <= 0 || samplesDecoded === 0 || !channelsHaveMatchingLengths) {
+      throw new Error(`${model} returned invalid WAV audio`);
+    }
+
+    return { ...decodedAudio, channelCount, samplesDecoded };
+  } catch (error) {
+    throw new Error(`${model} returned invalid WAV audio`, { cause: error });
+  }
+}
+
+/**
+ * Copies encoder-owned chunks into one stable upload buffer. The encoder reuses
+ * its WASM memory between encode and finalize, so the caller copies each chunk
+ * before invoking the next encoder operation.
+ */
+function combineMp3Chunks({
+  finalChunk,
+  firstChunk,
+}: {
+  finalChunk: Uint8Array;
+  firstChunk: Uint8Array;
+}): Uint8Array {
+  const audio = new Uint8Array(firstChunk.byteLength + finalChunk.byteLength);
+  audio.set(firstChunk);
+  audio.set(finalChunk, firstChunk.byteLength);
+  return audio;
+}
+
+/**
+ * Validates provider WAV and encodes it as a compact 48 kbps MP3. Keeping one
+ * final codec avoids shipping separate decoder paths and gives storage and
+ * playback a consistent media contract.
+ */
+export async function convertWavToMp3({
+  audio,
+  model,
+}: {
+  audio: Uint8Array;
+  model: SpeechModelName;
+}): Promise<Uint8Array> {
+  const decodedAudio = await decodeWavAudio({ audio, model });
+  assertAudibleAudioSignal({ audio: decodedAudio, model });
+
+  const encoder = await createMp3Encoder();
+
+  encoder.configure({
+    bitrate: MP3_BITRATE_KBPS,
+    channels: decodedAudio.channelCount,
+    outputSampleRate: MP3_SAMPLE_RATE,
+    sampleRate: decodedAudio.sampleRate,
+  });
+
+  const firstChunk = Uint8Array.from(encoder.encode(decodedAudio.channelData));
+  const finalChunk = Uint8Array.from(encoder.finalize());
+  return combineMp3Chunks({ finalChunk, firstChunk });
+}

--- a/packages/ai/src/tasks/audio/generate-language-audio.test.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.test.ts
@@ -1,14 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { generateLanguageAudio } from "./generate-language-audio";
 
-const { generateSpeechMock, getSpeechProviderMock } = vi.hoisted(() => ({
-  generateSpeechMock: vi.fn(),
-  getSpeechProviderMock: vi.fn(),
+const { convertWavToMp3Mock, generateSpeechWithProviderMock } = vi.hoisted(() => ({
+  convertWavToMp3Mock: vi.fn(),
+  generateSpeechWithProviderMock: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
-
-vi.mock("ai", () => ({ generateSpeech: generateSpeechMock }));
 
 vi.mock("./generate-language-audio.prompt.md", () => ({
   default:
@@ -17,35 +15,28 @@ vi.mock("./generate-language-audio.prompt.md", () => ({
 
 vi.mock("./generate-language-audio-alphabet-symbol.prompt.md", () => ({ default: "" }));
 
-vi.mock("./speech-provider", () => ({ getSpeechProvider: getSpeechProviderMock }));
+vi.mock("./convert-wav-to-mp3", () => ({ convertWavToMp3: convertWavToMp3Mock }));
 
-/**
- * Mirrors the provider resolver's public result so these tests can focus on
- * task behavior without constructing real SDK models or making network calls.
- */
-function createSpeechProvider({ model, voice }: { model: string; voice: string }) {
-  if (model.startsWith("google/")) {
-    return { format: "wav", model, voice };
-  }
-
-  return { format: "opus", model, voice: "marin" };
-}
-
-/**
- * Creates the minimal AI SDK speech result consumed by the task.
- */
-function createSpeechResult(audio = new Uint8Array([1, 2, 3])) {
-  return { audio: { uint8Array: audio } };
-}
+vi.mock("./speech-provider", () => ({
+  generateSpeechWithProvider: generateSpeechWithProviderMock,
+}));
 
 describe(generateLanguageAudio, () => {
+  const googleWavAudio = new Uint8Array([1, 2, 3]);
+  const googleMp3Audio = new Uint8Array([4, 5, 6]);
+  const openAIWavAudio = new Uint8Array([7, 8, 9]);
+  const openAIMp3Audio = new Uint8Array([10, 11, 12]);
+
   beforeEach(() => {
     vi.clearAllMocks();
-    getSpeechProviderMock.mockImplementation(createSpeechProvider);
-    generateSpeechMock.mockResolvedValue(createSpeechResult());
+    generateSpeechWithProviderMock.mockResolvedValue(googleWavAudio);
+    convertWavToMp3Mock.mockResolvedValue(googleMp3Audio);
   });
 
-  it("uses the requested speech model instead of the default provider order", async () => {
+  it("converts requested OpenAI WAV to MP3", async () => {
+    generateSpeechWithProviderMock.mockResolvedValue(openAIWavAudio);
+    convertWavToMp3Mock.mockResolvedValue(openAIMp3Audio);
+
     const result = await generateLanguageAudio({
       language: "en",
       model: "openai/gpt-4o-mini-tts",
@@ -53,88 +44,159 @@ describe(generateLanguageAudio, () => {
     });
 
     expect(result.error).toBeNull();
-    expect(result.data?.format).toBe("opus");
+    expect(result.data).toStrictEqual({ audio: openAIMp3Audio, format: "mp3" });
 
-    expect(getSpeechProviderMock).toHaveBeenCalledExactlyOnceWith({
+    expect(generateSpeechWithProviderMock).toHaveBeenCalledExactlyOnceWith({
       model: "openai/gpt-4o-mini-tts",
+      text: "fruit",
       voice: "Kore",
     });
 
-    expect(generateSpeechMock).toHaveBeenCalledExactlyOnceWith({
+    expect(convertWavToMp3Mock).toHaveBeenCalledExactlyOnceWith({
+      audio: openAIWavAudio,
       model: "openai/gpt-4o-mini-tts",
-      outputFormat: "opus",
-      text: "fruit",
-      voice: "marin",
     });
   });
 
-  it("uses Gemini first when no model is requested", async () => {
+  it("converts default Gemini WAV to MP3", async () => {
     const result = await generateLanguageAudio({ language: "en", text: "fruit" });
 
     expect(result.error).toBeNull();
-    expect(result.data?.format).toBe("wav");
+    expect(result.data).toStrictEqual({ audio: googleMp3Audio, format: "mp3" });
 
-    expect(getSpeechProviderMock).toHaveBeenCalledExactlyOnceWith({
+    expect(generateSpeechWithProviderMock).toHaveBeenCalledExactlyOnceWith({
       model: "google/gemini-2.5-flash-preview-tts",
-      voice: "Kore",
-    });
-
-    expect(generateSpeechMock).toHaveBeenCalledExactlyOnceWith({
-      model: "google/gemini-2.5-flash-preview-tts",
-      outputFormat: "wav",
       text: "fruit",
       voice: "Kore",
     });
+
+    expect(convertWavToMp3Mock).toHaveBeenCalledExactlyOnceWith({
+      audio: googleWavAudio,
+      model: "google/gemini-2.5-flash-preview-tts",
+    });
   });
 
-  it("falls back to OpenAI when the default Gemini model fails", async () => {
-    generateSpeechMock
+  it("falls back to OpenAI WAV when Gemini fails", async () => {
+    generateSpeechWithProviderMock
       .mockRejectedValueOnce(new Error("Gemini unavailable"))
-      .mockResolvedValueOnce(createSpeechResult());
+      .mockResolvedValueOnce(openAIWavAudio);
+
+    convertWavToMp3Mock.mockResolvedValue(openAIMp3Audio);
 
     const result = await generateLanguageAudio({ language: "en", text: "fruit" });
 
     expect(result.error).toBeNull();
-    expect(result.data?.format).toBe("opus");
+    expect(result.data).toStrictEqual({ audio: openAIMp3Audio, format: "mp3" });
 
-    expect(getSpeechProviderMock).toHaveBeenNthCalledWith(1, {
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(1, {
       model: "google/gemini-2.5-flash-preview-tts",
+      text: "fruit",
       voice: "Kore",
     });
 
-    expect(getSpeechProviderMock).toHaveBeenNthCalledWith(2, {
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(2, {
       model: "openai/gpt-4o-mini-tts",
+      text: "fruit",
       voice: "Kore",
+    });
+
+    expect(convertWavToMp3Mock).toHaveBeenCalledExactlyOnceWith({
+      audio: openAIWavAudio,
+      model: "openai/gpt-4o-mini-tts",
     });
   });
 
   it("keeps prompt instructions for non-English audio", async () => {
     const result = await generateLanguageAudio({ language: "nl", text: "fruit" });
-    const call = generateSpeechMock.mock.calls[0]?.[0];
+    const call = generateSpeechWithProviderMock.mock.calls[0]?.[0];
 
     expect(result.error).toBeNull();
     expect(call).toStrictEqual(expect.objectContaining({ text: "fruit" }));
     expect(call?.instructions).toContain("Some words may look like English words");
   });
 
-  it("falls back when Gemini returns suspiciously oversized WAV audio", async () => {
-    generateSpeechMock
-      .mockResolvedValueOnce(createSpeechResult(new Uint8Array(850 * 1024 + 1)))
-      .mockResolvedValueOnce(createSpeechResult());
+  it("falls back before conversion when Gemini returns oversized WAV", async () => {
+    generateSpeechWithProviderMock
+      .mockResolvedValueOnce(new Uint8Array(850 * 1024 + 1))
+      .mockResolvedValueOnce(openAIWavAudio);
+
+    convertWavToMp3Mock.mockResolvedValue(openAIMp3Audio);
 
     const result = await generateLanguageAudio({ language: "en", text: "fruit" });
 
     expect(result.error).toBeNull();
-    expect(result.data?.format).toBe("opus");
-    expect(generateSpeechMock).toHaveBeenCalledTimes(2);
+    expect(result.data).toStrictEqual({ audio: openAIMp3Audio, format: "mp3" });
+    expect(generateSpeechWithProviderMock).toHaveBeenCalledTimes(2);
+
+    expect(convertWavToMp3Mock).toHaveBeenCalledExactlyOnceWith({
+      audio: openAIWavAudio,
+      model: "openai/gpt-4o-mini-tts",
+    });
   });
 
-  it("rejects suspiciously oversized audio from an explicitly requested OpenAI model", async () => {
-    generateSpeechMock.mockResolvedValue(createSpeechResult(new Uint8Array(850 * 1024 + 1)));
+  it("falls back when Gemini returns silent WAV", async () => {
+    const silentWavAudio = new Uint8Array([13, 14, 15]);
+
+    generateSpeechWithProviderMock
+      .mockResolvedValueOnce(silentWavAudio)
+      .mockResolvedValueOnce(openAIWavAudio);
+
+    convertWavToMp3Mock
+      .mockRejectedValueOnce(new Error("google returned silent audio"))
+      .mockResolvedValueOnce(openAIMp3Audio);
+
+    const result = await generateLanguageAudio({ language: "en", text: "fruit" });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toStrictEqual({ audio: openAIMp3Audio, format: "mp3" });
+
+    expect(convertWavToMp3Mock).toHaveBeenNthCalledWith(1, {
+      audio: silentWavAudio,
+      model: "google/gemini-2.5-flash-preview-tts",
+    });
+
+    expect(convertWavToMp3Mock).toHaveBeenNthCalledWith(2, {
+      audio: openAIWavAudio,
+      model: "openai/gpt-4o-mini-tts",
+    });
+  });
+
+  it("retries silent WAV when OpenAI is requested explicitly", async () => {
+    const audibleWavAudio = new Uint8Array([16, 17, 18]);
+
+    generateSpeechWithProviderMock
+      .mockResolvedValueOnce(openAIWavAudio)
+      .mockResolvedValueOnce(audibleWavAudio);
+
+    convertWavToMp3Mock
+      .mockRejectedValueOnce(new Error("openai returned silent audio"))
+      .mockResolvedValueOnce(openAIMp3Audio);
+
+    const result = await generateLanguageAudio({ model: "openai/gpt-4o-mini-tts", text: "fruit" });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toStrictEqual({ audio: openAIMp3Audio, format: "mp3" });
+    expect(generateSpeechWithProviderMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns an error after explicitly requested OpenAI remains silent", async () => {
+    generateSpeechWithProviderMock.mockResolvedValue(openAIWavAudio);
+    convertWavToMp3Mock.mockRejectedValue(new Error("openai returned silent audio"));
+
+    const result = await generateLanguageAudio({ model: "openai/gpt-4o-mini-tts", text: "fruit" });
+
+    expect(result.data).toBeNull();
+    expect(result.error?.message).toContain("returned silent audio");
+    expect(generateSpeechWithProviderMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects oversized OpenAI WAV before conversion", async () => {
+    generateSpeechWithProviderMock.mockResolvedValue(new Uint8Array(850 * 1024 + 1));
 
     const result = await generateLanguageAudio({ model: "openai/gpt-4o-mini-tts", text: "fruit" });
 
     expect(result.data).toBeNull();
     expect(result.error?.message).toContain("returned oversized audio");
+    expect(convertWavToMp3Mock).not.toHaveBeenCalled();
   });
 });

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -2,24 +2,25 @@ import "server-only";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
 import { type TTSVoice } from "@zoonk/utils/languages";
 import { logError } from "@zoonk/utils/logger";
-import { generateSpeech } from "ai";
 import { getPromptLanguageName } from "../_utils/prompt-language";
+import { convertWavToMp3 } from "./convert-wav-to-mp3";
 import alphabetSymbolPrompt from "./generate-language-audio-alphabet-symbol.prompt.md";
 import promptTemplate from "./generate-language-audio.prompt.md";
 import { type SpeechModelName, speechModels } from "./speech-models";
-import { type AudioFormat, getSpeechProvider } from "./speech-provider";
+import { generateSpeechWithProvider } from "./speech-provider";
 
 const DEFAULT_VOICE: TTSVoice = "Kore";
 const defaultModel = speechModels.google;
 const fallbackModels = [speechModels.openai] as const;
+const MAX_ATTEMPTS_PER_PROVIDER = 2;
 
-/* oxlint-disable-next-line no-magic-numbers -- 850 KiB is the prompt-leak failure threshold observed in generated audio files. */
-const MAX_AUDIO_BYTES = 850 * 1024;
+/* oxlint-disable-next-line no-magic-numbers -- 850 KiB fits an 18-second 24 kHz mono WAV. */
+const MAX_PROVIDER_AUDIO_BYTES = 850 * 1024;
 
 const READ_ALOUD_TEMPLATE =
   "The following text is {{LANGUAGE}}. Speak clearly at a moderate pace suitable for language learners. Enunciate each word precisely; read it aloud in {{LANGUAGE}}.";
 
-export type AudioResult = { audio: Uint8Array; format: AudioFormat };
+export type AudioResult = { audio: Uint8Array; format: "mp3" };
 export type LanguageAudioUsage = "alphabetSymbol";
 
 const usagePrompts = { alphabetSymbol: alphabetSymbolPrompt } satisfies Record<
@@ -28,10 +29,11 @@ const usagePrompts = { alphabetSymbol: alphabetSymbolPrompt } satisfies Record<
 >;
 
 /**
- * Skips prompt guidance for normal English word and sentence audio because the
- * extra instructions exist to prevent non-English words from being read with
- * English pronunciation. Usage-specific audio, such as alphabet symbols, still
- * gets guidance because the text may not be a normal word.
+ * Skips task-level guidance for normal English word and sentence audio because
+ * the extra instructions exist to prevent non-English words from being read
+ * with English pronunciation. Usage-specific audio still gets its task prompt,
+ * and the provider supplies the minimal guidance Gemini needs to stay in speech
+ * mode.
  */
 function shouldBuildInstructions({
   languageCode,
@@ -75,11 +77,14 @@ function buildInstructions({
 }
 
 /**
- * Uses only the requested model when a task chooses one explicitly. Tasks that
- * omit a model retain the shared Gemini-first, OpenAI-fallback behavior.
+ * Tries each selected provider twice because transport retries cannot observe
+ * semantic failures discovered only after decoded-signal validation. Tasks
+ * without an explicit model alternate Gemini and OpenAI so either provider can
+ * recover from the other's malformed, silent, or unavailable output.
  */
 function getSpeechModels(model?: SpeechModelName): readonly SpeechModelName[] {
-  return model ? [model] : [defaultModel, ...fallbackModels];
+  const providerOrder = model ? [model] : [defaultModel, ...fallbackModels];
+  return Array.from({ length: MAX_ATTEMPTS_PER_PROVIDER }, () => providerOrder).flat();
 }
 
 /**
@@ -88,18 +93,20 @@ function getSpeechModels(model?: SpeechModelName): readonly SpeechModelName[] {
  * bypassing the prompt-leak safeguard when tasks choose different models.
  */
 function assertExpectedAudioSize({ audio, model }: { audio: Uint8Array; model: SpeechModelName }) {
-  if (audio.byteLength <= MAX_AUDIO_BYTES) {
+  if (audio.byteLength <= MAX_PROVIDER_AUDIO_BYTES) {
     return;
   }
 
   throw new Error(
-    `${model} returned oversized audio: ${audio.byteLength} bytes. Expected at most ${MAX_AUDIO_BYTES} bytes.`,
+    `${model} returned oversized audio: ${audio.byteLength} bytes. Expected at most ${MAX_PROVIDER_AUDIO_BYTES} bytes.`,
   );
 }
 
 /**
- * Generates one speech result through the AI SDK after the provider resolver
- * has selected the correct SDK model, output format, and compatible voice.
+ * Generates WAV and converts it to the one upload format inside the retry
+ * boundary. Malformed or silent audio therefore follows the same provider
+ * fallback path as transport and API failures, regardless of which provider
+ * produced it.
  */
 async function generateWithModel({
   instructions,
@@ -112,25 +119,22 @@ async function generateWithModel({
   text: string;
   voice: TTSVoice;
 }): Promise<AudioResult> {
-  const provider = getSpeechProvider({ model, voice });
-
-  const { audio } = await generateSpeech({
+  const wavAudio = await generateSpeechWithProvider({
     ...(instructions ? { instructions } : {}),
-    model: provider.model,
-    outputFormat: provider.format,
+    model,
     text,
-    voice: provider.voice,
+    voice,
   });
 
-  assertExpectedAudioSize({ audio: audio.uint8Array, model });
+  assertExpectedAudioSize({ audio: wavAudio, model });
 
-  return { audio: audio.uint8Array, format: provider.format };
+  const mp3Audio = await convertWavToMp3({ audio: wavAudio, model });
+  return { audio: mp3Audio, format: "mp3" };
 }
 
 /**
- * Tries provider-qualified models in order. AI SDK handles retries for each
- * model; this layer only owns cross-provider fallback when no model was chosen
- * explicitly by the calling task.
+ * Tries provider-qualified models in order. Each adapter owns transient request
+ * retries; this layer owns cross-provider and post-decode quality retries.
  */
 async function generateWithFallback({
   instructions,

--- a/packages/ai/src/tasks/audio/speech-provider.test.ts
+++ b/packages/ai/src/tasks/audio/speech-provider.test.ts
@@ -1,45 +1,94 @@
-import { describe, expect, it, vi } from "vitest";
-import { getSpeechProvider } from "./speech-provider";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateSpeechWithProvider } from "./speech-provider";
 
-const { createGoogleMock, googleSpeechMock, openAISpeechMock } = vi.hoisted(() => {
-  const googleSpeech = vi.fn((modelId: string) => ({ modelId, provider: "google" }));
+const { createGoogleMock, generateSpeechMock, googleSpeechMock, openAISpeechMock } = vi.hoisted(
+  () => {
+    const googleSpeech = vi.fn((modelId: string) => ({ modelId, provider: "google" }));
 
-  return {
-    createGoogleMock: vi.fn(() => ({ speech: googleSpeech })),
-    googleSpeechMock: googleSpeech,
-    openAISpeechMock: vi.fn((modelId: string) => ({ modelId, provider: "openai" })),
-  };
-});
+    return {
+      createGoogleMock: vi.fn(() => ({ speech: googleSpeech })),
+      generateSpeechMock: vi.fn(),
+      googleSpeechMock: googleSpeech,
+      openAISpeechMock: vi.fn((modelId: string) => ({ modelId, provider: "openai" })),
+    };
+  },
+);
 
+vi.mock("ai", () => ({ generateSpeech: generateSpeechMock }));
 vi.mock("@ai-sdk/google", () => ({ createGoogle: createGoogleMock }));
 vi.mock("@ai-sdk/openai", () => ({ openai: { speech: openAISpeechMock } }));
 
-describe(getSpeechProvider, () => {
-  it("uses the AI SDK Google provider and keeps Gemini WAV output", () => {
-    const provider = getSpeechProvider({
+describe(generateSpeechWithProvider, () => {
+  beforeEach(() => {
+    generateSpeechMock.mockReset();
+    googleSpeechMock.mockClear();
+    openAISpeechMock.mockClear();
+  });
+
+  it("uses the AI SDK Google provider with WAV output", async () => {
+    const audio = new Uint8Array([1, 2, 3]);
+    generateSpeechMock.mockResolvedValue({ audio: { uint8Array: audio } });
+
+    const result = await generateSpeechWithProvider({
+      instructions: "Speak clearly",
       model: "google/gemini-2.5-flash-preview-tts",
+      text: "Hallo",
       voice: "Kore",
     });
 
-    expect(createGoogleMock).toHaveBeenCalledWith({ apiKey: process.env.GEMINI_API_KEY });
-    expect(googleSpeechMock).toHaveBeenCalledWith("gemini-2.5-flash-preview-tts");
+    expect(result).toBe(audio);
+    expect(googleSpeechMock).toHaveBeenCalledExactlyOnceWith("gemini-2.5-flash-preview-tts");
 
-    expect(provider).toStrictEqual({
-      format: "wav",
+    expect(generateSpeechMock).toHaveBeenCalledExactlyOnceWith({
+      instructions: "Speak clearly",
       model: { modelId: "gemini-2.5-flash-preview-tts", provider: "google" },
+      outputFormat: "wav",
+      text: "Hallo",
+      voice: "Kore",
+    });
+
+    expect(openAISpeechMock).not.toHaveBeenCalled();
+  });
+
+  it("adds read-aloud guidance when Gemini receives no instructions", async () => {
+    const audio = new Uint8Array([1, 2, 3]);
+    generateSpeechMock.mockResolvedValue({ audio: { uint8Array: audio } });
+
+    await generateSpeechWithProvider({
+      model: "google/gemini-2.5-flash-preview-tts",
+      text: "Hello",
+      voice: "Kore",
+    });
+
+    expect(generateSpeechMock).toHaveBeenCalledExactlyOnceWith({
+      instructions: "Read the supplied transcript aloud. Return audio only.",
+      model: { modelId: "gemini-2.5-flash-preview-tts", provider: "google" },
+      outputFormat: "wav",
+      text: "Hello",
       voice: "Kore",
     });
   });
 
-  it("uses the AI SDK OpenAI provider with Opus and its compatible voice", () => {
-    const provider = getSpeechProvider({ model: "openai/gpt-4o-mini-tts", voice: "Kore" });
+  it("uses the AI SDK OpenAI provider with WAV output", async () => {
+    const audio = new Uint8Array([1, 2, 3]);
+    generateSpeechMock.mockResolvedValue({ audio: { uint8Array: audio } });
 
-    expect(openAISpeechMock).toHaveBeenCalledWith("gpt-4o-mini-tts");
+    const result = await generateSpeechWithProvider({
+      model: "openai/gpt-4o-mini-tts",
+      text: "Hallo",
+      voice: "Kore",
+    });
 
-    expect(provider).toStrictEqual({
-      format: "opus",
+    expect(result).toBe(audio);
+    expect(openAISpeechMock).toHaveBeenCalledExactlyOnceWith("gpt-4o-mini-tts");
+
+    expect(generateSpeechMock).toHaveBeenCalledExactlyOnceWith({
       model: { modelId: "gpt-4o-mini-tts", provider: "openai" },
+      outputFormat: "wav",
+      text: "Hallo",
       voice: "marin",
     });
+
+    expect(googleSpeechMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/ai/src/tasks/audio/speech-provider.ts
+++ b/packages/ai/src/tasks/audio/speech-provider.ts
@@ -1,49 +1,98 @@
 import { createGoogle } from "@ai-sdk/google";
 import { openai } from "@ai-sdk/openai";
 import { type TTSVoice } from "@zoonk/utils/languages";
-import { type SpeechModel } from "ai";
+import { type SpeechModel, generateSpeech } from "ai";
 import { type SpeechModelName, speechModels } from "./speech-models";
 
-export type AudioFormat = "opus" | "wav";
-
-type SpeechProvider = { format: AudioFormat; model: SpeechModel; voice: string };
+type SpeechProvider = { model: SpeechModel; voice: string };
 
 const google = createGoogle({ apiKey: process.env.GEMINI_API_KEY });
+const GEMINI_DEFAULT_INSTRUCTIONS = "Read the supplied transcript aloud. Return audio only.";
 
 /**
- * Removes the provider prefix after the typed model registry has already
- * established which provider owns the model. Provider SDKs expect the bare
- * model id, while task callers use provider-qualified names consistently with
- * the rest of the AI package.
+ * Removes the provider prefix after the typed registry has established which
+ * provider owns the model. Provider SDKs expect bare identifiers while task
+ * callers use provider-qualified names consistently across the AI package.
  */
-function getProviderModelId(model: SpeechModelName): string {
+function getSpeechModelId(model: SpeechModelName): string {
   const separatorIndex = model.indexOf("/");
   return model.slice(separatorIndex + 1);
 }
 
 /**
- * Resolves a provider-qualified model name into the AI SDK speech model and
- * provider-specific output settings. Gemini only returns PCM, which the Google
- * provider wraps as WAV, while OpenAI can return Opus directly. OpenAI voices
- * do not map one-to-one to Gemini voices, so its stable fallback voice remains
- * `marin` regardless of the requested Gemini voice.
+ * Adds minimal read-aloud guidance only when Gemini has no richer task prompt.
+ * Gemini otherwise treats some short transcripts, such as `Hello`, as a text
+ * request and rejects them before producing audio. OpenAI does not need this.
  */
-export function getSpeechProvider({
+function getSpeechInstructions({
+  instructions,
+  model,
+}: {
+  instructions?: string;
+  model: SpeechModelName;
+}): string | undefined {
+  if (instructions) {
+    return instructions;
+  }
+
+  if (model === speechModels.google) {
+    return GEMINI_DEFAULT_INSTRUCTIONS;
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolves a provider-qualified name into the corresponding AI SDK model and
+ * voice. Both providers return WAV so the task can apply one validation and
+ * encoding pipeline without codec-specific branches.
+ */
+function getSpeechProvider({
   model,
   voice,
 }: {
   model: SpeechModelName;
   voice: TTSVoice;
 }): SpeechProvider {
-  const modelId = getProviderModelId(model);
+  const modelId = getSpeechModelId(model);
 
   if (model === speechModels.google) {
-    return { format: "wav", model: google.speech(modelId), voice };
+    return { model: google.speech(modelId), voice };
   }
 
   if (model === speechModels.openai) {
-    return { format: "opus", model: openai.speech(modelId), voice: "marin" };
+    return { model: openai.speech(modelId), voice: "marin" };
   }
 
   throw new Error("Unsupported speech model");
+}
+
+/**
+ * Generates WAV through either AI SDK provider. WAV adds only a small header to
+ * the PCM samples while keeping the intermediate self-describing and avoiding
+ * provider-specific parsing in the task layer.
+ */
+export async function generateSpeechWithProvider({
+  instructions,
+  model,
+  text,
+  voice,
+}: {
+  instructions?: string;
+  model: SpeechModelName;
+  text: string;
+  voice: TTSVoice;
+}): Promise<Uint8Array> {
+  const provider = getSpeechProvider({ model, voice });
+  const speechInstructions = getSpeechInstructions({ instructions, model });
+
+  const { audio } = await generateSpeech({
+    ...(speechInstructions ? { instructions: speechInstructions } : {}),
+    model: provider.model,
+    outputFormat: "wav",
+    text,
+    voice: provider.voice,
+  });
+
+  return audio.uint8Array;
 }

--- a/packages/ai/src/tasks/audio/validate-audio-signal.test.ts
+++ b/packages/ai/src/tasks/audio/validate-audio-signal.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { assertAudibleAudioSignal } from "./validate-audio-signal";
+
+const SAMPLE_RATE = 48_000;
+
+/**
+ * Builds normalized decoded audio so each test can describe the signal rule it
+ * exercises without coupling the rule to a particular source codec.
+ */
+function createDecodedAudio(channelData: Float32Array[]) {
+  return { channelData, sampleRate: SAMPLE_RATE, samplesDecoded: channelData[0]?.length ?? 0 };
+}
+
+describe(assertAudibleAudioSignal, () => {
+  it("accepts sustained audible speech", () => {
+    const speech = new Float32Array(SAMPLE_RATE / 10).fill(0.1);
+
+    expect(() =>
+      assertAudibleAudioSignal({
+        audio: createDecodedAudio([speech]),
+        model: "openai/gpt-4o-mini-tts",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects silent audio", () => {
+    const silence = new Float32Array(SAMPLE_RATE / 10);
+
+    expect(() =>
+      assertAudibleAudioSignal({
+        audio: createDecodedAudio([silence]),
+        model: "openai/gpt-4o-mini-tts",
+      }),
+    ).toThrow("returned silent audio");
+  });
+
+  it("rejects an isolated loud click", () => {
+    const click = new Float32Array(SAMPLE_RATE / 10);
+    click[0] = 1;
+
+    expect(() =>
+      assertAudibleAudioSignal({
+        audio: createDecodedAudio([click]),
+        model: "openai/gpt-4o-mini-tts",
+      }),
+    ).toThrow("returned silent audio");
+  });
+
+  it("rejects audio longer than a learner phrase", () => {
+    const longSpeech = new Float32Array(SAMPLE_RATE * 19).fill(0.1);
+
+    expect(() =>
+      assertAudibleAudioSignal({
+        audio: createDecodedAudio([longSpeech]),
+        model: "google/gemini-2.5-flash-preview-tts",
+      }),
+    ).toThrow("returned audio longer than 18 seconds");
+  });
+
+  it("rejects sustained near-silence below the calibrated production floor", () => {
+    const nearSilence = new Float32Array(SAMPLE_RATE / 10).fill(0.0016);
+
+    expect(() =>
+      assertAudibleAudioSignal({
+        audio: createDecodedAudio([nearSilence]),
+        model: "openai/gpt-4o-mini-tts",
+      }),
+    ).toThrow("returned silent audio");
+  });
+
+  it("accepts quiet sustained speech above the calibrated production floor", () => {
+    const quietSpeech = new Float32Array(SAMPLE_RATE / 20).fill(0.006);
+
+    expect(() =>
+      assertAudibleAudioSignal({
+        audio: createDecodedAudio([quietSpeech]),
+        model: "openai/gpt-4o-mini-tts",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/ai/src/tasks/audio/validate-audio-signal.ts
+++ b/packages/ai/src/tasks/audio/validate-audio-signal.ts
@@ -1,0 +1,78 @@
+import { type SpeechModelName } from "./speech-models";
+
+const MAX_AUDIO_DURATION_SECONDS = 18;
+const MIN_AUDIBLE_AMPLITUDE = 0.005;
+const MIN_AUDIBLE_DURATION_SECONDS = 0.04;
+
+export type DecodedAudio = {
+  channelData: Float32Array[];
+  sampleRate: number;
+  samplesDecoded: number;
+};
+
+/**
+ * Checks one decoded sample frame across every channel. Using the strongest
+ * channel avoids rejecting valid stereo audio when speech is intentionally
+ * present on only one side.
+ */
+function isSampleFrameAudible({
+  channelData,
+  sampleIndex,
+}: {
+  channelData: Float32Array[];
+  sampleIndex: number;
+}): boolean {
+  return channelData.some(
+    (channel) => Math.abs(channel[sampleIndex] ?? 0) >= MIN_AUDIBLE_AMPLITUDE,
+  );
+}
+
+/**
+ * Requires at least 40 ms of meaningful signal so isolated clicks or decoder
+ * noise do not count as speech. The amplitude floor sits inside the large gap
+ * measured between near-silent and spoken files in the production audio corpus.
+ */
+function hasSustainedAudibleSignal({
+  channelData,
+  sampleRate,
+  samplesDecoded,
+}: DecodedAudio): boolean {
+  const referenceChannel = channelData[0]?.subarray(0, samplesDecoded);
+
+  if (!referenceChannel) {
+    return false;
+  }
+
+  const audibleSampleFrames = referenceChannel.reduce(
+    (count, _sample, sampleIndex) =>
+      count + Number(isSampleFrameAudible({ channelData, sampleIndex })),
+    0,
+  );
+
+  const minimumAudibleSampleFrames = Math.ceil(sampleRate * MIN_AUDIBLE_DURATION_SECONDS);
+
+  return audibleSampleFrames >= minimumAudibleSampleFrames;
+}
+
+/**
+ * Applies the provider-independent quality rules after a codec-specific parser
+ * has produced normalized PCM samples. This gives every speech provider one
+ * audibility and prompt-leak contract regardless of its transport details.
+ */
+export function assertAudibleAudioSignal({
+  audio,
+  model,
+}: {
+  audio: DecodedAudio;
+  model: SpeechModelName;
+}): void {
+  const durationSeconds = audio.samplesDecoded / audio.sampleRate;
+
+  if (durationSeconds > MAX_AUDIO_DURATION_SECONDS) {
+    throw new Error(`${model} returned audio longer than ${MAX_AUDIO_DURATION_SECONDS} seconds`);
+  }
+
+  if (!hasSustainedAudibleSignal(audio)) {
+    throw new Error(`${model} returned silent audio`);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,9 @@ importers:
       '@ai-sdk/openai':
         specifier: 4.0.11
         version: 4.0.11(zod@4.4.3)
+      '@audio/decode-wav':
+        specifier: 1.4.2
+        version: 1.4.2
       '@zoonk/utils':
         specifier: workspace:*
         version: link:../utils
@@ -591,6 +594,9 @@ importers:
       server-only:
         specifier: 'catalog:'
         version: 0.0.1
+      wasm-media-encoders:
+        specifier: 0.7.0
+        version: 0.7.0
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1145,6 +1151,10 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@audio/decode-wav@1.4.2':
+    resolution: {integrity: sha512-jcj7QrJtud8axqTiCT2/18xm5sRyYtkg4zJ4zLnVlHlL6SerRbumJwpY9hlLUsbkxXcJ4cIHbHQ/0ia2Cq+CTA==}
+    engines: {node: '>=18'}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -7359,6 +7369,10 @@ packages:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
 
+  wasm-media-encoders@0.7.0:
+    resolution: {integrity: sha512-Sp4wUasgxOK/IFfNhpon6LQQgYGwtpxyV4isjGIe1rvhnJL3w2KYr4f+CdqDNtGPDcgCDRY+uBanVfSx6Si0WQ==}
+    engines: {node: '>= 10'}
+
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
@@ -7641,6 +7655,8 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@audio/decode-wav@1.4.2': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -13868,6 +13884,10 @@ snapshots:
       xml-name-validator: 5.0.0
 
   walk-up-path@4.0.0: {}
+
+  wasm-media-encoders@0.7.0:
+    dependencies:
+      '@swc/helpers': 0.5.15
 
   watchpack@2.5.2:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Converts provider WAV output to MP3 and validates the audio signal to prevent silent or malformed clips. Adds retries and cross‑provider fallback to make TTS more reliable and smaller to upload/play.

- **Bug Fixes**
  - Rejects silent, malformed, or oversized WAV and retries (up to 2 attempts per provider; alternates Gemini ↔ OpenAI when no model is set).
  - Caps provider audio at 850 KiB and 18 seconds before conversion to catch prompt leaks and overly long clips.

- **Refactors**
  - Both providers now return WAV; we decode, validate, then encode a 48 kbps/24 kHz MP3 via `@audio/decode-wav` and `wasm-media-encoders`. `generateLanguageAudio` now returns `{ format: "mp3", audio }`.
  - Adds default Gemini guidance when no instructions are provided: “Read the supplied transcript aloud. Return audio only.”

<sup>Written for commit 51a26ca5fa920d94f9e129de5c0f4c8169fb6508. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

