### PR TITLE
fix(main): compare averages with full previous period

### DIFF
--- a/apps/main/src/data/progress/get-energy-history.test.ts
+++ b/apps/main/src/data/progress/get-energy-history.test.ts
@@ -2,7 +2,7 @@ import { prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { createSafeDate, createSameWeekDates } from "@zoonk/testing/fixtures/dates";
 import { userFixture } from "@zoonk/testing/fixtures/users";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getEnergyHistory } from "./get-energy-history";
 
 describe("unauthenticated users", () => {
@@ -13,6 +13,10 @@ describe("unauthenticated users", () => {
 });
 
 describe("authenticated users", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns null when user has no DailyProgress records", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
@@ -94,30 +98,48 @@ describe("authenticated users", () => {
       expect(result?.currentEnergy).toBe(46);
     });
 
-    it("calculates comparison with previous month", async () => {
+    it("compares with the same full previous month shown by period navigation", async () => {
       const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
-      const currentMonth = createSafeDate(0);
-      const lastMonth = createSafeDate(1, 14);
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+      const currentMonth = new Date("2026-03-15T00:00:00.000Z");
+      const previousMonthFirstDay = new Date("2026-02-15T00:00:00.000Z");
+      const previousMonthSecondDay = new Date("2026-02-16T00:00:00.000Z");
 
       await prisma.dailyProgress.createMany({
         data: [
           {
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
-            energyAtEnd: 80,
+            energyAtEnd: 97.8,
             userId: user.id,
           },
-          { date: lastMonth, dayOfWeek: lastMonth.getDay(), energyAtEnd: 60, userId: user.id },
+          {
+            date: previousMonthFirstDay,
+            dayOfWeek: previousMonthFirstDay.getDay(),
+            energyAtEnd: 24,
+            userId: user.id,
+          },
+          {
+            date: previousMonthSecondDay,
+            dayOfWeek: previousMonthSecondDay.getDay(),
+            energyAtEnd: 99.6,
+            userId: user.id,
+          },
         ],
       });
 
-      const result = await getEnergyHistory({ headers, period: "month" });
+      const [currentResult, previousResult] = await Promise.all([
+        getEnergyHistory({ headers, period: "month" }),
+        getEnergyHistory({ headers, offset: 1, period: "month" }),
+      ]);
 
-      expect(result).not.toBeNull();
-      expect(result?.average).toBe(80);
-      expect(result?.previousAverage).toBe(60);
+      expect(currentResult?.average).toBe(97.8);
+      expect(previousResult?.average).toBe(61.8);
+      expect(currentResult?.previousAverage).toBe(previousResult?.average);
     });
 
     it("navigates to previous month with offset", async () => {

--- a/apps/main/src/data/progress/get-energy-history.ts
+++ b/apps/main/src/data/progress/get-energy-history.ts
@@ -3,7 +3,7 @@ import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { type TimePeriod, aggregateByPeriod } from "@zoonk/utils/aggregation";
 import { formatLabel } from "@zoonk/utils/chart";
-import { type HistoryPeriod, calculateDateRanges } from "@zoonk/utils/date-ranges";
+import { type HistoryPeriod, calculateFullPeriodDateRanges } from "@zoonk/utils/date-ranges";
 import { computeDecayedEnergy } from "@zoonk/utils/energy";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
@@ -76,7 +76,7 @@ const cachedGetEnergyHistory = cache(
     }
 
     const userId = session.user.id;
-    const { current, previous } = calculateDateRanges(period, offset);
+    const { current, previous } = calculateFullPeriodDateRanges({ offset, period });
 
     const [currentResult, previousResult, progressResult] = await Promise.all([
       fetchDailyData(userId, current.start, current.end),

--- a/apps/main/src/data/progress/get-score-history.test.ts
+++ b/apps/main/src/data/progress/get-score-history.test.ts
@@ -2,7 +2,7 @@ import { prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
 import { createSafeDate, createSameWeekDates } from "@zoonk/testing/fixtures/dates";
 import { userFixture } from "@zoonk/testing/fixtures/users";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getScoreHistory } from "./get-score-history";
 
 describe("unauthenticated users", () => {
@@ -13,6 +13,10 @@ describe("unauthenticated users", () => {
 });
 
 describe("authenticated users", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns null when user has no DailyProgress records", async () => {
     const user = await userFixture();
     const headers = await signInAs(user.email, user.password);
@@ -101,37 +105,51 @@ describe("authenticated users", () => {
       expect(result?.average).toBe(85);
     });
 
-    it("calculates comparison with previous month", async () => {
+    it("compares with the same full previous month shown by period navigation", async () => {
       const user = await userFixture();
       const headers = await signInAs(user.email, user.password);
 
-      const currentMonth = createSafeDate(0);
-      const lastMonth = createSafeDate(1, 14);
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-03-15T12:00:00.000Z"));
+
+      const currentMonth = new Date("2026-03-15T00:00:00.000Z");
+      const previousMonthFirstDay = new Date("2026-02-15T00:00:00.000Z");
+      const previousMonthSecondDay = new Date("2026-02-16T00:00:00.000Z");
 
       await prisma.dailyProgress.createMany({
         data: [
           {
-            correctAnswers: 9,
+            correctAnswers: 3,
             date: currentMonth,
             dayOfWeek: currentMonth.getDay(),
             incorrectAnswers: 1,
             userId: user.id,
           },
           {
-            correctAnswers: 7,
-            date: lastMonth,
-            dayOfWeek: lastMonth.getDay(),
+            correctAnswers: 1,
+            date: previousMonthFirstDay,
+            dayOfWeek: previousMonthFirstDay.getDay(),
             incorrectAnswers: 3,
+            userId: user.id,
+          },
+          {
+            correctAnswers: 3,
+            date: previousMonthSecondDay,
+            dayOfWeek: previousMonthSecondDay.getDay(),
+            incorrectAnswers: 1,
             userId: user.id,
           },
         ],
       });
 
-      const result = await getScoreHistory({ headers, period: "month" });
+      const [currentResult, previousResult] = await Promise.all([
+        getScoreHistory({ headers, period: "month" }),
+        getScoreHistory({ headers, offset: 1, period: "month" }),
+      ]);
 
-      expect(result).not.toBeNull();
-      expect(result?.average).toBe(90);
-      expect(result?.previousAverage).toBe(70);
+      expect(currentResult?.average).toBe(75);
+      expect(previousResult?.average).toBe(50);
+      expect(currentResult?.previousAverage).toBe(previousResult?.average);
     });
 
     it("navigates to previous month with offset", async () => {

--- a/apps/main/src/data/progress/get-score-history.ts
+++ b/apps/main/src/data/progress/get-score-history.ts
@@ -3,7 +3,7 @@ import { getSession } from "@zoonk/core/users/session/get";
 import { prisma } from "@zoonk/db";
 import { aggregateScoreByPeriod } from "@zoonk/utils/aggregation";
 import { formatLabel } from "@zoonk/utils/chart";
-import { type HistoryPeriod, calculateDateRanges } from "@zoonk/utils/date-ranges";
+import { type HistoryPeriod, calculateFullPeriodDateRanges } from "@zoonk/utils/date-ranges";
 import { safeAsync } from "@zoonk/utils/error";
 import { cache } from "react";
 
@@ -136,7 +136,7 @@ const cachedGetScoreHistory = cache(
     }
 
     const userId = session.user.id;
-    const { current, previous } = calculateDateRanges(period, offset);
+    const { current, previous } = calculateFullPeriodDateRanges({ offset, period });
 
     const [currentResult, previousResult] = await Promise.all([
       fetchDailyData(userId, current.start, current.end),

--- a/packages/utils/src/date-ranges.test.ts
+++ b/packages/utils/src/date-ranges.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   calculateDateRanges,
+  calculateFullPeriodDateRanges,
   formatPeriodLabel,
   getDefaultStartDate,
   validatePeriod,
@@ -159,6 +160,22 @@ describe(calculateDateRanges, () => {
     expect(ranges.current.end).toStrictEqual(eod(2026, 11, 31));
     expect(ranges.previous.start).toStrictEqual(new Date(0));
     expect(ranges.previous.end).toStrictEqual(new Date(0));
+
+    vi.useRealTimers();
+  });
+});
+
+describe(calculateFullPeriodDateRanges, () => {
+  it("returns the full previous month for an active month", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2026, 2, 15)));
+
+    const ranges = calculateFullPeriodDateRanges({ offset: 0, period: "month" });
+
+    expect(ranges.current.start).toStrictEqual(new Date(Date.UTC(2026, 2, 1)));
+    expect(ranges.current.end).toStrictEqual(eod(2026, 2, 31));
+    expect(ranges.previous.start).toStrictEqual(new Date(Date.UTC(2026, 1, 1)));
+    expect(ranges.previous.end).toStrictEqual(eod(2026, 1, 28));
 
     vi.useRealTimers();
   });

--- a/packages/utils/src/date-ranges.ts
+++ b/packages/utils/src/date-ranges.ts
@@ -98,9 +98,11 @@ function getYearDateRanges(now: Date, offset: number): DateRanges {
   };
 }
 
-function getAllDateRanges(): DateRanges {
-  const now = new Date();
-
+/**
+ * Keeps the all-time range anchored to the same request timestamp used by the
+ * other calendar range calculations.
+ */
+function getAllDateRanges(now: Date): DateRanges {
   return {
     current: {
       end: endOfDay(new Date(Date.UTC(now.getUTCFullYear(), DECEMBER_INDEX, LAST_DAY_OF_DECEMBER))),
@@ -136,14 +138,54 @@ function clampPreviousEnd(ranges: DateRanges, now: Date): DateRanges {
   };
 }
 
-export function calculateDateRanges(period: HistoryPeriod, offset: number): DateRanges {
+/**
+ * Uses one timestamp for both full and period-to-date ranges so a request at a
+ * UTC calendar boundary cannot calculate its current and previous ranges from
+ * different months or years.
+ */
+function getFullPeriodDateRanges({
+  now,
+  offset,
+  period,
+}: {
+  now: Date;
+  offset: number;
+  period: HistoryPeriod;
+}): DateRanges {
   if (period === "all") {
-    return getAllDateRanges();
+    return getAllDateRanges(now);
   }
 
+  return getRangesForPeriod(period, now, offset);
+}
+
+/**
+ * Returns complete calendar periods so an average can use the same previous
+ * range that users see when they navigate back in a history chart.
+ */
+export function calculateFullPeriodDateRanges({
+  offset,
+  period,
+}: {
+  offset: number;
+  period: HistoryPeriod;
+}): DateRanges {
+  return getFullPeriodDateRanges({ now: new Date(), offset, period });
+}
+
+/**
+ * Keeps cumulative metric comparisons fair while a calendar period is still
+ * in progress by limiting the previous range to the same elapsed duration.
+ */
+export function calculateDateRanges(period: HistoryPeriod, offset: number): DateRanges {
   const now = new Date();
-  const ranges = getRangesForPeriod(period, now, offset);
-  return offset === 0 ? clampPreviousEnd(ranges, now) : ranges;
+  const ranges = getFullPeriodDateRanges({ now, offset, period });
+
+  if (period === "all" || offset !== 0) {
+    return ranges;
+  }
+
+  return clampPreviousEnd(ranges, now);
 }
 
 export function getDefaultStartDate(startDateIso?: string): Date {


### PR DESCRIPTION
Compare Energy and Score averages against the full previous calendar period while preserving period-to-date comparisons for cumulative metrics. Add regression coverage for the date-range contract and both progress histories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compare Energy and Score averages against the full previous calendar period to match chart navigation. Period-to-date comparisons for cumulative metrics remain unchanged.

- **Bug Fixes**
  - Added `calculateFullPeriodDateRanges` in `@zoonk/utils` date-ranges to return complete calendar periods using a shared timestamp.
  - Updated `calculateDateRanges` to clamp previous only for the active period (offset 0) to keep cumulative metrics fair.
  - Switched energy and score history queries to use full-period ranges for averages.
  - Added regression tests for date-range contract and progress histories with fixed timers to avoid boundary flakiness.

<sup>Written for commit 265082be454eec4e41fed6d97eabb45bcd56fb63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

