### PR TITLE
fix(main): align generation exit links

### DIFF
--- a/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generate-chapter-content.tsx
@@ -39,7 +39,7 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
             generationRunId={chapter.generationRunId}
             initialStatus={initialStatus}
           />
-          <GenerationExitLink href={backHref} shortcut="Esc">
+          <GenerationExitLink href={backHref} shortcut="Esc" width="content">
             {backLabel}
           </GenerationExitLink>
         </SubscriptionGate>

--- a/apps/main/src/app/generate/course/[id]/generate-course-prompt-content.tsx
+++ b/apps/main/src/app/generate/course/[id]/generate-course-prompt-content.tsx
@@ -87,7 +87,9 @@ export async function GenerateCoursePromptContent({ params }: { params: Promise<
           isLanguageCourse={isLanguageCourse}
           requestId={id}
         />
-        <GenerationExitLink href="/">{t("Back home")}</GenerationExitLink>
+        <GenerationExitLink href="/" width="content">
+          {t("Back home")}
+        </GenerationExitLink>
       </ContainerBody>
     </Container>
   );

--- a/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/generate/l/[id]/generate-lesson-content.tsx
@@ -77,7 +77,7 @@ export async function GenerateLessonContent({ params }: { params: Promise<{ id: 
           lessonSlug={lesson.slug}
           lessonTitle={lessonMeta.title}
         />
-        <GenerationExitLink href={backHref} shortcut="Esc">
+        <GenerationExitLink href={backHref} shortcut="Esc" width="content">
           {backLabel}
         </GenerationExitLink>
       </>

--- a/apps/main/src/components/generation/generation-exit-link.tsx
+++ b/apps/main/src/components/generation/generation-exit-link.tsx
@@ -1,22 +1,33 @@
 import { type Route } from "next";
 import { GenerationShortcutLink } from "./generation-shortcut-link";
 
+const generationExitLinkWidths = { content: "w-fit max-w-full self-start", full: "w-full" };
+
+type GenerationExitLinkWidth = keyof typeof generationExitLinkWidths;
+
 /**
- * Gives learners a quiet way out of generated-content waiting states. Keeping
- * this wrapper small lets generation screens opt into keyboard shortcuts
- * without duplicating button styling at each call site.
+ * Gives learners a quiet way out of generated-content waiting states. The
+ * width variant keeps page-level exit actions compact while preserving the
+ * full-width action layout used by empty states.
  */
 export function GenerationExitLink<Href extends string>({
   children,
   href,
   shortcut,
+  width = "full",
 }: {
   children: React.ReactNode;
   href: Route<Href>;
   shortcut?: "Esc";
+  width?: GenerationExitLinkWidth;
 }) {
   return (
-    <GenerationShortcutLink href={href} prefetch shortcut={shortcut}>
+    <GenerationShortcutLink
+      className={generationExitLinkWidths[width]}
+      href={href}
+      prefetch
+      shortcut={shortcut}
+    >
       {children}
     </GenerationShortcutLink>
   );


### PR DESCRIPTION
## Summary

- keep generation-page exit links compact and left aligned
- preserve full-width exit links in empty states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make generation exit links compact and left-aligned on generation screens, while keeping full-width links in empty states. Adds a width variant to the shared exit link to standardize layout.

- **Bug Fixes**
  - Added a width prop (`content` | `full`, default `full`) to GenerationExitLink.
  - Applied width="content" on chapter, lesson, and course generation pages for compact, self-start alignment.
  - Preserved full-width behavior for empty-state screens.

<sup>Written for commit 9b7dc7d4a390d47c2985c3c223365fdbe1414803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

