### PR TITLE
fix(player): preserve inline code in grammar explanations

### DIFF
--- a/packages/player/src/components/_utils/grammar-explanation-lines.test.ts
+++ b/packages/player/src/components/_utils/grammar-explanation-lines.test.ts
@@ -17,6 +17,17 @@ describe(getGrammarExplanationSentenceLines, () => {
       "This matters!",
     ]);
   });
+
+  it("does not split at punctuation inside inline code", () => {
+    expect(
+      getGrammarExplanationSentenceLines(
+        "Para fazer perguntas de sim ou não no passado, use `Did` + sujeito + verbo na forma base. O passado já está indicado por `Did`, então não use o verbo principal no passado: diga `Did she go?`, e não `Did she went?`.",
+      ),
+    ).toStrictEqual([
+      "Para fazer perguntas de sim ou não no passado, use `Did` + sujeito + verbo na forma base.",
+      "O passado já está indicado por `Did`, então não use o verbo principal no passado: diga `Did she go?`, e não `Did she went?`.",
+    ]);
+  });
 });
 
 describe(isInitialGrammarExplanationStep, () => {

--- a/packages/player/src/components/_utils/grammar-explanation-lines.ts
+++ b/packages/player/src/components/_utils/grammar-explanation-lines.ts
@@ -3,6 +3,22 @@ import { type LessonKind } from "@zoonk/core/steps/contract/content";
 import { describePlayerStep } from "../../player-step";
 
 const FALLBACK_SENTENCE_PATTERN = /[^.!?。！？]+[.!?。！？]+(?:["')\]”’]+)?|[^.!?。！？]+$/gu;
+const INLINE_CODE_PATTERN = /`[^`]*`/gu;
+const SENTENCE_PUNCTUATION_PATTERN = /[.!?。！？]/gu;
+
+/**
+ * Hides sentence punctuation inside supported inline-code markers before text
+ * is segmented. Grammar explanations often contrast examples such as
+ * `Did she go?` and `Did she went?`; those question marks belong to the code
+ * examples and must not split the markers that the rich-text renderer needs.
+ * Spaces preserve every original index so segments can still slice the source
+ * text without changing any learner-facing content.
+ */
+function getSentenceSegmentationText(text: string) {
+  return text.replaceAll(INLINE_CODE_PATTERN, (inlineCode) =>
+    inlineCode.replaceAll(SENTENCE_PUNCTUATION_PATTERN, " "),
+  );
+}
 
 /**
  * Removes layout-only whitespace from generated prose before each sentence is
@@ -34,9 +50,11 @@ function getSegmenterSentenceLines(text: string): string[] | null {
     return null;
   }
 
+  const segmentationText = getSentenceSegmentationText(text);
+
   return Array.from(
-    new SentenceSegmenter(undefined, { granularity: "sentence" }).segment(text),
-    ({ segment }) => segment,
+    new SentenceSegmenter(undefined, { granularity: "sentence" }).segment(segmentationText),
+    ({ index, segment }) => text.slice(index, index + segment.length),
   );
 }
 
@@ -46,7 +64,10 @@ function getSegmenterSentenceLines(text: string): string[] | null {
  * explanation display, not saved lesson content.
  */
 function getFallbackSentenceLines(text: string) {
-  return text.match(FALLBACK_SENTENCE_PATTERN) ?? [text];
+  const segmentationText = getSentenceSegmentationText(text);
+  const matches = segmentationText.matchAll(FALLBACK_SENTENCE_PATTERN);
+
+  return Array.from(matches, (match) => text.slice(match.index, match.index + match[0].length));
 }
 
 /**


### PR DESCRIPTION
Fix grammar explanation sentence splitting so punctuation inside inline code does not break rich-text markers. Add regression coverage for the affected Portuguese lesson copy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sentence splitting in grammar explanations so punctuation inside inline code (e.g., `Did she go?`) doesn’t break rich-text markers. Adds a regression test to cover the affected Portuguese copy.

- **Bug Fixes**
  - Mask sentence punctuation inside backticked inline code before segmentation to prevent false splits.
  - Apply the masking to both `Intl.Segmenter` and the regex fallback; slice segments from the original text to preserve content.
  - Add a regression test for the Portuguese lesson example.

<sup>Written for commit 08ec0f61630063e4e8ce61d48e87a271eb823393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

