### PR TITLE
feat(player): improve shortcut discovery

### DIFF
--- a/apps/main/e2e/player-shortcut-hints.test.ts
+++ b/apps/main/e2e/player-shortcut-hints.test.ts
@@ -1,0 +1,377 @@
+import { randomUUID } from "node:crypto";
+import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
+import { chapterWordFixture, wordFixture } from "@zoonk/testing/fixtures/words";
+import { type Page, expect, test } from "./fixtures";
+
+const FIRST_LOCAL_DAY = new Date("2030-06-15T12:00:00.000Z");
+const NEXT_LOCAL_DAY = new Date("2030-06-16T12:00:00.000Z");
+
+const SILENT_AUDIO_URL =
+  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=";
+
+type ShortcutHintLessons = Awaited<ReturnType<typeof createShortcutHintLessons>>;
+
+/**
+ * Creates one route for each player interaction family so the browser can prove
+ * that navigation, audio, choice, and submit hints remain independent while
+ * sharing the same daily browser history.
+ */
+async function createShortcutHintLessons() {
+  const organization = await getAiOrganization();
+  const uniqueId = randomUUID().slice(0, 8);
+
+  const course = await courseFixture({
+    isPublished: true,
+    organizationId: organization.id,
+    slug: `e2e-shortcut-hints-course-${uniqueId}`,
+    targetLanguage: "es",
+    title: `E2E Shortcut Hints Course ${uniqueId}`,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: organization.id,
+    position: 0,
+    slug: `e2e-shortcut-hints-chapter-${uniqueId}`,
+    title: `E2E Shortcut Hints Chapter ${uniqueId}`,
+  });
+
+  const firstNavigationTitle = `First shortcut step ${uniqueId}`;
+  const secondNavigationTitle = `Second shortcut step ${uniqueId}`;
+  const audioWordText = `Audio-${uniqueId}`;
+  const choiceOptionText = `Choice-${uniqueId}`;
+  const question = `Which option is correct ${uniqueId}?`;
+
+  const [navigationLesson, audioLesson, choiceLesson, audioWord] = await Promise.all([
+    lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "explanation",
+      organizationId: organization.id,
+      position: 0,
+      slug: `e2e-shortcut-hints-navigation-${uniqueId}`,
+      title: `E2E Shortcut Navigation ${uniqueId}`,
+    }),
+    lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "vocabulary",
+      organizationId: organization.id,
+      position: 1,
+      slug: `e2e-shortcut-hints-audio-${uniqueId}`,
+      title: `E2E Shortcut Audio ${uniqueId}`,
+    }),
+    lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "completed",
+      isPublished: true,
+      kind: "quiz",
+      organizationId: organization.id,
+      position: 2,
+      slug: `e2e-shortcut-hints-choice-${uniqueId}`,
+      title: `E2E Shortcut Choice ${uniqueId}`,
+    }),
+    wordFixture({
+      audioUrl: SILENT_AUDIO_URL,
+      organizationId: organization.id,
+      targetLanguage: "es",
+      word: audioWordText,
+    }),
+  ]);
+
+  const chapterWord = await chapterWordFixture({
+    sourceLessonId: audioLesson.id,
+    translation: `Audio translation ${uniqueId}`,
+    wordId: audioWord.id,
+  });
+
+  await Promise.all([
+    stepFixture({
+      content: {
+        text: `First shortcut body ${uniqueId}`,
+        title: firstNavigationTitle,
+        variant: "text",
+      },
+      isPublished: true,
+      lessonId: navigationLesson.id,
+      position: 0,
+    }),
+    stepFixture({
+      content: {
+        text: `Second shortcut body ${uniqueId}`,
+        title: secondNavigationTitle,
+        variant: "text",
+      },
+      isPublished: true,
+      lessonId: navigationLesson.id,
+      position: 1,
+    }),
+    stepFixture({
+      chapterWordId: chapterWord.id,
+      content: {},
+      isPublished: true,
+      kind: "vocabulary",
+      lessonId: audioLesson.id,
+      wordId: audioWord.id,
+    }),
+    stepFixture({
+      content: {
+        options: [
+          {
+            feedback: "Correct",
+            id: `correct-${uniqueId}`,
+            isCorrect: true,
+            text: choiceOptionText,
+          },
+          {
+            feedback: "Try again",
+            id: `incorrect-${uniqueId}`,
+            isCorrect: false,
+            text: `Other-${uniqueId}`,
+          },
+        ],
+        question,
+      },
+      isPublished: true,
+      kind: "multipleChoice",
+      lessonId: choiceLesson.id,
+    }),
+  ]);
+
+  const lessonPath = `/b/${organization.slug}/c/${course.slug}/ch/${chapter.slug}/l`;
+
+  return {
+    audio: { url: `${lessonPath}/${audioLesson.slug}`, word: audioWordText },
+    choice: { option: choiceOptionText, question, url: `${lessonPath}/${choiceLesson.slug}` },
+    navigation: {
+      firstTitle: firstNavigationTitle,
+      secondTitle: secondNavigationTitle,
+      url: `${lessonPath}/${navigationLesson.slug}`,
+    },
+  };
+}
+
+/**
+ * Sonner renders each notification as a semantic list item, while the visible
+ * key remains a separate text fragment so learners can scan the shortcut.
+ */
+function getShortcutHint({ page, shortcut }: { page: Page; shortcut: string }) {
+  return page.getByRole("listitem").filter({ has: page.getByText(shortcut, { exact: true }) });
+}
+
+/**
+ * Waiting for the player-specific heading confirms the server-rendered lesson
+ * is visible. Keyboard assertions retry their action separately because the
+ * client listeners can hydrate after this content appears.
+ */
+async function openNavigationLesson({
+  lessons,
+  page,
+}: {
+  lessons: ShortcutHintLessons;
+  page: Page;
+}) {
+  await page.goto(lessons.navigation.url);
+  await expect(page.getByRole("heading", { name: lessons.navigation.firstTitle })).toBeVisible();
+}
+
+/**
+ * Multiple-choice options are shuffled on the server, so the test reads the
+ * option's accessible shortcut instead of assuming a fixed rendered position.
+ */
+async function getChoiceShortcut({ lessons, page }: { lessons: ShortcutHintLessons; page: Page }) {
+  const option = page.getByRole("radio", { name: lessons.choice.option });
+  const shortcut = await option.getAttribute("aria-keyshortcuts");
+
+  if (!shortcut) {
+    throw new Error("Expected the multiple-choice option to expose its numeric shortcut");
+  }
+
+  expect(shortcut).toMatch(/^[1-9]$/u);
+
+  return { option, shortcut };
+}
+
+test.describe("Player shortcut hints", () => {
+  test("mouse interactions show five independent hints without duplicate arrow badges", async ({
+    userWithoutProgress,
+  }) => {
+    const lessons = await createShortcutHintLessons();
+
+    await openNavigationLesson({ lessons, page: userWithoutProgress });
+
+    const navigationControls = userWithoutProgress.getByRole("toolbar", {
+      name: /lesson controls/iu,
+    });
+
+    const nextButton = navigationControls.getByRole("button", { name: "Next step" });
+
+    await expect(nextButton).toHaveAttribute("aria-keyshortcuts", "ArrowRight");
+    await expect(nextButton.getByText("→", { exact: true })).not.toBeVisible();
+
+    await nextButton.click();
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "→" })).toBeVisible();
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { name: lessons.navigation.secondTitle }),
+    ).toBeVisible();
+
+    const previousButton = navigationControls.getByRole("button", { name: "Previous step" });
+
+    await expect(previousButton).toHaveAttribute("aria-keyshortcuts", "ArrowLeft");
+    await expect(previousButton.getByText("←", { exact: true })).not.toBeVisible();
+
+    await previousButton.click();
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "←" })).toBeVisible();
+
+    await userWithoutProgress.goto(lessons.audio.url);
+
+    const playButton = userWithoutProgress
+      .getByRole("toolbar", { name: /lesson controls/iu })
+      .getByRole("button", { name: /play pronunciation/iu });
+
+    await expect(playButton).toBeVisible();
+    await playButton.click();
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "P" })).toBeVisible();
+
+    await userWithoutProgress.goto(lessons.choice.url);
+
+    await expect(
+      userWithoutProgress.getByText(lessons.choice.question, { exact: true }),
+    ).toBeVisible();
+
+    const { option, shortcut } = await getChoiceShortcut({ lessons, page: userWithoutProgress });
+
+    await option.click();
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut })).toBeVisible();
+
+    const checkButton = userWithoutProgress.getByRole("button", { name: /check/iu });
+
+    await expect(checkButton).toBeEnabled();
+    await checkButton.click();
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "Enter" })).toBeVisible();
+  });
+
+  test("a shortcut hint appears once per local day and returns the next local day", async ({
+    userWithoutProgress,
+  }) => {
+    const lessons = await createShortcutHintLessons();
+
+    await userWithoutProgress.clock.setFixedTime(FIRST_LOCAL_DAY);
+    await openNavigationLesson({ lessons, page: userWithoutProgress });
+
+    await userWithoutProgress.getByRole("button", { name: "Next step" }).click();
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "→" })).toBeVisible();
+
+    await userWithoutProgress.reload();
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { name: lessons.navigation.firstTitle }),
+    ).toBeVisible();
+
+    await userWithoutProgress.getByRole("button", { name: "Next step" }).click();
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { name: lessons.navigation.secondTitle }),
+    ).toBeVisible();
+
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "→" })).toHaveCount(0);
+
+    await userWithoutProgress.clock.setFixedTime(NEXT_LOCAL_DAY);
+    await userWithoutProgress.reload();
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { name: lessons.navigation.firstTitle }),
+    ).toBeVisible();
+
+    await userWithoutProgress.getByRole("button", { name: "Next step" }).click();
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "→" })).toBeVisible();
+  });
+
+  test("using player keyboard shortcuts does not show mouse guidance", async ({
+    userWithoutProgress,
+  }) => {
+    const lessons = await createShortcutHintLessons();
+
+    await openNavigationLesson({ lessons, page: userWithoutProgress });
+
+    await expect(async () => {
+      await userWithoutProgress.keyboard.press("ArrowRight");
+
+      await expect(
+        userWithoutProgress.getByRole("heading", { name: lessons.navigation.secondTitle }),
+      ).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 5000 });
+
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "→" })).toHaveCount(0);
+
+    await userWithoutProgress.keyboard.press("ArrowLeft");
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { name: lessons.navigation.firstTitle }),
+    ).toBeVisible();
+
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "←" })).toHaveCount(0);
+
+    await userWithoutProgress.goto(lessons.audio.url);
+
+    await expect(
+      userWithoutProgress.getByRole("button", { name: /play pronunciation/iu }),
+    ).toBeVisible();
+
+    await userWithoutProgress.keyboard.press("p");
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "P" })).toHaveCount(0);
+
+    await userWithoutProgress.goto(lessons.choice.url);
+
+    await expect(
+      userWithoutProgress.getByText(lessons.choice.question, { exact: true }),
+    ).toBeVisible();
+
+    const { option, shortcut } = await getChoiceShortcut({ lessons, page: userWithoutProgress });
+
+    await expect(async () => {
+      await option.press(shortcut);
+      await expect(option).toHaveAttribute("aria-checked", "true", { timeout: 500 });
+    }).toPass({ timeout: 5000 });
+
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut })).toHaveCount(0);
+
+    await userWithoutProgress.keyboard.press("Enter");
+
+    await expect(userWithoutProgress.getByText(/your answer:/iu)).toBeVisible();
+
+    await expect(getShortcutHint({ page: userWithoutProgress, shortcut: "Enter" })).toHaveCount(0);
+  });
+
+  test.describe("touch input", () => {
+    test.use({ hasTouch: true, viewport: { height: 667, width: 375 } });
+
+    test("touch navigation does not show keyboard guidance", async ({ page }) => {
+      const lessons = await createShortcutHintLessons();
+
+      await page.goto(lessons.navigation.url);
+      await expect(page.getByRole("heading", { name: "Progress won't be saved" })).toBeVisible();
+      await page.getByRole("button", { name: "Continue without saving" }).tap();
+
+      await expect(
+        page.getByRole("heading", { name: lessons.navigation.firstTitle }),
+      ).toBeVisible();
+
+      await page.getByRole("button", { name: "Next" }).tap();
+
+      await expect(
+        page.getByRole("heading", { name: lessons.navigation.secondTitle }),
+      ).toBeVisible();
+
+      await expect(getShortcutHint({ page, shortcut: "→" })).toHaveCount(0);
+    });
+  });
+});

--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -52,6 +52,11 @@ msgctxt "e7WNdK"
 msgid "Word bank"
 msgstr "Wortschatz"
 
+#: src/components/choice-step-layout.tsx
+msgctxt "qjehBi"
+msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Drücke <kbd>{shortcut}</kbd>, um diese Antwort auszuwählen."
+
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
 msgid "Exit"
@@ -333,6 +338,11 @@ msgctxt "lYWSeP"
 msgid "Play pronunciation"
 msgstr "Aussprache abspielen"
 
+#: src/components/play-audio-button.tsx
+msgctxt "XHsJo3"
+msgid "Press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Drücke <kbd>{shortcut}</kbd>, um das Audio abzuspielen."
+
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
 msgid "Answer options"
@@ -388,6 +398,23 @@ msgstr "Ziehe die Elemente in die richtige Reihenfolge"
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Prüfen"
+
+#: src/components/step-action-button.tsx
+msgctxt "2VjMZp"
+msgid "Press <kbd>Enter</kbd> to check your answer."
+msgstr "Drücke <kbd>Enter</kbd>, um deine Antwort zu prüfen."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "XHEfA9"
+msgid "Press <kbd>←</kbd> to go back."
+msgstr "Drücke <kbd>←</kbd>, um zurückzugehen."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "nvVP6A"
+msgid "Press <kbd>→</kbd> to continue."
+msgstr "Drücke <kbd>→</kbd>, um fortzufahren."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -52,6 +52,11 @@ msgctxt "e7WNdK"
 msgid "Word bank"
 msgstr "Word bank"
 
+#: src/components/choice-step-layout.tsx
+msgctxt "qjehBi"
+msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Press <kbd>{shortcut}</kbd> to choose this answer."
+
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
 msgid "Exit"
@@ -333,6 +338,11 @@ msgctxt "lYWSeP"
 msgid "Play pronunciation"
 msgstr "Play pronunciation"
 
+#: src/components/play-audio-button.tsx
+msgctxt "XHsJo3"
+msgid "Press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Press <kbd>{shortcut}</kbd> to play audio."
+
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
 msgid "Answer options"
@@ -388,6 +398,23 @@ msgstr "Drag items into the correct order"
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Check"
+
+#: src/components/step-action-button.tsx
+msgctxt "2VjMZp"
+msgid "Press <kbd>Enter</kbd> to check your answer."
+msgstr "Press <kbd>Enter</kbd> to check your answer."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "XHEfA9"
+msgid "Press <kbd>←</kbd> to go back."
+msgstr "Press <kbd>←</kbd> to go back."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "nvVP6A"
+msgid "Press <kbd>→</kbd> to continue."
+msgstr "Press <kbd>→</kbd> to continue."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -52,6 +52,11 @@ msgctxt "e7WNdK"
 msgid "Word bank"
 msgstr "Banco de palabras"
 
+#: src/components/choice-step-layout.tsx
+msgctxt "qjehBi"
+msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Presiona <kbd>{shortcut}</kbd> para elegir esta respuesta."
+
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
 msgid "Exit"
@@ -333,6 +338,11 @@ msgctxt "lYWSeP"
 msgid "Play pronunciation"
 msgstr "Reproducir pronunciación"
 
+#: src/components/play-audio-button.tsx
+msgctxt "XHsJo3"
+msgid "Press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Presiona <kbd>{shortcut}</kbd> para reproducir el audio."
+
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
 msgid "Answer options"
@@ -388,6 +398,23 @@ msgstr "Arrastra los elementos al orden correcto"
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Revisar"
+
+#: src/components/step-action-button.tsx
+msgctxt "2VjMZp"
+msgid "Press <kbd>Enter</kbd> to check your answer."
+msgstr "Presiona <kbd>Enter</kbd> para comprobar tu respuesta."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "XHEfA9"
+msgid "Press <kbd>←</kbd> to go back."
+msgstr "Presiona <kbd>←</kbd> para volver."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "nvVP6A"
+msgid "Press <kbd>→</kbd> to continue."
+msgstr "Presiona <kbd>→</kbd> para continuar."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -52,6 +52,11 @@ msgctxt "e7WNdK"
 msgid "Word bank"
 msgstr "Banque de mots"
 
+#: src/components/choice-step-layout.tsx
+msgctxt "qjehBi"
+msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Appuie sur <kbd>{shortcut}</kbd> pour choisir cette réponse."
+
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
 msgid "Exit"
@@ -333,6 +338,11 @@ msgctxt "lYWSeP"
 msgid "Play pronunciation"
 msgstr "Écouter la prononciation"
 
+#: src/components/play-audio-button.tsx
+msgctxt "XHsJo3"
+msgid "Press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Appuie sur <kbd>{shortcut}</kbd> pour écouter l’audio."
+
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
 msgid "Answer options"
@@ -388,6 +398,23 @@ msgstr "Fais glisser les éléments dans le bon ordre"
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Vérifier"
+
+#: src/components/step-action-button.tsx
+msgctxt "2VjMZp"
+msgid "Press <kbd>Enter</kbd> to check your answer."
+msgstr "Appuie sur <kbd>Entrée</kbd> pour vérifier ta réponse."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "XHEfA9"
+msgid "Press <kbd>←</kbd> to go back."
+msgstr "Appuie sur <kbd>←</kbd> pour revenir en arrière."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "nvVP6A"
+msgid "Press <kbd>→</kbd> to continue."
+msgstr "Appuie sur <kbd>→</kbd> pour continuer."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -52,6 +52,11 @@ msgctxt "e7WNdK"
 msgid "Word bank"
 msgstr "Banco de palavras"
 
+#: src/components/choice-step-layout.tsx
+msgctxt "qjehBi"
+msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Pressione <kbd>{shortcut}</kbd> para escolher esta resposta."
+
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
 msgid "Exit"
@@ -333,6 +338,11 @@ msgctxt "lYWSeP"
 msgid "Play pronunciation"
 msgstr "Ouvir pronúncia"
 
+#: src/components/play-audio-button.tsx
+msgctxt "XHsJo3"
+msgid "Press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Pressione <kbd>{shortcut}</kbd> para ouvir o áudio."
+
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
 msgid "Answer options"
@@ -388,6 +398,23 @@ msgstr "Arraste os itens para a ordem correta"
 msgctxt "RDZVQL"
 msgid "Check"
 msgstr "Conferir"
+
+#: src/components/step-action-button.tsx
+msgctxt "2VjMZp"
+msgid "Press <kbd>Enter</kbd> to check your answer."
+msgstr "Pressione <kbd>Enter</kbd> para conferir sua resposta."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "XHEfA9"
+msgid "Press <kbd>←</kbd> to go back."
+msgstr "Pressione <kbd>←</kbd> para voltar."
+
+#: src/components/step-navigation-button-group.tsx
+#: src/components/swipe-navigable-step-layout.tsx
+msgctxt "nvVP6A"
+msgid "Press <kbd>→</kbd> to continue."
+msgstr "Pressione <kbd>→</kbd> para continuar."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/src/_test-utils/shims/next-intl.ts
+++ b/packages/player/src/_test-utils/shims/next-intl.ts
@@ -1,3 +1,8 @@
+import { Fragment, type ReactNode, createElement } from "react";
+
+type MessageValue = number | string;
+type RichMessageValue = MessageValue | ((children: ReactNode) => ReactNode);
+
 /**
  * Shared player browser tests assert the package's visible behavior, not
  * next-intl's runtime. Formatting the ICU subset used by player messages keeps
@@ -63,9 +68,74 @@ function formatExtractedMessage({
   );
 }
 
+/**
+ * Rich messages combine normal ICU values with tag-rendering functions. The
+ * browser-test shim separates those two roles so its existing ICU formatter
+ * never stringifies a React function into the learner-facing message.
+ */
+function getPrimitiveMessageValues(values: Record<string, RichMessageValue>) {
+  return Object.fromEntries(
+    Object.entries(values).filter(
+      (entry): entry is [string, MessageValue] => typeof entry[1] !== "function",
+    ),
+  );
+}
+
+/**
+ * A rich message part is either plain translated text or one tagged fragment.
+ * Keeping this parser in the shared next-intl shim lets browser tests exercise
+ * the same visible Kbd composition without requiring an app locale provider.
+ */
+function renderRichMessagePart({
+  index,
+  part,
+  values,
+}: {
+  index: number;
+  part: string;
+  values: Record<string, RichMessageValue>;
+}) {
+  const match = /^<(?<tag>\w+)>(?<children>[^<]*)<\/\k<tag>>$/u.exec(part);
+  const children = match?.groups?.children ?? "";
+  const tag = match?.groups?.tag;
+  const renderTag = tag ? values[tag] : null;
+
+  if (typeof renderTag !== "function") {
+    return part;
+  }
+
+  return createElement(Fragment, { key: index }, renderTag(children));
+}
+
+/**
+ * Supports the inline rich tags used by player copy while preserving the
+ * lightweight identity-style translation behavior expected by browser tests.
+ */
+function formatRichExtractedMessage({
+  value,
+  values,
+}: {
+  value: string;
+  values: Record<string, RichMessageValue>;
+}) {
+  const formattedValue = formatExtractedMessage({
+    value,
+    values: getPrimitiveMessageValues(values),
+  });
+
+  return formattedValue
+    .split(/(?<taggedPart><\w+>[^<]*<\/\w+>)/gu)
+    .map((part, index) => renderRichMessagePart({ index, part, values }));
+}
+
 export function useExtracted() {
-  return (value: string, values?: Record<string, number | string>) =>
+  const translate = (value: string, values?: Record<string, MessageValue>) =>
     formatExtractedMessage({ value, values });
+
+  translate.rich = (value: string, values: Record<string, RichMessageValue>) =>
+    formatRichExtractedMessage({ value, values });
+
+  return translate;
 }
 
 export function useLocale() {

--- a/packages/player/src/components/choice-step-layout.tsx
+++ b/packages/player/src/components/choice-step-layout.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { type StepImage } from "@zoonk/core/steps/contract/image";
+import { useExtracted } from "next-intl";
+import { type PointerEvent } from "react";
+import { renderPlayerShortcutHintKey, showPlayerShortcutHint } from "../player-shortcut-hint";
+import { getNumberKeyShortcut } from "../player-shortcuts";
 import {
   PlayerChoiceScene,
   PlayerChoiceSceneContext,
@@ -30,6 +34,7 @@ function ChoiceStepLayoutContent({
   question?: string | null;
   selectedKey: string | null;
 }) {
+  const t = useExtracted();
   const hasSelection = selectedKey !== null;
 
   const handleSelect = (index: number) => {
@@ -42,6 +47,35 @@ function ChoiceStepLayoutContent({
     onSelect(option.key);
   };
 
+  /**
+   * Multiple-choice cards visibly number their options, so the clicked card can
+   * teach the exact number key that would select the same answer next time.
+   * Translation choices use a different composition and intentionally do not
+   * opt into this callback.
+   */
+  function handleOptionPointerUp({
+    event,
+    index,
+  }: {
+    event: PointerEvent<HTMLButtonElement>;
+    index: number;
+  }) {
+    const shortcut = getNumberKeyShortcut(index);
+
+    if (!shortcut) {
+      return;
+    }
+
+    showPlayerShortcutHint({
+      event,
+      hint: "multipleChoiceNumber",
+      message: t.rich("Press <kbd>{shortcut}</kbd> to choose this answer.", {
+        kbd: renderPlayerShortcutHintKey,
+        shortcut,
+      }),
+    });
+  }
+
   return (
     <>
       {(context || question) && (
@@ -52,6 +86,7 @@ function ChoiceStepLayoutContent({
       )}
 
       <PlayerChoiceSceneOptions
+        onOptionPointerUp={handleOptionPointerUp}
         onSelect={handleSelect}
         options={options.map((option) => ({
           content: <PlayerChoiceSceneOptionText>{option.text}</PlayerChoiceSceneOptionText>,

--- a/packages/player/src/components/option-card.tsx
+++ b/packages/player/src/components/option-card.tsx
@@ -1,4 +1,6 @@
 import { cn } from "@zoonk/ui/lib/utils";
+import { type PointerEvent } from "react";
+import { getNumberKeyShortcut } from "../player-shortcuts";
 import { ResultKbd } from "./result-kbd";
 
 export function OptionCard({
@@ -7,6 +9,7 @@ export function OptionCard({
   index,
   isDimmed,
   isSelected,
+  onPointerUp,
   onSelect,
   resultState,
 }: {
@@ -15,13 +18,14 @@ export function OptionCard({
   index: number;
   isDimmed?: boolean;
   isSelected: boolean;
+  onPointerUp?: (event: PointerEvent<HTMLButtonElement>) => void;
   onSelect: () => void;
   resultState: "correct" | "incorrect" | null;
 }) {
   return (
     <button
       aria-checked={isSelected}
-      aria-keyshortcuts={String(index + 1)}
+      aria-keyshortcuts={getNumberKeyShortcut(index) ?? undefined}
       className={cn(
         "focus-visible:border-ring focus-visible:ring-ring/50 flex w-full items-center gap-3 rounded-xl border px-4 py-3.5 text-left transition-all duration-150 outline-none focus-visible:ring-[3px]",
         !disabled && !isSelected && "border-border hover:bg-accent",
@@ -34,6 +38,7 @@ export function OptionCard({
       )}
       disabled={disabled}
       onClick={onSelect}
+      onPointerUp={onPointerUp}
       role="radio"
       type="button"
     >

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -5,8 +5,9 @@ import { ShortcutKbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { PauseIcon, Volume2Icon } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { useState } from "react";
+import { type PointerEvent, useState } from "react";
 import { useSharedPlayerAudio } from "../player-audio-context";
+import { renderPlayerShortcutHintKey, showPlayerShortcutHint } from "../player-shortcut-hint";
 import { PLAYER_AUDIO_KEYBOARD_SHORTCUT } from "../player-shortcuts";
 import { useWordAudio } from "../use-word-audio";
 
@@ -77,6 +78,24 @@ export function PlayAudioButton({
   const Icon = isPlaying ? PauseIcon : Volume2Icon;
   const label = isPlaying ? t("Pause pronunciation") : t("Play pronunciation");
 
+  /**
+   * Only active prompt audio has a player keyboard shortcut. Standalone word
+   * audio keeps its normal click behavior without advertising a key that does
+   * not control it.
+   */
+  function handleAudioPointerUp(event: PointerEvent<HTMLButtonElement>) {
+    if (keyboardShortcut) {
+      showPlayerShortcutHint({
+        event,
+        hint: "promptAudio",
+        message: t.rich("Press <kbd>{shortcut}</kbd> to play audio.", {
+          kbd: renderPlayerShortcutHintKey,
+          shortcut: keyboardShortcut.toUpperCase(),
+        }),
+      });
+    }
+  }
+
   if (variant === "text") {
     return (
       <button
@@ -86,6 +105,7 @@ export function PlayAudioButton({
           className,
         )}
         onClick={handleClick}
+        onPointerUp={handleAudioPointerUp}
         type="button"
       >
         <Icon aria-hidden className="size-4" />
@@ -101,6 +121,7 @@ export function PlayAudioButton({
         aria-keyshortcuts={keyboardShortcut}
         className={cn("relative", className)}
         onClick={handleClick}
+        onPointerUp={handleAudioPointerUp}
         size={size === "md" ? "icon-lg" : "icon"}
         type="button"
         variant="outline"
@@ -125,6 +146,7 @@ export function PlayAudioButton({
         className,
       )}
       onClick={handleClick}
+      onPointerUp={handleAudioPointerUp}
       type="button"
     >
       <Icon className={size === "md" ? "size-6" : "size-5"} />

--- a/packages/player/src/components/player-choice-scene.tsx
+++ b/packages/player/src/components/player-choice-scene.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useExtracted } from "next-intl";
+import { type PointerEvent } from "react";
 import { useOptionKeyboard } from "../use-option-keyboard";
 import { OptionCard } from "./option-card";
 import { PlayerRichText } from "./player-rich-text";
@@ -105,17 +106,35 @@ export function PlayerChoiceSceneOptionText({ children }: { children: React.Reac
 export function PlayerChoiceSceneOptions({
   ariaLabel,
   keyboardEnabled = true,
+  onOptionPointerUp,
   onSelect,
   options,
 }: {
   ariaLabel?: string;
   keyboardEnabled?: boolean;
+  onOptionPointerUp?: (input: { event: PointerEvent<HTMLButtonElement>; index: number }) => void;
   onSelect: (index: number) => void;
   options: readonly PlayerChoiceSceneOption[];
 }) {
   const t = useExtracted();
 
   useOptionKeyboard({ enabled: keyboardEnabled, onSelect, optionCount: options.length });
+
+  /**
+   * Pointer-up identifies the physical input before the native click selects
+   * the option, while number keys keep calling the same selection action
+   * directly through useOptionKeyboard. This preserves one selection path
+   * without confusing its input source.
+   */
+  function handleOptionPointerUp({
+    event,
+    index,
+  }: {
+    event: PointerEvent<HTMLButtonElement>;
+    index: number;
+  }) {
+    onOptionPointerUp?.({ event, index });
+  }
 
   return (
     <div
@@ -131,6 +150,7 @@ export function PlayerChoiceSceneOptions({
           isDimmed={option.isDimmed}
           isSelected={option.isSelected}
           key={option.key}
+          onPointerUp={(event) => handleOptionPointerUp({ event, index })}
           onSelect={() => onSelect(index)}
           resultState={option.resultState ?? null}
         >

--- a/packages/player/src/components/step-action-button.tsx
+++ b/packages/player/src/components/step-action-button.tsx
@@ -4,7 +4,9 @@ import { Button } from "@zoonk/ui/components/button";
 import { ShortcutKbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
+import { type PointerEvent } from "react";
 import { usePlayerRuntime } from "../player-context";
+import { renderPlayerShortcutHintKey, showPlayerShortcutHint } from "../player-shortcut-hint";
 
 /**
  * Single source of truth for the step action button
@@ -22,7 +24,7 @@ import { usePlayerRuntime } from "../player-context";
 export function StepActionButton({
   className,
   ...props
-}: Omit<React.ComponentProps<typeof Button>, "children" | "onClick" | "size">) {
+}: Omit<React.ComponentProps<typeof Button>, "children" | "onClick" | "onPointerUp" | "size">) {
   const t = useExtracted();
   const { actions, screen } = usePlayerRuntime();
   const model = screen.bottomBar;
@@ -31,22 +33,41 @@ export function StepActionButton({
     return null;
   }
 
+  const { button, disabled, run } = model;
   const actionByRun = { check: actions.check, continue: actions.continue } as const;
 
   const labelByButton = { check: t("Check"), continue: t("Continue") } as const;
+
+  /**
+   * Enter submits a pending selection, but Continue is a separate progression
+   * action. Limiting the tip to Check keeps this coachmark aligned with the
+   * exact shortcut discovery moment the learner just missed.
+   */
+  function handleActionPointerUp(event: PointerEvent<HTMLButtonElement>) {
+    if (run === "check") {
+      showPlayerShortcutHint({
+        event,
+        hint: "checkAnswer",
+        message: t.rich("Press <kbd>Enter</kbd> to check your answer.", {
+          kbd: renderPlayerShortcutHintKey,
+        }),
+      });
+    }
+  }
 
   const buttonProps = {
     ...props,
     "aria-keyshortcuts": "Enter",
     className: cn("w-full", className),
-    disabled: model.disabled,
-    onClick: actionByRun[model.run],
+    disabled,
+    onClick: actionByRun[run],
+    onPointerUp: handleActionPointerUp,
     size: "lg" as const,
   };
 
   return (
     <Button {...buttonProps}>
-      {labelByButton[model.button]}
+      {labelByButton[button]}
       <ShortcutKbd tone="inverse">Enter</ShortcutKbd>
     </Button>
   );

--- a/packages/player/src/components/step-navigation-button-group.tsx
+++ b/packages/player/src/components/step-navigation-button-group.tsx
@@ -4,6 +4,8 @@ import { Button } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
+import { type PointerEvent } from "react";
+import { renderPlayerShortcutHintKey, showPlayerShortcutHint } from "../player-shortcut-hint";
 
 /**
  * Read-only steps need explicit touch targets because swipe gestures are
@@ -25,6 +27,30 @@ export function StepNavigationButtonGroup({
 }) {
   const t = useExtracted();
 
+  /**
+   * Narrow layouts can still be controlled with a mouse, so teach the back
+   * shortcut from the actual pointer instead of assuming this button is touch-only.
+   */
+  function handleNavigatePreviousPointerUp(event: PointerEvent<HTMLButtonElement>) {
+    showPlayerShortcutHint({
+      event,
+      hint: "navigatePrevious",
+      message: t.rich("Press <kbd>←</kbd> to go back.", { kbd: renderPlayerShortcutHintKey }),
+    });
+  }
+
+  /**
+   * Narrow desktop windows need the same contextual discovery as the floating
+   * desktop arrow while touch taps remain excluded by the shared pointer check.
+   */
+  function handleNavigateNextPointerUp(event: PointerEvent<HTMLButtonElement>) {
+    showPlayerShortcutHint({
+      event,
+      hint: "navigateNext",
+      message: t.rich("Press <kbd>→</kbd> to continue.", { kbd: renderPlayerShortcutHintKey }),
+    });
+  }
+
   return (
     <div className="flex w-full gap-2" data-slot="step-navigation-button-group">
       {canNavigatePrev && (
@@ -32,6 +58,7 @@ export function StepNavigationButtonGroup({
           aria-label={t("Previous")}
           aria-keyshortcuts="ArrowLeft"
           onClick={onNavigatePrev}
+          onPointerUp={handleNavigatePreviousPointerUp}
           size="icon-lg"
           type="button"
           variant="outline"
@@ -44,6 +71,7 @@ export function StepNavigationButtonGroup({
         aria-keyshortcuts="ArrowRight"
         className={cn("min-w-0 flex-1", !canNavigatePrev && !audioAction && "w-full")}
         onClick={onNavigateNext}
+        onPointerUp={handleNavigateNextPointerUp}
         size="lg"
         type="button"
       >

--- a/packages/player/src/components/swipe-navigable-step-layout.tsx
+++ b/packages/player/src/components/swipe-navigable-step-layout.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { Button } from "@zoonk/ui/components/button";
-import { ShortcutKbd } from "@zoonk/ui/components/kbd";
-import { cn } from "@zoonk/ui/lib/utils";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
-import { type TouchEvent, useEffect, useRef } from "react";
+import { type PointerEvent, type TouchEvent, useEffect, useRef } from "react";
+import { renderPlayerShortcutHintKey, showPlayerShortcutHint } from "../player-shortcut-hint";
 import { PlayAudioButton } from "./play-audio-button";
 import { NavigableStepLayout } from "./step-layouts";
 
@@ -43,25 +42,37 @@ function DesktopNavigationButton({
   "aria-label": ariaLabel,
   "aria-keyshortcuts": ariaKeyshortcuts,
   children,
+  hint,
+  hintMessage,
   onClick,
 }: {
   "aria-label": string;
   "aria-keyshortcuts": string;
   children: React.ReactNode;
+  hint: "navigateNext" | "navigatePrevious";
+  hintMessage: React.ReactNode;
   onClick: () => void;
 }) {
+  /**
+   * Pointer-up still identifies the physical input device before navigation
+   * replaces this button. The native click remains responsible for the action.
+   */
+  function handlePointerUp(event: PointerEvent<HTMLButtonElement>) {
+    showPlayerShortcutHint({ event, hint, message: hintMessage });
+  }
+
   return (
     <Button
       aria-label={ariaLabel}
       aria-keyshortcuts={ariaKeyshortcuts}
-      className={cn("relative", DESKTOP_NAVIGATION_CONTROL_CLASS)}
+      className={DESKTOP_NAVIGATION_CONTROL_CLASS}
       onClick={onClick}
+      onPointerUp={handlePointerUp}
       size="icon-lg"
       type="button"
       variant="outline"
     >
       {children}
-      <ShortcutKbd variant="badge">{ariaKeyshortcuts === "ArrowLeft" ? "←" : "→"}</ShortcutKbd>
     </Button>
   );
 }
@@ -96,6 +107,10 @@ function DesktopNavigationToolbar({
           <DesktopNavigationButton
             aria-label={t("Previous step")}
             aria-keyshortcuts="ArrowLeft"
+            hint="navigatePrevious"
+            hintMessage={t.rich("Press <kbd>←</kbd> to go back.", {
+              kbd: renderPlayerShortcutHintKey,
+            })}
             onClick={onNavigatePrev}
           >
             <ChevronLeftIcon />
@@ -115,6 +130,10 @@ function DesktopNavigationToolbar({
         <DesktopNavigationButton
           aria-label={t("Next step")}
           aria-keyshortcuts="ArrowRight"
+          hint="navigateNext"
+          hintMessage={t.rich("Press <kbd>→</kbd> to continue.", {
+            kbd: renderPlayerShortcutHintKey,
+          })}
           onClick={onNavigateNext}
         >
           <ChevronRightIcon />

--- a/packages/player/src/player-shortcut-hint-storage.test.ts
+++ b/packages/player/src/player-shortcut-hint-storage.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { claimPlayerShortcutHint } from "./player-shortcut-hint-storage";
+
+/**
+ * Gives each test an isolated browser-storage substitute so daily hint claims
+ * can be verified without depending on jsdom's shared localStorage state.
+ */
+function createShortcutHintStorage() {
+  const values = new Map<string, string>();
+
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+}
+
+describe(claimPlayerShortcutHint, () => {
+  it("claims each shortcut independently once per local calendar day", () => {
+    const storage = createShortcutHintStorage();
+    const localDate = "2026-07-13";
+
+    expect(claimPlayerShortcutHint({ hint: "navigateNext", localDate, storage })).toBe(true);
+
+    expect(claimPlayerShortcutHint({ hint: "navigateNext", localDate, storage })).toBe(false);
+
+    expect(claimPlayerShortcutHint({ hint: "navigatePrevious", localDate, storage })).toBe(true);
+  });
+
+  it("allows the same shortcut on the next local calendar day", () => {
+    const storage = createShortcutHintStorage();
+
+    expect(claimPlayerShortcutHint({ hint: "promptAudio", localDate: "2026-07-13", storage })).toBe(
+      true,
+    );
+
+    expect(claimPlayerShortcutHint({ hint: "promptAudio", localDate: "2026-07-14", storage })).toBe(
+      true,
+    );
+  });
+
+  it("recovers from corrupted stored history", () => {
+    const values = new Map<string, string>();
+
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? "not-a-date",
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    expect(claimPlayerShortcutHint({ hint: "checkAnswer", localDate: "2026-07-13", storage })).toBe(
+      true,
+    );
+
+    expect(claimPlayerShortcutHint({ hint: "checkAnswer", localDate: "2026-07-13", storage })).toBe(
+      false,
+    );
+  });
+
+  it("fails closed when browser storage is unavailable", () => {
+    const storage = {
+      getItem: () => {
+        throw new Error("Storage is unavailable");
+      },
+      setItem: () => {
+        throw new Error("Storage is unavailable");
+      },
+    };
+
+    expect(
+      claimPlayerShortcutHint({ hint: "multipleChoiceNumber", localDate: "2026-07-13", storage }),
+    ).toBe(false);
+  });
+});

--- a/packages/player/src/player-shortcut-hint-storage.ts
+++ b/packages/player/src/player-shortcut-hint-storage.ts
@@ -1,0 +1,47 @@
+const SHORTCUT_HINT_STORAGE_KEY_PREFIX = "zoonk-player-shortcut-hint:v1";
+
+export type PlayerShortcutHint =
+  | "checkAnswer"
+  | "multipleChoiceNumber"
+  | "navigateNext"
+  | "navigatePrevious"
+  | "promptAudio";
+
+type ShortcutHintStorage = Pick<Storage, "getItem" | "setItem">;
+
+/**
+ * Keeps every shortcut family on its own durable key so one corrupt or stale
+ * value cannot suppress the other player tips.
+ */
+function getShortcutHintStorageKey(hint: PlayerShortcutHint) {
+  return `${SHORTCUT_HINT_STORAGE_KEY_PREFIX}:${hint}`;
+}
+
+/**
+ * Atomically reserves a shortcut tip for the learner's current local day.
+ * Writing before the caller renders the message prevents rapid duplicate
+ * clicks, while a storage failure disables the tip instead of repeatedly
+ * interrupting learners whose browser blocks localStorage.
+ */
+export function claimPlayerShortcutHint({
+  hint,
+  localDate,
+  storage,
+}: {
+  hint: PlayerShortcutHint;
+  localDate: string;
+  storage: ShortcutHintStorage;
+}) {
+  const storageKey = getShortcutHintStorageKey(hint);
+
+  try {
+    if (storage.getItem(storageKey) === localDate) {
+      return false;
+    }
+
+    storage.setItem(storageKey, localDate);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/player/src/player-shortcut-hint.tsx
+++ b/packages/player/src/player-shortcut-hint.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Kbd } from "@zoonk/ui/components/kbd";
+import { toast } from "@zoonk/ui/components/sonner";
+import { type PointerEvent, type ReactNode } from "react";
+import { getLocalDate } from "./player-date";
+import { type PlayerShortcutHint, claimPlayerShortcutHint } from "./player-shortcut-hint-storage";
+
+const SHORTCUT_HINT_TOAST_ID = "player-shortcut-hint";
+const SHORTCUT_HINT_DURATION_MS = 10_000;
+
+/**
+ * Uses the real pointer that activated a control instead of inferring input
+ * from screen size. Hybrid laptops can have both touch and mouse input, so a
+ * touch tap must stay quiet even when the viewport also supports a fine pointer.
+ */
+function isPrimaryMousePointer(event: PointerEvent<HTMLElement>) {
+  return event.pointerType === "mouse" && event.button === 0;
+}
+
+/**
+ * Browser privacy settings can make localStorage unavailable even in a client
+ * component. Returning null lets the caller fail closed rather than showing a
+ * tip on every click when its daily limit cannot be saved.
+ */
+function getShortcutHintStorage() {
+  if (globalThis.window === undefined) {
+    return null;
+  }
+
+  try {
+    return globalThis.window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Gives translated shortcut messages the same compact key treatment without
+ * forcing every control to duplicate visual classes around the shared Kbd.
+ */
+export function renderPlayerShortcutHintKey(children: ReactNode) {
+  return <Kbd className="mx-0.5 align-middle">{children}</Kbd>;
+}
+
+/**
+ * Shows contextual keyboard guidance only after a real mouse click and only
+ * after reserving that shortcut's one tip for the learner's local day. A fixed
+ * toast ID replaces the previous tip when actions happen quickly, avoiding a
+ * stack of instructional messages over the player.
+ */
+export function showPlayerShortcutHint({
+  event,
+  hint,
+  message,
+}: {
+  event: PointerEvent<HTMLElement>;
+  hint: PlayerShortcutHint;
+  message: ReactNode;
+}) {
+  if (!isPrimaryMousePointer(event)) {
+    return;
+  }
+
+  const storage = getShortcutHintStorage();
+
+  if (!storage) {
+    return;
+  }
+
+  const shouldShowHint = claimPlayerShortcutHint({
+    hint,
+    localDate: getLocalDate(new Date()),
+    storage,
+  });
+
+  if (!shouldShowHint) {
+    return;
+  }
+
+  toast(message, {
+    duration: SHORTCUT_HINT_DURATION_MS,
+    id: SHORTCUT_HINT_TOAST_ID,
+    position: "bottom-center",
+    style: {
+      left: 0,
+      marginInline: "auto",
+      maxWidth: "calc(100vw - 2rem)",
+      right: 0,
+      width: "fit-content",
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- remove redundant arrow shortcut badges while preserving keyboard navigation
- add mouse-only, once-per-day shortcut hints for player navigation, audio, choices, and answer checks
- add translated copy and E2E coverage for persistence and input modality behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves shortcut discovery by removing inline arrow badges and adding contextual, mouse-only hints shown once per day per shortcut. Keyboard navigation remains intact, with translated copy and tests for persistence and input modality.

- **New Features**
  - Contextual hints for: ←/→ navigation, prompt audio (P), answer selection (1–9), and Check (Enter); triggered by mouse clicks only (not touch/keyboard).
  - Daily limit persisted per shortcut in localStorage with safe fallback when storage is unavailable.
  - Introduces `player-shortcut-hint*` utilities and rich `<kbd>` rendering in the `next-intl` test shim; adds translations in `en`, `es`, `fr`, `de`, `pt`.
  - Adds E2E and unit tests for modality behavior, per-day limits, and numbered multiple-choice shortcuts.

<sup>Written for commit d948a6e5cbe3aec2362f4027bcb88ca3930a0744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

