### PR TITLE
fix(api): prevent duplicate lesson steps

### DIFF
--- a/apps/api/src/workflows/lesson-generation/steps/_utils/replace-lesson-steps.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/replace-lesson-steps.test.ts
@@ -1,0 +1,60 @@
+import { prisma } from "@zoonk/db";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { stepAttemptFixture } from "@zoonk/testing/fixtures/step-attempts";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, it } from "vitest";
+import { createLessonContext } from "../_test-utils/create-lesson-context";
+import { replaceLessonSteps } from "./replace-lesson-steps";
+
+describe(replaceLessonSteps, () => {
+  it("preserves completed lesson steps and their attempts", async () => {
+    const organization = await aiOrganizationFixture();
+
+    const [context, user] = await Promise.all([
+      createLessonContext({ generationStatus: "completed", organizationId: organization.id }),
+      userFixture(),
+    ]);
+
+    const existingStep = await stepFixture({
+      content: { text: "Completed content", title: "Completed step", variant: "text" },
+      isPublished: true,
+      kind: "static",
+      lessonId: context.id,
+      position: 0,
+    });
+
+    const attempt = await stepAttemptFixture({
+      answer: {},
+      dayOfWeek: 1,
+      durationSeconds: 5,
+      hourOfDay: 12,
+      isCorrect: true,
+      stepId: existingStep.id,
+      userId: user.id,
+    });
+
+    await replaceLessonSteps({
+      lessonId: context.id,
+      saveSteps: async (transaction) => {
+        await transaction.step.create({
+          data: {
+            content: { text: "Stale replacement", title: "Stale step", variant: "text" },
+            isPublished: true,
+            kind: "static",
+            lessonId: context.id,
+            position: 0,
+          },
+        });
+      },
+    });
+
+    const [savedStep, savedAttempt] = await Promise.all([
+      prisma.step.findUnique({ where: { id: existingStep.id } }),
+      prisma.stepAttempt.findUnique({ where: { id: attempt.id } }),
+    ]);
+
+    expect(savedStep?.id).toBe(existingStep.id);
+    expect(savedAttempt?.stepId).toBe(existingStep.id);
+  });
+});

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/replace-lesson-steps.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/replace-lesson-steps.ts
@@ -1,10 +1,12 @@
-import { type TransactionClient, prisma } from "@zoonk/db";
+import { type Lesson, type TransactionClient, prisma } from "@zoonk/db";
 
 /**
  * Replaces one lesson's visible step batch while holding a lock on the lesson.
  * Workflow steps may execute concurrently during durable recovery, so the
  * parent-row lock keeps two replacements from deleting and inserting across
- * each other while still allowing unrelated lessons to save in parallel.
+ * each other while still allowing unrelated lessons to save in parallel. A
+ * completed lesson is immutable because a stale replacement would invalidate
+ * the step IDs referenced by learner attempts.
  */
 export async function replaceLessonSteps({
   lessonId,
@@ -14,7 +16,17 @@ export async function replaceLessonSteps({
   saveSteps: (transaction: TransactionClient) => Promise<void>;
 }): Promise<void> {
   await prisma.$transaction(async (transaction) => {
-    await transaction.$queryRaw`SELECT "id" FROM "lessons" WHERE "id" = ${lessonId}::uuid FOR UPDATE`;
+    const [lesson] = await transaction.$queryRaw<Pick<Lesson, "generationStatus">[]>`
+      SELECT "generation_status" AS "generationStatus"
+      FROM "lessons"
+      WHERE "id" = ${lessonId}::uuid
+      FOR UPDATE
+    `;
+
+    if (lesson?.generationStatus === "completed") {
+      return;
+    }
+
     await transaction.step.deleteMany({ where: { lessonId } });
     await saveSteps(transaction);
   });

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/replace-lesson-steps.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/replace-lesson-steps.ts
@@ -1,0 +1,21 @@
+import { type TransactionClient, prisma } from "@zoonk/db";
+
+/**
+ * Replaces one lesson's visible step batch while holding a lock on the lesson.
+ * Workflow steps may execute concurrently during durable recovery, so the
+ * parent-row lock keeps two replacements from deleting and inserting across
+ * each other while still allowing unrelated lessons to save in parallel.
+ */
+export async function replaceLessonSteps({
+  lessonId,
+  saveSteps,
+}: {
+  lessonId: string;
+  saveSteps: (transaction: TransactionClient) => Promise<void>;
+}): Promise<void> {
+  await prisma.$transaction(async (transaction) => {
+    await transaction.$queryRaw`SELECT "id" FROM "lessons" WHERE "id" = ${lessonId}::uuid FOR UPDATE`;
+    await transaction.step.deleteMany({ where: { lessonId } });
+    await saveSteps(transaction);
+  });
+}

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/save-core-lesson-content.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/save-core-lesson-content.ts
@@ -1,7 +1,7 @@
 import { type QuizQuestion } from "@zoonk/ai/tasks/lessons/core/quiz";
 import { assertStepContent } from "@zoonk/core/steps/contract/content";
 import { type StepImage } from "@zoonk/core/steps/contract/image";
-import { prisma } from "@zoonk/db";
+import { type TransactionClient } from "@zoonk/db";
 import { type LessonContext } from "../get-lesson-step";
 import { type GeneratedLessonContent, type StaticLessonStep } from "./generated-lesson-content";
 import { type StepRecord, addOptionIds } from "./save-lesson-content-helpers";
@@ -37,14 +37,16 @@ export async function saveStaticLessonContent({
   context,
   images,
   steps,
+  transaction,
 }: {
   context: LessonContext;
   images?: StepImage[];
   steps: StaticLessonStep[];
+  transaction: TransactionClient;
 }): Promise<void> {
   assertImageCount({ images, stepCount: steps.length });
 
-  await prisma.step.createMany({
+  await transaction.step.createMany({
     data: steps.map((step, position) => {
       const image = getOptionalStepImage(images, position);
 
@@ -69,10 +71,12 @@ export async function savePracticeLessonContent({
   content,
   context,
   images,
+  transaction,
 }: {
   content: Extract<GeneratedLessonContent, { kind: "practice" }>;
   context: LessonContext;
   images?: StepImage[];
+  transaction: TransactionClient;
 }): Promise<void> {
   assertImageCount({ images, stepCount: content.steps.length });
 
@@ -93,7 +97,7 @@ export async function savePracticeLessonContent({
     };
   });
 
-  await prisma.step.createMany({ data: questionSteps });
+  await transaction.step.createMany({ data: questionSteps });
 }
 
 /**
@@ -102,11 +106,13 @@ export async function savePracticeLessonContent({
 export async function saveQuizLessonContent({
   context,
   questions,
+  transaction,
 }: {
   context: LessonContext;
   questions: QuizQuestionWithUrls[];
+  transaction: TransactionClient;
 }): Promise<void> {
-  await prisma.step.createMany({
+  await transaction.step.createMany({
     data: questions.map((question, position) => ({
       content: buildQuizStepContent(question),
       isPublished: true,

--- a/apps/api/src/workflows/lesson-generation/steps/_utils/save-language-lesson-content.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/_utils/save-language-lesson-content.ts
@@ -1,6 +1,6 @@
 import { type LessonGrammarSchema } from "@zoonk/ai/tasks/lessons/language/grammar";
 import { assertStepContent } from "@zoonk/core/steps/contract/content";
-import { prisma } from "@zoonk/db";
+import { type TransactionClient } from "@zoonk/db";
 import { type LessonContext } from "../get-lesson-step";
 import { type GrammarLessonContent } from "./generated-lesson-content";
 import { type StepRecord, getOptionalQuestion } from "./save-lesson-content-helpers";
@@ -12,12 +12,14 @@ export async function saveGrammarLessonContent({
   content,
   context,
   romanizations = null,
+  transaction,
 }: {
   content: GrammarLessonContent;
   context: LessonContext;
   romanizations?: Record<string, string> | null;
+  transaction: TransactionClient;
 }): Promise<void> {
-  await prisma.step.createMany({
+  await transaction.step.createMany({
     data: buildGrammarSteps({ content: content.grammarContent, context, romanizations }),
   });
 }

--- a/apps/api/src/workflows/lesson-generation/steps/save-alphabet-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-alphabet-lesson-step.ts
@@ -1,8 +1,8 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { assertStepContent } from "@zoonk/core/steps/contract/content";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
-import { prisma } from "@zoonk/db";
 import { type AlphabetLessonContent } from "./_utils/generated-lesson-content";
+import { replaceLessonSteps } from "./_utils/replace-lesson-steps";
 import { type LessonContext } from "./get-lesson-step";
 
 const MAX_MATCHING_PAIRS = 8;
@@ -132,18 +132,21 @@ export async function saveAlphabetLessonStep({
   await using stream = createStepStream<LessonStepName>();
   await stream.status({ status: "started", step: "saveAlphabetLesson" });
 
-  await prisma.step.deleteMany({ where: { lessonId: context.id } });
-
   const steps = buildAlphabetLessonSteps({ audioUrls, content });
 
-  await prisma.step.createMany({
-    data: steps.map((step, position) => ({
-      content: step.content,
-      isPublished: true,
-      kind: step.kind,
-      lessonId: context.id,
-      position,
-    })),
+  await replaceLessonSteps({
+    lessonId: context.id,
+    saveSteps: async (transaction) => {
+      await transaction.step.createMany({
+        data: steps.map((step, position) => ({
+          content: step.content,
+          isPublished: true,
+          kind: step.kind,
+          lessonId: context.id,
+          position,
+        })),
+      });
+    },
   });
 
   await stream.status({ status: "completed", step: "saveAlphabetLesson" });

--- a/apps/api/src/workflows/lesson-generation/steps/save-grammar-lesson-step.test.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-grammar-lesson-step.test.ts
@@ -1,9 +1,44 @@
 import { randomUUID } from "node:crypto";
 import { prisma } from "@zoonk/db";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createLessonContext } from "./_test-utils/create-lesson-context";
 import { saveGrammarLessonStep } from "./save-grammar-lesson-step";
+
+/**
+ * Builds distinguishable grammar batches so the concurrency test can prove
+ * that persistence kept one complete generation instead of mixing both saves.
+ */
+function createGrammarContent({
+  includeSecondExample = false,
+  marker,
+}: {
+  includeSecondExample?: boolean;
+  marker: string;
+}) {
+  const examples = [
+    { highlight: `ist-${marker}`, sentence: `Das ist ${marker}`, translation: `That is ${marker}` },
+    includeSecondExample && {
+      highlight: `war-${marker}`,
+      sentence: `Das war ${marker}`,
+      translation: `That was ${marker}`,
+    },
+  ].filter((example): example is Exclude<typeof example, false> => Boolean(example));
+
+  return {
+    examples,
+    explanations: [{ text: `Explanation ${marker}`, title: `Rule ${marker}` }],
+    questions: [
+      {
+        answer: `ist-${marker}`,
+        distractors: [`war-${marker}`, `hat-${marker}`],
+        feedback: `Feedback ${marker}`,
+        question: `Question ${marker}`,
+        template: "Das [BLANK] gut",
+      },
+    ],
+  };
+}
 
 describe(saveGrammarLessonStep, () => {
   let organizationId: string;
@@ -91,5 +126,75 @@ describe(saveGrammarLessonStep, () => {
       },
       template: "Das [BLANK] gut",
     });
+  });
+
+  it("keeps one complete step batch when saves run concurrently", async () => {
+    const id = randomUUID().replaceAll("-", "").slice(0, 8);
+
+    const context = await createLessonContext({
+      kind: "grammar",
+      organizationId,
+      targetLanguage: "de",
+    });
+
+    const batches = [
+      {
+        content: createGrammarContent({ marker: `first-${id}` }),
+        expectedStepCount: 3,
+        marker: `first-${id}`,
+      },
+      {
+        content: createGrammarContent({ includeSecondExample: true, marker: `second-${id}` }),
+        expectedStepCount: 4,
+        marker: `second-${id}`,
+      },
+    ];
+
+    const firstDeleteCompleted = Promise.withResolvers<null>();
+    const secondDeleteCompleted = Promise.withResolvers<null>();
+    const deleteSteps = prisma.step.deleteMany.bind(prisma.step);
+    const deleteSpy = vi.spyOn(prisma.step, "deleteMany");
+
+    deleteSpy
+      .mockImplementationOnce(
+        (args) =>
+          deleteSteps(args).then(async (result) => {
+            firstDeleteCompleted.resolve(null);
+            await secondDeleteCompleted.promise;
+            return result;
+          }) as ReturnType<typeof deleteSteps>,
+      )
+      .mockImplementationOnce(
+        (args) =>
+          deleteSteps(args).then(async (result) => {
+            secondDeleteCompleted.resolve(null);
+            await firstDeleteCompleted.promise;
+            return result;
+          }) as ReturnType<typeof deleteSteps>,
+      );
+
+    try {
+      await Promise.all(
+        batches.map((batch) =>
+          saveGrammarLessonStep({ context, grammarContent: batch.content, romanizations: null }),
+        ),
+      );
+    } finally {
+      deleteSpy.mockRestore();
+    }
+
+    const steps = await prisma.step.findMany({
+      orderBy: { position: "asc" },
+      where: { lessonId: context.id },
+    });
+
+    const completeBatchWasSaved = batches.some(
+      (batch) =>
+        steps.length === batch.expectedStepCount &&
+        steps.every((step) => JSON.stringify(step.content).includes(batch.marker)),
+    );
+
+    expect(completeBatchWasSaved).toBe(true);
+    expect(new Set(steps.map((step) => step.position)).size).toBe(steps.length);
   });
 });

--- a/apps/api/src/workflows/lesson-generation/steps/save-grammar-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-grammar-lesson-step.ts
@@ -1,8 +1,8 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type generateLessonGrammar } from "@zoonk/ai/tasks/lessons/language/grammar";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
-import { prisma } from "@zoonk/db";
 import { type GrammarLessonContent } from "./_utils/generated-lesson-content";
+import { replaceLessonSteps } from "./_utils/replace-lesson-steps";
 import { saveGrammarLessonContent } from "./_utils/save-language-lesson-content";
 import { type LessonContext } from "./get-lesson-step";
 
@@ -24,8 +24,11 @@ export async function saveGrammarLessonStep({
 
   const content: GrammarLessonContent = { grammarContent, kind: "grammar" };
 
-  await prisma.step.deleteMany({ where: { lessonId: context.id } });
-  await saveGrammarLessonContent({ content, context, romanizations });
+  await replaceLessonSteps({
+    lessonId: context.id,
+    saveSteps: (transaction) =>
+      saveGrammarLessonContent({ content, context, romanizations, transaction }),
+  });
 
   await stream.status({ status: "completed", step: "saveGrammarLesson" });
 }

--- a/apps/api/src/workflows/lesson-generation/steps/save-listening-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-listening-lesson-step.ts
@@ -4,6 +4,7 @@ import { assertStepContent } from "@zoonk/core/steps/contract/content";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
+import { replaceLessonSteps } from "./_utils/replace-lesson-steps";
 import { type LessonContext } from "./get-lesson-step";
 
 /**
@@ -65,25 +66,26 @@ export async function saveListeningLessonStep(context: LessonContext): Promise<v
     throw new FatalError("Listening save needs reading sentences");
   }
 
-  await prisma.$transaction(async (tx) => {
-    await tx.step.deleteMany({ where: { lessonId: listeningLesson.id } });
+  await replaceLessonSteps({
+    lessonId: listeningLesson.id,
+    saveSteps: async (transaction) => {
+      await transaction.step.createMany({
+        data: sentenceSteps.map((readingStep) => ({
+          chapterSentenceId: readingStep.chapterSentenceId,
+          content: assertStepContent("listening", {}),
+          isPublished: true,
+          kind: "listening" as const,
+          lessonId: listeningLesson.id,
+          position: readingStep.position,
+          sentenceId: readingStep.sentenceId,
+        })),
+      });
 
-    await tx.step.createMany({
-      data: sentenceSteps.map((readingStep) => ({
-        chapterSentenceId: readingStep.chapterSentenceId,
-        content: assertStepContent("listening", {}),
-        isPublished: true,
-        kind: "listening" as const,
-        lessonId: listeningLesson.id,
-        position: readingStep.position,
-        sentenceId: readingStep.sentenceId,
-      })),
-    });
-
-    await tx.lesson.update({
-      data: { generationRunId: null, generationStatus: "completed" },
-      where: { id: listeningLesson.id },
-    });
+      await transaction.lesson.update({
+        data: { generationRunId: null, generationStatus: "completed" },
+        where: { id: listeningLesson.id },
+      });
+    },
   });
 
   await stream.status({ status: "completed", step: "saveListeningLesson" });

--- a/apps/api/src/workflows/lesson-generation/steps/save-practice-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-practice-lesson-step.ts
@@ -1,8 +1,8 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type StepImage } from "@zoonk/core/steps/contract/image";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
-import { prisma } from "@zoonk/db";
 import { type PracticeLessonContent } from "./_utils/generated-lesson-content";
+import { replaceLessonSteps } from "./_utils/replace-lesson-steps";
 import { savePracticeLessonContent } from "./_utils/save-core-lesson-content";
 import { type LessonContext } from "./get-lesson-step";
 
@@ -24,8 +24,11 @@ export async function savePracticeLessonStep({
   await using stream = createStepStream<LessonStepName>();
   await stream.status({ status: "started", step: "savePracticeLesson" });
 
-  await prisma.step.deleteMany({ where: { lessonId: context.id } });
-  await savePracticeLessonContent({ content, context, images });
+  await replaceLessonSteps({
+    lessonId: context.id,
+    saveSteps: (transaction) =>
+      savePracticeLessonContent({ content, context, images, transaction }),
+  });
 
   await stream.status({ status: "completed", step: "savePracticeLesson" });
 }

--- a/apps/api/src/workflows/lesson-generation/steps/save-quiz-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-quiz-lesson-step.ts
@@ -1,6 +1,6 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
-import { prisma } from "@zoonk/db";
+import { replaceLessonSteps } from "./_utils/replace-lesson-steps";
 import {
   type QuizQuestionWithUrls,
   saveQuizLessonContent,
@@ -23,8 +23,10 @@ export async function saveQuizLessonStep({
   await using stream = createStepStream<LessonStepName>();
   await stream.status({ status: "started", step: "saveQuizLesson" });
 
-  await prisma.step.deleteMany({ where: { lessonId: context.id } });
-  await saveQuizLessonContent({ context, questions });
+  await replaceLessonSteps({
+    lessonId: context.id,
+    saveSteps: (transaction) => saveQuizLessonContent({ context, questions, transaction }),
+  });
 
   await stream.status({ status: "completed", step: "saveQuizLesson" });
 }

--- a/apps/api/src/workflows/lesson-generation/steps/save-reading-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-reading-lesson-step.ts
@@ -5,6 +5,8 @@ import { prisma } from "@zoonk/db";
 import { sanitizeDistractors } from "@zoonk/utils/distractors";
 import { emptyToNull, normalizePunctuation } from "@zoonk/utils/string";
 import { type ReadingLessonContent } from "./_utils/generated-lesson-content";
+import { replaceLessonSteps } from "./_utils/replace-lesson-steps";
+import { type StepRecord } from "./_utils/save-lesson-content-helpers";
 import { saveReadingTargetWords } from "./_utils/save-reading-target-words";
 import { type WordMetadataEntry } from "./generate-sentence-word-metadata-step";
 import { type LessonContext } from "./get-lesson-step";
@@ -45,36 +47,42 @@ export async function saveReadingLessonStep(params: {
   await using stream = createStepStream<LessonStepName>();
   await stream.status({ status: "started", step: "saveReadingLesson" });
 
-  await prisma.step.deleteMany({ where: { lessonId: params.context.id } });
-
-  await Promise.all(
-    params.sentences.map((readingSentence, position) =>
-      saveOneSentence({
-        context: params.context,
-        distractors: params.distractors,
-        organizationId,
-        position,
-        readingSentence,
-        sentenceAudioUrls: params.sentenceAudioUrls,
-        sentenceRomanizations: params.sentenceRomanizations,
-        targetLanguage,
-        translationDistractors: params.translationDistractors,
-        userLanguage: params.context.language,
-      }),
+  const [sentenceSteps] = await Promise.all([
+    Promise.all(
+      params.sentences.map((readingSentence, position) =>
+        saveOneSentence({
+          context: params.context,
+          distractors: params.distractors,
+          organizationId,
+          position,
+          readingSentence,
+          sentenceAudioUrls: params.sentenceAudioUrls,
+          sentenceRomanizations: params.sentenceRomanizations,
+          targetLanguage,
+          translationDistractors: params.translationDistractors,
+          userLanguage: params.context.language,
+        }),
+      ),
     ),
-  );
+    saveReadingTargetWords({
+      chapterId: params.context.chapterId,
+      distractors: params.distractors,
+      organizationId,
+      pronunciations: params.pronunciations,
+      sentences: params.sentences,
+      sourceLessonId: params.context.id,
+      targetLanguage,
+      userLanguage: params.context.language,
+      wordAudioUrls: params.wordAudioUrls,
+      wordMetadata: params.wordMetadata,
+    }),
+  ]);
 
-  await saveReadingTargetWords({
-    chapterId: params.context.chapterId,
-    distractors: params.distractors,
-    organizationId,
-    pronunciations: params.pronunciations,
-    sentences: params.sentences,
-    sourceLessonId: params.context.id,
-    targetLanguage,
-    userLanguage: params.context.language,
-    wordAudioUrls: params.wordAudioUrls,
-    wordMetadata: params.wordMetadata,
+  await replaceLessonSteps({
+    lessonId: params.context.id,
+    saveSteps: async (transaction) => {
+      await transaction.step.createMany({ data: sentenceSteps });
+    },
   });
 
   await stream.status({ status: "completed", step: "saveReadingLesson" });
@@ -96,7 +104,7 @@ async function saveOneSentence(params: {
   targetLanguage: string;
   translationDistractors: Record<string, string[]>;
   userLanguage: string;
-}): Promise<void> {
+}): Promise<StepRecord> {
   const sentence = normalizePunctuation(params.readingSentence.sentence);
   const translation = normalizePunctuation(params.readingSentence.translation);
 
@@ -153,15 +161,13 @@ async function saveOneSentence(params: {
     where: { chapterSentenceSource: { sentenceId: record.id, sourceLessonId: params.context.id } },
   });
 
-  await prisma.step.create({
-    data: {
-      chapterSentenceId: chapterSentence.id,
-      content: assertStepContent("reading", {}),
-      isPublished: true,
-      kind: "reading",
-      lessonId: params.context.id,
-      position: params.position,
-      sentenceId: record.id,
-    },
-  });
+  return {
+    chapterSentenceId: chapterSentence.id,
+    content: assertStepContent("reading", {}),
+    isPublished: true,
+    kind: "reading",
+    lessonId: params.context.id,
+    position: params.position,
+    sentenceId: record.id,
+  };
 }

--- a/apps/api/src/workflows/lesson-generation/steps/save-static-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-static-lesson-step.ts
@@ -1,8 +1,8 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
 import { type StepImage } from "@zoonk/core/steps/contract/image";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
-import { prisma } from "@zoonk/db";
 import { type StaticLessonStep } from "./_utils/generated-lesson-content";
+import { replaceLessonSteps } from "./_utils/replace-lesson-steps";
 import { saveStaticLessonContent } from "./_utils/save-core-lesson-content";
 import { type LessonContext } from "./get-lesson-step";
 
@@ -24,8 +24,10 @@ async function saveStaticLessonStep({
   await using stream = createStepStream<LessonStepName>();
   await stream.status({ status: "started", step });
 
-  await prisma.step.deleteMany({ where: { lessonId: context.id } });
-  await saveStaticLessonContent({ context, images, steps });
+  await replaceLessonSteps({
+    lessonId: context.id,
+    saveSteps: (transaction) => saveStaticLessonContent({ context, images, steps, transaction }),
+  });
 
   await stream.status({ status: "completed", step });
 }

--- a/apps/api/src/workflows/lesson-generation/steps/save-translation-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-translation-lesson-step.ts
@@ -4,6 +4,7 @@ import { assertStepContent } from "@zoonk/core/steps/contract/content";
 import { type LessonStepName } from "@zoonk/core/workflows/steps";
 import { prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
+import { replaceLessonSteps } from "./_utils/replace-lesson-steps";
 import { type LessonContext } from "./get-lesson-step";
 
 /**
@@ -60,25 +61,26 @@ export async function saveTranslationLessonStep(context: LessonContext): Promise
     throw new FatalError("Translation save needs vocabulary words");
   }
 
-  await prisma.$transaction(async (tx) => {
-    await tx.step.deleteMany({ where: { lessonId: translationLesson.id } });
+  await replaceLessonSteps({
+    lessonId: translationLesson.id,
+    saveSteps: async (transaction) => {
+      await transaction.step.createMany({
+        data: wordSteps.map((step, position) => ({
+          chapterWordId: step.chapterWordId,
+          content: assertStepContent("translation", {}),
+          isPublished: true,
+          kind: "translation" as const,
+          lessonId: translationLesson.id,
+          position,
+          wordId: step.wordId,
+        })),
+      });
 
-    await tx.step.createMany({
-      data: wordSteps.map((step, position) => ({
-        chapterWordId: step.chapterWordId,
-        content: assertStepContent("translation", {}),
-        isPublished: true,
-        kind: "translation" as const,
-        lessonId: translationLesson.id,
-        position,
-        wordId: step.wordId,
-      })),
-    });
-
-    await tx.lesson.update({
-      data: { generationRunId: null, generationStatus: "completed" },
-      where: { id: translationLesson.id },
-    });
+      await transaction.lesson.update({
+        data: { generationRunId: null, generationStatus: "completed" },
+        where: { id: translationLesson.id },
+      });
+    },
   });
 
   await stream.status({ status: "completed", step: "saveTranslationLesson" });

--- a/apps/api/src/workflows/lesson-generation/steps/save-vocabulary-lesson-step.ts
+++ b/apps/api/src/workflows/lesson-generation/steps/save-vocabulary-lesson-step.ts
@@ -7,6 +7,8 @@ import { sanitizeDistractors } from "@zoonk/utils/distractors";
 import { normalizePunctuation } from "@zoonk/utils/string";
 import { collectVocabularyTargetWords } from "./_utils/collect-vocabulary-target-words";
 import { fetchExistingWordCasing } from "./_utils/fetch-existing-word-casing";
+import { replaceLessonSteps } from "./_utils/replace-lesson-steps";
+import { type StepRecord } from "./_utils/save-lesson-content-helpers";
 import { upsertWordWithPronunciation } from "./_utils/upsert-word-with-pronunciation";
 import { type LessonContext } from "./get-lesson-step";
 
@@ -48,8 +50,6 @@ export async function saveVocabularyLessonStep({
   await using stream = createStepStream<LessonStepName>();
   await stream.status({ status: "started", step: "saveVocabularyLesson" });
 
-  await prisma.step.deleteMany({ where: { lessonId: context.id } });
-
   const allTargetWords = collectVocabularyTargetWords({ distractors, words });
 
   const existingCasing = await fetchExistingWordCasing({
@@ -61,7 +61,7 @@ export async function saveVocabularyLessonStep({
   const canonicalWords = new Set(words.map((word) => word.word));
   const distractorWords = allTargetWords.filter((word) => !canonicalWords.has(word));
 
-  await Promise.all(
+  const wordSteps = await Promise.all(
     words.map((word, position) =>
       saveOneVocabularyWord({
         context,
@@ -96,6 +96,13 @@ export async function saveVocabularyLessonStep({
     }),
   );
 
+  await replaceLessonSteps({
+    lessonId: context.id,
+    saveSteps: async (transaction) => {
+      await transaction.step.createMany({ data: wordSteps });
+    },
+  });
+
   await stream.status({ status: "completed", step: "saveVocabularyLesson" });
 }
 
@@ -116,7 +123,7 @@ async function saveOneVocabularyWord(params: {
   userLanguage: string;
   word: VocabularyWord;
   wordAudioUrls: Record<string, string>;
-}): Promise<void> {
+}): Promise<StepRecord> {
   const dbWord = params.existingCasing[params.word.word.toLowerCase()] ?? params.word.word;
   const romanization = params.romanizations[params.word.word] ?? null;
 
@@ -153,15 +160,13 @@ async function saveOneVocabularyWord(params: {
     where: { chapterWordSource: { sourceLessonId: params.context.id, wordId } },
   });
 
-  await prisma.step.create({
-    data: {
-      chapterWordId: chapterWord.id,
-      content: assertStepContent("vocabulary", {}),
-      isPublished: true,
-      kind: "vocabulary",
-      lessonId: params.context.id,
-      position: params.position,
-      wordId,
-    },
-  });
+  return {
+    chapterWordId: chapterWord.id,
+    content: assertStepContent("vocabulary", {}),
+    isPublished: true,
+    kind: "vocabulary",
+    lessonId: params.context.id,
+    position: params.position,
+    wordId,
+  };
 }

--- a/packages/core/src/player/queries/get-review-steps.test.ts
+++ b/packages/core/src/player/queries/get-review-steps.test.ts
@@ -684,6 +684,7 @@ describe(getReviewValidationData, () => {
         isPublished: true,
         kind: "static",
         lessonId: quizLesson.id,
+        position: 1,
       }),
     ]);
   });

--- a/packages/db/src/prisma/migrations/20260712211833_lesson_step_position_unique/migration.sql
+++ b/packages/db/src/prisma/migrations/20260712211833_lesson_step_position_unique/migration.sql
@@ -1,0 +1,79 @@
+BEGIN;
+
+-- Prevent lesson saves and attempts from changing while duplicate rows are reconciled.
+LOCK TABLE "steps" IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE "step_attempts" IN SHARE ROW EXCLUSIVE MODE;
+
+-- Preserve learner history while removing only content-identical duplicate steps.
+-- Any heterogeneous position collision remains and makes the unique index fail safely.
+WITH "ranked_steps" AS (
+  SELECT
+    "id",
+    FIRST_VALUE("id") OVER (
+      PARTITION BY
+        "lesson_id",
+        "position",
+        "word_id",
+        "sentence_id",
+        "chapter_word_id",
+        "chapter_sentence_id",
+        "kind",
+        "is_published",
+        "content"
+      ORDER BY "created_at", "id"
+    ) AS "retained_id",
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        "lesson_id",
+        "position",
+        "word_id",
+        "sentence_id",
+        "chapter_word_id",
+        "chapter_sentence_id",
+        "kind",
+        "is_published",
+        "content"
+      ORDER BY "created_at", "id"
+    ) AS "duplicate_rank"
+  FROM "steps"
+),
+"duplicate_steps" AS (
+  SELECT "id", "retained_id"
+  FROM "ranked_steps"
+  WHERE "duplicate_rank" > 1
+)
+UPDATE "step_attempts"
+SET "step_id" = "duplicate_steps"."retained_id"
+FROM "duplicate_steps"
+WHERE "step_attempts"."step_id" = "duplicate_steps"."id";
+
+WITH "ranked_steps" AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        "lesson_id",
+        "position",
+        "word_id",
+        "sentence_id",
+        "chapter_word_id",
+        "chapter_sentence_id",
+        "kind",
+        "is_published",
+        "content"
+      ORDER BY "created_at", "id"
+    ) AS "duplicate_rank"
+  FROM "steps"
+)
+DELETE FROM "steps"
+USING "ranked_steps"
+WHERE "steps"."id" = "ranked_steps"."id"
+  AND "ranked_steps"."duplicate_rank" > 1;
+
+-- DropIndex
+DROP INDEX "steps_lesson_id_position_idx";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "steps_lesson_id_position_key" ON "steps"("lesson_id", "position");
+
+COMMIT;

--- a/packages/db/src/prisma/models/lessons.prisma
+++ b/packages/db/src/prisma/models/lessons.prisma
@@ -50,7 +50,7 @@ model Step {
   updatedAt         DateTime         @default(now()) @updatedAt @map("updated_at")
   attempts          StepAttempt[]
 
-  @@index([lessonId, position])
+  @@unique([lessonId, position], name: "lessonStepPosition")
   @@index([lessonId, kind, position])
   @@index([wordId])
   @@index([sentenceId])


### PR DESCRIPTION
## Summary

- serialize lesson-step replacement per lesson so concurrent workflow saves cannot interleave
- enforce one step per lesson position at the database boundary
- preserve existing attempts while cleaning up content-identical duplicates during migration
- cover concurrent grammar saves with an integration regression test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate lesson steps by serializing step replacement per lesson, enforcing a unique `(lesson, position)` constraint, and skipping saves for completed lessons. Fixes race conditions in concurrent saves and preserves learner attempts.

- **Bug Fixes**
  - Added `replaceLessonSteps` to lock the lesson row and atomically delete+insert steps; it no-ops for `completed` lessons. Applied to alphabet, grammar, listening, practice, quiz, reading, translation, vocabulary, and static saves.
  - Save helpers now take a transaction client; reading and vocabulary build step records and bulk insert to avoid partial batches. Listening and translation finalize generation status within the same transaction.
  - Added tests to keep one complete batch under concurrent grammar saves and to preserve completed lesson steps and their attempts.

- **Migration**
  - Deduplicates content-identical `steps`, remaps `step_attempts` to retained rows, and adds a unique index on `(lesson_id, position)` to enforce one step per slot.
  - No manual action needed; heterogeneous duplicates will fail the unique index to surface the issue.

<sup>Written for commit 19b3688028590c189a3aeff01cc900aa5e384df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

