### PR TITLE
fix(ai): revert gpt-5.6-sol as default model

### DIFF
--- a/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
+++ b/packages/ai/src/tasks/chapters/language-chapter-lessons.ts
@@ -5,7 +5,7 @@ import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./language-chapter-lessons.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["google/gemini-3.1-pro-preview", "anthropic/claude-sonnet-4.6"] as const;
 
 const schema = z.object({

--- a/packages/ai/src/tasks/courses/course-chapters.ts
+++ b/packages/ai/src/tasks/courses/course-chapters.ts
@@ -5,7 +5,7 @@ import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-chapters.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
+const defaultModel = "openai/gpt-5.5";
 
 const fallbackModels = [
   "openai/gpt-5.5",

--- a/packages/ai/src/tasks/courses/course-introduction.ts
+++ b/packages/ai/src/tasks/courses/course-introduction.ts
@@ -5,13 +5,8 @@ import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./course-introduction.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-
-const fallbackModels = [
-  "openai/gpt-5.5",
-  "anthropic/claude-opus-4.8",
-  "openai/gpt-5.6-luna",
-] as const;
+const defaultModel = "openai/gpt-5.5";
+const fallbackModels = ["anthropic/claude-opus-4.8", "openai/gpt-5.6-luna"] as const;
 
 const INTRODUCTION_LESSON_MIN_COUNT = 3;
 const INTRODUCTION_LESSON_MAX_COUNT = 5;

--- a/packages/ai/src/tasks/courses/language-course-chapters.ts
+++ b/packages/ai/src/tasks/courses/language-course-chapters.ts
@@ -5,8 +5,13 @@ import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./language-course-chapters.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["openai/gpt-5.6-terra", "anthropic/claude-fable-5"] as const;
+const defaultModel = "openai/gpt-5.5";
+
+const fallbackModels = [
+  "openai/gpt-5.6-terra",
+  "anthropic/claude-fable-5",
+  "google/gemini-3.1-pro-preview",
+] as const;
 
 const schema = z.object({
   chapters: z.array(z.object({ description: z.string(), title: z.string() })),

--- a/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
@@ -6,8 +6,8 @@ import { getPromptLanguageName } from "../../_utils/prompt-language";
 import { appendLessonRichTextPrompt } from "../_utils/append-lesson-rich-text-prompt";
 import baseSystemPrompt from "./lesson-explanation.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-luna"] as const;
+const defaultModel = "openai/gpt-5.5";
+const fallbackModels = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-sol"] as const;
 const systemPrompt = appendLessonRichTextPrompt(baseSystemPrompt);
 
 const anchorSchema = z.object({ text: z.string(), title: z.string().min(1) }).strict();

--- a/packages/ai/src/tasks/lessons/core/lesson-practice.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.ts
@@ -7,8 +7,8 @@ import { appendLessonRichTextPrompt } from "../_utils/append-lesson-rich-text-pr
 import { type SourceLesson, formatSourceLessonForPrompt } from "../_utils/source-lessons";
 import baseSystemPrompt from "./lesson-practice.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["anthropic/claude-sonnet-5", "openai/gpt-5.5"] as const;
+const defaultModel = "openai/gpt-5.5";
+const fallbackModels = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-sol"] as const;
 const systemPrompt = appendLessonRichTextPrompt(baseSystemPrompt);
 
 const practiceOptionSchema = z.object({

--- a/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
@@ -6,8 +6,14 @@ import { getPromptLanguageName } from "../../_utils/prompt-language";
 import { type SourceLesson, formatSourceLessonForPrompt } from "../_utils/source-lessons";
 import systemPrompt from "./lesson-quiz.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["anthropic/claude-opus-4.8", "openai/gpt-5.5"] as const;
+const defaultModel = "openai/gpt-5.5";
+
+const fallbackModels = [
+  "anthropic/claude-opus-4.8",
+  "openai/gpt-5.6-sol",
+  "google/gemini-3.1-pro-preview",
+] as const;
+
 const maximumQuestions = 15;
 const minimumQuestions = 5;
 

--- a/packages/ai/src/tasks/lessons/language/lesson-alphabet.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-alphabet.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-alphabet.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["google/gemini-3.5-flash"] as const;
 
 const formSchema = z.object({ label: z.string(), symbol: z.string() }).strict();

--- a/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-distractors.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["google/gemini-3.1-flash-lite", "anthropic/claude-sonnet-4.6"] as const;
 
 const schema = z.object({ distractors: z.array(z.string().min(1)).min(1) });

--- a/packages/ai/src/tasks/lessons/language/lesson-grammar.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-grammar.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-grammar.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["anthropic/claude-opus-4.8", "google/gemini-3.5-flash"] as const;
 
 const explanationSchema = z.object({ text: z.string(), title: z.string() });

--- a/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
@@ -6,8 +6,8 @@ import { getLanguagePromptContext } from "../../_utils/prompt-language";
 import { type SourceLesson, formatSourceLessonsForPrompt } from "../_utils/source-lessons";
 import systemPrompt from "./lesson-sentences.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["google/gemini-3.5-flash", "openai/gpt-5.5"] as const;
+const defaultModel = "openai/gpt-5.5";
+const fallbackModels = ["google/gemini-3.5-flash", "openai/gpt-5.6-sol"] as const;
 
 const sentenceSchema = z.object({
   explanation: z.string(),

--- a/packages/ai/src/tasks/lessons/language/lesson-vocabulary.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-vocabulary.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-vocabulary.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["google/gemini-3.5-flash", "openai/gpt-5.6-luna"] as const;
+const defaultModel = "google/gemini-3.5-flash";
+const fallbackModels = ["openai/gpt-5.5"] as const;
 
 const wordSchema = z.object({ translation: z.string(), word: z.string() });
 

--- a/packages/ai/src/tasks/steps/step-image-prompts.ts
+++ b/packages/ai/src/tasks/steps/step-image-prompts.ts
@@ -5,7 +5,7 @@ import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./step-image-prompts.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
+const defaultModel = "openai/gpt-5.5";
 const fallbackModels = ["anthropic/claude-opus-4.8", "google/gemini-3.1-pro-preview"] as const;
 
 const imagePromptSchema = z.string().min(1);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverted the default model from `openai/gpt-5.6-sol` to `openai/gpt-5.5` across course, chapter, lesson, and image prompt tasks. Updated fallbacks to include `openai/gpt-5.6-sol` and additional `google`/`anthropic` options; vocabulary lessons now default to `google/gemini-3.5-flash` with `openai/gpt-5.5` as fallback.

- **Bug Fixes**
  - Set `openai/gpt-5.5` as default in: language chapter lessons, course chapters/introduction, lesson explanation/practice/quiz, alphabet/distractors/grammar/sentences, and image prompts.
  - Adjusted fallbacks: added `google/gemini-3.1-pro-preview` and `google/gemini-3.5-flash`; moved `openai/gpt-5.6-sol` to fallback where relevant.

<sup>Written for commit ddf81e9fb5742b3f8b37d10e38049884abcbe30d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

