### PR TITLE
fix(player): stabilize word bank layout

### DIFF
--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -70,7 +70,10 @@ function WordBank({
   return (
     <div
       aria-label={t("Word bank")}
-      className={cn("flex flex-wrap gap-2.5", disabled && "pointer-events-none opacity-50")}
+      className={cn(
+        "mt-auto flex flex-wrap gap-2.5 pt-6 sm:pt-8 lg:mt-0 lg:pt-0",
+        disabled && "pointer-events-none opacity-50",
+      )}
       role="group"
     >
       {tiles.map((tile) => (
@@ -204,7 +207,7 @@ export function ArrangeWordsInteraction({
   );
 
   return (
-    <InteractiveStepLayout>
+    <InteractiveStepLayout className="my-0 flex-1 lg:my-auto lg:flex-none">
       {children}
 
       <ArrangeWordsAnswerArea

--- a/packages/player/src/components/stage-content.tsx
+++ b/packages/player/src/components/stage-content.tsx
@@ -1,4 +1,5 @@
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
+import { cn } from "@zoonk/ui/lib/utils";
 import {
   type PlayerRuntimeContextValue,
   usePlayerNavigation,
@@ -59,6 +60,22 @@ function hasEmbeddedDesktopAction({ step }: { step?: SerializedStep }) {
   }
 
   return false;
+}
+
+/**
+ * Reading and listening steps need the full stage height on smaller screens so
+ * their word bank can stay above the bottom controls while a multi-line answer
+ * grows into the space between them. Desktop restores the compact centered
+ * layout because its action is already part of the content column.
+ */
+function getStepContentLayoutClass({ step }: { step?: SerializedStep }) {
+  const descriptor = describePlayerStep(step);
+
+  if (descriptor?.kind === "reading" || descriptor?.kind === "listening") {
+    return "min-h-0 flex-1 lg:my-auto lg:flex-none";
+  }
+
+  return "my-auto";
 }
 
 export function StageContent() {
@@ -135,7 +152,12 @@ export function StageContent() {
 
     if (showInlineAction) {
       return (
-        <div className="my-auto flex w-full flex-col gap-6">
+        <div
+          className={cn(
+            "flex w-full flex-col gap-6",
+            getStepContentLayoutClass({ step: currentStep }),
+          )}
+        >
           {stepContent}
           <DesktopInlineAction />
         </div>


### PR DESCRIPTION
- Keep arrange-word banks anchored above mobile controls while answers wrap.
- Restore the compact centered layout when desktop controls are shown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the arrange-words word bank on mobile by anchoring it above the bottom controls as answers wrap. Restores the compact, centered layout for desktop steps with inline actions to prevent layout shifts.

- Bug Fixes
  - On small screens, reading/listening steps use full stage height so answers can grow while the word bank stays above controls.
  - Updated layout classes in the arrange-words interaction and stage content to manage spacing and restore the centered desktop layout.

<sup>Written for commit 1c659bf41cb7fa5525cbae44126c865fb3e03885. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

