### PR TITLE
fix(main): show generation progress immediately

### DIFF
--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -37,6 +37,7 @@ const TEST_RUN_ID = "test-run-id-12345";
 
 type MockApiOptions = {
   assertBearerAuth?: boolean;
+  triggerResponseGate?: Promise<unknown>;
   triggerResponse?: { runId?: string; error?: string; status?: number };
   streamMessages?: { entityId?: string; reason?: string; step: string; status: string }[];
   streamError?: boolean;
@@ -70,6 +71,7 @@ function createRouteHandler(options: MockApiOptions) {
   const {
     assertBearerAuth = false,
     statusDelayMs = 0,
+    triggerResponseGate,
     triggerResponse = { runId: TEST_RUN_ID },
     streamMessages = [],
     streamError = false,
@@ -84,6 +86,8 @@ function createRouteHandler(options: MockApiOptions) {
       if (assertBearerAuth) {
         expectBearerAuthorization(route);
       }
+
+      await triggerResponseGate;
 
       if (triggerResponse.error) {
         await route.fulfill({
@@ -226,6 +230,43 @@ test.describe("Generate Course Page", () => {
   });
 
   test.describe("Initial triggering state", () => {
+    test("shows active generation feedback while the workflow is still starting", async ({
+      authenticatedPage,
+    }) => {
+      const request = await coursePromptFixture({
+        canonicalTitle: "E2E Immediate Generation Feedback",
+        generationStatus: "pending",
+        language: "en",
+      });
+
+      const triggerResponse = Promise.withResolvers<null>();
+
+      await setupMockApis(authenticatedPage, { triggerResponseGate: triggerResponse.promise });
+
+      const triggerRequest = authenticatedPage.waitForRequest(
+        (pageRequest) =>
+          pageRequest.method() === "POST" &&
+          pageRequest.url().includes("/v1/workflows/course-generation/trigger"),
+      );
+
+      try {
+        await authenticatedPage.goto(`/generate/course/${request.id}`);
+        await triggerRequest;
+
+        await expect(
+          authenticatedPage.getByRole("heading", {
+            name: "Creating the E2E Immediate Generation Feedback course",
+          }),
+        ).toBeVisible();
+
+        await expect(
+          authenticatedPage.getByText("Getting started...", { exact: true }),
+        ).toBeVisible();
+      } finally {
+        triggerResponse.resolve(null);
+      }
+    });
+
     test("shows triggering state immediately on page load", async ({ authenticatedPage }) => {
       // Create a unique request to avoid PPR caching issues with seeded data
       const request = await coursePromptFixture({

--- a/apps/main/src/app/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/ch/[id]/generation-client.tsx
@@ -11,7 +11,7 @@ import {
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import { WorkflowGenerationError } from "@/components/generation/workflow-generation-error";
-import { type GenerationStatus } from "@/lib/workflow/generation-store";
+import { type GenerationStatus, isGenerationInProgress } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
@@ -61,7 +61,7 @@ export function GenerationClient({
     generation.startedSteps,
   );
 
-  const isActive = generation.status === "triggering" || generation.status === "streaming";
+  const isActive = isGenerationInProgress(generation.status);
 
   const displayProgress = useAnimatedProgress({
     estimatedDurationMs: activePhaseDurationMs,

--- a/apps/main/src/app/generate/course/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/course/[id]/generation-client.tsx
@@ -11,6 +11,7 @@ import {
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import { WorkflowGenerationError } from "@/components/generation/workflow-generation-error";
+import { isGenerationInProgress } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
@@ -86,7 +87,7 @@ export function GenerationClient({
     isLanguageCourse,
   );
 
-  const isActive = generation.status === "triggering" || generation.status === "streaming";
+  const isActive = isGenerationInProgress(generation.status);
 
   const displayProgress = useAnimatedProgress({
     estimatedDurationMs: activePhaseDurationMs,

--- a/apps/main/src/app/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/generate/l/[id]/generation-client.tsx
@@ -11,7 +11,7 @@ import {
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import { WorkflowGenerationError } from "@/components/generation/workflow-generation-error";
-import { type GenerationStatus } from "@/lib/workflow/generation-store";
+import { type GenerationStatus, isGenerationInProgress } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
@@ -67,7 +67,7 @@ export function GenerationClient({
     generation.startedSteps,
   );
 
-  const isActive = generation.status === "triggering" || generation.status === "streaming";
+  const isActive = isGenerationInProgress(generation.status);
 
   const displayProgress = useAnimatedProgress({
     estimatedDurationMs: activePhaseDurationMs,

--- a/apps/main/src/lib/generation-phases.test.ts
+++ b/apps/main/src/lib/generation-phases.test.ts
@@ -134,8 +134,8 @@ describe(calculateWeightedProgress, () => {
 });
 
 describe(calculateTargetProgress, () => {
-  it("returns 0 when no steps completed and no active phases", () => {
-    expect(calculateTargetProgress([], null, testConfig)).toBe(0);
+  it("targets the first phase before the workflow reports its first step", () => {
+    expect(calculateTargetProgress([], null, testConfig)).toBe(20);
   });
 
   it("returns 100 when all steps completed", () => {
@@ -194,9 +194,14 @@ function makePhase(status: PhaseStatus) {
 }
 
 describe(enforcePhaseProgression, () => {
-  it("does not change when all phases are pending", () => {
+  it("starts the first phase when the workflow has not reported a step yet", () => {
     const input = [makePhase("pending"), makePhase("pending"), makePhase("pending")];
-    expect(enforcePhaseProgression(input)).toStrictEqual(input);
+
+    expect(enforcePhaseProgression(input)).toStrictEqual([
+      makePhase("active"),
+      makePhase("pending"),
+      makePhase("pending"),
+    ]);
   });
 
   it("does not change linear [completed, active, pending]", () => {

--- a/apps/main/src/lib/generation-phases.ts
+++ b/apps/main/src/lib/generation-phases.ts
@@ -47,6 +47,23 @@ function shouldPromote<T extends { status: PhaseStatus }>(phase: T, index: numbe
   return phases[index - 1]?.status === "completed";
 }
 
+/**
+ * Generation pages auto-start their workflows, so an all-pending timeline is
+ * only waiting for the first server event. Starting the first phase
+ * optimistically gives learners immediate feedback while the real stream is
+ * connecting, and the first event naturally replaces this provisional state.
+ */
+function startFirstPhase<T extends { status: PhaseStatus }>(phases: T[]): T[] {
+  const firstPhase = phases[0];
+  const hasReportedProgress = phases.some((phase) => phase.status !== "pending");
+
+  if (!firstPhase || hasReportedProgress) {
+    return phases;
+  }
+
+  return [{ ...firstPhase, status: "active" }, ...phases.slice(1)];
+}
+
 function clampLastPhase<T extends { status: PhaseStatus }>(phases: T[]): T[] {
   const allPredecessorsCompleted = phases.slice(0, -1).every((item) => item.status === "completed");
 
@@ -64,10 +81,12 @@ function clampLastPhase<T extends { status: PhaseStatus }>(phases: T[]): T[] {
 }
 
 export function enforcePhaseProgression<T extends { status: PhaseStatus }>(phases: T[]): T[] {
+  const started = startFirstPhase(phases);
+
   // Promotion doesn't cascade (pending -> active, not completed), so
   // each element only needs the original previous element's status.
-  const promoted = phases.map((phase, index) =>
-    shouldPromote(phase, index, phases) ? { ...phase, status: "active" as const } : phase,
+  const promoted = started.map((phase, index) =>
+    shouldPromote(phase, index, started) ? { ...phase, status: "active" as const } : phase,
   );
 
   return clampLastPhase(promoted);

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -6,6 +6,7 @@ import {
   generationReducer,
   handleStepStreamMessage,
   initialGenerationState,
+  isGenerationInProgress,
 } from "./generation-store";
 
 /**
@@ -15,6 +16,16 @@ import {
 function applyActions(actions: GenerationAction[], initial: GenerationState) {
   return actions.reduce((state, action) => generationReducer(state, action), initial);
 }
+
+describe(isGenerationInProgress, () => {
+  it("keeps auto-triggered generation visible before and during the workflow connection", () => {
+    expect(isGenerationInProgress("idle")).toBe(true);
+    expect(isGenerationInProgress("triggering")).toBe(true);
+    expect(isGenerationInProgress("streaming")).toBe(true);
+    expect(isGenerationInProgress("completed")).toBe(false);
+    expect(isGenerationInProgress("error")).toBe(false);
+  });
+});
 
 describe(generationReducer, () => {
   describe("stepCompleted", () => {

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -4,6 +4,16 @@ export type GenerationStatus = "idle" | "triggering" | "streaming" | "completed"
 
 export type GenerationErrorKind = "connection" | "generation";
 
+/**
+ * The generation page's internal idle state means its automatic trigger is
+ * waiting for the client to mount, not that the learner needs to take action.
+ * Keeping that state visible prevents a blank page before the trigger and
+ * status stream connections begin.
+ */
+export function isGenerationInProgress(status: GenerationStatus): boolean {
+  return status === "idle" || status === "triggering" || status === "streaming";
+}
+
 export type GenerationState<TStep extends string = string> = {
   completedSteps: TStep[];
   currentStep: TStep | null;


### PR DESCRIPTION
## Summary

- show generation progress as soon as the page renders
- activate the first phase while the workflow connection is starting
- cover the startup state with unit and end-to-end tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show generation progress immediately on page load so learners see feedback while the workflow connection starts. The first phase activates optimistically until the first server event arrives.

- **Bug Fixes**
  - Auto-activate the first phase when all phases are pending; target progress starts at the first phase.
  - Add `isGenerationInProgress` to treat `idle`, `triggering`, and `streaming` as active; update generation clients to use it.
  - Improve phase progression to start the first phase before reported steps, preserving linear progression.
  - Add unit and E2E tests for startup behavior, including a gated trigger to simulate delayed workflow connection.

<sup>Written for commit 98cb9ec23a4ee118c704094694aa831ba2de3486. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

