### PR TITLE
feat(main): add learn form submit button

### DIFF
--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -171,6 +171,33 @@ test.describe("Learn Form", () => {
     await expect(input).toBeFocused();
   });
 
+  test("submits by button and shows its pending state while the prompt is routing", async ({
+    page,
+  }) => {
+    const cached = await cacheWaitlistedPrompt(`e2e pending topic ${randomUUID()}`);
+
+    await page.goto("/start/learn");
+
+    const pendingNavigation = Promise.withResolvers<null>();
+
+    await page.route("**/start/learn/**", async (route) => {
+      await pendingNavigation.promise;
+      await route.continue();
+    });
+
+    try {
+      await page.getByRole("textbox").fill(cached.prompt);
+      const submitButton = page.getByRole("button", { name: /start a course/iu });
+
+      await submitButton.click();
+
+      await expect(submitButton).toBeDisabled();
+      await expect(submitButton.getByRole("status", { name: "Loading" })).toBeVisible();
+    } finally {
+      pendingNavigation.resolve(null);
+    }
+  });
+
   test("clicking a suggested subject starts topic course generation", async ({
     authenticatedPage,
   }) => {

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -563,6 +563,7 @@ msgid "Start learning something new today."
 msgstr "Fang noch heute an, etwas Neues zu lernen."
 
 #: src/app/(catalog)/my/user-course-list.tsx
+#: src/app/(catalog)/start/learn/learn-form.tsx
 msgctxt "9m9h0p"
 msgid "Start a course"
 msgstr "Kurs starten"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -563,6 +563,7 @@ msgid "Start learning something new today."
 msgstr "Start learning something new today."
 
 #: src/app/(catalog)/my/user-course-list.tsx
+#: src/app/(catalog)/start/learn/learn-form.tsx
 msgctxt "9m9h0p"
 msgid "Start a course"
 msgstr "Start a course"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -563,6 +563,7 @@ msgid "Start learning something new today."
 msgstr "Empieza a aprender algo nuevo hoy."
 
 #: src/app/(catalog)/my/user-course-list.tsx
+#: src/app/(catalog)/start/learn/learn-form.tsx
 msgctxt "9m9h0p"
 msgid "Start a course"
 msgstr "Empezar un curso"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -563,6 +563,7 @@ msgid "Start learning something new today."
 msgstr "Commence à apprendre quelque chose de nouveau aujourd'hui."
 
 #: src/app/(catalog)/my/user-course-list.tsx
+#: src/app/(catalog)/start/learn/learn-form.tsx
 msgctxt "9m9h0p"
 msgid "Start a course"
 msgstr "Commencer un cours"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -563,6 +563,7 @@ msgid "Start learning something new today."
 msgstr "Comece a aprender algo novo hoje."
 
 #: src/app/(catalog)/my/user-course-list.tsx
+#: src/app/(catalog)/start/learn/learn-form.tsx
 msgctxt "9m9h0p"
 msgid "Start a course"
 msgstr "Começar um curso"

--- a/apps/main/src/app/(catalog)/start/learn/learn-form.tsx
+++ b/apps/main/src/app/(catalog)/start/learn/learn-form.tsx
@@ -2,9 +2,16 @@
 
 import { trackLearnForm } from "@/lib/track-events";
 import { CyclingText } from "@zoonk/ui/components/cycling-text";
-import { InputGroup, InputGroupInput } from "@zoonk/ui/components/input-group";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@zoonk/ui/components/input-group";
 import { Label } from "@zoonk/ui/components/label";
+import { Spinner } from "@zoonk/ui/components/spinner";
 import { cn } from "@zoonk/ui/lib/utils";
+import { ArrowUpIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useEffect, useId, useTransition } from "react";
@@ -76,6 +83,19 @@ export function LearnForm({ placeholders }: { placeholders: string[] }) {
             </CyclingText>
           </div>
         </div>
+
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton
+            aria-busy={isPending}
+            aria-label={t("Start a course")}
+            disabled={isPending}
+            size="icon-sm"
+            type="submit"
+            variant="default"
+          >
+            {isPending ? <Spinner /> : <ArrowUpIcon aria-hidden="true" />}
+          </InputGroupButton>
+        </InputGroupAddon>
       </InputGroup>
     </form>
   );

--- a/packages/ui/src/components/loading.tsx
+++ b/packages/ui/src/components/loading.tsx
@@ -1,6 +1,11 @@
 export function FullPageLoading() {
   return (
-    <div aria-busy="true" className="bg-background fixed inset-0 flex items-center justify-center">
+    <div
+      aria-busy="true"
+      aria-label="Loading"
+      className="bg-background fixed inset-0 flex items-center justify-center"
+      role="status"
+    >
       <div
         aria-hidden="true"
         className="bg-foreground/80 animate-breathe inset-0 size-5 rounded-full"


### PR DESCRIPTION
Adds a compact submit action to the learn prompt without interrupting the page during navigation.

- swaps the arrow for an inline spinner while routing
- keeps the submit action accessible and translated
- covers button submission and pending feedback in the learn E2E flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact submit button to the Learn form with an inline spinner, so users can submit without page flicker and see a clear pending state while routing. Improves accessibility with a translated label and better ARIA signals.

- **New Features**
  - Added inline submit button to the Learn form using `@zoonk/ui` `InputGroupAddon`, `InputGroupButton`, and `Spinner`; arrow swaps to a spinner when pending.
  - Button is disabled while routing and uses the translated “Start a course” label.
  - E2E test covers button submission and pending state.

- **Bug Fixes**
  - Updated `FullPageLoading` to include `role="status"` and `aria-label="Loading"` for proper screen reader feedback.

<sup>Written for commit a5e00fa8e56140fd0f73805e04c8fcad926dc54c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

