### PR TITLE
fix(ai): update language audio providers

### DIFF
--- a/apps/api/src/workflows/lesson-generation/steps/_utils/generate-audio-for-text.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/generate-audio-for-text.ts
@@ -2,6 +2,7 @@ import { generateLanguageAudio } from "@zoonk/core/audio/generate";
 
 type AudioUsage = Parameters<typeof generateLanguageAudio>[0]["usage"];
 type AudioModel = Parameters<typeof generateLanguageAudio>[0]["model"];
+type AudioTextType = Parameters<typeof generateLanguageAudio>[0]["textType"];
 
 /**
  * Generates and uploads audio for one text snippet used by a lesson step.
@@ -14,12 +15,14 @@ export async function generateAudioForText({
   model,
   orgSlug,
   text,
+  textType,
   usage,
 }: {
   language: string;
   model?: AudioModel;
   orgSlug?: string;
   text: string;
+  textType?: AudioTextType;
   usage?: AudioUsage;
 }): Promise<{ audioUrl: string; text: string }> {
   const { data, error } = await generateLanguageAudio({
@@ -27,6 +30,7 @@ export async function generateAudioForText({
     ...(model ? { model } : {}),
     orgSlug,
     text,
+    ...(textType ? { textType } : {}),
     ...(usage ? { usage } : {}),
   });
 

--- a/apps/api/src/workflows/lesson-generation/steps/generate-reading-audio-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-reading-audio-step.test.ts
@@ -60,6 +60,7 @@ describe(generateReadingAudioStep, () => {
       language: "ja",
       orgSlug: "ai",
       text: newSentence,
+      textType: "sentence",
     });
   });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/generate-reading-audio-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/generate-reading-audio-step.ts
@@ -54,6 +54,7 @@ export async function generateReadingAudioStep({
         language: targetLanguage,
         orgSlug: organization.slug,
         text: entry.sentence,
+        textType: "sentence",
       }),
     ),
   );

--- a/packages/ai/src/tasks/audio/generate-language-audio.test.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.test.ts
@@ -58,13 +58,46 @@ describe(generateLanguageAudio, () => {
     });
   });
 
-  it("converts default Gemini WAV to MP3", async () => {
+  it("uses OpenAI for English words", async () => {
+    generateSpeechWithProviderMock.mockResolvedValue(openAIWavAudio);
+    convertWavToMp3Mock.mockResolvedValue(openAIMp3Audio);
+
+    const result = await generateLanguageAudio({ language: "en", text: "fruit" });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toStrictEqual({ audio: openAIMp3Audio, format: "mp3" });
+
+    expect(generateSpeechWithProviderMock).toHaveBeenCalledExactlyOnceWith({
+      model: "openai/gpt-4o-mini-tts",
+      text: "fruit",
+      voice: "Kore",
+    });
+
+    expect(convertWavToMp3Mock).toHaveBeenCalledExactlyOnceWith({
+      audio: openAIWavAudio,
+      model: "openai/gpt-4o-mini-tts",
+    });
+  });
+
+  it("falls back to Gemini when OpenAI fails for English words", async () => {
+    generateSpeechWithProviderMock
+      .mockRejectedValueOnce(new Error("OpenAI unavailable"))
+      .mockResolvedValueOnce(googleWavAudio);
+
+    convertWavToMp3Mock.mockResolvedValue(googleMp3Audio);
+
     const result = await generateLanguageAudio({ language: "en", text: "fruit" });
 
     expect(result.error).toBeNull();
     expect(result.data).toStrictEqual({ audio: googleMp3Audio, format: "mp3" });
 
-    expect(generateSpeechWithProviderMock).toHaveBeenCalledExactlyOnceWith({
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(1, {
+      model: "openai/gpt-4o-mini-tts",
+      text: "fruit",
+      voice: "Kore",
+    });
+
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(2, {
       model: "google/gemini-2.5-flash-preview-tts",
       text: "fruit",
       voice: "Kore",
@@ -76,34 +109,78 @@ describe(generateLanguageAudio, () => {
     });
   });
 
-  it("falls back to OpenAI WAV when Gemini fails", async () => {
+  it("falls back to Gemini when OpenAI fails for supported non-English sentences", async () => {
+    generateSpeechWithProviderMock
+      .mockRejectedValueOnce(new Error("OpenAI unavailable"))
+      .mockResolvedValueOnce(googleWavAudio);
+
+    convertWavToMp3Mock.mockResolvedValue(googleMp3Audio);
+
+    const result = await generateLanguageAudio({
+      language: "es",
+      text: "La fruta es deliciosa.",
+      textType: "sentence",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).toStrictEqual({ audio: googleMp3Audio, format: "mp3" });
+
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ model: "openai/gpt-4o-mini-tts" }),
+    );
+
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ model: "google/gemini-2.5-flash-preview-tts" }),
+    );
+  });
+
+  it("falls back to OpenAI when Gemini fails for supported non-English words", async () => {
     generateSpeechWithProviderMock
       .mockRejectedValueOnce(new Error("Gemini unavailable"))
       .mockResolvedValueOnce(openAIWavAudio);
 
     convertWavToMp3Mock.mockResolvedValue(openAIMp3Audio);
 
-    const result = await generateLanguageAudio({ language: "en", text: "fruit" });
+    const result = await generateLanguageAudio({ language: "nl", text: "fruit" });
 
     expect(result.error).toBeNull();
     expect(result.data).toStrictEqual({ audio: openAIMp3Audio, format: "mp3" });
 
-    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(1, {
-      model: "google/gemini-2.5-flash-preview-tts",
-      text: "fruit",
-      voice: "Kore",
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ model: "google/gemini-2.5-flash-preview-tts" }),
+    );
+
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ model: "openai/gpt-4o-mini-tts" }),
+    );
+  });
+
+  it("never uses OpenAI for unsupported languages", async () => {
+    generateSpeechWithProviderMock.mockRejectedValue(new Error("Gemini unavailable"));
+
+    const result = await generateLanguageAudio({
+      language: "am",
+      text: "ሰላም ነው።",
+      textType: "sentence",
     });
 
-    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(2, {
-      model: "openai/gpt-4o-mini-tts",
-      text: "fruit",
-      voice: "Kore",
-    });
+    expect(result.data).toBeNull();
+    expect(result.error?.message).toBe("Gemini unavailable");
+    expect(generateSpeechWithProviderMock).toHaveBeenCalledTimes(2);
 
-    expect(convertWavToMp3Mock).toHaveBeenCalledExactlyOnceWith({
-      audio: openAIWavAudio,
-      model: "openai/gpt-4o-mini-tts",
-    });
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ model: "google/gemini-2.5-flash-preview-tts" }),
+    );
+
+    expect(generateSpeechWithProviderMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ model: "google/gemini-2.5-flash-preview-tts" }),
+    );
   });
 
   it("keeps prompt instructions for non-English audio", async () => {
@@ -115,49 +192,49 @@ describe(generateLanguageAudio, () => {
     expect(call?.instructions).toContain("Some words may look like English words");
   });
 
-  it("falls back before conversion when Gemini returns oversized WAV", async () => {
+  it("falls back before conversion when OpenAI returns oversized English WAV", async () => {
     generateSpeechWithProviderMock
       .mockResolvedValueOnce(new Uint8Array(850 * 1024 + 1))
-      .mockResolvedValueOnce(openAIWavAudio);
+      .mockResolvedValueOnce(googleWavAudio);
 
-    convertWavToMp3Mock.mockResolvedValue(openAIMp3Audio);
+    convertWavToMp3Mock.mockResolvedValue(googleMp3Audio);
 
     const result = await generateLanguageAudio({ language: "en", text: "fruit" });
 
     expect(result.error).toBeNull();
-    expect(result.data).toStrictEqual({ audio: openAIMp3Audio, format: "mp3" });
+    expect(result.data).toStrictEqual({ audio: googleMp3Audio, format: "mp3" });
     expect(generateSpeechWithProviderMock).toHaveBeenCalledTimes(2);
 
     expect(convertWavToMp3Mock).toHaveBeenCalledExactlyOnceWith({
-      audio: openAIWavAudio,
-      model: "openai/gpt-4o-mini-tts",
+      audio: googleWavAudio,
+      model: "google/gemini-2.5-flash-preview-tts",
     });
   });
 
-  it("falls back when Gemini returns silent WAV", async () => {
+  it("falls back when OpenAI returns silent English WAV", async () => {
     const silentWavAudio = new Uint8Array([13, 14, 15]);
 
     generateSpeechWithProviderMock
       .mockResolvedValueOnce(silentWavAudio)
-      .mockResolvedValueOnce(openAIWavAudio);
+      .mockResolvedValueOnce(googleWavAudio);
 
     convertWavToMp3Mock
-      .mockRejectedValueOnce(new Error("google returned silent audio"))
-      .mockResolvedValueOnce(openAIMp3Audio);
+      .mockRejectedValueOnce(new Error("openai returned silent audio"))
+      .mockResolvedValueOnce(googleMp3Audio);
 
     const result = await generateLanguageAudio({ language: "en", text: "fruit" });
 
     expect(result.error).toBeNull();
-    expect(result.data).toStrictEqual({ audio: openAIMp3Audio, format: "mp3" });
+    expect(result.data).toStrictEqual({ audio: googleMp3Audio, format: "mp3" });
 
     expect(convertWavToMp3Mock).toHaveBeenNthCalledWith(1, {
       audio: silentWavAudio,
-      model: "google/gemini-2.5-flash-preview-tts",
+      model: "openai/gpt-4o-mini-tts",
     });
 
     expect(convertWavToMp3Mock).toHaveBeenNthCalledWith(2, {
-      audio: openAIWavAudio,
-      model: "openai/gpt-4o-mini-tts",
+      audio: googleWavAudio,
+      model: "google/gemini-2.5-flash-preview-tts",
     });
   });
 

--- a/packages/ai/src/tasks/audio/generate-language-audio.ts
+++ b/packages/ai/src/tasks/audio/generate-language-audio.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { type SafeReturn, safeAsync } from "@zoonk/utils/error";
-import { type TTSVoice } from "@zoonk/utils/languages";
+import { type TTSVoice, isOpenAITTSSupportedLanguage } from "@zoonk/utils/languages";
 import { logError } from "@zoonk/utils/logger";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import { convertWavToMp3 } from "./convert-wav-to-mp3";
@@ -10,8 +10,6 @@ import { type SpeechModelName, speechModels } from "./speech-models";
 import { generateSpeechWithProvider } from "./speech-provider";
 
 const DEFAULT_VOICE: TTSVoice = "Kore";
-const defaultModel = speechModels.google;
-const fallbackModels = [speechModels.openai] as const;
 const MAX_ATTEMPTS_PER_PROVIDER = 2;
 
 /* oxlint-disable-next-line no-magic-numbers -- 850 KiB fits an 18-second 24 kHz mono WAV. */
@@ -21,6 +19,7 @@ const READ_ALOUD_TEMPLATE =
   "The following text is {{LANGUAGE}}. Speak clearly at a moderate pace suitable for language learners. Enunciate each word precisely; read it aloud in {{LANGUAGE}}.";
 
 export type AudioResult = { audio: Uint8Array; format: "mp3" };
+export type LanguageAudioTextType = "sentence" | "word";
 export type LanguageAudioUsage = "alphabetSymbol";
 
 const usagePrompts = { alphabetSymbol: alphabetSymbolPrompt } satisfies Record<
@@ -77,13 +76,51 @@ function buildInstructions({
 }
 
 /**
- * Tries each selected provider twice because transport retries cannot observe
- * semantic failures discovered only after decoded-signal validation. Tasks
- * without an explicit model alternate Gemini and OpenAI so either provider can
- * recover from the other's malformed, silent, or unavailable output.
+ * Chooses the automatic provider order from language support and content type.
+ * English always prefers OpenAI. Other supported languages prefer OpenAI for
+ * sentences and Gemini for words, while Gemini-only languages never reach
+ * OpenAI.
  */
-function getSpeechModels(model?: SpeechModelName): readonly SpeechModelName[] {
-  const providerOrder = model ? [model] : [defaultModel, ...fallbackModels];
+function getDefaultProviderOrder({
+  languageCode,
+  textType,
+}: {
+  languageCode?: string;
+  textType: LanguageAudioTextType;
+}): readonly SpeechModelName[] {
+  if (languageCode === "en") {
+    return [speechModels.openai, speechModels.google];
+  }
+
+  if (!isOpenAITTSSupportedLanguage(languageCode)) {
+    return [speechModels.google];
+  }
+
+  if (textType === "sentence") {
+    return [speechModels.openai, speechModels.google];
+  }
+
+  return [speechModels.google, speechModels.openai];
+}
+
+/**
+ * Tries every selected provider twice because transport retries cannot observe
+ * semantic failures discovered only after decoded-signal validation. Explicit
+ * model requests keep their existing two attempts for the audio test tool.
+ */
+function getSpeechModels({
+  languageCode,
+  model,
+  textType,
+}: {
+  languageCode?: string;
+  model?: SpeechModelName;
+  textType: LanguageAudioTextType;
+}): readonly SpeechModelName[] {
+  const providerOrder = model
+    ? [model]
+    : getDefaultProviderOrder({ ...(languageCode ? { languageCode } : {}), textType });
+
   return Array.from({ length: MAX_ATTEMPTS_PER_PROVIDER }, () => providerOrder).flat();
 }
 
@@ -177,19 +214,22 @@ async function generateWithFallback({
 }
 
 /**
- * Generates audio for the given text using Gemini TTS as the primary
- * provider and OpenAI TTS as a fallback unless the task requests one model.
+ * Generates audio with a language-aware provider order. Callers only need to
+ * identify sentences because words are the default used by vocabulary and
+ * alphabet generation. An explicit model bypasses automatic provider choice.
  */
 export async function generateLanguageAudio({
   language,
   model,
   text,
+  textType = "word",
   usage,
   voice = DEFAULT_VOICE,
 }: {
   language?: string;
   model?: SpeechModelName;
   text: string;
+  textType?: LanguageAudioTextType;
   usage?: LanguageAudioUsage;
   voice?: TTSVoice;
 }): Promise<SafeReturn<AudioResult>> {
@@ -198,7 +238,11 @@ export async function generateLanguageAudio({
   return safeAsync(() =>
     generateWithFallback({
       ...(instructions ? { instructions } : {}),
-      models: getSpeechModels(model),
+      models: getSpeechModels({
+        ...(language ? { languageCode: language } : {}),
+        ...(model ? { model } : {}),
+        textType,
+      }),
       text,
       voice,
     }),

--- a/packages/core/src/audio/generate-language-audio.ts
+++ b/packages/core/src/audio/generate-language-audio.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { type SpeechModelName } from "@zoonk/ai/speech-models";
 import {
+  type LanguageAudioTextType,
   type LanguageAudioUsage,
   generateLanguageAudio as generateAudio,
 } from "@zoonk/ai/tasks/audio";
@@ -14,6 +15,7 @@ export async function generateLanguageAudio({
   model,
   orgSlug,
   text,
+  textType,
   usage,
   voice,
 }: {
@@ -21,6 +23,7 @@ export async function generateLanguageAudio({
   model?: SpeechModelName;
   orgSlug?: string;
   text: string;
+  textType?: LanguageAudioTextType;
   usage?: LanguageAudioUsage;
   voice?: TTSVoice;
 }): Promise<SafeReturn<string>> {
@@ -28,6 +31,7 @@ export async function generateLanguageAudio({
     language,
     ...(model ? { model } : {}),
     text,
+    ...(textType ? { textType } : {}),
     voice,
     ...(usage ? { usage } : {}),
   });

--- a/packages/utils/src/languages.test.ts
+++ b/packages/utils/src/languages.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { getLanguageName, isTTSSupportedLanguage, needsRomanization } from "./languages";
+import {
+  getLanguageName,
+  isOpenAITTSSupportedLanguage,
+  isTTSSupportedLanguage,
+  needsRomanization,
+} from "./languages";
+
+describe(isOpenAITTSSupportedLanguage, () => {
+  it("returns true for a language supported by OpenAI TTS", () => {
+    expect(isOpenAITTSSupportedLanguage("es")).toBe(true);
+  });
+
+  it("returns false for a Gemini-only language", () => {
+    expect(isOpenAITTSSupportedLanguage("am")).toBe(false);
+  });
+});
 
 describe(isTTSSupportedLanguage, () => {
   it("returns true for a valid language code", () => {

--- a/packages/utils/src/languages.ts
+++ b/packages/utils/src/languages.ts
@@ -82,6 +82,86 @@ export const TTS_SUPPORTED_LANGUAGE_CODES = [
 
 export type TTSSupportedLanguageCode = (typeof TTS_SUPPORTED_LANGUAGE_CODES)[number];
 
+/**
+ * ISO 639-1 codes supported by OpenAI TTS. OpenAI documents its TTS language
+ * support as following Whisper, while Gemini covers the broader course list.
+ * Source: https://developers.openai.com/api/docs/guides/text-to-speech#supported-languages
+ */
+export const OPENAI_TTS_SUPPORTED_LANGUAGE_CODES = [
+  "af",
+  "ar",
+  "hy",
+  "az",
+  "be",
+  "bs",
+  "bg",
+  "ca",
+  "zh",
+  "hr",
+  "cs",
+  "da",
+  "nl",
+  "en",
+  "et",
+  "fi",
+  "fr",
+  "gl",
+  "de",
+  "el",
+  "he",
+  "hi",
+  "hu",
+  "is",
+  "id",
+  "it",
+  "ja",
+  "kn",
+  "kk",
+  "ko",
+  "lv",
+  "lt",
+  "mk",
+  "ms",
+  "mr",
+  "mi",
+  "ne",
+  "no",
+  "fa",
+  "pl",
+  "pt",
+  "ro",
+  "ru",
+  "sr",
+  "sk",
+  "sl",
+  "es",
+  "sw",
+  "sv",
+  "tl",
+  "ta",
+  "th",
+  "tr",
+  "uk",
+  "ur",
+  "vi",
+  "cy",
+] as const;
+
+const OPENAI_TTS_SUPPORTED_LANGUAGE_SET: ReadonlySet<string> = new Set(
+  OPENAI_TTS_SUPPORTED_LANGUAGE_CODES,
+);
+
+/**
+ * Distinguishes languages that can safely use OpenAI in the automatic TTS
+ * provider order. Languages outside this list must remain on Gemini so a
+ * fallback never sends unsupported text to OpenAI.
+ */
+export function isOpenAITTSSupportedLanguage(
+  code: unknown,
+): code is (typeof OPENAI_TTS_SUPPORTED_LANGUAGE_CODES)[number] {
+  return typeof code === "string" && OPENAI_TTS_SUPPORTED_LANGUAGE_SET.has(code);
+}
+
 const TTS_SUPPORTED_LANGUAGE_SET: ReadonlySet<string> = new Set(TTS_SUPPORTED_LANGUAGE_CODES);
 
 export function isTTSSupportedLanguage(


### PR DESCRIPTION
Updates automatic language-course TTS routing.

- Prefer OpenAI for English and supported-language sentences.
- Keep Gemini first for non-English words and Gemini-only languages.
- Pass sentence context from reading generation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route language-course TTS by language and content type: prefer OpenAI for English and supported-language sentences, keep Gemini first for non‑English words and Gemini‑only languages. Reading generation now passes sentence context for better routing.

- **New Features**
  - Added `textType` ("sentence" | "word") to `generateLanguageAudio`; reading audio step sets `"sentence"`.
  - Automatic provider order:
    - English: OpenAI → Gemini.
    - Supported non‑English: sentences OpenAI → Gemini; words Gemini → OpenAI.
    - Unsupported languages: Gemini only.
    - Still retries each provider twice.
  - Introduced `isOpenAITTSSupportedLanguage` and an OpenAI TTS language list in `@zoonk/utils/languages`.
  - Updated tests to cover new routing, fallbacks, and kept non‑English prompt instructions.

<sup>Written for commit 24a650ce412b1faf76579c8f4da7dcdfb6b5c82d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

