### PR TITLE
chore(evals): enable cache components

### DIFF
--- a/apps/evals/next.config.ts
+++ b/apps/evals/next.config.ts
@@ -2,6 +2,7 @@ import { type NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["*.local"],
+  cacheComponents: true,
   experimental: {
     turbopackFileSystemCacheForBuild: true,
     turbopackRustReactCompiler: true,
@@ -15,6 +16,7 @@ const nextConfig: NextConfig = {
     ],
   },
   pageExtensions: ["ts", "tsx"],
+  partialPrefetching: true,
   reactCompiler: true,
   turbopack: {
     rules: {

--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/page.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/page.tsx
@@ -1,5 +1,6 @@
 import {
   AppBreadcrumb,
+  AppBreadcrumbItemSkeleton,
   HomeLinkBreadcrumb,
   ModelPageBreadcrumb,
   TaskLinkBreadcrumb,
@@ -11,27 +12,35 @@ import {
   getOutputStatus,
   loadModelOutputs,
 } from "@/lib/output-loader";
-import { RUNS_PER_TEST_CASE, TASKS } from "@/tasks";
+import { RUNS_PER_TEST_CASE } from "@/tasks";
 import { BreadcrumbSeparator } from "@zoonk/ui/components/breadcrumb";
 import {
   ContainerBody,
   ContainerDescription,
   ContainerHeader,
   ContainerHeaderGroup,
+  ContainerHeaderSkeleton,
   ContainerTitle,
 } from "@zoonk/ui/components/container";
-import { notFound, redirect } from "next/navigation";
+import { redirect } from "next/navigation";
+import { Suspense, cache } from "react";
+import { getTaskRoute } from "../_utils/task-route";
 import { EvalResults } from "./eval-results";
 import { GeneratedOutputs } from "./generated-outputs";
-import { TaskModelActionsCard } from "./task-model-actions-card";
+import { TaskModelActionsCard, TaskModelActionsCardSkeleton } from "./task-model-actions-card";
 
-export default async function TaskModelPage({ params }: PageProps<"/tasks/[taskId]/[modelId]">) {
-  const { taskId, modelId: rawModelId } = await params;
-  const task = TASKS.find((item) => item.id === taskId);
+type TaskModelRouteParams = PageProps<"/tasks/[taskId]/[modelId]">["params"];
+type TaskModelRouteProps = { params: TaskModelRouteParams };
 
-  if (!task) {
-    notFound();
-  }
+/**
+ * Resolves the task and model URL once for the breadcrumb, header, and body so
+ * each Suspense region shares identical validation and decoded model data.
+ */
+const getTaskModelRoute = cache(async (params: TaskModelRouteParams) => {
+  const [{ modelId: rawModelId }, { task, taskId }] = await Promise.all([
+    params,
+    getTaskRoute(params),
+  ]);
 
   const modelId = decodeURIComponent(rawModelId);
   const model = EVAL_MODELS.find((item) => item.id === modelId);
@@ -39,6 +48,65 @@ export default async function TaskModelPage({ params }: PageProps<"/tasks/[taskI
   if (!model) {
     redirect(`/tasks/${taskId}`);
   }
+
+  return { model, modelId, task, taskId };
+});
+
+/**
+ * Keeps the two URL-dependent breadcrumb positions visible while their task
+ * and model labels resolve.
+ */
+function TaskModelBreadcrumbSkeleton() {
+  return (
+    <>
+      <AppBreadcrumbItemSkeleton className="w-32" />
+      <BreadcrumbSeparator />
+      <AppBreadcrumbItemSkeleton className="w-24" />
+    </>
+  );
+}
+
+/**
+ * Resolves both dynamic labels together so the breadcrumb never mixes task and
+ * model names from different route states.
+ */
+async function TaskModelBreadcrumb({ params }: TaskModelRouteProps) {
+  const { model, task } = await getTaskModelRoute(params);
+
+  return (
+    <>
+      <TaskLinkBreadcrumb taskId={task.id} taskName={task.name} />
+      <BreadcrumbSeparator />
+      <ModelPageBreadcrumb modelName={getModelDisplayName(model)} />
+    </>
+  );
+}
+
+/**
+ * Streams URL-specific task metadata into a focused header boundary while the
+ * rest of the model page shell remains available.
+ */
+async function TaskModelHeader({ params }: TaskModelRouteProps) {
+  const { task } = await getTaskModelRoute(params);
+
+  return (
+    <ContainerHeader>
+      <ContainerHeaderGroup>
+        <ContainerTitle>{task.name}</ContainerTitle>
+        <ContainerDescription>
+          Generate outputs and run evaluations for this task
+        </ContainerDescription>
+      </ContainerHeaderGroup>
+    </ContainerHeader>
+  );
+}
+
+/**
+ * Reads results, generated outputs, and progress in parallel because none of
+ * those mutable files depends on another to render the model body.
+ */
+const getTaskModelContent = cache(async (params: TaskModelRouteParams) => {
+  const { model, modelId, task, taskId } = await getTaskModelRoute(params);
 
   const [results, modelOutputs, outputStatus] = await Promise.all([
     getTaskResults(taskId, modelId),
@@ -50,44 +118,74 @@ export default async function TaskModelPage({ params }: PageProps<"/tasks/[taskI
     ? combineOutputsWithTestCases({ modelOutputs, task })
     : null;
 
+  return { generatedOutputs, model, modelId, outputStatus, results, taskId };
+});
+
+/**
+ * Keeps the guaranteed action card independent from the optional output or
+ * result section so its fallback always has a matching resolved element.
+ */
+async function TaskModelActions({ params }: TaskModelRouteProps) {
+  const { generatedOutputs, model, modelId, outputStatus, taskId } =
+    await getTaskModelContent(params);
+
+  return (
+    <TaskModelActionsCard
+      exportEntries={
+        generatedOutputs?.outputs.map((output) => ({
+          input: output.testCase.userInput,
+          output: output.output,
+        })) ?? []
+      }
+      model={model}
+      modelId={modelId}
+      outputStatus={outputStatus}
+      taskId={taskId}
+    />
+  );
+}
+
+/**
+ * Avoids guessing whether mutable files will resolve to evaluated results,
+ * generated-only outputs, or no secondary section at all.
+ */
+async function TaskModelResults({ params }: TaskModelRouteProps) {
+  const { generatedOutputs, results } = await getTaskModelContent(params);
+
+  if (results) {
+    return <EvalResults results={results} />;
+  }
+
+  return generatedOutputs && <GeneratedOutputs outputs={generatedOutputs} />;
+}
+
+/**
+ * Prefetches the stable model-page structure while URL labels and current eval
+ * files stream through focused, visible Suspense fallbacks.
+ */
+export default function TaskModelPage({ params }: TaskModelRouteProps) {
   return (
     <main className="flex flex-col gap-4">
       <AppBreadcrumb>
         <HomeLinkBreadcrumb />
         <BreadcrumbSeparator />
-        <TaskLinkBreadcrumb taskId={task.id} taskName={task.name} />
-        <BreadcrumbSeparator />
-        <ModelPageBreadcrumb modelName={getModelDisplayName(model)} />
+        <Suspense fallback={<TaskModelBreadcrumbSkeleton />}>
+          <TaskModelBreadcrumb params={params} />
+        </Suspense>
       </AppBreadcrumb>
 
-      <ContainerHeader>
-        <ContainerHeaderGroup>
-          <ContainerTitle>{task.name}</ContainerTitle>
-          <ContainerDescription>
-            Generate outputs and run evaluations for this task
-          </ContainerDescription>
-        </ContainerHeaderGroup>
-      </ContainerHeader>
+      <Suspense fallback={<ContainerHeaderSkeleton />}>
+        <TaskModelHeader params={params} />
+      </Suspense>
 
       <ContainerBody>
-        <TaskModelActionsCard
-          exportEntries={
-            generatedOutputs?.outputs.map((output) => ({
-              input: output.testCase.userInput,
-              output: output.output,
-            })) ?? []
-          }
-          model={model}
-          modelId={modelId}
-          outputStatus={outputStatus}
-          taskId={taskId}
-        />
+        <Suspense fallback={<TaskModelActionsCardSkeleton />}>
+          <TaskModelActions params={params} />
+        </Suspense>
 
-        {results ? (
-          <EvalResults results={results} />
-        ) : (
-          generatedOutputs && <GeneratedOutputs outputs={generatedOutputs} />
-        )}
+        <Suspense fallback={null}>
+          <TaskModelResults params={params} />
+        </Suspense>
       </ContainerBody>
     </main>
   );

--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/task-model-actions-card.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/task-model-actions-card.tsx
@@ -1,7 +1,7 @@
-import { ModelStatusBadge } from "@/components/model-status-badge";
+import { ModelStatusBadge, ModelStatusBadgeSkeleton } from "@/components/model-status-badge";
 import { type ModelConfig } from "@/lib/models";
 import { type OutputProgress } from "@/lib/output-loader";
-import { Button } from "@zoonk/ui/components/button";
+import { Button, ButtonSkeleton } from "@zoonk/ui/components/button";
 import {
   Card,
   CardContent,
@@ -9,8 +9,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@zoonk/ui/components/card";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
-import { PlayIcon, SparklesIcon } from "lucide-react";
+import { DownloadIcon, PlayIcon, SparklesIcon } from "lucide-react";
 import Link from "next/link";
 import { generateOutputsAction, runEvalAction } from "./actions";
 import { type OutputExportEntry, OutputsExport } from "./outputs-export";
@@ -74,6 +75,48 @@ export function TaskModelActionsCard({
           </Link>
 
           <OutputsExport entries={exportEntries} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Uses the action card's real header, content rows, badge, and button geometry
+ * so filesystem-backed state can stream in without resizing the card.
+ */
+export function TaskModelActionsCardSkeleton() {
+  return (
+    <Card aria-hidden="true">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Skeleton className="h-6 w-16 rounded" />
+          <ModelStatusBadgeSkeleton />
+        </CardTitle>
+        <CardDescription>
+          <Skeleton className="h-5 w-48 rounded" />
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex items-center gap-4">
+          <ButtonSkeleton>
+            <SparklesIcon />
+            Generate Outputs
+          </ButtonSkeleton>
+          <Skeleton className="h-5 w-40 rounded" />
+        </div>
+
+        <div className="flex items-center gap-4">
+          <ButtonSkeleton>
+            <PlayIcon />
+            Run Eval
+          </ButtonSkeleton>
+          <ButtonSkeleton variant="outline">Change Model</ButtonSkeleton>
+          <ButtonSkeleton variant="outline">
+            <DownloadIcon />
+            Export Outputs
+          </ButtonSkeleton>
         </div>
       </CardContent>
     </Card>

--- a/apps/evals/src/app/tasks/[taskId]/_utils/task-route.ts
+++ b/apps/evals/src/app/tasks/[taskId]/_utils/task-route.ts
@@ -1,0 +1,21 @@
+import { getTaskById } from "@/tasks";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+
+export type TaskRouteParams = Promise<{ taskId: string }>;
+
+/**
+ * Resolves and validates the shared task route parameter once so sibling
+ * Suspense regions can render independently without repeating route lookup
+ * work or drifting on invalid-task behavior.
+ */
+export const getTaskRoute = cache(async (params: TaskRouteParams) => {
+  const { taskId } = await params;
+  const task = getTaskById(taskId);
+
+  if (!task) {
+    notFound();
+  }
+
+  return { task, taskId };
+});

--- a/apps/evals/src/app/tasks/[taskId]/battles/battle-matchup-list.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/battles/battle-matchup-list.tsx
@@ -9,9 +9,22 @@ import {
   AccordionTrigger,
 } from "@zoonk/ui/components/accordion";
 import { Badge } from "@zoonk/ui/components/badge";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { RankingItem } from "./ranking-item";
 
 type TestCaseEntry = { testCaseId: string; score: number; reasoning: string; anonymousId: string };
+
+/**
+ * Matches the empty-state footprint without assuming how many judges or model
+ * rankings have been persisted in mutable battle result files.
+ */
+export function BattleMatchupListSkeleton() {
+  return (
+    <div aria-hidden="true" className="py-8">
+      <Skeleton className="mx-auto h-6 w-48 rounded" />
+    </div>
+  );
+}
 
 /**
  * Some judges output bare anonymous letters (e.g. "C") as modelId

--- a/apps/evals/src/app/tasks/[taskId]/battles/page.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/battles/page.tsx
@@ -1,11 +1,11 @@
 import {
   AppBreadcrumb,
+  AppBreadcrumbItemSkeleton,
   BattlesPageBreadcrumb,
   HomeLinkBreadcrumb,
   TaskLinkBreadcrumb,
 } from "@/components/breadcrumb";
 import { getBattleMatchups } from "@/lib/battle-loader";
-import { getTaskById } from "@/tasks";
 import { BreadcrumbSeparator } from "@zoonk/ui/components/breadcrumb";
 import {
   ContainerBody,
@@ -14,25 +14,46 @@ import {
   ContainerHeaderGroup,
   ContainerTitle,
 } from "@zoonk/ui/components/container";
-import { notFound } from "next/navigation";
-import { BattleMatchupList } from "./battle-matchup-list";
+import { Suspense } from "react";
+import { type TaskRouteParams, getTaskRoute } from "../_utils/task-route";
+import { BattleMatchupList, BattleMatchupListSkeleton } from "./battle-matchup-list";
 
-export default async function BattlesPage({ params }: { params: Promise<{ taskId: string }> }) {
-  const { taskId } = await params;
-  const task = getTaskById(taskId);
+type BattlesRouteProps = { params: TaskRouteParams };
 
-  if (!task) {
-    notFound();
-  }
+/**
+ * Streams the task label independently while the Home and Battles breadcrumb
+ * items remain available in the shared route shell.
+ */
+async function BattlesTaskBreadcrumb({ params }: BattlesRouteProps) {
+  const { task, taskId } = await getTaskRoute(params);
 
+  return <TaskLinkBreadcrumb taskId={taskId} taskName={task.name} />;
+}
+
+/**
+ * Reads mutable battle files behind the page body's Suspense boundary so the
+ * stable title and navigation never wait on filesystem work.
+ */
+async function BattleResults({ params }: BattlesRouteProps) {
+  const { taskId } = await getTaskRoute(params);
   const matchups = await getBattleMatchups(taskId);
 
+  return <BattleMatchupList matchups={matchups} />;
+}
+
+/**
+ * Prefetches the stable battles page structure and limits runtime streaming to
+ * the URL-dependent task label and its current result list.
+ */
+export default function BattlesPage({ params }: BattlesRouteProps) {
   return (
     <main className="flex flex-col gap-4">
       <AppBreadcrumb>
         <HomeLinkBreadcrumb />
         <BreadcrumbSeparator />
-        <TaskLinkBreadcrumb taskId={taskId} taskName={task.name} />
+        <Suspense fallback={<AppBreadcrumbItemSkeleton />}>
+          <BattlesTaskBreadcrumb params={params} />
+        </Suspense>
         <BreadcrumbSeparator />
         <BattlesPageBreadcrumb />
       </AppBreadcrumb>
@@ -47,7 +68,9 @@ export default async function BattlesPage({ params }: { params: Promise<{ taskId
       </ContainerHeader>
 
       <ContainerBody>
-        <BattleMatchupList matchups={matchups} />
+        <Suspense fallback={<BattleMatchupListSkeleton />}>
+          <BattleResults params={params} />
+        </Suspense>
       </ContainerBody>
     </main>
   );

--- a/apps/evals/src/app/tasks/[taskId]/layout.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/layout.tsx
@@ -1,5 +1,0 @@
-import { Suspense } from "react";
-
-export default function Layout({ children }: LayoutProps<"/tasks/[taskId]">) {
-  return <Suspense>{children}</Suspense>;
-}

--- a/apps/evals/src/app/tasks/[taskId]/leaderboard-tabs.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/leaderboard-tabs.tsx
@@ -1,10 +1,31 @@
 "use client";
 
 import { type BattleLeaderboardEntry, type TaskEvalResults } from "@/lib/types";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@zoonk/ui/components/tabs";
 import { useRouter, useSearchParams } from "next/navigation";
 import { BattleLeaderboard } from "./battle-leaderboard";
 import { Leaderboard } from "./leaderboard";
+
+const LEADERBOARD_SKELETON_ROWS = ["leaderboard-row-1", "leaderboard-row-2", "leaderboard-row-3"];
+
+/**
+ * Uses neutral table-height rows because URL data decides whether this region
+ * becomes Battle Mode tabs, a regular leaderboard, or no leaderboard at all.
+ */
+export function LeaderboardTabsSkeleton() {
+  return (
+    <div aria-hidden="true" className="flex flex-col divide-y">
+      {LEADERBOARD_SKELETON_ROWS.map((rowId) => (
+        <div className="flex h-12 items-center gap-6 px-2" key={rowId}>
+          <Skeleton className="h-5 flex-1 rounded" />
+          <Skeleton className="h-5 w-24 rounded" />
+          <Skeleton className="h-5 w-20 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export function LeaderboardTabs({
   taskId,

--- a/apps/evals/src/app/tasks/[taskId]/loading.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/loading.tsx
@@ -1,5 +1,0 @@
-import { FullPageLoading } from "@zoonk/ui/components/loading";
-
-export default function Loading() {
-  return <FullPageLoading />;
-}

--- a/apps/evals/src/app/tasks/[taskId]/model-card.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/model-card.tsx
@@ -1,6 +1,6 @@
-import { ModelStatusBadge } from "@/components/model-status-badge";
+import { ModelStatusBadge, ModelStatusBadgeSkeleton } from "@/components/model-status-badge";
 import { type ModelConfig, getModelDisplayName } from "@/lib/models";
-import { buttonVariants } from "@zoonk/ui/components/button";
+import { ButtonSkeleton, buttonVariants } from "@zoonk/ui/components/button";
 import {
   Item,
   ItemActions,
@@ -8,14 +8,15 @@ import {
   ItemDescription,
   ItemTitle,
 } from "@zoonk/ui/components/item";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import Link from "next/link";
 
 export function ModelCard({ model, taskId }: { model: ModelConfig; taskId: string }) {
   return (
     <Item variant="outline">
-      <ItemContent>
-        <ItemTitle>
-          {getModelDisplayName(model)}
+      <ItemContent className="min-w-0">
+        <ItemTitle className="w-full">
+          <span className="truncate">{getModelDisplayName(model)}</span>
           <ModelStatusBadge modelId={model.id} taskId={taskId} />
         </ItemTitle>
         <ItemDescription>
@@ -30,6 +31,28 @@ export function ModelCard({ model, taskId }: { model: ModelConfig; taskId: strin
         >
           See Evals
         </Link>
+      </ItemActions>
+    </Item>
+  );
+}
+
+/**
+ * Keeps the model grid stable while fresh output and result files determine
+ * each model's order and status.
+ */
+export function ModelCardSkeleton() {
+  return (
+    <Item aria-hidden="true" variant="outline">
+      <ItemContent className="min-w-0">
+        <ItemTitle className="w-full">
+          <Skeleton className="h-5 w-32 rounded" />
+          <ModelStatusBadgeSkeleton />
+        </ItemTitle>
+        <Skeleton className="h-5 w-44 rounded" />
+      </ItemContent>
+
+      <ItemActions>
+        <ButtonSkeleton variant="outline">See Evals</ButtonSkeleton>
       </ItemActions>
     </Item>
   );

--- a/apps/evals/src/app/tasks/[taskId]/page.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/page.tsx
@@ -1,103 +1,205 @@
-import { AppBreadcrumb, HomeLinkBreadcrumb, TaskPageBreadcrumb } from "@/components/breadcrumb";
+import {
+  AppBreadcrumb,
+  AppBreadcrumbItemSkeleton,
+  HomeLinkBreadcrumb,
+  TaskPageBreadcrumb,
+} from "@/components/breadcrumb";
 import { getBattleLeaderboard } from "@/lib/battle-loader";
+import { EVAL_MODELS } from "@/lib/models";
 import { getModelsWithCompleteOutputs } from "@/lib/output-loader";
 import { supportsJudgeMode } from "@/lib/types";
 import { getModelsWithResults, getSortedModels } from "@/lib/utils";
-import { RUNS_PER_TEST_CASE, getTaskById } from "@/tasks";
+import { RUNS_PER_TEST_CASE } from "@/tasks";
 import { BreadcrumbSeparator } from "@zoonk/ui/components/breadcrumb";
-import { buttonVariants } from "@zoonk/ui/components/button";
+import { ButtonSkeleton, buttonVariants } from "@zoonk/ui/components/button";
 import {
   ContainerBody,
   ContainerDescription,
   ContainerHeader,
   ContainerHeaderGroup,
+  ContainerHeaderSkeleton,
   ContainerTitle,
 } from "@zoonk/ui/components/container";
 import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
 import { MessageSquareTextIcon, SwordsIcon } from "lucide-react";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { type TaskRouteParams, getTaskRoute } from "./_utils/task-route";
 import { runBattleModeAction } from "./actions";
-import { LeaderboardTabs } from "./leaderboard-tabs";
-import { ModelCard } from "./model-card";
+import { LeaderboardTabs, LeaderboardTabsSkeleton } from "./leaderboard-tabs";
+import { ModelCard, ModelCardSkeleton } from "./model-card";
 
-export default async function TaskPage({ params }: { params: Promise<{ taskId: string }> }) {
-  const { taskId } = await params;
-  const task = getTaskById(taskId);
+type TaskRouteProps = { params: TaskRouteParams };
 
-  if (!task) {
-    notFound();
-  }
+/**
+ * Replaces only the task-dependent breadcrumb item while the shared Home link
+ * remains part of the prefetched App Shell.
+ */
+async function TaskBreadcrumb({ params }: TaskRouteProps) {
+  const { task } = await getTaskRoute(params);
 
+  return <TaskPageBreadcrumb taskName={task.name} />;
+}
+
+/**
+ * Keeps both task actions in place while output files are checked to decide
+ * whether Battle Mode is ready to run.
+ */
+function TaskHeaderActionsSkeleton() {
+  return (
+    <div aria-hidden="true" className="flex items-center gap-2">
+      <ButtonSkeleton variant="outline">
+        <MessageSquareTextIcon />
+        View Judge Comments
+      </ButtonSkeleton>
+      <ButtonSkeleton>
+        <SwordsIcon />
+        Run Battle Mode
+      </ButtonSkeleton>
+    </div>
+  );
+}
+
+/**
+ * Loads Battle Mode readiness separately from the task title so filesystem
+ * work cannot delay the rest of the header.
+ */
+async function TaskHeaderActions({ params }: TaskRouteProps) {
+  const { task, taskId } = await getTaskRoute(params);
+  const modelsReadyForBattle = await getModelsWithCompleteOutputs({ runsPerTestCase: 1, task });
+  const canRunBattle = modelsReadyForBattle.length >= 2;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Link className={buttonVariants({ variant: "outline" })} href={`/tasks/${taskId}/battles`}>
+        <MessageSquareTextIcon className="size-4" />
+        View Judge Comments
+      </Link>
+
+      <form action={runBattleModeAction}>
+        <input name="taskId" type="hidden" value={taskId} />
+        <SubmitButton disabled={!canRunBattle} icon={<SwordsIcon />}>
+          Run Battle Mode
+        </SubmitButton>
+      </form>
+    </div>
+  );
+}
+
+/**
+ * Resolves URL-dependent task metadata first, then lets optional action state
+ * stream through its own boundary instead of holding back the title.
+ */
+async function TaskHeader({ params }: TaskRouteProps) {
+  const { task } = await getTaskRoute(params);
+
+  const judgeModeSupported = supportsJudgeMode(task);
+
+  return (
+    <ContainerHeader>
+      <ContainerHeaderGroup>
+        <ContainerTitle>{task.name}</ContainerTitle>
+        <ContainerDescription>
+          Choose a model to run evaluations on {task.testCases.length} test cases (
+          {RUNS_PER_TEST_CASE} runs each)
+        </ContainerDescription>
+      </ContainerHeaderGroup>
+
+      {judgeModeSupported && (
+        <Suspense fallback={<TaskHeaderActionsSkeleton />}>
+          <TaskHeaderActions params={params} />
+        </Suspense>
+      )}
+    </ContainerHeader>
+  );
+}
+
+/**
+ * Reads regular and Battle Mode result files in parallel while the task header
+ * and model grid remain independently interactive.
+ */
+async function TaskLeaderboard({ params }: TaskRouteProps) {
+  const { task, taskId } = await getTaskRoute(params);
   const judgeModeSupported = supportsJudgeMode(task);
 
   const battleEntriesPromise = judgeModeSupported
     ? getBattleLeaderboard(taskId)
     : Promise.resolve([]);
 
-  const modelsReadyForBattlePromise = judgeModeSupported
-    ? getModelsWithCompleteOutputs({ runsPerTestCase: 1, task })
-    : Promise.resolve([]);
-
-  const [sortedModels, modelsWithResults, battleEntries, modelsReadyForBattle] = await Promise.all([
-    getSortedModels(taskId),
+  const [modelsWithResults, battleEntries] = await Promise.all([
     getModelsWithResults(taskId),
     battleEntriesPromise,
-    modelsReadyForBattlePromise,
   ]);
 
-  const canRunBattle = modelsReadyForBattle.length >= 2;
+  return (
+    <LeaderboardTabs
+      battleEntries={battleEntries}
+      results={modelsWithResults}
+      supportsJudgeMode={judgeModeSupported}
+      taskId={taskId}
+    />
+  );
+}
 
+/**
+ * Loads model ordering and status separately because those values come from
+ * mutable eval files and should not be frozen into the shared App Shell.
+ */
+async function TaskModelGrid({ params }: TaskRouteProps) {
+  const { taskId } = await getTaskRoute(params);
+  const sortedModels = await getSortedModels(taskId);
+
+  return (
+    <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {sortedModels.map((model) => (
+        <ModelCard key={model.id} model={model} taskId={taskId} />
+      ))}
+    </section>
+  );
+}
+
+/**
+ * Uses one exact-size placeholder per configured model. Completed models are
+ * the only cards the resolved grid can remove, so this preserves the grid's
+ * normal row count without maintaining a second model-count constant.
+ */
+function TaskModelGridSkeleton() {
+  return (
+    <section aria-hidden="true" className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {EVAL_MODELS.map((model) => (
+        <ModelCardSkeleton key={model.id} />
+      ))}
+    </section>
+  );
+}
+
+/**
+ * Keeps stable page structure in the shared App Shell and scopes each runtime
+ * read to the smallest region with a useful loading state.
+ */
+export default function TaskPage({ params }: TaskRouteProps) {
   return (
     <main className="flex flex-col gap-4">
       <AppBreadcrumb>
         <HomeLinkBreadcrumb />
         <BreadcrumbSeparator />
-        <TaskPageBreadcrumb taskName={task.name} />
+        <Suspense fallback={<AppBreadcrumbItemSkeleton />}>
+          <TaskBreadcrumb params={params} />
+        </Suspense>
       </AppBreadcrumb>
 
-      <ContainerHeader>
-        <ContainerHeaderGroup>
-          <ContainerTitle>{task.name}</ContainerTitle>
-          <ContainerDescription>
-            Choose a model to run evaluations on {task.testCases.length} test cases (
-            {RUNS_PER_TEST_CASE} runs each)
-          </ContainerDescription>
-        </ContainerHeaderGroup>
-
-        {judgeModeSupported && (
-          <div className="flex items-center gap-2">
-            <Link
-              className={buttonVariants({ variant: "outline" })}
-              href={`/tasks/${taskId}/battles`}
-            >
-              <MessageSquareTextIcon className="size-4" />
-              View Judge Comments
-            </Link>
-
-            <form action={runBattleModeAction}>
-              <input name="taskId" type="hidden" value={taskId} />
-              <SubmitButton disabled={!canRunBattle} icon={<SwordsIcon />}>
-                Run Battle Mode
-              </SubmitButton>
-            </form>
-          </div>
-        )}
-      </ContainerHeader>
+      <Suspense fallback={<ContainerHeaderSkeleton />}>
+        <TaskHeader params={params} />
+      </Suspense>
 
       <ContainerBody>
-        <LeaderboardTabs
-          battleEntries={battleEntries}
-          results={modelsWithResults}
-          supportsJudgeMode={judgeModeSupported}
-          taskId={taskId}
-        />
+        <Suspense fallback={<LeaderboardTabsSkeleton />}>
+          <TaskLeaderboard params={params} />
+        </Suspense>
 
-        <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {sortedModels.map((model) => (
-            <ModelCard key={model.id} model={model} taskId={taskId} />
-          ))}
-        </section>
+        <Suspense fallback={<TaskModelGridSkeleton />}>
+          <TaskModelGrid params={params} />
+        </Suspense>
       </ContainerBody>
     </main>
   );

--- a/apps/evals/src/components/breadcrumb.tsx
+++ b/apps/evals/src/components/breadcrumb.tsx
@@ -5,6 +5,7 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
 } from "@zoonk/ui/components/breadcrumb";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
 import Link from "next/link";
 
@@ -13,6 +14,18 @@ function AppBreadcrumb({ children, className, ...props }: React.ComponentProps<"
     <Breadcrumb className={cn("px-4 pt-4", className)} {...props}>
       <BreadcrumbList>{children}</BreadcrumbList>
     </Breadcrumb>
+  );
+}
+
+/**
+ * Preserves the breadcrumb's height and hierarchy while a URL-dependent
+ * breadcrumb item resolves inside its own Suspense boundary.
+ */
+function AppBreadcrumbItemSkeleton({ className }: { className?: string }) {
+  return (
+    <BreadcrumbItem aria-hidden="true">
+      <Skeleton className={cn("h-5 w-24 rounded", className)} />
+    </BreadcrumbItem>
   );
 }
 
@@ -66,6 +79,7 @@ function BattlesPageBreadcrumb() {
 
 export {
   AppBreadcrumb,
+  AppBreadcrumbItemSkeleton,
   HomePageBreadcrumb,
   HomeLinkBreadcrumb,
   TaskPageBreadcrumb,

--- a/apps/evals/src/components/model-status-badge.tsx
+++ b/apps/evals/src/components/model-status-badge.tsx
@@ -1,5 +1,6 @@
 import { type ModelStatus, getModelStatus } from "@/lib/utils";
 import { Badge } from "@zoonk/ui/components/badge";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 
 const labelMap: Record<ModelStatus, string> = {
   completed: "Evaluated",
@@ -19,4 +20,12 @@ export async function ModelStatusBadge({ taskId, modelId }: { taskId: string; mo
   const status = await getModelStatus(taskId, modelId);
 
   return <Badge variant={variantMap[status]}>{labelMap[status]}</Badge>;
+}
+
+/**
+ * Preserves the badge's exact height while its filesystem-backed model status
+ * is still being resolved.
+ */
+export function ModelStatusBadgeSkeleton() {
+  return <Skeleton className="h-5 w-20 rounded-full" />;
 }

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,6 +1,7 @@
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
+import { Skeleton } from "./skeleton";
 
 const buttonVariants = cva(
   "group/button focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 relative inline-flex shrink-0 items-center justify-center rounded-4xl border bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none before:absolute before:top-1/2 before:left-1/2 before:size-full before:min-h-11 before:min-w-11 before:-translate-x-1/2 before:-translate-y-1/2 focus-visible:ring-[3px] active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-[3px] lg:pointer-fine:has-data-[slot=shortcut-kbd]:justify-between [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -54,4 +55,33 @@ function Button({
   );
 }
 
-export { Button, buttonVariants };
+type ButtonSkeletonProps = Pick<
+  React.ComponentProps<typeof Button>,
+  "children" | "className" | "size" | "variant"
+>;
+
+/**
+ * Uses the real button layout with invisible content so loading placeholders
+ * always reserve the exact intrinsic width of their eventual action.
+ */
+function ButtonSkeleton({ children, className, size, variant }: ButtonSkeletonProps) {
+  return (
+    <Button
+      aria-hidden="true"
+      className={cn(
+        "bg-background hover:bg-background text-transparent disabled:opacity-100 [&_svg]:opacity-0",
+        className,
+      )}
+      disabled
+      size={size}
+      tabIndex={-1}
+      type="button"
+      variant={variant}
+    >
+      {children}
+      <Skeleton className="pointer-events-none absolute inset-0 rounded-4xl" />
+    </Button>
+  );
+}
+
+export { Button, ButtonSkeleton, buttonVariants };

--- a/packages/ui/src/components/container.tsx
+++ b/packages/ui/src/components/container.tsx
@@ -136,11 +136,17 @@ export function ContainerBody({ children, className }: ContainerBodyProps) {
 
 export type ContainerHeaderSkeletonProps = { className?: string };
 
+/**
+ * Mirrors the real header primitives so streamed titles replace the fallback
+ * without changing the header's height, padding, or sibling spacing.
+ */
 export function ContainerHeaderSkeleton({ className }: ContainerHeaderSkeletonProps) {
   return (
-    <header className={cn("flex flex-col gap-1", className)}>
-      <Skeleton className="mb-1 h-6 w-1/2" />
-      <Skeleton className="h-4 w-1/3" />
-    </header>
+    <ContainerHeader aria-hidden="true" className={className}>
+      <ContainerHeaderGroup className="min-w-0 flex-1">
+        <Skeleton className="h-4.5 w-1/2 rounded" />
+        <Skeleton className="h-5 w-3/4 rounded" />
+      </ContainerHeaderGroup>
+    </ContainerHeader>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables Next.js Cache Components and partial prefetching, and refactors eval task pages to stream data with Suspense and skeletons for faster, steadier navigation and fewer layout shifts.

- **Refactors**
  - Turned on `cacheComponents` and `partialPrefetching` in `next.config.ts`.
  - Added cached route helper (`getTaskRoute`) and shared cached loaders to resolve task/model once per request.
  - Split task pages into focused Suspense boundaries (breadcrumb, header, actions, leaderboard, model grid, results, battles) with parallel data reads.
  - Replaced `layout.tsx` and `loading.tsx` with colocated skeleton fallbacks to avoid full-page spinners.

- **New Features**
  - Introduced precise skeletons: breadcrumb item, container header, model status badge, button, model card, leaderboard tabs, battle list, and task model actions.
  - Exported shared UI skeletons (`ButtonSkeleton`, `ContainerHeaderSkeleton`) from `@zoonk/ui` for consistent placeholders across pages.

<sup>Written for commit 0b2cf1b92bba8625f38e30fecc0fcbd2e0564e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

