### PR TITLE
fix(main): truncate chapter course title

### DIFF
--- a/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
+++ b/apps/main/src/app/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
@@ -39,7 +39,7 @@ export function ChapterHeader({
       <MediaCardContent>
         <MediaCardBreadcrumb className="hidden sm:block">
           <Link
-            className="hover:text-foreground truncate transition-colors"
+            className="hover:text-foreground block truncate transition-colors"
             href={`/b/${brandSlug}/c/${courseSlug}`}
           >
             {chapter.course.title}


### PR DESCRIPTION
Fix the chapter header breadcrumb so long course titles truncate within the available content width.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chapter header breadcrumb so long course titles truncate within the available width on desktop. Makes the course link a block element so `truncate` works and prevents overflow.

<sup>Written for commit eadb33a2359672b6bfd18ae497f4598fc8410925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

