### PR TITLE
fix(main): increase first lesson weight

### DIFF
--- a/apps/main/src/app/generate/course/[id]/generation-phases.ts
+++ b/apps/main/src/app/generate/course/[id]/generation-phases.ts
@@ -150,7 +150,7 @@ const PHASE_WEIGHTS: Record<PhaseName, number> = {
   savingCourseInfo: 1,
   savingIntroduction: 1,
   writingDescription: 4,
-  writingFirstLesson: 60,
+  writingFirstLesson: 110,
   writingLandingPage: 8,
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increases the `PHASE_WEIGHTS` value for `writingFirstLesson` from 60 to 110 to better reflect its runtime and improve course generation progress accuracy.

<sup>Written for commit e677228a1a1f75ade8bda5252a104fb7e5520910. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

