### PR TITLE
chore(dev): add local to allowed dev origin

### DIFF
--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -3,6 +3,7 @@ import { type NextConfig } from "next";
 const CACHE_IMAGE_DAYS = 30;
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ["*.local"],
   devIndicators: false,
   experimental: { authInterrupts: true, serverActions: { bodySizeLimit: "10mb" }, typedEnv: true },
   images: {

--- a/apps/api/next.config.ts
+++ b/apps/api/next.config.ts
@@ -12,6 +12,7 @@ const e2eAliases: Record<string, string> = isE2E
   : {};
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ["*.local"],
   devIndicators: false,
   distDir: isE2E ? ".next-e2e" : ".next",
   experimental: { authInterrupts: true, typedEnv: true },

--- a/apps/blog/next.config.ts
+++ b/apps/blog/next.config.ts
@@ -2,6 +2,7 @@ import createMDX from "@next/mdx";
 import { type NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ["*.local"],
   devIndicators: false,
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
   reactCompiler: true,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `allowedDevOrigins: ["*.local"]` to `apps/admin`, `apps/api`, and `apps/blog` Next.js configs. This lets dev servers accept requests from `.local` hosts (e.g., `admin.local`) for easier local testing.

<sup>Written for commit fcc928d3b9d01dcd2e5caee491fccac3b74051d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

