### PR TITLE
fix(admin): use full width for user details

### DIFF
--- a/apps/admin/src/app/(private)/users/[id]/page.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/page.tsx
@@ -78,7 +78,7 @@ export default async function UserDetailPage({ params }: PageProps<"/users/[id]"
         </ContainerHeaderGroup>
       </ContainerHeader>
 
-      <ContainerBody className="max-w-4xl gap-8">
+      <ContainerBody className="gap-8">
         <Suspense fallback={<HeaderSkeleton />}>
           <UserHeader userId={userId} />
         </Suspense>

--- a/turbo.json
+++ b/turbo.json
@@ -35,6 +35,7 @@
         ".next/**",
         "!.next/cache/**",
         "!.next/dev/**",
+        "next-env.d.ts",
         "messages/**",
         "src/app/.well-known/workflow/**"
       ]
@@ -45,6 +46,7 @@
         ".next-e2e/**",
         "!.next-e2e/cache/**",
         "!.next-e2e/dev/**",
+        "next-env.d.ts",
         "messages/**",
         "src/app/.well-known/workflow/**"
       ]
@@ -67,6 +69,9 @@
       "dependsOn": ["db:generate", "^db:setup:test"],
       "persistent": true
     },
-    "typecheck": { "dependsOn": ["db:generate", "^typecheck"], "outputs": [".next/types/**"] }
+    "typecheck": {
+      "dependsOn": ["db:generate", "^typecheck"],
+      "outputs": [".next/types/**", "next-env.d.ts"]
+    }
   }
 }


### PR DESCRIPTION
Removes the user detail page width cap so it uses the same full-width layout as the other admin pages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the admin user detail page to full-width by removing the `max-w-4xl` constraint. Also includes `next-env.d.ts` in Turborepo outputs to improve typecheck/Next task caching.

<sup>Written for commit 77ba2bd3828f55e41f0789edc24d63284299ed8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

