### PR TITLE
fix(api): skip core first chapter generation

### DIFF
--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
+import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
 import { generateCourseCategories } from "@zoonk/ai/tasks/courses/categories";
 import { generateCourseChapters } from "@zoonk/ai/tasks/courses/chapters";
@@ -158,6 +159,10 @@ vi.mock("@zoonk/core/content/thumbnail", () => ({
 
 vi.mock("@/workflows/lesson-generation/lesson-generation-workflow", () => ({
   lessonGenerationWorkflow: vi.fn().mockResolvedValue("ready"),
+}));
+
+vi.mock("@/workflows/chapter-generation/chapter-generation-workflow", () => ({
+  chapterGenerationWorkflow: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock("./_internal/get-or-create-course", async (importOriginal) => {
@@ -379,7 +384,9 @@ describe(courseGenerationWorkflow, () => {
   });
 
   describe("happy path", () => {
-    it("creates an intro chapter, enqueues intro lessons, then generates the first main chapter", async () => {
+    it("creates an intro chapter without triggering chapter generation for core courses", async () => {
+      vi.mocked(chapterGenerationWorkflow).mockClear();
+
       const title = `Intro Chapter Course ${randomUUID()}`;
       const slug = getCourseSlugForTitle({ language: "en", title });
 
@@ -400,11 +407,11 @@ describe(courseGenerationWorkflow, () => {
         where: { slug },
       });
 
-      const firstChapter = course.chapters[0]!;
-      expect(firstChapter.generationStatus).toBe("completed");
-      expect(firstChapter.title).toBe("A quick guide to the field");
+      const introductionChapter = course.chapters[0]!;
+      expect(introductionChapter.generationStatus).toBe("completed");
+      expect(introductionChapter.title).toBe("A quick guide to the field");
 
-      expect(firstChapter.lessons.map((lesson) => lesson.kind)).toStrictEqual([
+      expect(introductionChapter.lessons.map((lesson) => lesson.kind)).toStrictEqual([
         "explanation",
         "quiz",
         "practice",
@@ -417,32 +424,20 @@ describe(courseGenerationWorkflow, () => {
         "review",
       ]);
 
-      expect(firstChapter.imageUrl).toBeNull();
+      expect(introductionChapter.imageUrl).toBeNull();
 
-      const secondChapter = course.chapters[1]!;
-      expect(secondChapter.generationStatus).toBe("completed");
-      expect(secondChapter.position).toBe(1);
-      expect(secondChapter.title).toBe("Chapter 1");
-
-      expect(secondChapter.lessons.map((lesson) => lesson.kind)).toStrictEqual([
-        "explanation",
-        "quiz",
-        "practice",
-        "explanation",
-        "quiz",
-        "practice",
-        "review",
-      ]);
-
-      expect(secondChapter.imageUrl).toBeNull();
+      const firstMainChapter = course.chapters[1]!;
+      expect(firstMainChapter.position).toBe(1);
+      expect(firstMainChapter.title).toBe("Chapter 1");
+      expect(firstMainChapter.imageUrl).toBeNull();
 
       const thirdChapter = course.chapters[2]!;
       expect(thirdChapter.position).toBe(2);
       expect(thirdChapter.title).toBe("Chapter 2");
 
-      const firstLesson = firstChapter.lessons[0]!;
-      const secondLesson = firstChapter.lessons[1]!;
-      const thirdLesson = firstChapter.lessons[2]!;
+      const firstLesson = introductionChapter.lessons[0]!;
+      const secondLesson = introductionChapter.lessons[1]!;
+      const thirdLesson = introductionChapter.lessons[2]!;
 
       expect(lessonGenerationWorkflow).toHaveBeenCalledWith(firstLesson.id);
       expect(startMock).toHaveBeenCalledWith(lessonGenerationWorkflow, [secondLesson.id]);
@@ -454,6 +449,8 @@ describe(courseGenerationWorkflow, () => {
         courseTitle: title,
         language: "en",
       });
+
+      expect(chapterGenerationWorkflow).not.toHaveBeenCalled();
     });
 
     it("starts the first intro lesson before the main course setup finishes", async () => {
@@ -563,8 +560,9 @@ describe(courseGenerationWorkflow, () => {
       }
     });
 
-    it("keeps language courses on the existing course completion path", async () => {
+    it("triggers first chapter generation while keeping the language course completion path", async () => {
       vi.mocked(generateCourseIntroduction).mockClear();
+      vi.mocked(chapterGenerationWorkflow).mockClear();
       startMock.mockClear();
 
       const title = `Language Course ${randomUUID()}`;
@@ -593,12 +591,7 @@ describe(courseGenerationWorkflow, () => {
       });
 
       const course = await prisma.course.findUniqueOrThrow({
-        include: {
-          chapters: {
-            include: { lessons: { orderBy: { position: "asc" } } },
-            orderBy: { position: "asc" },
-          },
-        },
+        include: { chapters: { orderBy: { position: "asc" } } },
         where: { id: updatedRequest.courseId! },
       });
 
@@ -610,8 +603,7 @@ describe(courseGenerationWorkflow, () => {
       ]);
 
       const firstChapter = course.chapters[0]!;
-      expect(firstChapter.generationStatus).toBe("completed");
-      expect(firstChapter.lessons.map((lesson) => lesson.title)).toContain("Lang Lesson 1");
+      expect(chapterGenerationWorkflow).toHaveBeenCalledExactlyOnceWith(firstChapter.id);
 
       const completionEvent = getStreamedEvents().find(
         (event) => event.step === COURSE_COMPLETION_STEP && event.status === "completed",

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -1,6 +1,6 @@
 import { serializeWorkflowError } from "@/workflows/_shared/workflow-error";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
-import { type Chapter } from "@zoonk/db";
+import { type Chapter, type Course } from "@zoonk/db";
 import { logError } from "@zoonk/utils/logger";
 import { getWorkflowMetadata } from "workflow";
 import { getOrCreateCourse } from "./_internal/get-or-create-course";
@@ -52,22 +52,25 @@ async function startChapterImagesWithoutFailingCourse(courseId: string): Promise
 }
 
 /**
- * Starts the optional image workflow while the first chapter workflow runs.
- * The image path only waits for the child workflow to be enqueued, not for the
- * background artwork generation to complete.
+ * Starts the optional image workflow for every course and generates the first
+ * chapter only for language courses. Core courses already generate their
+ * introduction lessons during setup, so they no longer need another chapter
+ * workflow to start automatically.
  */
-async function generateFirstChapterAndStartChapterImages({
+async function startChapterImagesAndGenerateFirstLanguageChapter({
   chapters,
   courseId,
+  format,
 }: {
   chapters: Chapter[];
   courseId: string;
+  format: Course["format"];
 }): Promise<void> {
-  const firstChapter = chapters[0];
+  const firstLanguageChapter = format === "language" ? chapters[0] : null;
 
   const [, chapterResult] = await Promise.allSettled([
     startChapterImagesWithoutFailingCourse(courseId),
-    firstChapter ? chapterGenerationWorkflow(firstChapter.id) : Promise.resolve(),
+    firstLanguageChapter ? chapterGenerationWorkflow(firstLanguageChapter.id) : Promise.resolve(),
   ]);
 
   if (chapterResult.status === "rejected") {
@@ -138,11 +141,12 @@ export async function courseGenerationWorkflow(coursePromptId: string): Promise<
     throw error;
   });
 
-  // Start chapter generation outside the course error handling.
-  // Chapter generation has its own error handling that marks the chapter as failed.
+  // Start post-setup workflows outside the course error handling.
+  // Language chapter generation has its own error handling that marks the chapter as failed.
   // We don't want chapter failures to mark the entire course as failed.
-  await generateFirstChapterAndStartChapterImages({
+  await startChapterImagesAndGenerateFirstLanguageChapter({
     chapters,
     courseId: courseSetup.course.courseId,
+    format: courseSetup.course.format,
   });
 }


### PR DESCRIPTION
Stops core course generation from starting the chapter generation workflow after the introduction is prepared. Language courses continue to trigger generation for their first chapter, with direct workflow invocation coverage for both course formats.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip starting the chapter-generation workflow for core courses after the introduction. Language courses still trigger first-chapter generation, and chapter images start for all courses.

- **Bug Fixes**
  - Core courses no longer auto-start chapter generation after intro, avoiding redundant work.
  - Language courses keep the existing path and trigger first-chapter generation.
  - Added direct workflow invocation tests for both formats; verified core skips and language calls `chapterGenerationWorkflow`.

<sup>Written for commit c6c52702b13905b975ffd2af9fb00c02ab112e07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

