### PR TITLE
feat(main): add guest my courses login state

### DIFF
--- a/apps/main/e2e/my-courses.test.ts
+++ b/apps/main/e2e/my-courses.test.ts
@@ -11,7 +11,7 @@ test.describe("My Courses", () => {
       page.getByText(/keep your courses and progress in one place by logging in to your account/iu),
     ).toBeVisible();
 
-    const loginLink = page.getByRole("link", { name: /log in to your account/iu });
+    const loginLink = page.getByRole("link", { name: /log in/iu });
 
     await expect(loginLink).toHaveAttribute("href", "/login?next=%2Fmy");
     await expect(page.getByText(/no courses yet/iu)).toHaveCount(0);

--- a/apps/main/e2e/my-courses.test.ts
+++ b/apps/main/e2e/my-courses.test.ts
@@ -1,6 +1,22 @@
 import { expect, test } from "./fixtures";
 
 test.describe("My Courses", () => {
+  test("signed-out learners are prompted to log in to track their courses", async ({ page }) => {
+    await page.goto("/my");
+
+    await expect(page.getByRole("heading", { name: /my courses/iu })).toHaveCount(0);
+    await expect(page.getByText(/log in to track your courses/iu)).toBeVisible();
+
+    await expect(
+      page.getByText(/keep your courses and progress in one place by logging in to your account/iu),
+    ).toBeVisible();
+
+    const loginLink = page.getByRole("link", { name: /log in to your account/iu });
+
+    await expect(loginLink).toHaveAttribute("href", "/login?next=%2Fmy");
+    await expect(page.getByText(/no courses yet/iu)).toHaveCount(0);
+  });
+
   test("empty state starts a course from the start page", async ({ userWithoutProgress }) => {
     await userWithoutProgress.goto("/my");
 

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -543,9 +543,9 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Melde dich an, um deine Kurse und Fortschritte an einem Ort zu verwalten."
 
 #: src/app/(catalog)/my/page.tsx
-msgctxt "tncgXz"
-msgid "Log in to your account"
-msgstr "Bei deinem Konto anmelden"
+msgctxt "odXlk8"
+msgid "Log in"
+msgstr "Anmelden"
 
 #: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -533,6 +533,21 @@ msgid "My Courses"
 msgstr "Meine Kurse"
 
 #: src/app/(catalog)/my/page.tsx
+msgctxt "88WJDU"
+msgid "Log in to track your courses"
+msgstr "Melde dich an, um deine Kurse zu verfolgen"
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "4J8O50"
+msgid "Keep your courses and progress in one place by logging in to your account."
+msgstr "Melde dich an, um deine Kurse und Fortschritte an einem Ort zu verwalten."
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "tncgXz"
+msgid "Log in to your account"
+msgstr "Bei deinem Konto anmelden"
+
+#: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Mach dort weiter, wo du aufgehört hast"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -533,6 +533,21 @@ msgid "My Courses"
 msgstr "My Courses"
 
 #: src/app/(catalog)/my/page.tsx
+msgctxt "88WJDU"
+msgid "Log in to track your courses"
+msgstr "Log in to track your courses"
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "4J8O50"
+msgid "Keep your courses and progress in one place by logging in to your account."
+msgstr "Keep your courses and progress in one place by logging in to your account."
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "tncgXz"
+msgid "Log in to your account"
+msgstr "Log in to your account"
+
+#: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Continue where you left off"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -543,9 +543,9 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Keep your courses and progress in one place by logging in to your account."
 
 #: src/app/(catalog)/my/page.tsx
-msgctxt "tncgXz"
-msgid "Log in to your account"
-msgstr "Log in to your account"
+msgctxt "odXlk8"
+msgid "Log in"
+msgstr "Log in"
 
 #: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -543,9 +543,9 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Inicia sesión en tu cuenta para tener tus cursos y tu progreso en un solo lugar."
 
 #: src/app/(catalog)/my/page.tsx
-msgctxt "tncgXz"
-msgid "Log in to your account"
-msgstr "Inicia sesión en tu cuenta"
+msgctxt "odXlk8"
+msgid "Log in"
+msgstr "Inicia sesión"
 
 #: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -533,6 +533,21 @@ msgid "My Courses"
 msgstr "Mis cursos"
 
 #: src/app/(catalog)/my/page.tsx
+msgctxt "88WJDU"
+msgid "Log in to track your courses"
+msgstr "Inicia sesión para seguir tus cursos"
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "4J8O50"
+msgid "Keep your courses and progress in one place by logging in to your account."
+msgstr "Inicia sesión en tu cuenta para tener tus cursos y tu progreso en un solo lugar."
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "tncgXz"
+msgid "Log in to your account"
+msgstr "Inicia sesión en tu cuenta"
+
+#: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Continúa donde lo dejaste"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -543,9 +543,9 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Connecte-toi à ton compte pour retrouver tes cours et ta progression au même endroit."
 
 #: src/app/(catalog)/my/page.tsx
-msgctxt "tncgXz"
-msgid "Log in to your account"
-msgstr "Connecte-toi à ton compte"
+msgctxt "odXlk8"
+msgid "Log in"
+msgstr "Se connecter"
 
 #: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -533,6 +533,21 @@ msgid "My Courses"
 msgstr "Mes cours"
 
 #: src/app/(catalog)/my/page.tsx
+msgctxt "88WJDU"
+msgid "Log in to track your courses"
+msgstr "Connecte-toi pour suivre tes cours"
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "4J8O50"
+msgid "Keep your courses and progress in one place by logging in to your account."
+msgstr "Connecte-toi à ton compte pour retrouver tes cours et ta progression au même endroit."
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "tncgXz"
+msgid "Log in to your account"
+msgstr "Connecte-toi à ton compte"
+
+#: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Reprends là où tu t'es arrêté"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -543,9 +543,9 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Entre na sua conta para manter seus cursos e progresso em um só lugar."
 
 #: src/app/(catalog)/my/page.tsx
-msgctxt "tncgXz"
-msgid "Log in to your account"
-msgstr "Entre na sua conta"
+msgctxt "odXlk8"
+msgid "Log in"
+msgstr "Entrar"
 
 #: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -533,6 +533,21 @@ msgid "My Courses"
 msgstr "Meus cursos"
 
 #: src/app/(catalog)/my/page.tsx
+msgctxt "88WJDU"
+msgid "Log in to track your courses"
+msgstr "Entre para acompanhar seus cursos"
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "4J8O50"
+msgid "Keep your courses and progress in one place by logging in to your account."
+msgstr "Entre na sua conta para manter seus cursos e progresso em um só lugar."
+
+#: src/app/(catalog)/my/page.tsx
+msgctxt "tncgXz"
+msgid "Log in to your account"
+msgstr "Entre na sua conta"
+
+#: src/app/(catalog)/my/page.tsx
 msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Continue de onde parou"

--- a/apps/main/src/app/(catalog)/my/page.tsx
+++ b/apps/main/src/app/(catalog)/my/page.tsx
@@ -58,7 +58,7 @@ export default async function MyCourses() {
               href="/login?next=%2Fmy"
               prefetch={false}
             >
-              {t("Log in to your account")}
+              {t("Log in")}
             </Link>
           </EmptyContent>
         </Empty>

--- a/apps/main/src/app/(catalog)/my/page.tsx
+++ b/apps/main/src/app/(catalog)/my/page.tsx
@@ -1,3 +1,5 @@
+import { getSession } from "@zoonk/core/users/session/get";
+import { buttonVariants } from "@zoonk/ui/components/button";
 import {
   Container,
   ContainerDescription,
@@ -5,8 +7,18 @@ import {
   ContainerHeaderGroup,
   ContainerTitle,
 } from "@zoonk/ui/components/container";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@zoonk/ui/components/empty";
+import { LogInIcon } from "lucide-react";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
+import Link from "next/link";
 import { Suspense } from "react";
 import { UserCourseList, UserCourseListSkeleton } from "./user-course-list";
 
@@ -22,7 +34,37 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function MyCourses() {
+  const sessionPromise = getSession();
   const t = await getExtracted();
+  const session = await sessionPromise;
+
+  if (!session) {
+    return (
+      <Container className="min-h-0 flex-1 px-4" variant="centered">
+        <Empty className="p-0">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <LogInIcon aria-hidden="true" />
+            </EmptyMedia>
+            <EmptyTitle>{t("Log in to track your courses")}</EmptyTitle>
+            <EmptyDescription>
+              {t("Keep your courses and progress in one place by logging in to your account.")}
+            </EmptyDescription>
+          </EmptyHeader>
+
+          <EmptyContent>
+            <Link
+              className={buttonVariants({ variant: "outline" })}
+              href="/login?next=%2Fmy"
+              prefetch={false}
+            >
+              {t("Log in to your account")}
+            </Link>
+          </EmptyContent>
+        </Empty>
+      </Container>
+    );
+  }
 
   return (
     <Container variant="list">


### PR DESCRIPTION
## Summary

- show a dedicated signed-out state on My Courses with a login CTA
- return learners to My Courses after authentication
- add translated copy and E2E coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guest-specific state on My Courses that prompts learners to log in instead of showing an empty list. After login, users are returned to My Courses.

- **New Features**
  - Show a signed-out state on /my with a login CTA; hide course content until logged in.
  - Login link uses /login?next=%2Fmy and disables prefetch to return users to My Courses after authentication.
  - Added translations (en, de, es, fr, pt) and E2E coverage for the guest state.

- **Bug Fixes**
  - Stabilized the E2E test for the signed-out view to verify the login copy and the /login?next=%2Fmy link.

<sup>Written for commit 69bf742814b3a90d3016256c7c00da634752aa5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

