### PR TITLE
fix(evals): use primitive react cache keys

### DIFF
--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/page.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/page.tsx
@@ -36,12 +36,8 @@ type TaskModelRouteProps = { params: TaskModelRouteParams };
  * Resolves the task and model URL once for the breadcrumb, header, and body so
  * each Suspense region shares identical validation and decoded model data.
  */
-const getTaskModelRoute = cache(async (params: TaskModelRouteParams) => {
-  const [{ modelId: rawModelId }, { task, taskId }] = await Promise.all([
-    params,
-    getTaskRoute(params),
-  ]);
-
+const getTaskModelRoute = cache(async (taskId: string, rawModelId: string) => {
+  const { task } = await getTaskRoute(taskId);
   const modelId = decodeURIComponent(rawModelId);
   const model = EVAL_MODELS.find((item) => item.id === modelId);
 
@@ -51,6 +47,16 @@ const getTaskModelRoute = cache(async (params: TaskModelRouteParams) => {
 
   return { model, modelId, task, taskId };
 });
+
+/**
+ * Resolves Next's Promise-based route params before passing stable primitive
+ * cache keys to the shared task and model lookup.
+ */
+async function getTaskModelRouteFromParams(params: TaskModelRouteParams) {
+  const { modelId, taskId } = await params;
+
+  return getTaskModelRoute(taskId, modelId);
+}
 
 /**
  * Keeps the two URL-dependent breadcrumb positions visible while their task
@@ -71,7 +77,7 @@ function TaskModelBreadcrumbSkeleton() {
  * model names from different route states.
  */
 async function TaskModelBreadcrumb({ params }: TaskModelRouteProps) {
-  const { model, task } = await getTaskModelRoute(params);
+  const { model, task } = await getTaskModelRouteFromParams(params);
 
   return (
     <>
@@ -87,7 +93,7 @@ async function TaskModelBreadcrumb({ params }: TaskModelRouteProps) {
  * rest of the model page shell remains available.
  */
 async function TaskModelHeader({ params }: TaskModelRouteProps) {
-  const { task } = await getTaskModelRoute(params);
+  const { task } = await getTaskModelRouteFromParams(params);
 
   return (
     <ContainerHeader>
@@ -105,8 +111,8 @@ async function TaskModelHeader({ params }: TaskModelRouteProps) {
  * Reads results, generated outputs, and progress in parallel because none of
  * those mutable files depends on another to render the model body.
  */
-const getTaskModelContent = cache(async (params: TaskModelRouteParams) => {
-  const { model, modelId, task, taskId } = await getTaskModelRoute(params);
+const getTaskModelContent = cache(async (taskId: string, rawModelId: string) => {
+  const { model, modelId, task } = await getTaskModelRoute(taskId, rawModelId);
 
   const [results, modelOutputs, outputStatus] = await Promise.all([
     getTaskResults(taskId, modelId),
@@ -122,12 +128,22 @@ const getTaskModelContent = cache(async (params: TaskModelRouteParams) => {
 });
 
 /**
+ * Resolves the model route once per consumer before reusing the primitive-keyed
+ * content cache across the action and results Suspense regions.
+ */
+async function getTaskModelContentFromParams(params: TaskModelRouteParams) {
+  const { modelId, taskId } = await params;
+
+  return getTaskModelContent(taskId, modelId);
+}
+
+/**
  * Keeps the guaranteed action card independent from the optional output or
  * result section so its fallback always has a matching resolved element.
  */
 async function TaskModelActions({ params }: TaskModelRouteProps) {
   const { generatedOutputs, model, modelId, outputStatus, taskId } =
-    await getTaskModelContent(params);
+    await getTaskModelContentFromParams(params);
 
   return (
     <TaskModelActionsCard
@@ -150,7 +166,7 @@ async function TaskModelActions({ params }: TaskModelRouteProps) {
  * generated-only outputs, or no secondary section at all.
  */
 async function TaskModelResults({ params }: TaskModelRouteProps) {
-  const { generatedOutputs, results } = await getTaskModelContent(params);
+  const { generatedOutputs, results } = await getTaskModelContentFromParams(params);
 
   if (results) {
     return <EvalResults results={results} />;

--- a/apps/evals/src/app/tasks/[taskId]/_utils/task-route.ts
+++ b/apps/evals/src/app/tasks/[taskId]/_utils/task-route.ts
@@ -5,12 +5,11 @@ import { cache } from "react";
 export type TaskRouteParams = Promise<{ taskId: string }>;
 
 /**
- * Resolves and validates the shared task route parameter once so sibling
+ * Resolves and validates the shared task route value once so sibling
  * Suspense regions can render independently without repeating route lookup
  * work or drifting on invalid-task behavior.
  */
-export const getTaskRoute = cache(async (params: TaskRouteParams) => {
-  const { taskId } = await params;
+export const getTaskRoute = cache(async (taskId: string) => {
   const task = getTaskById(taskId);
 
   if (!task) {
@@ -19,3 +18,13 @@ export const getTaskRoute = cache(async (params: TaskRouteParams) => {
 
   return { task, taskId };
 });
+
+/**
+ * Next exposes route params as a Promise, while React cache needs the resolved
+ * primitive value to deduplicate lookups across independently streamed regions.
+ */
+export async function getTaskRouteFromParams(params: TaskRouteParams) {
+  const { taskId } = await params;
+
+  return getTaskRoute(taskId);
+}

--- a/apps/evals/src/app/tasks/[taskId]/battles/page.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/battles/page.tsx
@@ -15,7 +15,7 @@ import {
   ContainerTitle,
 } from "@zoonk/ui/components/container";
 import { Suspense } from "react";
-import { type TaskRouteParams, getTaskRoute } from "../_utils/task-route";
+import { type TaskRouteParams, getTaskRouteFromParams } from "../_utils/task-route";
 import { BattleMatchupList, BattleMatchupListSkeleton } from "./battle-matchup-list";
 
 type BattlesRouteProps = { params: TaskRouteParams };
@@ -25,7 +25,7 @@ type BattlesRouteProps = { params: TaskRouteParams };
  * items remain available in the shared route shell.
  */
 async function BattlesTaskBreadcrumb({ params }: BattlesRouteProps) {
-  const { task, taskId } = await getTaskRoute(params);
+  const { task, taskId } = await getTaskRouteFromParams(params);
 
   return <TaskLinkBreadcrumb taskId={taskId} taskName={task.name} />;
 }
@@ -35,7 +35,7 @@ async function BattlesTaskBreadcrumb({ params }: BattlesRouteProps) {
  * stable title and navigation never wait on filesystem work.
  */
 async function BattleResults({ params }: BattlesRouteProps) {
-  const { taskId } = await getTaskRoute(params);
+  const { taskId } = await getTaskRouteFromParams(params);
   const matchups = await getBattleMatchups(taskId);
 
   return <BattleMatchupList matchups={matchups} />;

--- a/apps/evals/src/app/tasks/[taskId]/page.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/page.tsx
@@ -24,7 +24,7 @@ import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
 import { MessageSquareTextIcon, SwordsIcon } from "lucide-react";
 import Link from "next/link";
 import { Suspense } from "react";
-import { type TaskRouteParams, getTaskRoute } from "./_utils/task-route";
+import { type TaskRouteParams, getTaskRouteFromParams } from "./_utils/task-route";
 import { runBattleModeAction } from "./actions";
 import { LeaderboardTabs, LeaderboardTabsSkeleton } from "./leaderboard-tabs";
 import { ModelCard, ModelCardSkeleton } from "./model-card";
@@ -36,7 +36,7 @@ type TaskRouteProps = { params: TaskRouteParams };
  * remains part of the prefetched App Shell.
  */
 async function TaskBreadcrumb({ params }: TaskRouteProps) {
-  const { task } = await getTaskRoute(params);
+  const { task } = await getTaskRouteFromParams(params);
 
   return <TaskPageBreadcrumb taskName={task.name} />;
 }
@@ -65,7 +65,7 @@ function TaskHeaderActionsSkeleton() {
  * work cannot delay the rest of the header.
  */
 async function TaskHeaderActions({ params }: TaskRouteProps) {
-  const { task, taskId } = await getTaskRoute(params);
+  const { task, taskId } = await getTaskRouteFromParams(params);
   const modelsReadyForBattle = await getModelsWithCompleteOutputs({ runsPerTestCase: 1, task });
   const canRunBattle = modelsReadyForBattle.length >= 2;
 
@@ -91,7 +91,7 @@ async function TaskHeaderActions({ params }: TaskRouteProps) {
  * stream through its own boundary instead of holding back the title.
  */
 async function TaskHeader({ params }: TaskRouteProps) {
-  const { task } = await getTaskRoute(params);
+  const { task } = await getTaskRouteFromParams(params);
 
   const judgeModeSupported = supportsJudgeMode(task);
 
@@ -119,7 +119,7 @@ async function TaskHeader({ params }: TaskRouteProps) {
  * and model grid remain independently interactive.
  */
 async function TaskLeaderboard({ params }: TaskRouteProps) {
-  const { task, taskId } = await getTaskRoute(params);
+  const { task, taskId } = await getTaskRouteFromParams(params);
   const judgeModeSupported = supportsJudgeMode(task);
 
   const battleEntriesPromise = judgeModeSupported
@@ -146,7 +146,7 @@ async function TaskLeaderboard({ params }: TaskRouteProps) {
  * mutable eval files and should not be frozen into the shared App Shell.
  */
 async function TaskModelGrid({ params }: TaskRouteProps) {
-  const { taskId } = await getTaskRoute(params);
+  const { taskId } = await getTaskRouteFromParams(params);
   const sortedModels = await getSortedModels(taskId);
 
   return (

--- a/packages/oxlint-plugin/rules/no-object-params-in-cache.js
+++ b/packages/oxlint-plugin/rules/no-object-params-in-cache.js
@@ -1,49 +1,133 @@
 import { defineRule } from "@oxlint/plugins";
 
+const OBJECT_TYPE_REFERENCES = new Set([
+  "Array",
+  "Date",
+  "Map",
+  "Promise",
+  "ReadonlyArray",
+  "Set",
+  "WeakMap",
+  "WeakSet",
+]);
+
+/**
+ * Destructuring proves that a cache parameter receives one object even when no TypeScript
+ * annotation is present, so this syntax can always be reported safely.
+ */
 function isObjectPattern(param) {
   return param.type === "ObjectPattern";
 }
 
-function isObjectTypeLiteral(typeAnnotation) {
-  if (!typeAnnotation) {
-    return false;
+/**
+ * Only simple type-reference names can match local aliases, built-in object types, or configured
+ * exceptions. Qualified names remain unknown rather than being guessed from partial syntax.
+ */
+function getTypeReferenceName(typeNode) {
+  if (typeNode.type !== "TSTypeReference") {
+    return null;
   }
 
-  const inner = typeAnnotation.typeAnnotation;
-
-  if (!inner) {
-    return false;
-  }
-
-  return inner.type === "TSTypeLiteral";
+  return typeNode.typeName.type === "Identifier" ? typeNode.typeName.name : null;
 }
 
-function isAllowedTypeReference(typeAnnotation, exceptions) {
-  if (!typeAnnotation) {
-    return false;
-  }
+/**
+ * Some reference-valued arguments, such as request Headers, are deliberately shared by identity.
+ * Keeping that policy configurable prevents the object detector from overriding known exceptions.
+ */
+function isAllowedTypeReference({ exceptions, typeNode }) {
+  const name = getTypeReferenceName(typeNode);
 
-  const inner = typeAnnotation.typeAnnotation;
-
-  if (!inner) {
-    return false;
-  }
-
-  if (inner.type !== "TSTypeReference") {
-    return false;
-  }
-
-  const typeName = inner.typeName;
-
-  if (!typeName) {
-    return false;
-  }
-
-  const name = typeName.type === "Identifier" ? typeName.name : null;
-
-  return name && exceptions.includes(name.toLowerCase());
+  return name ? exceptions.includes(name.toLowerCase()) : false;
 }
 
+/**
+ * Next generates route params as a Promise hidden behind an indexed PageProps type. Recognizing
+ * that syntax keeps the rule useful without treating every indexed access as an object.
+ */
+function isNextRouteParams(typeNode) {
+  if (typeNode.type !== "TSIndexedAccessType") {
+    return false;
+  }
+
+  const objectTypeName = getTypeReferenceName(typeNode.objectType);
+  const indexType = typeNode.indexType;
+  const indexName = indexType.type === "TSLiteralType" ? indexType.literal.value : null;
+
+  return (
+    (objectTypeName === "LayoutProps" || objectTypeName === "PageProps") && indexName === "params"
+  );
+}
+
+/**
+ * Local aliases preserve readable public types but can hide reference-valued cache parameters from
+ * a syntax-only rule. Following those aliases catches the object shape without guessing about
+ * imported aliases that may resolve to primitive unions.
+ */
+function isObjectType({ exceptions, typeAliases, typeNode, visitedAliases = new Set() }) {
+  if (
+    typeNode.type === "TSArrayType" ||
+    typeNode.type === "TSConstructorType" ||
+    typeNode.type === "TSFunctionType" ||
+    typeNode.type === "TSMappedType" ||
+    typeNode.type === "TSObjectKeyword" ||
+    typeNode.type === "TSTupleType" ||
+    typeNode.type === "TSTypeLiteral"
+  ) {
+    return true;
+  }
+
+  if (typeNode.type === "TSParenthesizedType") {
+    return isObjectType({
+      exceptions,
+      typeAliases,
+      typeNode: typeNode.typeAnnotation,
+      visitedAliases,
+    });
+  }
+
+  if (typeNode.type === "TSUnionType" || typeNode.type === "TSIntersectionType") {
+    return typeNode.types.some((member) =>
+      isObjectType({ exceptions, typeAliases, typeNode: member, visitedAliases }),
+    );
+  }
+
+  if (isNextRouteParams(typeNode)) {
+    return true;
+  }
+
+  if (typeNode.type !== "TSTypeReference" || isAllowedTypeReference({ exceptions, typeNode })) {
+    return false;
+  }
+
+  const name = getTypeReferenceName(typeNode);
+
+  if (!name) {
+    return false;
+  }
+
+  if (OBJECT_TYPE_REFERENCES.has(name)) {
+    return true;
+  }
+
+  const aliasedType = typeAliases.get(name);
+
+  if (!aliasedType || visitedAliases.has(name)) {
+    return false;
+  }
+
+  return isObjectType({
+    exceptions,
+    typeAliases,
+    typeNode: aliasedType,
+    visitedAliases: new Set([...visitedAliases, name]),
+  });
+}
+
+/**
+ * Diagnostics should name the declared parameter regardless of defaults or rest syntax so the
+ * developer can identify the unstable cache key immediately.
+ */
 function getParamName(param) {
   if (param.type === "Identifier") {
     return param.name;
@@ -57,10 +141,18 @@ function getParamName(param) {
     return getParamName(param.left);
   }
 
+  if (param.type === "RestElement") {
+    return getParamName(param.argument);
+  }
+
   return "(unknown)";
 }
 
-function isParamViolation(param, exceptions) {
+/**
+ * A rest annotation describes the array collected inside the function, not a single cache key.
+ * Inspecting its element type distinguishes safe primitive rest arguments from object arguments.
+ */
+function isParamViolation({ exceptions, param, typeAliases }) {
   // Destructured object pattern like ({ orgSlug }) is always a violation
   if (isObjectPattern(param)) {
     return true;
@@ -73,13 +165,14 @@ function isParamViolation(param, exceptions) {
     return false;
   }
 
-  // Allowed type references like Headers are not violations
-  if (isAllowedTypeReference(typeAnnotation, exceptions)) {
-    return false;
-  }
+  const parameterType = typeAnnotation.typeAnnotation;
 
-  // Object type literals like { orgSlug: string } are violations
-  return isObjectTypeLiteral(typeAnnotation);
+  const cacheArgumentType =
+    param.type === "RestElement" && parameterType.type === "TSArrayType"
+      ? parameterType.elementType
+      : parameterType;
+
+  return isObjectType({ exceptions, typeAliases, typeNode: cacheArgumentType });
 }
 
 export default defineRule({
@@ -87,6 +180,7 @@ export default defineRule({
     let exceptions;
     let cacheImported;
     let cacheLocalName;
+    let typeAliases;
 
     return {
       before() {
@@ -98,6 +192,11 @@ export default defineRule({
 
         cacheImported = false;
         cacheLocalName = "cache";
+        typeAliases = new Map();
+      },
+
+      TSTypeAliasDeclaration(node) {
+        typeAliases.set(node.id.name, node.typeAnnotation);
       },
 
       ImportDeclaration(node) {
@@ -138,7 +237,7 @@ export default defineRule({
         for (const param of firstArg.params) {
           const paramToCheck = param.type === "AssignmentPattern" ? param.left : param;
 
-          const shouldReport = isParamViolation(paramToCheck, exceptions);
+          const shouldReport = isParamViolation({ exceptions, param: paramToCheck, typeAliases });
 
           if (shouldReport) {
             context.report({

--- a/packages/oxlint-plugin/rules/no-object-params-in-cache.js
+++ b/packages/oxlint-plugin/rules/no-object-params-in-cache.js
@@ -11,13 +11,18 @@ const OBJECT_TYPE_REFERENCES = new Set([
   "WeakSet",
 ]);
 
-/**
- * Destructuring proves that a cache parameter receives one object even when no TypeScript
- * annotation is present, so this syntax can always be reported safely.
- */
-function isObjectPattern(param) {
-  return param.type === "ObjectPattern";
-}
+const ARRAY_TYPE_REFERENCES = new Set(["Array", "ReadonlyArray"]);
+const COMPOSITE_TYPE_NODES = new Set(["TSIntersectionType", "TSUnionType"]);
+
+const OBJECT_TYPE_NODES = new Set([
+  "TSArrayType",
+  "TSConstructorType",
+  "TSFunctionType",
+  "TSMappedType",
+  "TSObjectKeyword",
+  "TSTupleType",
+  "TSTypeLiteral",
+]);
 
 /**
  * Only simple type-reference names can match local aliases, built-in object types, or configured
@@ -60,42 +65,99 @@ function isNextRouteParams(typeNode) {
 }
 
 /**
- * Local aliases preserve readable public types but can hide reference-valued cache parameters from
- * a syntax-only rule. Following those aliases catches the object shape without guessing about
- * imported aliases that may resolve to primitive unions.
+ * A tuple rest annotation describes separate runtime arguments. Unwrapping optional, named, and
+ * nested rest elements lets the rule inspect each cache key instead of treating the tuple itself as
+ * one object.
  */
-function isObjectType({ exceptions, typeAliases, typeNode, visitedAliases = new Set() }) {
-  if (
-    typeNode.type === "TSArrayType" ||
-    typeNode.type === "TSConstructorType" ||
-    typeNode.type === "TSFunctionType" ||
-    typeNode.type === "TSMappedType" ||
-    typeNode.type === "TSObjectKeyword" ||
-    typeNode.type === "TSTupleType" ||
-    typeNode.type === "TSTypeLiteral"
-  ) {
-    return true;
+function getTupleCacheArgument(element) {
+  if (element.type === "TSNamedTupleMember") {
+    return getTupleCacheArgument(element.elementType);
   }
 
+  if (element.type === "TSOptionalType") {
+    return { spreadsArguments: false, typeNode: element.typeAnnotation };
+  }
+
+  if (element.type === "TSRestType") {
+    return { spreadsArguments: true, typeNode: element.typeAnnotation };
+  }
+
+  return { spreadsArguments: false, typeNode: element };
+}
+
+/**
+ * Parentheses and the readonly modifier change TypeScript syntax without changing whether the
+ * runtime value is reference-valued. Returning their inner type keeps that normalization out of
+ * the main classifier.
+ */
+function getTransparentType(typeNode) {
   if (typeNode.type === "TSParenthesizedType") {
+    return typeNode.typeAnnotation;
+  }
+
+  if (typeNode.type === "TSTypeOperator" && typeNode.operator === "readonly") {
+    return typeNode.typeAnnotation;
+  }
+
+  return null;
+}
+
+/**
+ * Rest parameter annotations describe a collection, while React receives each collected value as
+ * its own cache key. This returns null for non-collection syntax so normal object classification can
+ * continue.
+ */
+function getSpreadObjectResult({
+  exceptions,
+  spreadsArguments,
+  typeAliases,
+  typeNode,
+  visitedAliases,
+}) {
+  if (!spreadsArguments) {
+    return null;
+  }
+
+  if (typeNode.type === "TSArrayType") {
     return isObjectType({
       exceptions,
       typeAliases,
-      typeNode: typeNode.typeAnnotation,
+      typeNode: typeNode.elementType,
       visitedAliases,
     });
   }
 
-  if (typeNode.type === "TSUnionType" || typeNode.type === "TSIntersectionType") {
-    return typeNode.types.some((member) =>
-      isObjectType({ exceptions, typeAliases, typeNode: member, visitedAliases }),
+  if (typeNode.type === "TSTupleType") {
+    return typeNode.elementTypes.some((element) =>
+      isTupleCacheArgumentObject({ element, exceptions, typeAliases, visitedAliases }),
     );
   }
 
-  if (isNextRouteParams(typeNode)) {
-    return true;
+  const name = getTypeReferenceName(typeNode);
+
+  if (!name || !ARRAY_TYPE_REFERENCES.has(name)) {
+    return null;
   }
 
+  const elementType = typeNode.typeArguments?.params[0];
+
+  return elementType
+    ? isObjectType({ exceptions, typeAliases, typeNode: elementType, visitedAliases })
+    : false;
+}
+
+/**
+ * Named types may be known reference-valued built-ins or local aliases. Imported unknown types stay
+ * unreported because this syntax-only rule cannot safely distinguish object types from primitive
+ * unions defined in another module.
+ */
+function isTypeReferenceObject({
+  exceptions,
+  spreadsArguments,
+  typeAliases,
+  typeNode,
+  visitedAliases,
+}) {
   if (typeNode.type !== "TSTypeReference" || isAllowedTypeReference({ exceptions, typeNode })) {
     return false;
   }
@@ -118,9 +180,81 @@ function isObjectType({ exceptions, typeAliases, typeNode, visitedAliases = new 
 
   return isObjectType({
     exceptions,
+    spreadsArguments,
     typeAliases,
     typeNode: aliasedType,
     visitedAliases: new Set([...visitedAliases, name]),
+  });
+}
+
+/**
+ * React compares each runtime cache argument by identity. Following local aliases and TypeScript
+ * wrappers reveals reference-valued keys while spread annotations are inspected as the separate
+ * arguments they produce.
+ */
+function isObjectType({
+  exceptions,
+  spreadsArguments = false,
+  typeAliases,
+  typeNode,
+  visitedAliases = new Set(),
+}) {
+  const transparentType = getTransparentType(typeNode);
+
+  if (transparentType) {
+    return isObjectType({
+      exceptions,
+      spreadsArguments,
+      typeAliases,
+      typeNode: transparentType,
+      visitedAliases,
+    });
+  }
+
+  if (COMPOSITE_TYPE_NODES.has(typeNode.type)) {
+    return typeNode.types.some((member) =>
+      isObjectType({ exceptions, spreadsArguments, typeAliases, typeNode: member, visitedAliases }),
+    );
+  }
+
+  const spreadObjectResult = getSpreadObjectResult({
+    exceptions,
+    spreadsArguments,
+    typeAliases,
+    typeNode,
+    visitedAliases,
+  });
+
+  if (spreadObjectResult !== null) {
+    return spreadObjectResult;
+  }
+
+  if (OBJECT_TYPE_NODES.has(typeNode.type) || isNextRouteParams(typeNode)) {
+    return true;
+  }
+
+  return isTypeReferenceObject({
+    exceptions,
+    spreadsArguments,
+    typeAliases,
+    typeNode,
+    visitedAliases,
+  });
+}
+
+/**
+ * Tuple elements may be optional, named, or themselves variadic. Normalizing one element before
+ * classification keeps the tuple traversal declarative and preserves nested rest semantics.
+ */
+function isTupleCacheArgumentObject({ element, exceptions, typeAliases, visitedAliases }) {
+  const cacheArgument = getTupleCacheArgument(element);
+
+  return isObjectType({
+    exceptions,
+    spreadsArguments: cacheArgument.spreadsArguments,
+    typeAliases,
+    typeNode: cacheArgument.typeNode,
+    visitedAliases,
   });
 }
 
@@ -154,7 +288,7 @@ function getParamName(param) {
  */
 function isParamViolation({ exceptions, param, typeAliases }) {
   // Destructured object pattern like ({ orgSlug }) is always a violation
-  if (isObjectPattern(param)) {
+  if (param.type === "ObjectPattern") {
     return true;
   }
 
@@ -165,14 +299,12 @@ function isParamViolation({ exceptions, param, typeAliases }) {
     return false;
   }
 
-  const parameterType = typeAnnotation.typeAnnotation;
-
-  const cacheArgumentType =
-    param.type === "RestElement" && parameterType.type === "TSArrayType"
-      ? parameterType.elementType
-      : parameterType;
-
-  return isObjectType({ exceptions, typeAliases, typeNode: cacheArgumentType });
+  return isObjectType({
+    exceptions,
+    spreadsArguments: param.type === "RestElement",
+    typeAliases,
+    typeNode: typeAnnotation.typeAnnotation,
+  });
 }
 
 export default defineRule({
@@ -180,6 +312,7 @@ export default defineRule({
     let exceptions;
     let cacheImported;
     let cacheLocalName;
+    let paramsToCheck;
     let typeAliases;
 
     return {
@@ -192,7 +325,20 @@ export default defineRule({
 
         cacheImported = false;
         cacheLocalName = "cache";
+        paramsToCheck = [];
         typeAliases = new Map();
+      },
+
+      after() {
+        for (const param of paramsToCheck) {
+          if (isParamViolation({ exceptions, param, typeAliases })) {
+            context.report({
+              data: { name: getParamName(param) },
+              loc: param.loc,
+              messageId: "noObjectParams",
+            });
+          }
+        }
       },
 
       TSTypeAliasDeclaration(node) {
@@ -236,16 +382,7 @@ export default defineRule({
 
         for (const param of firstArg.params) {
           const paramToCheck = param.type === "AssignmentPattern" ? param.left : param;
-
-          const shouldReport = isParamViolation({ exceptions, param: paramToCheck, typeAliases });
-
-          if (shouldReport) {
-            context.report({
-              data: { name: getParamName(paramToCheck) },
-              loc: paramToCheck.loc,
-              messageId: "noObjectParams",
-            });
-          }
+          paramsToCheck.push(paramToCheck);
         }
       },
     };


### PR DESCRIPTION
## Summary

- make the React cache lint rule detect named object aliases and Next route params
- pass primitive task and model identifiers into the evals cache functions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch eval routes to primitive keys for `react` cache and resolve `next` route params before caching to prevent cache misses and inconsistent UI. Strengthens the `no-object-params-in-cache` rule in our `oxlint` plugin to better catch object-like cache keys, including aliased and Next params.

- **Bug Fixes**
  - Use primitive cache keys: `getTaskRoute(taskId)`, `getTaskModelRoute(taskId, modelId)`, `getTaskModelContent(taskId, modelId)`.
  - Add `getTaskRouteFromParams`, `getTaskModelRouteFromParams`, and `getTaskModelContentFromParams` to resolve `PageProps["params"]` Promises and pass stable keys.
  - Update task, model, and battles pages to call the new helpers.

- **Refactors**
  - Expand `no-object-params-in-cache` to detect destructuring, tuples/rest args, parenthesized/readonly wrappers, TS object/union/intersection, local `type` aliases, built-ins (e.g., `Array`), and `PageProps["params"]`/`LayoutProps["params"]`.
  - Support exceptions for allowed reference types, follow alias chains, and improve parameter naming in diagnostics.

<sup>Written for commit 905f2ef3a5ba4d2af1ea19bc6a026b5cb82a9fd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

