### PR TITLE
feat(admin): add brain power leaderboard

### DIFF
--- a/apps/admin/src/app/(private)/app-sidebar.tsx
+++ b/apps/admin/src/app/(private)/app-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   HomeIcon,
   LayersIcon,
   MessageSquareTextIcon,
+  TrophyIcon,
   Users,
 } from "lucide-react";
 import { usePathname } from "next/navigation";
@@ -25,6 +26,7 @@ const menuItems = [
   { icon: HomeIcon, label: "Home", url: "/" },
   { icon: BarChart3Icon, label: "Stats", url: "/stats" },
   { icon: Users, label: "Users", url: "/users" },
+  { icon: TrophyIcon, label: "Leaderboard", url: "/leaderboard" },
   { icon: CreditCardIcon, label: "Subscriptions", url: "/subscriptions" },
   { icon: BookOpen, label: "Courses", url: "/courses" },
   { icon: MessageSquareTextIcon, label: "Course Prompts", url: "/course-prompts" },

--- a/apps/admin/src/app/(private)/app-stats-engagement.tsx
+++ b/apps/admin/src/app/(private)/app-stats-engagement.tsx
@@ -7,43 +7,20 @@ import { getAvgLessonsPerLearner } from "@/data/stats/get-avg-lessons-per-learne
 import { getCompletionRate } from "@/data/stats/get-completion-rate";
 import { getTotalLearningTime } from "@/data/stats/get-total-learning-time";
 import { formatDuration } from "@/lib/format-duration";
+import { getRollingUtcDateWindowStarts } from "@/lib/rolling-date-windows";
 import { BookOpenIcon, CheckCircleIcon, ClockIcon, LayersIcon, TargetIcon } from "lucide-react";
 import { connection } from "next/server";
 
 const DAYS_7 = 7;
 
-/**
- * Dashboard comparisons use whole UTC dates because the source table stores a
- * date-only learning day instead of a timestamp.
- */
-function startOfUtcToday(now: Date) {
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-}
-
-/**
- * Date math is kept in one helper so the current and previous 7-day windows
- * stay the same length when the dashboard card builds its comparison.
- */
-function addUtcDays({ date, days }: { date: Date; days: number }) {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + days));
-}
-
-/**
- * The current 7-day window includes today and the 6 preceding calendar days;
- * the previous window is the 7 calendar days immediately before that.
- */
-function getActiveLearnerWindows(now: Date) {
-  const today = startOfUtcToday(now);
-  const currentPeriodStart = addUtcDays({ date: today, days: 1 - DAYS_7 });
-  const previousPeriodStart = addUtcDays({ date: currentPeriodStart, days: -DAYS_7 });
-
-  return { currentPeriodStart, previousPeriodStart };
-}
-
 export async function EngagementStats() {
   await connection();
   const now = new Date();
-  const { currentPeriodStart, previousPeriodStart } = getActiveLearnerWindows(now);
+
+  const { currentPeriodStart, previousPeriodStart } = getRollingUtcDateWindowStarts({
+    days: DAYS_7,
+    now,
+  });
 
   const [
     activeLearners,

--- a/apps/admin/src/app/(private)/leaderboard/brain-power-leaderboard.tsx
+++ b/apps/admin/src/app/(private)/leaderboard/brain-power-leaderboard.tsx
@@ -1,0 +1,183 @@
+import { AdminPagination } from "@/components/pagination";
+import {
+  type BrainPowerLeader,
+  listBrainPowerLeaders,
+} from "@/data/users/list-brain-power-leaders";
+import { parseSearchParams } from "@/lib/parse-search-params";
+import { getRollingUtcDateWindowStarts } from "@/lib/rolling-date-windows";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
+import Link from "next/link";
+
+const LEADERBOARD_DAYS = 7;
+const SKELETON_ROW_COUNT = 5;
+const TABLE_COLUMN_COUNT = 4;
+
+/**
+ * The leaderboard stays server-rendered so ranking and pagination are resolved
+ * together from URL state that can be refreshed or shared.
+ */
+export async function BrainPowerLeaderboard({
+  searchParams,
+}: {
+  searchParams: PageProps<"/leaderboard">["searchParams"];
+}) {
+  const params = await searchParams;
+  const { limit, offset, page } = parseSearchParams(params);
+
+  const { currentPeriodStart } = getRollingUtcDateWindowStarts({
+    days: LEADERBOARD_DAYS,
+    now: new Date(),
+  });
+
+  const { leaders, total } = await listBrainPowerLeaders({
+    limit,
+    offset,
+    startDate: currentPeriodStart,
+  });
+
+  const totalPages = Math.ceil(total / limit);
+
+  return (
+    <>
+      <p className="text-muted-foreground text-sm">
+        {total.toLocaleString()} users earned Brain Power in the past 7 days.
+      </p>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableCaption className="sr-only">
+            Brain Power leaderboard for the past 7 days
+          </TableCaption>
+          <BrainPowerLeaderboardHeader />
+
+          <TableBody>
+            {leaders.length > 0 ? (
+              leaders.map((leader) => (
+                <BrainPowerLeaderboardRow key={leader.user.id} leader={leader} />
+              ))
+            ) : (
+              <BrainPowerLeaderboardEmptyRow />
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <AdminPagination basePath="/leaderboard" limit={limit} page={page} totalPages={totalPages} />
+    </>
+  );
+}
+
+/**
+ * The fallback matches the loaded table structure so the page remains stable
+ * while grouped Brain Power totals are loading.
+ */
+export function BrainPowerLeaderboardSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Skeleton className="h-4 w-56" />
+
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <BrainPowerLeaderboardHeader />
+
+          <TableBody>
+            {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
+              // oxlint-disable-next-line react/no-array-index-key -- Skeleton rows are static placeholders.
+              <BrainPowerLeaderboardSkeletonRow key={index} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The loaded and loading tables share column labels and alignment so their
+ * layout cannot drift as the leaderboard evolves.
+ */
+function BrainPowerLeaderboardHeader() {
+  return (
+    <TableHeader>
+      <TableRow>
+        <TableHead className="w-16 text-right">Rank</TableHead>
+        <TableHead>User</TableHead>
+        <TableHead>Username</TableHead>
+        <TableHead className="text-right">Brain Power</TableHead>
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+/**
+ * An empty row keeps the table visible when no one earned Brain Power during
+ * the rolling window, making the absence of activity explicit.
+ */
+function BrainPowerLeaderboardEmptyRow() {
+  return (
+    <TableRow>
+      <TableCell className="text-muted-foreground" colSpan={TABLE_COLUMN_COUNT}>
+        No Brain Power earned in the past 7 days.
+      </TableCell>
+    </TableRow>
+  );
+}
+
+/**
+ * Each leaderboard row links the user identity to account detail while keeping
+ * the rank and Brain Power total aligned for quick comparison.
+ */
+function BrainPowerLeaderboardRow({ leader }: { leader: BrainPowerLeader }) {
+  return (
+    <TableRow>
+      <TableCell className="text-muted-foreground text-right tabular-nums">
+        {leader.rank.toLocaleString()}
+      </TableCell>
+      <TableCell>
+        <Link className="block" href={`/users/${leader.user.id}`}>
+          <span className="font-medium">{leader.user.name || "—"}</span>
+          <span className="text-muted-foreground block text-xs">{leader.user.email}</span>
+        </Link>
+      </TableCell>
+      <TableCell>{leader.user.username || "—"}</TableCell>
+      <TableCell className="text-right font-medium tabular-nums">
+        {leader.brainPower.toLocaleString()}
+      </TableCell>
+    </TableRow>
+  );
+}
+
+/**
+ * Placeholder cells mirror the loaded row widths closely enough to avoid a
+ * noticeable shift when the leaderboard streams into the page.
+ */
+function BrainPowerLeaderboardSkeletonRow() {
+  return (
+    <TableRow>
+      <TableCell>
+        <Skeleton className="ml-auto h-4 w-6" />
+      </TableCell>
+      <TableCell>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-48" />
+        </div>
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="ml-auto h-4 w-16" />
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/apps/admin/src/app/(private)/leaderboard/page.tsx
+++ b/apps/admin/src/app/(private)/leaderboard/page.tsx
@@ -1,0 +1,38 @@
+import {
+  Container,
+  ContainerBody,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { type Metadata } from "next";
+import { Suspense } from "react";
+import { BrainPowerLeaderboard, BrainPowerLeaderboardSkeleton } from "./brain-power-leaderboard";
+
+export const metadata: Metadata = { title: "Brain Power Leaderboard" };
+
+/**
+ * The leaderboard gives admins one focused view of recent learning activity,
+ * separate from the lifetime Brain Power ordering on the broader users page.
+ */
+export default function LeaderboardPage({ searchParams }: PageProps<"/leaderboard">) {
+  return (
+    <Container>
+      <ContainerHeader variant="sidebar">
+        <ContainerHeaderGroup>
+          <ContainerTitle>Brain Power Leaderboard</ContainerTitle>
+          <ContainerDescription>
+            Users who earned the most Brain Power in the past 7 days.
+          </ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <Suspense fallback={<BrainPowerLeaderboardSkeleton />}>
+          <BrainPowerLeaderboard searchParams={searchParams} />
+        </Suspense>
+      </ContainerBody>
+    </Container>
+  );
+}

--- a/apps/admin/src/data/users/list-brain-power-leaders.ts
+++ b/apps/admin/src/data/users/list-brain-power-leaders.ts
@@ -1,0 +1,126 @@
+import "server-only";
+import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { type User, prisma } from "@zoonk/db";
+
+export type BrainPowerLeader = { brainPower: number; rank: number; user: User };
+
+type BrainPowerByUser = Awaited<ReturnType<typeof listBrainPowerByUser>>[number];
+
+/**
+ * The cached loader coordinates the ranked progress query, matching user count,
+ * and account lookup while keeping its positional arguments stable for React's
+ * request memoization.
+ */
+const cachedListBrainPowerLeaders = cacheAdminData(
+  async (startDateIso: string, limit: number, offset: number) => {
+    const startDate = new Date(startDateIso);
+
+    const [brainPowerByUser, total] = await Promise.all([
+      listBrainPowerByUser({ limit, offset, startDate }),
+      prisma.user.count({
+        where: { dailyProgress: { some: getBrainPowerProgressWhere({ startDate }) } },
+      }),
+    ]);
+
+    const userIds = brainPowerByUser.map((row) => row.userId);
+    const users = await prisma.user.findMany({ where: { id: { in: userIds } } });
+    const leaders = mergeBrainPowerWithUsers({ brainPowerByUser, offset, users });
+
+    return { leaders, total };
+  },
+);
+
+/**
+ * The leaderboard ranks users by Brain Power earned on or after the supplied
+ * date. The start date stays explicit so the route owns what “past 7 days”
+ * means and the cached database helper remains deterministic.
+ */
+export function listBrainPowerLeaders({
+  limit,
+  offset,
+  startDate,
+}: {
+  limit: number;
+  offset: number;
+  startDate: Date;
+}) {
+  return cachedListBrainPowerLeaders(startDate.toISOString(), limit, offset);
+}
+
+/**
+ * Grouping daily rows produces one ranked total per user. The user id provides
+ * a deterministic tie-breaker so pagination cannot reorder equal BP totals
+ * between requests.
+ */
+function listBrainPowerByUser({
+  limit,
+  offset,
+  startDate,
+}: {
+  limit: number;
+  offset: number;
+  startDate: Date;
+}) {
+  return prisma.dailyProgress.groupBy({
+    _sum: { brainPowerEarned: true },
+    by: ["userId"],
+    orderBy: [{ _sum: { brainPowerEarned: "desc" } }, { userId: "asc" }],
+    skip: offset,
+    take: limit,
+    where: getBrainPowerProgressWhere({ startDate }),
+  });
+}
+
+/**
+ * The grouped ranking and qualifying-user count must use the same daily-row
+ * boundary or pagination totals can disagree with the visible leaderboard.
+ */
+function getBrainPowerProgressWhere({ startDate }: { startDate: Date }) {
+  return { brainPowerEarned: { gt: 0 }, date: { gte: startDate } };
+}
+
+/**
+ * Prisma can rank the grouped progress totals but cannot include each user in
+ * the same group query. Rebuilding rows from the ranked ids preserves the
+ * database order after the account records are loaded separately.
+ */
+function mergeBrainPowerWithUsers({
+  brainPowerByUser,
+  offset,
+  users,
+}: {
+  brainPowerByUser: Awaited<ReturnType<typeof listBrainPowerByUser>>;
+  offset: number;
+  users: User[];
+}): BrainPowerLeader[] {
+  const usersById = new Map(users.map((user) => [user.id, user]));
+
+  return brainPowerByUser.flatMap((row, index) =>
+    createBrainPowerLeader({ index, offset, row, usersById }),
+  );
+}
+
+/**
+ * A user can disappear between the grouped progress query and the account
+ * lookup if an admin deletes it concurrently. Omitting that stale row keeps
+ * the page usable instead of failing the whole leaderboard request.
+ */
+function createBrainPowerLeader({
+  index,
+  offset,
+  row,
+  usersById,
+}: {
+  index: number;
+  offset: number;
+  row: BrainPowerByUser;
+  usersById: Map<string, User>;
+}): BrainPowerLeader[] {
+  const user = usersById.get(row.userId);
+
+  if (!user) {
+    return [];
+  }
+
+  return [{ brainPower: row._sum.brainPowerEarned ?? 0, rank: offset + index + 1, user }];
+}

--- a/apps/admin/src/lib/rolling-date-windows.ts
+++ b/apps/admin/src/lib/rolling-date-windows.ts
@@ -1,0 +1,22 @@
+import { toUTCMidnight } from "@zoonk/utils/energy";
+
+/**
+ * Admin rolling metrics use date-only database rows, so their boundaries must
+ * be calculated in UTC. The current window includes today and the preceding
+ * days; the previous start keeps comparisons on equal calendar-day windows.
+ */
+export function getRollingUtcDateWindowStarts({ days, now }: { days: number; now: Date }) {
+  const currentPeriodStart = addUtcDays({ date: toUTCMidnight(now), days: 1 - days });
+  const previousPeriodStart = addUtcDays({ date: currentPeriodStart, days: -days });
+
+  return { currentPeriodStart, previousPeriodStart };
+}
+
+/**
+ * UTC date construction handles month and year boundaries without relying on
+ * local timezone offsets, which would shift date-only progress rows for some
+ * deployments.
+ */
+function addUtcDays({ date, days }: { date: Date; days: number }) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + days));
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -39,6 +39,7 @@ export type {
   Sentence,
   Subscription,
   StepKind,
+  User,
   UserProgress,
   Word,
   WordPronunciation,


### PR DESCRIPTION
## Summary

- add a paginated seven-day Brain Power leaderboard to the admin app
- link leaderboard entries to user detail pages
- share the UTC rolling-window boundary with the active learner metric

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a seven-day Brain Power leaderboard to the admin app with pagination and links to user detail pages. Aligns rolling UTC window logic with engagement stats for consistent reporting.

- **New Features**
  - New `/leaderboard` page: server-rendered table with pagination and a loading skeleton.
  - Ranks users by Brain Power earned in the past 7 days; deterministic order; each row links to the user detail.
  - Sidebar now includes a Leaderboard nav item.

- **Refactors**
  - Added `getRollingUtcDateWindowStarts` and updated engagement stats to use it for consistent UTC windows.
  - Implemented a cached loader and grouped queries to keep totals and pagination aligned and skip deleted users gracefully.
  - Exported `User` type from `@zoonk/db` for leaderboard data merging.

<sup>Written for commit 29516ab49a95f125c43eff7d1f35899d27590b91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

