### PR TITLE
chore(admin): enable cache components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - When writing comments, use `/** ... */` for functions, so we can get JSDoc tooltips
 - When refactoring code, double check if the remaining or replaced logic still makes sense. For example, it's pointless to just reassign a type or const like `type ExistingCourse = Course` or `const existingCourse = course`. Just use the original type or const instead of creating an alias that adds no value
 - Never move independent async work out of an existing Promise.all because it can create a waterfall. Preserving or increasing parallelism is required, even if one branch does not use every result. Treat newly serialized async reads as a performance regression unless there is a concrete dependency between them. You should always avoid waterfalls
+- Run browser-launching test commands such as Playwright, Cypress, Puppeteer, Selenium, or repository E2E scripts with escalated sandbox permissions on the first attempt. Chromium-based browsers require Mach services that are blocked by the workspace sandbox, so do not first run these commands inside the sandbox; send the exact command to Auto-review for approval instead
 
 ## Prisma Queries
 

--- a/apps/admin/AGENTS.md
+++ b/apps/admin/AGENTS.md
@@ -5,5 +5,4 @@
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
 
 This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
-
 <!-- END:nextjs-agent-rules -->

--- a/apps/admin/next.config.ts
+++ b/apps/admin/next.config.ts
@@ -4,6 +4,7 @@ const CACHE_IMAGE_DAYS = 30;
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["*.local"],
+  cacheComponents: true,
   experimental: {
     authInterrupts: true,
     serverActions: { bodySizeLimit: "10mb" },
@@ -21,6 +22,7 @@ const nextConfig: NextConfig = {
       new URL("https://*.githubusercontent.com/**"),
     ],
   },
+  partialPrefetching: true,
   reactCompiler: true,
   typedRoutes: false,
   typescript: { ignoreBuildErrors: true },

--- a/apps/admin/src/app/(private)/app-sidebar-menu-item.tsx
+++ b/apps/admin/src/app/(private)/app-sidebar-menu-item.tsx
@@ -18,7 +18,7 @@ export function AppSidebarMenuItem<T extends string>({
 }) {
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton isActive={isActive} render={<Link href={url} />}>
+      <SidebarMenuButton isActive={isActive} render={<Link href={url} prefetch />}>
         <Icon aria-hidden="true" />
         <span>{label}</span>
       </SidebarMenuButton>

--- a/apps/admin/src/app/(private)/app-stats-content.tsx
+++ b/apps/admin/src/app/(private)/app-stats-content.tsx
@@ -4,10 +4,9 @@ import { countCoursePrompts } from "@/data/course-prompts/list-course-prompts";
 import { countContent } from "@/data/stats/count-content";
 import { countCourses } from "@/data/stats/count-courses";
 import { BookOpenIcon, LayersIcon, MessageSquareTextIcon } from "lucide-react";
-import { connection } from "next/server";
 
 export async function ContentStats() {
-  await connection();
+  "use cache: private";
 
   const [totalCourses, content, promptCount] = await Promise.all([
     countCourses(),

--- a/apps/admin/src/app/(private)/app-stats-engagement.tsx
+++ b/apps/admin/src/app/(private)/app-stats-engagement.tsx
@@ -9,12 +9,12 @@ import { getTotalLearningTime } from "@/data/stats/get-total-learning-time";
 import { formatDuration } from "@/lib/format-duration";
 import { getRollingUtcDateWindowStarts } from "@/lib/rolling-date-windows";
 import { BookOpenIcon, CheckCircleIcon, ClockIcon, LayersIcon, TargetIcon } from "lucide-react";
-import { connection } from "next/server";
 
 const DAYS_7 = 7;
 
 export async function EngagementStats() {
-  await connection();
+  "use cache: private";
+
   const now = new Date();
 
   const { currentPeriodStart, previousPeriodStart } = getRollingUtcDateWindowStarts({

--- a/apps/admin/src/app/(private)/app-stats-growth.tsx
+++ b/apps/admin/src/app/(private)/app-stats-growth.tsx
@@ -5,10 +5,9 @@ import { countUsers } from "@/data/stats/count-users";
 import { getActivationRate } from "@/data/stats/get-activation-rate";
 import { getConversionRate } from "@/data/stats/get-conversion-rate";
 import { CreditCardIcon, TargetIcon, UsersIcon } from "lucide-react";
-import { connection } from "next/server";
 
 export async function GrowthStats() {
-  await connection();
+  "use cache: private";
 
   const [totalUsers, subscribersByPlan, activation, conversion] = await Promise.all([
     countUsers(),

--- a/apps/admin/src/app/(private)/course-prompts/course-prompt-list.tsx
+++ b/apps/admin/src/app/(private)/course-prompts/course-prompt-list.tsx
@@ -1,3 +1,4 @@
+import { AdminTableSkeleton, AdminTableSkeletonRows } from "@/components/admin-table-skeleton";
 import { AdminPagination } from "@/components/pagination";
 import {
   type ListedCoursePrompt,
@@ -15,7 +16,6 @@ import {
   TableRow,
 } from "@zoonk/ui/components/table";
 
-const SKELETON_ROW_COUNT = 5;
 const TABLE_COLUMN_COUNT = 7;
 
 /**
@@ -28,6 +28,27 @@ export async function CoursePromptList({
   searchParams: PageProps<"/course-prompts">["searchParams"];
 }) {
   const { page, limit, offset, search } = parseSearchParams(await searchParams);
+
+  return <CachedCoursePromptList limit={limit} offset={offset} page={page} search={search} />;
+}
+
+/**
+ * Normalized pagination values provide a stable private-cache key while the
+ * cached result keeps prompt data ready for runtime-prefetched navigation.
+ */
+async function CachedCoursePromptList({
+  limit,
+  offset,
+  page,
+  search,
+}: {
+  limit: number;
+  offset: number;
+  page: number;
+  search?: string;
+}) {
+  "use cache: private";
+
   const { prompts, total } = await listCoursePrompts({ limit, offset, search });
   const totalPages = Math.ceil(total / limit);
 
@@ -71,18 +92,15 @@ export function CoursePromptListSkeleton() {
     <div className="flex flex-col gap-4">
       <Skeleton className="h-4 w-40" />
 
-      <div className="overflow-x-auto rounded-lg border">
+      <AdminTableSkeleton className="overflow-x-auto">
         <Table>
           <CoursePromptTableHeader />
 
-          <TableBody>
-            {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
-              // oxlint-disable-next-line react/no-array-index-key -- Skeleton rows are fixed placeholders.
-              <CoursePromptSkeletonRow key={index} />
-            ))}
-          </TableBody>
+          <AdminTableSkeletonRows>
+            <CoursePromptSkeletonRow />
+          </AdminTableSkeletonRows>
         </Table>
-      </div>
+      </AdminTableSkeleton>
     </div>
   );
 }

--- a/apps/admin/src/app/(private)/course-prompts/page.tsx
+++ b/apps/admin/src/app/(private)/course-prompts/page.tsx
@@ -1,4 +1,4 @@
-import { AdminSearch } from "@/components/admin-search";
+import { AdminSearch, AdminSearchSkeleton } from "@/components/admin-search";
 import {
   Container,
   ContainerBody,
@@ -32,7 +32,7 @@ export default function CoursePromptsPage({ searchParams }: PageProps<"/course-p
       </ContainerHeader>
 
       <ContainerBody>
-        <Suspense fallback={<div className="h-10" />}>
+        <Suspense fallback={<AdminSearchSkeleton />}>
           <AdminSearch placeholder="Search by prompt, title, intent, format, or course..." />
         </Suspense>
 

--- a/apps/admin/src/app/(private)/course-prompts/page.tsx
+++ b/apps/admin/src/app/(private)/course-prompts/page.tsx
@@ -12,6 +12,7 @@ import { Suspense } from "react";
 import { CoursePromptList, CoursePromptListSkeleton } from "./course-prompt-list";
 
 export const metadata: Metadata = { title: "Course Prompts" };
+export const prefetch = "allow-runtime";
 
 /**
  * Shows the durable routing decisions created by course-start entry points.

--- a/apps/admin/src/app/(private)/courses/course-list.tsx
+++ b/apps/admin/src/app/(private)/courses/course-list.tsx
@@ -1,15 +1,49 @@
+import { AdminTableSkeleton, AdminTableSkeletonRows } from "@/components/admin-table-skeleton";
 import { AdminPagination } from "@/components/pagination";
 import { listCourses } from "@/data/courses/list-courses";
 import { parseSearchParams } from "@/lib/parse-search-params";
-import { Table, TableBody, TableHead, TableHeader, TableRow } from "@zoonk/ui/components/table";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
 import { CourseRow } from "./course-row";
 
+/**
+ * Course URL state, protected loading, and pagination resolve together so a
+ * refreshed or shared admin URL always describes the rows on screen.
+ */
 export async function CourseList({
   searchParams,
 }: {
   searchParams: PageProps<"/courses">["searchParams"];
 }) {
   const { page, limit, offset, search } = parseSearchParams(await searchParams);
+
+  return <CachedCourseList limit={limit} offset={offset} page={page} search={search} />;
+}
+
+/**
+ * Primitive URL values make each list state a deterministic browser-private
+ * cache entry that runtime prefetching can prepare before navigation.
+ */
+async function CachedCourseList({
+  limit,
+  offset,
+  page,
+  search,
+}: {
+  limit: number;
+  offset: number;
+  page: number;
+  search?: string;
+}) {
+  "use cache: private";
+
   const { courses, total } = await listCourses({ limit, offset, search });
   const totalPages = Math.ceil(total / limit);
 
@@ -17,16 +51,7 @@ export async function CourseList({
     <>
       <div className="overflow-x-auto rounded-lg border">
         <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Title</TableHead>
-              <TableHead>Organization</TableHead>
-              <TableHead>Language</TableHead>
-              <TableHead className="text-right">Completed Lessons</TableHead>
-              <TableHead>Published</TableHead>
-              <TableHead>Created At</TableHead>
-            </TableRow>
-          </TableHeader>
+          <CourseTableHeader />
 
           <TableBody>
             {courses.map((course) => (
@@ -44,5 +69,71 @@ export async function CourseList({
         totalPages={totalPages}
       />
     </>
+  );
+}
+
+/**
+ * The fallback uses the real course columns so admins see the table structure
+ * immediately while private course data streams in.
+ */
+export function CourseListSkeleton() {
+  return (
+    <AdminTableSkeleton className="overflow-x-auto">
+      <Table>
+        <CourseTableHeader />
+
+        <AdminTableSkeletonRows>
+          <CourseSkeletonRow />
+        </AdminTableSkeletonRows>
+      </Table>
+    </AdminTableSkeleton>
+  );
+}
+
+/**
+ * Loaded and loading course tables share one header so their columns cannot
+ * drift as the admin catalog grows.
+ */
+function CourseTableHeader() {
+  return (
+    <TableHeader>
+      <TableRow>
+        <TableHead>Title</TableHead>
+        <TableHead>Organization</TableHead>
+        <TableHead>Language</TableHead>
+        <TableHead className="text-right">Completed Lessons</TableHead>
+        <TableHead>Published</TableHead>
+        <TableHead>Created At</TableHead>
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+/**
+ * Course row placeholders preserve the relative width of identity, ownership,
+ * status, and date fields during streaming.
+ */
+function CourseSkeletonRow() {
+  return (
+    <TableRow>
+      <TableCell>
+        <Skeleton className="h-4 w-48" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-32" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-10" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="ml-auto h-4 w-10" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-5" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+    </TableRow>
   );
 }

--- a/apps/admin/src/app/(private)/courses/page.tsx
+++ b/apps/admin/src/app/(private)/courses/page.tsx
@@ -12,6 +12,7 @@ import { Suspense } from "react";
 import { CourseList, CourseListSkeleton } from "./course-list";
 
 export const metadata: Metadata = { title: "Courses" };
+export const prefetch = "allow-runtime";
 
 export default function CoursesPage({ searchParams }: PageProps<"/courses">) {
   return (

--- a/apps/admin/src/app/(private)/courses/page.tsx
+++ b/apps/admin/src/app/(private)/courses/page.tsx
@@ -1,4 +1,4 @@
-import { AdminSearch } from "@/components/admin-search";
+import { AdminSearch, AdminSearchSkeleton } from "@/components/admin-search";
 import {
   Container,
   ContainerBody,
@@ -9,7 +9,7 @@ import {
 } from "@zoonk/ui/components/container";
 import { type Metadata } from "next";
 import { Suspense } from "react";
-import { CourseList } from "./course-list";
+import { CourseList, CourseListSkeleton } from "./course-list";
 
 export const metadata: Metadata = { title: "Courses" };
 
@@ -24,11 +24,11 @@ export default function CoursesPage({ searchParams }: PageProps<"/courses">) {
       </ContainerHeader>
 
       <ContainerBody>
-        <Suspense fallback={<div className="h-10" />}>
+        <Suspense fallback={<AdminSearchSkeleton />}>
           <AdminSearch placeholder="Search by title..." />
         </Suspense>
 
-        <Suspense>
+        <Suspense fallback={<CourseListSkeleton />}>
           <CourseList searchParams={searchParams} />
         </Suspense>
       </ContainerBody>

--- a/apps/admin/src/app/(private)/leaderboard/brain-power-leaderboard.tsx
+++ b/apps/admin/src/app/(private)/leaderboard/brain-power-leaderboard.tsx
@@ -1,3 +1,4 @@
+import { AdminTableSkeleton, AdminTableSkeletonRows } from "@/components/admin-table-skeleton";
 import { AdminPagination } from "@/components/pagination";
 import {
   type BrainPowerLeader,
@@ -18,7 +19,6 @@ import {
 import Link from "next/link";
 
 const LEADERBOARD_DAYS = 7;
-const SKELETON_ROW_COUNT = 5;
 const TABLE_COLUMN_COUNT = 4;
 
 /**
@@ -32,6 +32,24 @@ export async function BrainPowerLeaderboard({
 }) {
   const params = await searchParams;
   const { limit, offset, page } = parseSearchParams(params);
+
+  return <CachedBrainPowerLeaderboard limit={limit} offset={offset} page={page} />;
+}
+
+/**
+ * Parsed pagination values and the minute cache lifetime keep the rolling
+ * leaderboard deterministic and available to runtime prefetching.
+ */
+async function CachedBrainPowerLeaderboard({
+  limit,
+  offset,
+  page,
+}: {
+  limit: number;
+  offset: number;
+  page: number;
+}) {
+  "use cache: private";
 
   const { currentPeriodStart } = getRollingUtcDateWindowStarts({
     days: LEADERBOARD_DAYS,
@@ -85,18 +103,15 @@ export function BrainPowerLeaderboardSkeleton() {
     <div className="flex flex-col gap-4">
       <Skeleton className="h-4 w-56" />
 
-      <div className="overflow-x-auto rounded-lg border">
+      <AdminTableSkeleton className="overflow-x-auto">
         <Table>
           <BrainPowerLeaderboardHeader />
 
-          <TableBody>
-            {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
-              // oxlint-disable-next-line react/no-array-index-key -- Skeleton rows are static placeholders.
-              <BrainPowerLeaderboardSkeletonRow key={index} />
-            ))}
-          </TableBody>
+          <AdminTableSkeletonRows>
+            <BrainPowerLeaderboardSkeletonRow />
+          </AdminTableSkeletonRows>
         </Table>
-      </div>
+      </AdminTableSkeleton>
     </div>
   );
 }
@@ -143,7 +158,7 @@ function BrainPowerLeaderboardRow({ leader }: { leader: BrainPowerLeader }) {
         {leader.rank.toLocaleString()}
       </TableCell>
       <TableCell>
-        <Link className="block" href={`/users/${leader.user.id}`}>
+        <Link className="block" href={`/users/${leader.user.id}`} prefetch>
           <span className="font-medium">{leader.user.name || "—"}</span>
           <span className="text-muted-foreground block text-xs">{leader.user.email}</span>
         </Link>

--- a/apps/admin/src/app/(private)/leaderboard/page.tsx
+++ b/apps/admin/src/app/(private)/leaderboard/page.tsx
@@ -11,6 +11,7 @@ import { Suspense } from "react";
 import { BrainPowerLeaderboard, BrainPowerLeaderboardSkeleton } from "./brain-power-leaderboard";
 
 export const metadata: Metadata = { title: "Brain Power Leaderboard" };
+export const prefetch = "allow-runtime";
 
 /**
  * The leaderboard gives admins one focused view of recent learning activity,

--- a/apps/admin/src/app/(private)/lessons/generated-lesson-list.tsx
+++ b/apps/admin/src/app/(private)/lessons/generated-lesson-list.tsx
@@ -1,7 +1,12 @@
+import { AdminTableSkeleton, AdminTableSkeletonRows } from "@/components/admin-table-skeleton";
 import { AdminPagination } from "@/components/pagination";
 import { listGeneratedLessons } from "@/data/lessons/list-generated-lessons";
-import { parseGeneratedLessonStatus } from "@/lib/generated-lesson-status";
+import {
+  type GeneratedLessonStatus,
+  parseGeneratedLessonStatus,
+} from "@/lib/generated-lesson-status";
 import { parseSearchParams } from "@/lib/parse-search-params";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import {
   Table,
   TableBody,
@@ -24,6 +29,37 @@ export async function GeneratedLessonList({
   const params = await searchParams;
   const { page, limit, offset, search } = parseSearchParams(params);
   const status = parseGeneratedLessonStatus(params.status);
+
+  return (
+    <CachedGeneratedLessonList
+      limit={limit}
+      offset={offset}
+      page={page}
+      search={search}
+      status={status}
+    />
+  );
+}
+
+/**
+ * Parsed filter and pagination primitives produce deterministic private-cache
+ * entries for every generated-lesson URL that can be prefetched.
+ */
+async function CachedGeneratedLessonList({
+  limit,
+  offset,
+  page,
+  search,
+  status,
+}: {
+  limit: number;
+  offset: number;
+  page: number;
+  search?: string;
+  status: GeneratedLessonStatus;
+}) {
+  "use cache: private";
+
   const { lessons, total } = await listGeneratedLessons({ limit, offset, search, status });
   const totalPages = Math.ceil(total / limit);
 
@@ -31,18 +67,7 @@ export async function GeneratedLessonList({
     <>
       <div className="overflow-x-auto rounded-lg border">
         <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Lesson</TableHead>
-              <TableHead>Kind</TableHead>
-              <TableHead>Course</TableHead>
-              <TableHead>Chapter</TableHead>
-              <TableHead>Organization</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead className="text-right">Steps</TableHead>
-              <TableHead>Updated At</TableHead>
-            </TableRow>
-          </TableHeader>
+          <GeneratedLessonTableHeader />
 
           <TableBody>
             {lessons.length > 0 ? (
@@ -67,5 +92,79 @@ export async function GeneratedLessonList({
         totalPages={totalPages}
       />
     </>
+  );
+}
+
+/**
+ * The fallback exposes the complete operational table structure while the
+ * selected status, search, and private lesson rows stream together.
+ */
+export function GeneratedLessonListSkeleton() {
+  return (
+    <AdminTableSkeleton className="overflow-x-auto">
+      <Table>
+        <GeneratedLessonTableHeader />
+
+        <AdminTableSkeletonRows>
+          <GeneratedLessonSkeletonRow />
+        </AdminTableSkeletonRows>
+      </Table>
+    </AdminTableSkeleton>
+  );
+}
+
+/**
+ * Loaded and loading lesson tables share one header so review fields cannot
+ * drift between the streamed states.
+ */
+function GeneratedLessonTableHeader() {
+  return (
+    <TableHeader>
+      <TableRow>
+        <TableHead>Lesson</TableHead>
+        <TableHead>Kind</TableHead>
+        <TableHead>Course</TableHead>
+        <TableHead>Chapter</TableHead>
+        <TableHead>Organization</TableHead>
+        <TableHead>Status</TableHead>
+        <TableHead className="text-right">Steps</TableHead>
+        <TableHead>Updated At</TableHead>
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+/**
+ * Lesson row placeholders retain the wider identity columns and compact status
+ * fields used by the generated-content log.
+ */
+function GeneratedLessonSkeletonRow() {
+  return (
+    <TableRow>
+      <TableCell>
+        <Skeleton className="h-4 w-48" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-40" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-40" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-32" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-5 w-20" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="ml-auto h-4 w-8" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+    </TableRow>
   );
 }

--- a/apps/admin/src/app/(private)/lessons/generated-lesson-status-filter.tsx
+++ b/apps/admin/src/app/(private)/lessons/generated-lesson-status-filter.tsx
@@ -1,5 +1,6 @@
 import { type GeneratedLessonStatus, generatedLessonStatuses } from "@/lib/generated-lesson-status";
 import { Button } from "@zoonk/ui/components/button";
+import Link from "next/link";
 
 const statusLabels: Record<GeneratedLessonStatus, string> = {
   completed: "Completed",
@@ -27,10 +28,10 @@ export function GeneratedLessonStatusFilter({
           key={item}
           nativeButton={false}
           render={
-            // oxlint-disable-next-line jsx-a11y/anchor-has-content -- render prop receives Button children
-            <a
+            <Link
               aria-current={status === item ? "page" : undefined}
               href={buildStatusHref({ search, status: item })}
+              prefetch
             />
           }
           size="sm"
@@ -53,7 +54,7 @@ function buildStatusHref({
 }: {
   search?: string;
   status: GeneratedLessonStatus;
-}): string {
+}): `/lessons?${string}` {
   const entries: StatusQueryEntry[] = [["status", status], search ? ["search", search] : undefined];
 
   const params = new URLSearchParams(entries.filter((entry) => isQueryEntry(entry)));

--- a/apps/admin/src/app/(private)/lessons/page.tsx
+++ b/apps/admin/src/app/(private)/lessons/page.tsx
@@ -1,4 +1,4 @@
-import { AdminSearch } from "@/components/admin-search";
+import { AdminSearch, AdminSearchSkeleton } from "@/components/admin-search";
 import { parseGeneratedLessonStatus } from "@/lib/generated-lesson-status";
 import {
   Container,
@@ -8,9 +8,10 @@ import {
   ContainerHeaderGroup,
   ContainerTitle,
 } from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { type Metadata } from "next";
 import { Suspense } from "react";
-import { GeneratedLessonList } from "./generated-lesson-list";
+import { GeneratedLessonList, GeneratedLessonListSkeleton } from "./generated-lesson-list";
 import { GeneratedLessonStatusFilter } from "./generated-lesson-status-filter";
 
 export const metadata: Metadata = { title: "Generated Lessons" };
@@ -19,11 +20,7 @@ export const metadata: Metadata = { title: "Generated Lessons" };
  * This page gives admins a terminal-state log for lesson generation so they can
  * see failed generations first and switch to completed output when auditing.
  */
-export default async function GeneratedLessonsPage({ searchParams }: PageProps<"/lessons">) {
-  const params = await searchParams;
-  const status = parseGeneratedLessonStatus(params.status);
-  const search = Array.isArray(params.search) ? params.search[0] : params.search;
-
+export default function GeneratedLessonsPage({ searchParams }: PageProps<"/lessons">) {
   return (
     <Container>
       <ContainerHeader variant="sidebar">
@@ -36,18 +33,49 @@ export default async function GeneratedLessonsPage({ searchParams }: PageProps<"
       </ContainerHeader>
 
       <ContainerBody>
-        <div className="flex flex-col gap-3">
-          <Suspense fallback={<div className="h-10" />}>
-            <AdminSearch placeholder="Search by lesson, chapter, or course..." />
-          </Suspense>
+        <Suspense fallback={<GeneratedLessonFiltersSkeleton />}>
+          <GeneratedLessonFilters searchParams={searchParams} />
+        </Suspense>
 
-          <GeneratedLessonStatusFilter search={search} status={status} />
-        </div>
-
-        <Suspense>
+        <Suspense fallback={<GeneratedLessonListSkeleton />}>
           <GeneratedLessonList searchParams={searchParams} />
         </Suspense>
       </ContainerBody>
     </Container>
+  );
+}
+
+/**
+ * The selected generation status is request URL state, so only the filter
+ * controls need to wait while the page heading remains in the static shell.
+ */
+async function GeneratedLessonFilters({
+  searchParams,
+}: Pick<PageProps<"/lessons">, "searchParams">) {
+  const params = await searchParams;
+  const status = parseGeneratedLessonStatus(params.status);
+  const search = Array.isArray(params.search) ? params.search[0] : params.search;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <AdminSearch placeholder="Search by lesson, chapter, or course..." />
+      <GeneratedLessonStatusFilter search={search} status={status} />
+    </div>
+  );
+}
+
+/**
+ * Both filter rows depend on the same URL state, so their placeholder preserves
+ * the complete control footprint until that state is available.
+ */
+function GeneratedLessonFiltersSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      <AdminSearchSkeleton />
+      <div className="flex gap-1">
+        <Skeleton className="h-8 w-24 rounded-4xl" />
+        <Skeleton className="h-8 w-24 rounded-4xl" />
+      </div>
+    </div>
   );
 }

--- a/apps/admin/src/app/(private)/lessons/page.tsx
+++ b/apps/admin/src/app/(private)/lessons/page.tsx
@@ -15,6 +15,7 @@ import { GeneratedLessonList, GeneratedLessonListSkeleton } from "./generated-le
 import { GeneratedLessonStatusFilter } from "./generated-lesson-status-filter";
 
 export const metadata: Metadata = { title: "Generated Lessons" };
+export const prefetch = "allow-runtime";
 
 /**
  * This page gives admins a terminal-state log for lesson generation so they can

--- a/apps/admin/src/app/(private)/page.tsx
+++ b/apps/admin/src/app/(private)/page.tsx
@@ -11,6 +11,7 @@ import { Suspense } from "react";
 import { AppStats, AppStatsFallback } from "./app-stats";
 
 export const metadata: Metadata = { title: "Zoonk Admin" };
+export const prefetch = "allow-runtime";
 
 export default function Home() {
   return (

--- a/apps/admin/src/app/(private)/stats/_components/admin-period-navigation.tsx
+++ b/apps/admin/src/app/(private)/stats/_components/admin-period-navigation.tsx
@@ -1,45 +1,115 @@
-"use client";
-
 import { Button } from "@zoonk/ui/components/button";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
-import { useQueryState } from "nuqs";
+import Link from "next/link";
 
+type StatsPeriodPath = "/stats/content" | "/stats/engagement" | "/stats/growth";
+type StatsPeriodHref = `${StatsPeriodPath}?${string}`;
+type StatsPeriodQueryParams = Record<string, string | string[] | undefined>;
+type StatsPeriodQueryEntry = [string, string] | undefined;
+
+/**
+ * Period navigation has two predictable destinations, so Next links can fetch
+ * their cached analytics payloads before the admin clicks either direction.
+ */
 export function AdminPeriodNavigation({
-  hasNext,
+  basePath,
+  offset,
+  period,
   periodLabel,
+  queryParams,
 }: {
-  hasNext: boolean;
+  basePath: StatsPeriodPath;
+  offset: number;
+  period: HistoryPeriod;
   periodLabel: string;
+  queryParams?: StatsPeriodQueryParams;
 }) {
-  const [offset, setOffset] = useQueryState("offset", { defaultValue: "0", shallow: false });
+  const previousHref = buildStatsPeriodHref({ basePath, offset: offset + 1, period, queryParams });
 
-  const currentOffset = Number(offset) || 0;
-
-  function handlePrevious() {
-    void setOffset(String(currentOffset + 1));
-  }
-
-  function handleNext() {
-    void setOffset(String(Math.max(0, currentOffset - 1)));
-  }
+  const nextHref =
+    offset > 0
+      ? buildStatsPeriodHref({ basePath, offset: offset - 1, period, queryParams })
+      : undefined;
 
   return (
     <div className="flex items-center gap-2">
-      <Button aria-label="Previous period" onClick={handlePrevious} size="icon" variant="outline">
+      <Button
+        aria-label="Previous period"
+        nativeButton={false}
+        render={<Link href={previousHref} prefetch />}
+        size="icon"
+        variant="outline"
+      >
         <ChevronLeftIcon aria-hidden />
       </Button>
 
       <span className="min-w-32 text-center text-sm font-medium">{periodLabel}</span>
 
-      <Button
-        aria-label="Next period"
-        disabled={!hasNext}
-        onClick={handleNext}
-        size="icon"
-        variant="outline"
-      >
-        <ChevronRightIcon aria-hidden />
-      </Button>
+      {nextHref ? (
+        <Button
+          aria-label="Next period"
+          nativeButton={false}
+          render={<Link href={nextHref} prefetch />}
+          size="icon"
+          variant="outline"
+        >
+          <ChevronRightIcon aria-hidden />
+        </Button>
+      ) : (
+        <Button aria-label="Next period" disabled size="icon" variant="outline">
+          <ChevronRightIcon aria-hidden />
+        </Button>
+      )}
     </div>
   );
+}
+
+/**
+ * Existing analytics filters must survive a period change, while period and
+ * offset are replaced with the destination selected by the pager.
+ */
+function buildStatsPeriodHref({
+  basePath,
+  offset,
+  period,
+  queryParams,
+}: {
+  basePath: StatsPeriodPath;
+  offset: number;
+  period: HistoryPeriod;
+  queryParams?: StatsPeriodQueryParams;
+}): StatsPeriodHref {
+  const preservedEntries = Object.entries(queryParams ?? {})
+    .map((entry) => getStatsPeriodQueryEntry(entry))
+    .filter((entry) => isStatsPeriodQueryEntry(entry))
+    .filter(([key]) => key !== "offset" && key !== "period");
+
+  const entries = [
+    ...preservedEntries,
+    ["period", period],
+    ["offset", offset.toString()],
+  ] satisfies [string, string][];
+
+  return `${basePath}?${new URLSearchParams(entries).toString()}`;
+}
+
+/**
+ * Repeated query values are not used by analytics filters, so preserving the
+ * first value keeps navigation deterministic without discarding the filter.
+ */
+function getStatsPeriodQueryEntry([key, value]: [
+  string,
+  string | string[] | undefined,
+]): StatsPeriodQueryEntry {
+  const firstValue = Array.isArray(value) ? value[0] : value;
+  return firstValue ? [key, firstValue] : undefined;
+}
+
+/**
+ * URLSearchParams accepts only complete string pairs after optional filters
+ * have been normalized.
+ */
+function isStatsPeriodQueryEntry(entry: StatsPeriodQueryEntry): entry is [string, string] {
+  return Array.isArray(entry);
 }

--- a/apps/admin/src/app/(private)/stats/_components/stats-page-layout.tsx
+++ b/apps/admin/src/app/(private)/stats/_components/stats-page-layout.tsx
@@ -13,8 +13,9 @@ import {
   ContainerHeaderGroup,
   ContainerTitle,
 } from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import Link from "next/link";
-import { Fragment } from "react";
+import { Fragment, Suspense } from "react";
 import { AdminPeriodTabs } from "./admin-period-tabs";
 
 type StatsBreadcrumbItem = { href?: string; label: string };
@@ -30,11 +31,11 @@ function StatsBreadcrumb({ items }: { items: StatsBreadcrumbItem[] }) {
     <Breadcrumb>
       <BreadcrumbList>
         <BreadcrumbItem>
-          <BreadcrumbLink render={<Link href="/" />}>Dashboard</BreadcrumbLink>
+          <BreadcrumbLink render={<Link href="/" prefetch />}>Dashboard</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbLink render={<Link href="/stats" />}>Stats</BreadcrumbLink>
+          <BreadcrumbLink render={<Link href="/stats" prefetch />}>Stats</BreadcrumbLink>
         </BreadcrumbItem>
 
         {items.map((item, index) => {
@@ -48,7 +49,9 @@ function StatsBreadcrumb({ items }: { items: StatsBreadcrumbItem[] }) {
                 {isLastItem || !item.href ? (
                   <BreadcrumbPage>{item.label}</BreadcrumbPage>
                 ) : (
-                  <BreadcrumbLink render={<Link href={item.href} />}>{item.label}</BreadcrumbLink>
+                  <BreadcrumbLink render={<Link href={item.href} prefetch />}>
+                    {item.label}
+                  </BreadcrumbLink>
                 )}
               </BreadcrumbItem>
             </Fragment>
@@ -89,7 +92,11 @@ export function StatsPageLayout({
 
           {showControls ? (
             <div className="flex flex-wrap items-center justify-between gap-3 pt-3">
-              {showPeriodTabs ? <AdminPeriodTabs /> : null}
+              {showPeriodTabs ? (
+                <Suspense fallback={<StatsPeriodTabsSkeleton />}>
+                  <AdminPeriodTabs />
+                </Suspense>
+              ) : null}
               {navigation}
             </div>
           ) : null}
@@ -98,5 +105,62 @@ export function StatsPageLayout({
 
       <ContainerBody>{children}</ContainerBody>
     </Container>
+  );
+}
+
+/**
+ * Stats routes need a complete prerendered shell while their URL-dependent
+ * controls and metrics wait for request data. This keeps that loading shell
+ * consistent across every analytics page instead of duplicating it per route.
+ */
+export function StatsPageSkeleton({
+  breadcrumbItems,
+  children,
+  showPeriodControls = true,
+  title,
+}: {
+  breadcrumbItems?: StatsBreadcrumbItem[];
+  children: React.ReactNode;
+  showPeriodControls?: boolean;
+  title: string;
+}) {
+  return (
+    <StatsPageLayout
+      breadcrumbItems={breadcrumbItems}
+      navigation={showPeriodControls ? <StatsPeriodNavigationSkeleton /> : undefined}
+      showPeriodTabs={showPeriodControls}
+      title={title}
+    >
+      {children}
+    </StatsPageLayout>
+  );
+}
+
+/**
+ * Period tabs read the current URL in a client component, so this local
+ * fallback keeps that small hook from making the whole analytics shell wait.
+ */
+function StatsPeriodTabsSkeleton() {
+  return (
+    <div className="flex gap-1">
+      <Skeleton className="h-8 w-16 rounded-4xl" />
+      <Skeleton className="h-8 w-20 rounded-4xl" />
+      <Skeleton className="h-8 w-14 rounded-4xl" />
+      <Skeleton className="h-8 w-12 rounded-4xl" />
+    </div>
+  );
+}
+
+/**
+ * The selected date label depends on URL data and a cached clock read. This
+ * reserves only that control while runtime prefetching resolves it.
+ */
+export function StatsPeriodNavigationSkeleton() {
+  return (
+    <div className="flex items-center gap-2">
+      <Skeleton className="size-9 rounded-4xl" />
+      <Skeleton className="h-5 w-32" />
+      <Skeleton className="size-9 rounded-4xl" />
+    </div>
   );
 }

--- a/apps/admin/src/app/(private)/stats/_utils/stats-period.ts
+++ b/apps/admin/src/app/(private)/stats/_utils/stats-period.ts
@@ -1,0 +1,44 @@
+import { calculateDateRanges, formatPeriodLabel, validatePeriod } from "@zoonk/utils/date-ranges";
+import { validateOffset } from "@zoonk/utils/number";
+import { cache } from "react";
+
+type StatsSearchParams = Promise<{ offset?: string | string[]; period?: string | string[] }>;
+
+/**
+ * Calendar ranges are shared across admins and only change at period
+ * boundaries. Caching this synchronous clock read lets runtime prefetching
+ * resolve URL-backed controls without tying them to a live connection.
+ */
+async function getCachedStatsPeriod({
+  rawOffset,
+  rawPeriod,
+}: {
+  rawOffset?: string | string[];
+  rawPeriod?: string | string[];
+}) {
+  "use cache";
+
+  const period = validatePeriod(String(rawPeriod ?? "month"));
+  const offset = validateOffset(rawOffset);
+  const { current, previous } = calculateDateRanges(period, offset);
+
+  return {
+    current,
+    offset,
+    period,
+    periodLabel: formatPeriodLabel(current.start, current.end, period, "en"),
+    previous,
+  };
+}
+
+/**
+ * A route can request its period context from multiple local Suspense
+ * boundaries. React request memoization keeps those reads coordinated while
+ * the inner Cache Component supplies the reusable time-based value.
+ */
+export const getStatsPeriod = cache(async (searchParams: StatsSearchParams) => {
+  const { offset, period } = await searchParams;
+  return getCachedStatsPeriod({ rawOffset: offset, rawPeriod: period });
+});
+
+export type StatsPeriod = Awaited<ReturnType<typeof getStatsPeriod>>;

--- a/apps/admin/src/app/(private)/stats/_utils/stats-period.ts
+++ b/apps/admin/src/app/(private)/stats/_utils/stats-period.ts
@@ -1,22 +1,17 @@
 import { calculateDateRanges, formatPeriodLabel, validatePeriod } from "@zoonk/utils/date-ranges";
 import { validateOffset } from "@zoonk/utils/number";
-import { cache } from "react";
 
 type StatsSearchParams = Promise<{ offset?: string | string[]; period?: string | string[] }>;
 
 /**
- * Calendar ranges are shared across admins and only change at period
- * boundaries. Caching this synchronous clock read lets runtime prefetching
- * resolve URL-backed controls without tying them to a live connection.
+ * Calendar ranges only change at period boundaries. Private caching lets
+ * runtime prefetching resolve URL-backed controls while reading search params
+ * inside the same function.
  */
-async function getCachedStatsPeriod({
-  rawOffset,
-  rawPeriod,
-}: {
-  rawOffset?: string | string[];
-  rawPeriod?: string | string[];
-}) {
-  "use cache";
+export async function getStatsPeriod(searchParams: StatsSearchParams) {
+  "use cache: private";
+
+  const { offset: rawOffset, period: rawPeriod } = await searchParams;
 
   const period = validatePeriod(String(rawPeriod ?? "month"));
   const offset = validateOffset(rawOffset);
@@ -30,15 +25,5 @@ async function getCachedStatsPeriod({
     previous,
   };
 }
-
-/**
- * A route can request its period context from multiple local Suspense
- * boundaries. React request memoization keeps those reads coordinated while
- * the inner Cache Component supplies the reusable time-based value.
- */
-export const getStatsPeriod = cache(async (searchParams: StatsSearchParams) => {
-  const { offset, period } = await searchParams;
-  return getCachedStatsPeriod({ rawOffset: offset, rawPeriod: period });
-});
 
 export type StatsPeriod = Awaited<ReturnType<typeof getStatsPeriod>>;

--- a/apps/admin/src/app/(private)/stats/content/content-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/content/content-metrics.tsx
@@ -2,11 +2,11 @@ import { countContent } from "@/data/stats/count-content";
 import { getDailyContentCreated } from "@/data/stats/get-daily-content-created";
 import { getPeriodContentCreated } from "@/data/stats/get-period-content-created";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
-import { type HistoryPeriod, calculateDateRanges, validatePeriod } from "@zoonk/utils/date-ranges";
-import { validateOffset } from "@zoonk/utils/number";
+import { type HistoryPeriod } from "@zoonk/utils/date-ranges";
 import { BookOpenIcon, LayersIcon } from "lucide-react";
 import { Suspense } from "react";
 import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
+import { type StatsPeriod } from "../_utils/stats-period";
 import { CompletedLessonsByKindTable } from "./completed-lessons-by-kind-table";
 import { ContentChart } from "./content-chart-filter";
 import { ContentTotalsTable } from "./content-totals-table";
@@ -24,15 +24,10 @@ async function ContentChartSection({
   return <ContentChart dailyContent={dailyContent} period={period} />;
 }
 
-export async function ContentMetrics({
-  searchParams,
-}: {
-  searchParams: Promise<{ period?: string; offset?: string }>;
-}) {
-  const { period: rawPeriod, offset: rawOffset } = await searchParams;
-  const period = validatePeriod(rawPeriod ?? "month");
-  const offset = validateOffset(rawOffset);
-  const { current, previous } = calculateDateRanges(period, offset);
+export async function ContentMetrics({ statsPeriod }: { statsPeriod: StatsPeriod }) {
+  "use cache: private";
+
+  const { current, period, previous } = statsPeriod;
 
   const [currentCreated, previousCreated, totals] = await Promise.all([
     getPeriodContentCreated(current.start, current.end),

--- a/apps/admin/src/app/(private)/stats/content/page.tsx
+++ b/apps/admin/src/app/(private)/stats/content/page.tsx
@@ -1,32 +1,67 @@
-import { calculateDateRanges, formatPeriodLabel, validatePeriod } from "@zoonk/utils/date-ranges";
-import { validateOffset } from "@zoonk/utils/number";
 import { type Metadata } from "next";
 import { Suspense } from "react";
 import { AdminPeriodNavigation } from "../_components/admin-period-navigation";
-import { StatsPageLayout } from "../_components/stats-page-layout";
+import { StatsPageLayout, StatsPeriodNavigationSkeleton } from "../_components/stats-page-layout";
+import { getStatsPeriod } from "../_utils/stats-period";
 import { ContentMetrics, ContentMetricsSkeleton } from "./content-metrics";
 
 export const metadata: Metadata = { title: "Content & Operations" };
 
-export default async function ContentPage({ searchParams }: PageProps<"/stats/content">) {
-  const { period: rawPeriod, offset: rawOffset } = await searchParams;
-  const period = validatePeriod(String(rawPeriod ?? "month"));
-  const offset = validateOffset(rawOffset);
-  const { current } = calculateDateRanges(period, offset);
-  const periodLabel = formatPeriodLabel(current.start, current.end, period, "en");
-
+/**
+ * Stable analytics chrome stays in the App Shell while URL-backed controls and
+ * cached metrics resolve in independent boundaries.
+ */
+export default function ContentPage({ searchParams }: PageProps<"/stats/content">) {
   return (
     <StatsPageLayout
       navigation={
-        period === "all" ? null : (
-          <AdminPeriodNavigation hasNext={offset > 0} periodLabel={periodLabel} />
-        )
+        <Suspense fallback={<StatsPeriodNavigationSkeleton />}>
+          <ContentPeriodNavigation searchParams={searchParams} />
+        </Suspense>
       }
       title="Content & Operations"
     >
-      <Suspense fallback={<ContentMetricsSkeleton />} key={`${period}-${offset}`}>
-        <ContentMetrics searchParams={searchParams} />
+      <Suspense fallback={<ContentMetricsSkeleton />}>
+        <ContentMetricsRegion searchParams={searchParams} />
       </Suspense>
     </StatsPageLayout>
+  );
+}
+
+/**
+ * Runtime prefetching can resolve the selected period before navigation while
+ * the shared title and breadcrumbs remain available from the route shell.
+ */
+async function ContentPeriodNavigation({
+  searchParams,
+}: Pick<PageProps<"/stats/content">, "searchParams">) {
+  const { offset, period, periodLabel } = await getStatsPeriod(searchParams);
+
+  return period === "all" ? null : (
+    <AdminPeriodNavigation
+      basePath="/stats/content"
+      offset={offset}
+      period={period}
+      periodLabel={periodLabel}
+    />
+  );
+}
+
+/**
+ * The URL and cached calendar range resolve before the private analytics query.
+ * The keyed inner boundary resets only the metric body when the period changes.
+ */
+async function ContentMetricsRegion({
+  searchParams,
+}: Pick<PageProps<"/stats/content">, "searchParams">) {
+  const statsPeriod = await getStatsPeriod(searchParams);
+
+  return (
+    <Suspense
+      fallback={<ContentMetricsSkeleton />}
+      key={`${statsPeriod.period}-${statsPeriod.offset}`}
+    >
+      <ContentMetrics statsPeriod={statsPeriod} />
+    </Suspense>
   );
 }

--- a/apps/admin/src/app/(private)/stats/content/page.tsx
+++ b/apps/admin/src/app/(private)/stats/content/page.tsx
@@ -6,6 +6,7 @@ import { getStatsPeriod } from "../_utils/stats-period";
 import { ContentMetrics, ContentMetricsSkeleton } from "./content-metrics";
 
 export const metadata: Metadata = { title: "Content & Operations" };
+export const prefetch = "allow-runtime";
 
 /**
  * Stable analytics chrome stays in the App Shell while URL-backed controls and

--- a/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/engagement-metrics.tsx
@@ -8,27 +8,16 @@ import { getPeriodLearningTime } from "@/data/stats/get-period-learning-time";
 import { formatDuration } from "@/lib/format-duration";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { buildChartData } from "@zoonk/utils/chart";
-import { calculateDateRanges, validatePeriod } from "@zoonk/utils/date-ranges";
-import { validateOffset } from "@zoonk/utils/number";
 import { BookOpenIcon, CheckCircleIcon, ClockIcon, TargetIcon, TimerIcon } from "lucide-react";
 import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
 import { AdminTrendChart } from "../_components/admin-trend-chart";
+import { type StatsPeriod } from "../_utils/stats-period";
 import { LessonBreakdownTable } from "./lesson-breakdown-table";
 
-export async function EngagementMetrics({
-  searchParams,
-}: {
-  searchParams: {
-    completedLessons?: string | string[];
-    learningDays?: string | string[];
-    offset?: string | string[];
-    period?: string | string[];
-  };
-}) {
-  const { period: rawPeriod, offset: rawOffset } = searchParams;
-  const period = validatePeriod(String(rawPeriod ?? "month"));
-  const offset = validateOffset(rawOffset);
-  const { current, previous } = calculateDateRanges(period, offset);
+export async function EngagementMetrics({ statsPeriod }: { statsPeriod: StatsPeriod }) {
+  "use cache: private";
+
+  const { current, period, previous } = statsPeriod;
 
   const [
     currentActiveLearners,

--- a/apps/admin/src/app/(private)/stats/engagement/learner-milestones.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learner-milestones.tsx
@@ -12,6 +12,7 @@ import { Input } from "@zoonk/ui/components/input";
 import { Label } from "@zoonk/ui/components/label";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { BookCheckIcon, CalendarDaysIcon } from "lucide-react";
+import Form from "next/form";
 import Link from "next/link";
 import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
 
@@ -26,11 +27,7 @@ type EngagementSearchParams = {
  * Learner milestones are all-time threshold questions, so they live as a quiet
  * engagement subsection with URL-backed inputs and linked counts.
  */
-export async function LearnerMilestones({
-  searchParams,
-}: {
-  searchParams: EngagementSearchParams;
-}) {
+export function LearnerMilestones({ searchParams }: { searchParams: EngagementSearchParams }) {
   const completedLessonsThreshold = parseLearnerMilestoneThreshold({
     defaultValue: DEFAULT_COMPLETED_LESSONS_THRESHOLD,
     value: searchParams.completedLessons,
@@ -40,6 +37,33 @@ export async function LearnerMilestones({
     defaultValue: DEFAULT_LEARNING_DAYS_THRESHOLD,
     value: searchParams.learningDays,
   });
+
+  return (
+    <CachedLearnerMilestones
+      completedLessonsThreshold={completedLessonsThreshold}
+      learningDaysThreshold={learningDaysThreshold}
+      offset={getFirstSearchParamValue(searchParams.offset)}
+      period={getFirstSearchParamValue(searchParams.period)}
+    />
+  );
+}
+
+/**
+ * Parsed thresholds and scalar period state provide deterministic private-cache
+ * keys while keeping the milestone result available before navigation.
+ */
+async function CachedLearnerMilestones({
+  completedLessonsThreshold,
+  learningDaysThreshold,
+  offset,
+  period,
+}: {
+  completedLessonsThreshold: number;
+  learningDaysThreshold: number;
+  offset?: string;
+  period?: string;
+}) {
+  "use cache: private";
 
   const summary = await getLearnerMilestoneSummary(
     completedLessonsThreshold,
@@ -51,8 +75,8 @@ export async function LearnerMilestones({
       <LearnerMilestoneForm
         completedLessonsThreshold={completedLessonsThreshold}
         learningDaysThreshold={learningDaysThreshold}
-        offset={searchParams.offset}
-        period={searchParams.period}
+        offset={offset}
+        period={period}
       />
 
       <div className="grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-2">
@@ -75,6 +99,14 @@ export async function LearnerMilestones({
 }
 
 /**
+ * Analytics controls use one value per key, so repeated query values collapse
+ * to the first value before they cross the private-cache boundary.
+ */
+function getFirstSearchParamValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
  * The threshold form updates the engagement page with a plain GET request, so
  * admins can bookmark or share the exact thresholds they are inspecting.
  */
@@ -90,7 +122,7 @@ function LearnerMilestoneForm({
   period?: string | string[];
 }) {
   return (
-    <form action="/stats/engagement" className="flex flex-col gap-4">
+    <Form action="/stats/engagement" className="flex flex-col gap-4">
       <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col gap-1">
           <h3 className="text-base font-semibold tracking-tight">Learner Milestones</h3>
@@ -122,7 +154,7 @@ function LearnerMilestoneForm({
           name="learningDays"
         />
       </div>
-    </form>
+    </Form>
   );
 }
 
@@ -144,7 +176,14 @@ function MilestoneThresholdField({
   return (
     <div className="flex min-w-0 flex-col gap-2">
       <Label htmlFor={id}>{label}</Label>
-      <Input defaultValue={defaultValue} id={id} min={1} name={name} type="number" />
+      <Input
+        defaultValue={defaultValue}
+        id={id}
+        key={defaultValue}
+        min={1}
+        name={name}
+        type="number"
+      />
     </div>
   );
 }
@@ -184,6 +223,7 @@ function LearnerMilestoneCard({
     <Link
       className="hover:bg-muted/50 rounded-lg p-2 transition-colors"
       href={buildLearnerMilestoneUsersHref({ kind, threshold })}
+      prefetch
     >
       <AdminMetricCard
         description="Open user list"

--- a/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-threshold-form.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-threshold-form.tsx
@@ -2,6 +2,7 @@ import { type LearnerMilestoneKind } from "@/lib/learner-milestone-filters";
 import { Button } from "@zoonk/ui/components/button";
 import { Input } from "@zoonk/ui/components/input";
 import { Label } from "@zoonk/ui/components/label";
+import Form from "next/form";
 
 /**
  * The drill-down page keeps the threshold editable so admins can move from one
@@ -17,7 +18,7 @@ export function LearnerMilestoneThresholdForm({
   threshold: number;
 }) {
   return (
-    <form
+    <Form
       action="/stats/engagement/learners"
       className="flex max-w-md flex-col gap-3 sm:flex-row sm:items-end"
     >
@@ -28,6 +29,7 @@ export function LearnerMilestoneThresholdForm({
         <Input
           defaultValue={threshold}
           id="milestone-threshold"
+          key={threshold}
           min={1}
           name="threshold"
           type="number"
@@ -37,6 +39,6 @@ export function LearnerMilestoneThresholdForm({
       <Button type="submit" variant="outline">
         Apply
       </Button>
-    </form>
+    </Form>
   );
 }

--- a/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-users-table.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-users-table.tsx
@@ -1,3 +1,4 @@
+import { AdminTableSkeleton, AdminTableSkeletonRows } from "@/components/admin-table-skeleton";
 import { type LearnerMilestoneUser } from "@/data/stats/get-learner-milestones";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import {
@@ -10,8 +11,6 @@ import {
   TableRow,
 } from "@zoonk/ui/components/table";
 import Link from "next/link";
-
-const SKELETON_ROW_COUNT = 5;
 
 /**
  * The table focuses on the metrics that explain why each learner matched the
@@ -50,18 +49,15 @@ export function LearnerMilestoneUsersTable({
  */
 export function LearnerMilestoneUsersTableSkeleton() {
   return (
-    <div className="rounded-lg border">
+    <AdminTableSkeleton>
       <Table>
         <LearnerMilestoneUsersTableHeader />
 
-        <TableBody>
-          {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
-            // oxlint-disable-next-line react/no-array-index-key -- Skeleton rows are static placeholders.
-            <LearnerMilestoneSkeletonRow key={index} />
-          ))}
-        </TableBody>
+        <AdminTableSkeletonRows>
+          <LearnerMilestoneSkeletonRow />
+        </AdminTableSkeletonRows>
       </Table>
-    </div>
+    </AdminTableSkeleton>
   );
 }
 
@@ -124,7 +120,7 @@ function LearnerMilestoneUserRow({ user }: { user: LearnerMilestoneUser }) {
   return (
     <TableRow>
       <TableCell>
-        <Link className="block" href={`/users/${user.id}`}>
+        <Link className="block" href={`/users/${user.id}`} prefetch>
           <span className="font-medium">{user.name || "—"}</span>
           <span className="text-muted-foreground block text-xs">{user.email}</span>
         </Link>

--- a/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-users.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learners/learner-milestone-users.tsx
@@ -12,7 +12,7 @@ import {
  * The user list is the slowest part of the drill-down page, so it streams after
  * the page title and threshold controls are already available.
  */
-export async function LearnerMilestoneUsers({
+export function LearnerMilestoneUsers({
   emptyMessage,
   kind,
   params,
@@ -24,6 +24,40 @@ export async function LearnerMilestoneUsers({
   threshold: number;
 }) {
   const { limit, offset, page } = parseSearchParams(params);
+
+  return (
+    <CachedLearnerMilestoneUsers
+      emptyMessage={emptyMessage}
+      kind={kind}
+      limit={limit}
+      offset={offset}
+      page={page}
+      threshold={threshold}
+    />
+  );
+}
+
+/**
+ * The normalized milestone and pagination values remain stable across both
+ * phases of runtime prefetching, unlike the raw search-parameter object.
+ */
+async function CachedLearnerMilestoneUsers({
+  emptyMessage,
+  kind,
+  limit,
+  offset,
+  page,
+  threshold,
+}: {
+  emptyMessage: string;
+  kind: LearnerMilestoneKind;
+  limit: number;
+  offset: number;
+  page: number;
+  threshold: number;
+}) {
+  "use cache: private";
+
   const { total, users } = await listLearnerMilestoneUsers(kind, threshold, limit, offset);
   const totalPages = Math.ceil(total / limit);
 

--- a/apps/admin/src/app/(private)/stats/engagement/learners/page.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learners/page.tsx
@@ -12,6 +12,7 @@ import { LearnerMilestoneThresholdForm } from "./learner-milestone-threshold-for
 import { LearnerMilestoneUsers, LearnerMilestoneUsersSkeleton } from "./learner-milestone-users";
 
 export const metadata: Metadata = { title: "Learner Milestones" };
+export const prefetch = "allow-runtime";
 
 /**
  * The route keeps a useful analytics shell while its milestone definition is

--- a/apps/admin/src/app/(private)/stats/engagement/learners/page.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/learners/page.tsx
@@ -4,17 +4,49 @@ import {
   parseLearnerMilestoneKind,
   parseLearnerMilestoneThreshold,
 } from "@/lib/learner-milestone-filters";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { type Metadata } from "next";
 import { Suspense } from "react";
-import { StatsPageLayout } from "../../_components/stats-page-layout";
+import { StatsPageLayout, StatsPageSkeleton } from "../../_components/stats-page-layout";
 import { LearnerMilestoneThresholdForm } from "./learner-milestone-threshold-form";
 import { LearnerMilestoneUsers, LearnerMilestoneUsersSkeleton } from "./learner-milestone-users";
 
 export const metadata: Metadata = { title: "Learner Milestones" };
 
-export default async function LearnerMilestoneUsersPage({
+/**
+ * The route keeps a useful analytics shell while its milestone definition is
+ * derived from request-time query parameters.
+ */
+export default function LearnerMilestoneUsersPage({
   searchParams,
 }: PageProps<"/stats/engagement/learners">) {
+  return (
+    <Suspense
+      fallback={
+        <StatsPageSkeleton
+          breadcrumbItems={[
+            { href: "/stats/engagement", label: "Engagement & Learning" },
+            { label: "Learner Milestones" },
+          ]}
+          showPeriodControls={false}
+          title="Learner Milestones"
+        >
+          <LearnerMilestoneUsersPageSkeleton />
+        </StatsPageSkeleton>
+      }
+    >
+      <LearnerMilestoneUsersPageContent searchParams={searchParams} />
+    </Suspense>
+  );
+}
+
+/**
+ * Parsing and validation remain together inside Suspense so every downstream
+ * component receives one consistent milestone definition.
+ */
+async function LearnerMilestoneUsersPageContent({
+  searchParams,
+}: Pick<PageProps<"/stats/engagement/learners">, "searchParams">) {
   const params = await searchParams;
   const kind = parseLearnerMilestoneKind(params.kind);
 
@@ -55,5 +87,19 @@ export default async function LearnerMilestoneUsersPage({
         </Suspense>
       </div>
     </StatsPageLayout>
+  );
+}
+
+/**
+ * The page-level fallback covers the query-derived heading and threshold form
+ * as well as the independently streamed user table.
+ */
+function LearnerMilestoneUsersPageSkeleton() {
+  return (
+    <div className="flex flex-col gap-6">
+      <Skeleton className="h-4 w-80 max-w-full" />
+      <Skeleton className="h-16 w-full rounded-lg" />
+      <LearnerMilestoneUsersSkeleton />
+    </div>
   );
 }

--- a/apps/admin/src/app/(private)/stats/engagement/page.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/page.tsx
@@ -7,6 +7,7 @@ import { EngagementMetrics, EngagementMetricsSkeleton } from "./engagement-metri
 import { LearnerMilestones, LearnerMilestonesSkeleton } from "./learner-milestones";
 
 export const metadata: Metadata = { title: "Engagement & Learning" };
+export const prefetch = "allow-runtime";
 
 /**
  * Stable analytics chrome stays in the App Shell while period metrics and

--- a/apps/admin/src/app/(private)/stats/engagement/page.tsx
+++ b/apps/admin/src/app/(private)/stats/engagement/page.tsx
@@ -1,40 +1,88 @@
-import { calculateDateRanges, formatPeriodLabel, validatePeriod } from "@zoonk/utils/date-ranges";
-import { validateOffset } from "@zoonk/utils/number";
 import { type Metadata } from "next";
 import { Suspense } from "react";
 import { AdminPeriodNavigation } from "../_components/admin-period-navigation";
-import { StatsPageLayout } from "../_components/stats-page-layout";
+import { StatsPageLayout, StatsPeriodNavigationSkeleton } from "../_components/stats-page-layout";
+import { getStatsPeriod } from "../_utils/stats-period";
 import { EngagementMetrics, EngagementMetricsSkeleton } from "./engagement-metrics";
 import { LearnerMilestones, LearnerMilestonesSkeleton } from "./learner-milestones";
 
 export const metadata: Metadata = { title: "Engagement & Learning" };
 
-export default async function EngagementPage({ searchParams }: PageProps<"/stats/engagement">) {
-  const params = await searchParams;
-  const { period: rawPeriod, offset: rawOffset } = params;
-  const period = validatePeriod(String(rawPeriod ?? "month"));
-  const offset = validateOffset(rawOffset);
-  const { current } = calculateDateRanges(period, offset);
-  const periodLabel = formatPeriodLabel(current.start, current.end, period, "en");
-
+/**
+ * Stable analytics chrome stays in the App Shell while period metrics and
+ * learner milestones resolve in independent boundaries.
+ */
+export default function EngagementPage({ searchParams }: PageProps<"/stats/engagement">) {
   return (
     <StatsPageLayout
       navigation={
-        period === "all" ? null : (
-          <AdminPeriodNavigation hasNext={offset > 0} periodLabel={periodLabel} />
-        )
+        <Suspense fallback={<StatsPeriodNavigationSkeleton />}>
+          <EngagementPeriodNavigation searchParams={searchParams} />
+        </Suspense>
       }
       title="Engagement & Learning"
     >
       <div className="flex flex-col gap-8">
-        <Suspense fallback={<EngagementMetricsSkeleton />} key={`${period}-${offset}`}>
-          <EngagementMetrics searchParams={params} />
+        <Suspense fallback={<EngagementMetricsSkeleton />}>
+          <EngagementMetricsRegion searchParams={searchParams} />
         </Suspense>
 
         <Suspense fallback={<LearnerMilestonesSkeleton />}>
-          <LearnerMilestones searchParams={params} />
+          <LearnerMilestonesRegion searchParams={searchParams} />
         </Suspense>
       </div>
     </StatsPageLayout>
   );
+}
+
+/**
+ * Runtime prefetching can resolve the selected period before navigation while
+ * the shared title and breadcrumbs remain available from the route shell.
+ */
+async function EngagementPeriodNavigation({
+  searchParams,
+}: Pick<PageProps<"/stats/engagement">, "searchParams">) {
+  const [params, { offset, period, periodLabel }] = await Promise.all([
+    searchParams,
+    getStatsPeriod(searchParams),
+  ]);
+
+  return period === "all" ? null : (
+    <AdminPeriodNavigation
+      basePath="/stats/engagement"
+      offset={offset}
+      period={period}
+      periodLabel={periodLabel}
+      queryParams={params}
+    />
+  );
+}
+
+/**
+ * The URL and cached calendar range resolve before the private analytics query.
+ * The keyed inner boundary resets only the metric body when the period changes.
+ */
+async function EngagementMetricsRegion({
+  searchParams,
+}: Pick<PageProps<"/stats/engagement">, "searchParams">) {
+  const statsPeriod = await getStatsPeriod(searchParams);
+
+  return (
+    <Suspense
+      fallback={<EngagementMetricsSkeleton />}
+      key={`${statsPeriod.period}-${statsPeriod.offset}`}
+    >
+      <EngagementMetrics statsPeriod={statsPeriod} />
+    </Suspense>
+  );
+}
+
+/**
+ * Milestone thresholds are independent from the selected calendar period, so
+ * their URL read and cached aggregate should stream in parallel with metrics.
+ */
+async function LearnerMilestonesRegion({
+  searchParams,
+}: Pick<PageProps<"/stats/engagement">, "searchParams">) {
+  return <LearnerMilestones searchParams={await searchParams} />;
 }

--- a/apps/admin/src/app/(private)/stats/growth/growth-metrics.tsx
+++ b/apps/admin/src/app/(private)/stats/growth/growth-metrics.tsx
@@ -5,22 +5,16 @@ import { getDailySignups } from "@/data/stats/get-daily-signups";
 import { getNewSignups } from "@/data/stats/get-new-signups";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { buildChartData } from "@zoonk/utils/chart";
-import { calculateDateRanges, validatePeriod } from "@zoonk/utils/date-ranges";
-import { validateOffset } from "@zoonk/utils/number";
 import { CreditCardIcon, TargetIcon, UsersIcon } from "lucide-react";
 import { AdminMetricCard, AdminMetricCardSkeleton } from "../_components/admin-metric-card";
 import { AdminTrendChart } from "../_components/admin-trend-chart";
+import { type StatsPeriod } from "../_utils/stats-period";
 import { SubscribersTable } from "./subscribers-table";
 
-export async function GrowthMetrics({
-  searchParams,
-}: {
-  searchParams: Promise<{ period?: string; offset?: string }>;
-}) {
-  const { period: rawPeriod, offset: rawOffset } = await searchParams;
-  const period = validatePeriod(rawPeriod ?? "month");
-  const offset = validateOffset(rawOffset);
-  const { current, previous } = calculateDateRanges(period, offset);
+export async function GrowthMetrics({ statsPeriod }: { statsPeriod: StatsPeriod }) {
+  "use cache: private";
+
+  const { current, period, previous } = statsPeriod;
 
   const [
     currentSignups,

--- a/apps/admin/src/app/(private)/stats/growth/page.tsx
+++ b/apps/admin/src/app/(private)/stats/growth/page.tsx
@@ -1,32 +1,67 @@
-import { calculateDateRanges, formatPeriodLabel, validatePeriod } from "@zoonk/utils/date-ranges";
-import { validateOffset } from "@zoonk/utils/number";
 import { type Metadata } from "next";
 import { Suspense } from "react";
 import { AdminPeriodNavigation } from "../_components/admin-period-navigation";
-import { StatsPageLayout } from "../_components/stats-page-layout";
+import { StatsPageLayout, StatsPeriodNavigationSkeleton } from "../_components/stats-page-layout";
+import { getStatsPeriod } from "../_utils/stats-period";
 import { GrowthMetrics, GrowthMetricsSkeleton } from "./growth-metrics";
 
 export const metadata: Metadata = { title: "Growth & Sustainability" };
 
-export default async function GrowthPage({ searchParams }: PageProps<"/stats/growth">) {
-  const { period: rawPeriod, offset: rawOffset } = await searchParams;
-  const period = validatePeriod(String(rawPeriod ?? "month"));
-  const offset = validateOffset(rawOffset);
-  const { current } = calculateDateRanges(period, offset);
-  const periodLabel = formatPeriodLabel(current.start, current.end, period, "en");
-
+/**
+ * Stable analytics chrome stays in the App Shell while URL-backed controls and
+ * cached metrics resolve in independent boundaries.
+ */
+export default function GrowthPage({ searchParams }: PageProps<"/stats/growth">) {
   return (
     <StatsPageLayout
       navigation={
-        period === "all" ? null : (
-          <AdminPeriodNavigation hasNext={offset > 0} periodLabel={periodLabel} />
-        )
+        <Suspense fallback={<StatsPeriodNavigationSkeleton />}>
+          <GrowthPeriodNavigation searchParams={searchParams} />
+        </Suspense>
       }
       title="Growth & Sustainability"
     >
-      <Suspense fallback={<GrowthMetricsSkeleton />} key={`${period}-${offset}`}>
-        <GrowthMetrics searchParams={searchParams} />
+      <Suspense fallback={<GrowthMetricsSkeleton />}>
+        <GrowthMetricsRegion searchParams={searchParams} />
       </Suspense>
     </StatsPageLayout>
+  );
+}
+
+/**
+ * Runtime prefetching can resolve the selected period before navigation while
+ * the shared title and breadcrumbs remain available from the route shell.
+ */
+async function GrowthPeriodNavigation({
+  searchParams,
+}: Pick<PageProps<"/stats/growth">, "searchParams">) {
+  const { offset, period, periodLabel } = await getStatsPeriod(searchParams);
+
+  return period === "all" ? null : (
+    <AdminPeriodNavigation
+      basePath="/stats/growth"
+      offset={offset}
+      period={period}
+      periodLabel={periodLabel}
+    />
+  );
+}
+
+/**
+ * The URL and cached calendar range resolve before the private analytics query.
+ * The keyed inner boundary resets only the metric body when the period changes.
+ */
+async function GrowthMetricsRegion({
+  searchParams,
+}: Pick<PageProps<"/stats/growth">, "searchParams">) {
+  const statsPeriod = await getStatsPeriod(searchParams);
+
+  return (
+    <Suspense
+      fallback={<GrowthMetricsSkeleton />}
+      key={`${statsPeriod.period}-${statsPeriod.offset}`}
+    >
+      <GrowthMetrics statsPeriod={statsPeriod} />
+    </Suspense>
   );
 }

--- a/apps/admin/src/app/(private)/stats/growth/page.tsx
+++ b/apps/admin/src/app/(private)/stats/growth/page.tsx
@@ -6,6 +6,7 @@ import { getStatsPeriod } from "../_utils/stats-period";
 import { GrowthMetrics, GrowthMetricsSkeleton } from "./growth-metrics";
 
 export const metadata: Metadata = { title: "Growth & Sustainability" };
+export const prefetch = "allow-runtime";
 
 /**
  * Stable analytics chrome stays in the App Shell while URL-backed controls and

--- a/apps/admin/src/app/(private)/stats/page.tsx
+++ b/apps/admin/src/app/(private)/stats/page.tsx
@@ -20,6 +20,7 @@ import { type Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = { title: "Stats" };
+export const prefetch = "allow-runtime";
 
 const sections = [
   {

--- a/apps/admin/src/app/(private)/stats/page.tsx
+++ b/apps/admin/src/app/(private)/stats/page.tsx
@@ -56,7 +56,7 @@ export default function StatsPage() {
       <ContainerBody>
         <ItemGroup>
           {sections.map((section) => (
-            <Item key={section.href} render={<Link href={section.href} />}>
+            <Item key={section.href} render={<Link href={section.href} prefetch />}>
               <ItemMedia variant="icon">
                 <section.icon />
               </ItemMedia>

--- a/apps/admin/src/app/(private)/subscriptions/incomplete-subscription-list.tsx
+++ b/apps/admin/src/app/(private)/subscriptions/incomplete-subscription-list.tsx
@@ -1,3 +1,4 @@
+import { AdminTableSkeleton, AdminTableSkeletonRows } from "@/components/admin-table-skeleton";
 import { AdminPagination } from "@/components/pagination";
 import {
   type IncompleteSubscription,
@@ -16,7 +17,6 @@ import {
 } from "@zoonk/ui/components/table";
 import Link from "next/link";
 
-const SKELETON_ROW_COUNT = 5;
 const TABLE_COLUMN_COUNT = 7;
 
 /**
@@ -30,6 +30,25 @@ export async function IncompleteSubscriptionList({
 }) {
   const params = await searchParams;
   const { limit, offset, page } = parseSearchParams(params);
+
+  return <CachedIncompleteSubscriptionList limit={limit} offset={offset} page={page} />;
+}
+
+/**
+ * Pagination primitives form a stable cache key so runtime prefetching can
+ * resolve the support queue before its link is clicked.
+ */
+async function CachedIncompleteSubscriptionList({
+  limit,
+  offset,
+  page,
+}: {
+  limit: number;
+  offset: number;
+  page: number;
+}) {
+  "use cache: private";
+
   const { subscriptions, total } = await listIncompleteSubscriptions({ limit, offset });
   const totalPages = Math.ceil(total / limit);
 
@@ -74,18 +93,15 @@ export function IncompleteSubscriptionListSkeleton() {
     <div className="flex flex-col gap-4">
       <Skeleton className="h-4 w-44" />
 
-      <div className="overflow-x-auto rounded-lg border">
+      <AdminTableSkeleton className="overflow-x-auto">
         <Table>
           <IncompleteSubscriptionTableHeader />
 
-          <TableBody>
-            {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
-              // oxlint-disable-next-line react/no-array-index-key -- Skeleton rows are static placeholders.
-              <IncompleteSubscriptionSkeletonRow key={index} />
-            ))}
-          </TableBody>
+          <AdminTableSkeletonRows>
+            <IncompleteSubscriptionSkeletonRow />
+          </AdminTableSkeletonRows>
         </Table>
-      </div>
+      </AdminTableSkeleton>
     </div>
   );
 }
@@ -167,7 +183,7 @@ function IncompleteSubscriptionRow({ subscription }: { subscription: IncompleteS
   return (
     <TableRow>
       <TableCell>
-        <Link className="block" href={`/users/${subscription.user.id}`}>
+        <Link className="block" href={`/users/${subscription.user.id}`} prefetch>
           <span className="font-medium">{subscription.user.name || "—"}</span>
           <span className="text-muted-foreground block text-xs">{subscription.user.email}</span>
         </Link>

--- a/apps/admin/src/app/(private)/subscriptions/page.tsx
+++ b/apps/admin/src/app/(private)/subscriptions/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "./incomplete-subscription-list";
 
 export const metadata: Metadata = { title: "Incomplete Subscriptions" };
+export const prefetch = "allow-runtime";
 
 /**
  * This route gives support a focused queue of checkout records that did not

--- a/apps/admin/src/app/(private)/users/[id]/page.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/page.tsx
@@ -28,7 +28,7 @@ function UserBreadcrumb() {
     <Breadcrumb>
       <BreadcrumbList>
         <BreadcrumbItem>
-          <BreadcrumbLink render={<Link href="/users" />}>Users</BreadcrumbLink>
+          <BreadcrumbLink render={<Link href="/users" prefetch />}>Users</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -63,13 +63,11 @@ function SectionSkeleton() {
   );
 }
 
-export default async function UserDetailPage({ params }: PageProps<"/users/[id]">) {
-  const { id: userId } = await params;
-
-  if (!isUuid(userId)) {
-    notFound();
-  }
-
+/**
+ * The account shell and breadcrumb do not depend on the dynamic user id, so
+ * they remain available while the requested account content streams in.
+ */
+export default function UserDetailPage({ params }: PageProps<"/users/[id]">) {
   return (
     <Container>
       <ContainerHeader variant="sidebar">
@@ -79,26 +77,62 @@ export default async function UserDetailPage({ params }: PageProps<"/users/[id]"
       </ContainerHeader>
 
       <ContainerBody className="gap-8">
-        <Suspense fallback={<HeaderSkeleton />}>
-          <UserHeader userId={userId} />
-        </Suspense>
-
-        <Suspense fallback={<SectionSkeleton />}>
-          <UserAccount userId={userId} />
-        </Suspense>
-
-        <Suspense fallback={<SectionSkeleton />}>
-          <UserSubscription userId={userId} />
-        </Suspense>
-
-        <Suspense fallback={<SectionSkeleton />}>
-          <UserLesson userId={userId} />
-        </Suspense>
-
-        <Suspense fallback={<SectionSkeleton />}>
-          <UserCourses userId={userId} />
+        <Suspense fallback={<UserDetailSkeleton />}>
+          <UserDetailContent params={params} />
         </Suspense>
       </ContainerBody>
     </Container>
+  );
+}
+
+/**
+ * Parameter validation must happen after the dynamic route value resolves and
+ * before any independent account query receives the user id.
+ */
+async function UserDetailContent({ params }: Pick<PageProps<"/users/[id]">, "params">) {
+  const { id: userId } = await params;
+
+  if (!isUuid(userId)) {
+    notFound();
+  }
+
+  return (
+    <>
+      <Suspense fallback={<HeaderSkeleton />}>
+        <UserHeader userId={userId} />
+      </Suspense>
+
+      <Suspense fallback={<SectionSkeleton />}>
+        <UserAccount userId={userId} />
+      </Suspense>
+
+      <Suspense fallback={<SectionSkeleton />}>
+        <UserSubscription userId={userId} />
+      </Suspense>
+
+      <Suspense fallback={<SectionSkeleton />}>
+        <UserLesson userId={userId} />
+      </Suspense>
+
+      <Suspense fallback={<SectionSkeleton />}>
+        <UserCourses userId={userId} />
+      </Suspense>
+    </>
+  );
+}
+
+/**
+ * The dynamic-route fallback mirrors every independently streamed account
+ * section so the page remains stable until the user id is available.
+ */
+function UserDetailSkeleton() {
+  return (
+    <>
+      <HeaderSkeleton />
+      <SectionSkeleton />
+      <SectionSkeleton />
+      <SectionSkeleton />
+      <SectionSkeleton />
+    </>
   );
 }

--- a/apps/admin/src/app/(private)/users/[id]/page.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/page.tsx
@@ -23,6 +23,8 @@ import { UserHeader } from "./user-header";
 import { UserLesson } from "./user-lesson";
 import { UserSubscription } from "./user-subscription";
 
+export const prefetch = "allow-runtime";
+
 function UserBreadcrumb() {
   return (
     <Breadcrumb>

--- a/apps/admin/src/app/(private)/users/[id]/user-account.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-account.tsx
@@ -5,6 +5,8 @@ import { updateUserAnalyticsDisabledAction } from "./_actions/update-user-analyt
 import { DetailField } from "./detail-field";
 
 export async function UserAccount({ userId }: { userId: string }) {
+  "use cache: private";
+
   const user = await getUser(userId);
 
   if (!user) {

--- a/apps/admin/src/app/(private)/users/[id]/user-courses.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-courses.tsx
@@ -17,6 +17,8 @@ import {
  * by the most recent completion so support can scan recent learning context.
  */
 export async function UserCourses({ userId }: { userId: string }) {
+  "use cache: private";
+
   const courses = await listUserCompletedLessonCourses({ userId });
 
   return (

--- a/apps/admin/src/app/(private)/users/[id]/user-header.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-header.tsx
@@ -7,6 +7,8 @@ import { RevokeSessionsDialog } from "./revoke-sessions-dialog";
 import { UnbanUserDialog } from "./unban-user-dialog";
 
 export async function UserHeader({ userId }: { userId: string }) {
+  "use cache: private";
+
   const user = await getUser(userId);
 
   if (!user) {

--- a/apps/admin/src/app/(private)/users/[id]/user-lesson.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-lesson.tsx
@@ -26,6 +26,8 @@ const ENERGY_FORMATTER = new Intl.NumberFormat("en", {
  * completion stats so support can answer learning-history questions in one view.
  */
 export async function UserLesson({ userId }: { userId: string }) {
+  "use cache: private";
+
   const [user, learningStats] = await Promise.all([
     getUser(userId),
     getUserLearningStats({ userId }),

--- a/apps/admin/src/app/(private)/users/[id]/user-subscription.tsx
+++ b/apps/admin/src/app/(private)/users/[id]/user-subscription.tsx
@@ -4,6 +4,8 @@ import { ChangePlanDialog } from "./change-plan-dialog";
 import { DetailField } from "./detail-field";
 
 export async function UserSubscription({ userId }: { userId: string }) {
+  "use cache: private";
+
   const subscription = await getUserSubscription(userId);
   const canChangePlan = !subscription || subscription.provider === "zoonk";
   const providerLabel = subscription ? getSubscriptionProviderLabel(subscription.provider) : "—";

--- a/apps/admin/src/app/(private)/users/page.tsx
+++ b/apps/admin/src/app/(private)/users/page.tsx
@@ -12,6 +12,7 @@ import { Suspense } from "react";
 import { UserList, UserListSkeleton } from "./user-list";
 
 export const metadata: Metadata = { title: "Users" };
+export const prefetch = "allow-runtime";
 
 export default function UsersPage({ searchParams }: PageProps<"/users">) {
   return (

--- a/apps/admin/src/app/(private)/users/page.tsx
+++ b/apps/admin/src/app/(private)/users/page.tsx
@@ -1,4 +1,4 @@
-import { AdminSearch } from "@/components/admin-search";
+import { AdminSearch, AdminSearchSkeleton } from "@/components/admin-search";
 import {
   Container,
   ContainerBody,
@@ -9,7 +9,7 @@ import {
 } from "@zoonk/ui/components/container";
 import { type Metadata } from "next";
 import { Suspense } from "react";
-import { UserList } from "./user-list";
+import { UserList, UserListSkeleton } from "./user-list";
 
 export const metadata: Metadata = { title: "Users" };
 
@@ -24,11 +24,11 @@ export default function UsersPage({ searchParams }: PageProps<"/users">) {
       </ContainerHeader>
 
       <ContainerBody>
-        <Suspense fallback={<div className="h-10" />}>
+        <Suspense fallback={<AdminSearchSkeleton />}>
           <AdminSearch placeholder="Search by name, username, or email..." />
         </Suspense>
 
-        <Suspense>
+        <Suspense fallback={<UserListSkeleton />}>
           <UserList searchParams={searchParams} />
         </Suspense>
       </ContainerBody>

--- a/apps/admin/src/app/(private)/users/user-list.tsx
+++ b/apps/admin/src/app/(private)/users/user-list.tsx
@@ -1,13 +1,27 @@
+import { AdminTableSkeleton, AdminTableSkeletonRows } from "@/components/admin-table-skeleton";
 import { AdminPagination } from "@/components/pagination";
 import { listUsers } from "@/data/users/list-users";
 import { parseSearchParams } from "@/lib/parse-search-params";
 import { type UserSort, getUserSortQueryValue, parseUserSort } from "@/lib/user-sort";
-import { Table, TableBody, TableHead, TableHeader, TableRow } from "@zoonk/ui/components/table";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@zoonk/ui/components/table";
 import { ArrowDown } from "lucide-react";
+import Link from "next/link";
 import { UserRow } from "./user-row";
 
 type SortQueryEntry = [string, string | undefined] | undefined;
 
+/**
+ * User URL state, protected account loading, and pagination resolve together
+ * so sorting and search remain consistent across refreshes and shared links.
+ */
 export async function UserList({
   searchParams,
 }: {
@@ -16,6 +30,29 @@ export async function UserList({
   const params = await searchParams;
   const { page, limit, offset, search } = parseSearchParams(params);
   const sort = parseUserSort(params.sort);
+
+  return <CachedUserList limit={limit} offset={offset} page={page} search={search} sort={sort} />;
+}
+
+/**
+ * Normalized pagination, search, and sort values keep each private-cache key
+ * deterministic across the warm-up and final runtime-prefetch passes.
+ */
+async function CachedUserList({
+  limit,
+  offset,
+  page,
+  search,
+  sort,
+}: {
+  limit: number;
+  offset: number;
+  page: number;
+  search?: string;
+  sort: UserSort;
+}) {
+  "use cache: private";
+
   const { users, total } = await listUsers({ limit, offset, search, sort });
   const totalPages = Math.ceil(total / limit);
 
@@ -23,27 +60,7 @@ export async function UserList({
     <>
       <div className="rounded-lg border">
         <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>User</TableHead>
-              <TableHead>Username</TableHead>
-              <SortableUserTableHead
-                align="right"
-                className="text-right"
-                label="Brain Power"
-                search={search}
-                selectedSort={sort}
-                sort="brain-power"
-              />
-              <SortableUserTableHead
-                label="Joined"
-                search={search}
-                selectedSort={sort}
-                sort="newest-signups"
-              />
-              <TableHead>Subscription</TableHead>
-            </TableRow>
-          </TableHeader>
+          <UserTableHeader search={search} sort={sort} />
 
           <TableBody>
             {users.map((user) => (
@@ -66,8 +83,86 @@ export async function UserList({
 }
 
 /**
- * Sorting from the column header matches the way admins scan the table: the
- * column label is both the data label and the control for that ordering.
+ * The fallback keeps sortable column labels visible while account data and the
+ * selected URL ordering resolve together.
+ */
+export function UserListSkeleton() {
+  return (
+    <AdminTableSkeleton>
+      <Table>
+        <UserTableHeader />
+
+        <AdminTableSkeletonRows>
+          <UserSkeletonRow />
+        </AdminTableSkeletonRows>
+      </Table>
+    </AdminTableSkeleton>
+  );
+}
+
+/**
+ * Loaded and loading user tables share their sortable header so accessibility
+ * labels and column alignment remain identical in both states.
+ */
+function UserTableHeader({ search, sort }: { search?: string; sort?: UserSort }) {
+  return (
+    <TableHeader>
+      <TableRow>
+        <TableHead>User</TableHead>
+        <TableHead>Username</TableHead>
+        <SortableUserTableHead
+          align="right"
+          className="text-right"
+          label="Brain Power"
+          search={search}
+          selectedSort={sort}
+          sort="brain-power"
+        />
+        <SortableUserTableHead
+          label="Joined"
+          search={search}
+          selectedSort={sort}
+          sort="newest-signups"
+        />
+        <TableHead>Subscription</TableHead>
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+/**
+ * User row placeholders preserve the two-line identity cell and compact
+ * account fields so the table does not shift when results arrive.
+ */
+function UserSkeletonRow() {
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-48" />
+        </div>
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="ml-auto h-4 w-12" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-5 w-16" />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+/**
+ * Sorting from the loaded column header matches the way admins scan the table.
+ * Loading headers stay noninteractive until the request URL establishes which
+ * ordering and search query their links must preserve.
  */
 function SortableUserTableHead({
   className,
@@ -81,9 +176,13 @@ function SortableUserTableHead({
   className?: string;
   label: string;
   search?: string;
-  selectedSort: UserSort;
+  selectedSort?: UserSort;
   sort: UserSort;
 }) {
+  if (!selectedSort) {
+    return <TableHead className={className}>{label}</TableHead>;
+  }
+
   const isSelected = selectedSort === sort;
 
   const linkClassName =
@@ -93,14 +192,15 @@ function SortableUserTableHead({
 
   return (
     <TableHead aria-sort={isSelected ? "descending" : undefined} className={className}>
-      <a
+      <Link
         aria-current={isSelected ? "page" : undefined}
         className={linkClassName}
         href={buildSortHref({ search, sort })}
+        prefetch
       >
         {label}
         {isSelected ? <ArrowDown className="size-3.5" /> : null}
-      </a>
+      </Link>
     </TableHead>
   );
 }
@@ -109,7 +209,7 @@ function SortableUserTableHead({
  * Sorting changes should preserve search but reset pagination so a valid page
  * number from one ordering does not land on an unexpectedly sparse result set.
  */
-function buildSortHref({ search, sort }: { search?: string; sort: UserSort }): string {
+function buildSortHref({ search, sort }: { search?: string; sort: UserSort }): `/users${string}` {
   const entries: SortQueryEntry[] = [
     getUserSortQueryValue(sort) ? ["sort", sort] : undefined,
     search ? ["search", search] : undefined,

--- a/apps/admin/src/app/(private)/users/user-row.tsx
+++ b/apps/admin/src/app/(private)/users/user-row.tsx
@@ -15,7 +15,7 @@ export function UserRow({
   return (
     <TableRow>
       <TableCell>
-        <Link className="block" href={`/users/${user.id}`}>
+        <Link className="block" href={`/users/${user.id}`} prefetch>
           <span className="font-medium">{user.name || "—"}</span>
           <span className="text-muted-foreground block text-xs">{user.email}</span>
         </Link>

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -5,6 +5,8 @@ export const metadata: Metadata = {
   title: { default: "Zoonk Admin", template: "%s | Zoonk Admin" },
 };
 
+export const prefetch = "allow-runtime";
+
 export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     <html lang="en">

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -5,8 +5,6 @@ export const metadata: Metadata = {
   title: { default: "Zoonk Admin", template: "%s | Zoonk Admin" },
 };
 
-export const prefetch = "allow-runtime";
-
 export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     <html lang="en">

--- a/apps/admin/src/app/loading.tsx
+++ b/apps/admin/src/app/loading.tsx
@@ -1,5 +1,0 @@
-import { FullPageLoading } from "@zoonk/ui/components/loading";
-
-export default function Loading() {
-  return <FullPageLoading />;
-}

--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -1,6 +1,8 @@
 import { OneTimeTokenLoginRedirect } from "@zoonk/core/auth/ott/login";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
 
+export const prefetch = "allow-runtime";
+
 export default function LoginPage() {
   return (
     <>

--- a/apps/admin/src/components/admin-search.tsx
+++ b/apps/admin/src/components/admin-search.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Input } from "@zoonk/ui/components/input";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { SEARCH_QUERY_THROTTLE_MS } from "@zoonk/utils/search";
 import { Search } from "lucide-react";
 import { throttle, useQueryState } from "nuqs";
@@ -29,4 +30,12 @@ export function AdminSearch({ placeholder }: { placeholder: string }) {
       />
     </div>
   );
+}
+
+/**
+ * Search state comes from the request URL during prerendering, so list pages
+ * reserve the input's exact height until the client control can render.
+ */
+export function AdminSearchSkeleton() {
+  return <Skeleton className="h-10 w-full" />;
 }

--- a/apps/admin/src/components/admin-table-skeleton.tsx
+++ b/apps/admin/src/components/admin-table-skeleton.tsx
@@ -1,0 +1,34 @@
+import { TableBody } from "@zoonk/ui/components/table";
+import { cn } from "@zoonk/ui/lib/utils";
+import { Fragment } from "react";
+
+const SKELETON_ROW_KEYS = ["first", "second", "third", "fourth", "fifth"];
+
+/**
+ * Admin data tables share one bordered loading frame so every route preserves
+ * the same table footprint while keeping its domain-specific header and rows
+ * colocated with the real table.
+ */
+export function AdminTableSkeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("rounded-lg border", className)}
+      data-slot="admin-table-skeleton"
+      {...props}
+    />
+  );
+}
+
+/**
+ * Loading tables all use five stable placeholder rows. Centralizing the row
+ * repetition removes index keys and keeps the route-specific row markup clear.
+ */
+export function AdminTableSkeletonRows({ children }: React.PropsWithChildren) {
+  return (
+    <TableBody>
+      {SKELETON_ROW_KEYS.map((rowKey) => (
+        <Fragment key={rowKey}>{children}</Fragment>
+      ))}
+    </TableBody>
+  );
+}

--- a/apps/admin/src/components/pagination.tsx
+++ b/apps/admin/src/components/pagination.tsx
@@ -7,9 +7,20 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@zoonk/ui/components/pagination";
+import Link from "next/link";
+
+type AdminPaginationPath =
+  | "/course-prompts"
+  | "/courses"
+  | "/leaderboard"
+  | "/lessons"
+  | "/stats/engagement/learners"
+  | "/subscriptions"
+  | "/users";
 
 type PaginationQueryParams = Record<string, string | undefined>;
 type PaginationEntry = [string, string | undefined] | undefined;
+type PaginationHref = `${AdminPaginationPath}?${string}`;
 
 /**
  * Pagination links need to carry page state plus route-specific filters, such
@@ -22,12 +33,12 @@ function buildPageUrl({
   queryParams,
   search,
 }: {
-  basePath: string;
+  basePath: AdminPaginationPath;
   limit: number;
   pageNumber: number;
   queryParams?: PaginationQueryParams;
   search?: string;
-}): string {
+}): PaginationHref {
   const rawEntries: PaginationEntry[] = [
     ...Object.entries(queryParams ?? {}),
     ["page", pageNumber.toString()],
@@ -63,20 +74,56 @@ function addEllipsesToPages(pageNumbers: number[]): (number | "ellipsis")[] {
   });
 }
 
+/**
+ * Every available page is prefetched so pagination can switch URL-backed admin
+ * data without waiting for a server round trip after the click.
+ */
+function AdminPaginationPageLink({
+  basePath,
+  currentPage,
+  limit,
+  pageNumber,
+  queryParams,
+  search,
+}: {
+  basePath: AdminPaginationPath;
+  currentPage: number;
+  limit: number;
+  pageNumber: number;
+  queryParams?: PaginationQueryParams;
+  search?: string;
+}) {
+  const isActive = pageNumber === currentPage;
+
+  const href = isActive
+    ? undefined
+    : buildPageUrl({ basePath, limit, pageNumber, queryParams, search });
+
+  return (
+    <PaginationLink
+      href={href ?? "#"}
+      isActive={isActive}
+      render={href ? <Link href={href} prefetch /> : undefined}
+    >
+      {pageNumber}
+    </PaginationLink>
+  );
+}
+
 export function AdminPagination({
   basePath,
-  page,
   limit,
-  totalPages,
-  search,
+  page,
   queryParams,
+  search,
+  totalPages,
 }: {
-  basePath: string;
-  page: number;
+  basePath: AdminPaginationPath;
   limit: number;
-  totalPages: number;
-  search?: string;
+  page: number;
   queryParams?: PaginationQueryParams;
+  search?: string;
+  totalPages: number;
 }) {
   if (totalPages <= 1) {
     return null;
@@ -87,6 +134,14 @@ export function AdminPagination({
   const visiblePages = getVisiblePageNumbers(page, totalPages);
   const pagesWithEllipses = addEllipsesToPages(visiblePages);
 
+  const previousHref = isFirstPage
+    ? undefined
+    : buildPageUrl({ basePath, limit, pageNumber: page - 1, queryParams, search });
+
+  const nextHref = isLastPage
+    ? undefined
+    : buildPageUrl({ basePath, limit, pageNumber: page + 1, queryParams, search });
+
   return (
     <Pagination>
       <PaginationContent>
@@ -94,11 +149,8 @@ export function AdminPagination({
           <PaginationPrevious
             aria-disabled={isFirstPage}
             className={isFirstPage ? "pointer-events-none opacity-50" : ""}
-            href={
-              isFirstPage
-                ? "#"
-                : buildPageUrl({ basePath, limit, pageNumber: page - 1, queryParams, search })
-            }
+            href={previousHref ?? "#"}
+            render={previousHref ? <Link href={previousHref} prefetch /> : undefined}
           />
         </PaginationItem>
 
@@ -108,22 +160,14 @@ export function AdminPagination({
             {pageOrEllipsis === "ellipsis" ? (
               <PaginationEllipsis />
             ) : (
-              <PaginationLink
-                href={
-                  pageOrEllipsis === page
-                    ? "#"
-                    : buildPageUrl({
-                        basePath,
-                        limit,
-                        pageNumber: pageOrEllipsis,
-                        queryParams,
-                        search,
-                      })
-                }
-                isActive={pageOrEllipsis === page}
-              >
-                {pageOrEllipsis}
-              </PaginationLink>
+              <AdminPaginationPageLink
+                basePath={basePath}
+                currentPage={page}
+                limit={limit}
+                pageNumber={pageOrEllipsis}
+                queryParams={queryParams}
+                search={search}
+              />
             )}
           </PaginationItem>
         ))}
@@ -132,11 +176,8 @@ export function AdminPagination({
           <PaginationNext
             aria-disabled={isLastPage}
             className={isLastPage ? "pointer-events-none opacity-50" : ""}
-            href={
-              isLastPage
-                ? "#"
-                : buildPageUrl({ basePath, limit, pageNumber: page + 1, queryParams, search })
-            }
+            href={nextHref ?? "#"}
+            render={nextHref ? <Link href={nextHref} prefetch /> : undefined}
           />
         </PaginationItem>
       </PaginationContent>

--- a/apps/admin/src/components/stats.tsx
+++ b/apps/admin/src/components/stats.tsx
@@ -51,7 +51,7 @@ export function Stats({
 
   if (href) {
     return (
-      <Link className="hover:bg-muted/50 rounded-lg p-2 transition-colors" href={href}>
+      <Link className="hover:bg-muted/50 rounded-lg p-2 transition-colors" href={href} prefetch>
         {content}
       </Link>
     );

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -1,5 +1,8 @@
-import { Button } from "@zoonk/ui/components/button";
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { buttonVariants } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
+import { type VariantProps } from "class-variance-authority";
 import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from "lucide-react";
 import type * as React from "react";
 
@@ -28,30 +31,31 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
   return <li data-slot="pagination-item" {...props} />;
 }
 
+type PaginationLinkProps = { isActive?: boolean } & Pick<
+  VariantProps<typeof buttonVariants>,
+  "size"
+> &
+  useRender.ComponentProps<"a">;
+
 function PaginationLink({
   className,
   isActive,
+  render,
   size = "icon",
   ...props
-}: { isActive?: boolean } & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">) {
-  return (
-    <Button
-      className={cn(className)}
-      nativeButton={false}
-      render={
-        // oxlint-disable-next-line jsx-a11y/anchor-has-content -- render prop
-        <a
-          aria-current={isActive ? "page" : undefined}
-          data-active={isActive}
-          data-slot="pagination-link"
-          {...props}
-        />
-      }
-      size={size}
-      variant={isActive ? "outline" : "ghost"}
-    />
-  );
+}: PaginationLinkProps) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        "aria-current": isActive ? "page" : undefined,
+        className: cn(buttonVariants({ className, size, variant: isActive ? "outline" : "ghost" })),
+      },
+      props,
+    ),
+    render,
+    state: { active: isActive, slot: "pagination-link" },
+  });
 }
 
 function PaginationPrevious({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Cache Components and runtime prefetching in the admin to speed up navigation and stabilize loading. Adds shared skeletons and link prefetch so lists, tables, and analytics render their shells instantly while data streams.

- **Refactors**
  - Enabled `cacheComponents` and `partialPrefetching` in `apps/admin/next.config.ts`; added `prefetch = "allow-runtime"` on admin routes.
  - Split list/detail pages into parsed URL wrappers and cached functions using `"use cache: private"` (users, courses, lessons, prompts, subscriptions, leaderboard, stats).
  - Rebuilt analytics period navigation to link-based, prefetchable routes; added `getStatsPeriod` and keyed Suspense regions for metrics.
  - Updated admin pagination to prefetch pages with typed HREFs; switched `@zoonk/ui` pagination to a link-render API.
  - Added `prefetch` to `Link` across admin and removed the global `app/loading.tsx`.

- **New Features**
  - Introduced `AdminTableSkeleton`, `AdminTableSkeletonRows`, `AdminSearchSkeleton`, and stats skeletons for consistent loading shells.
  - Wrapped search, lists, and analytics in Suspense so headings and shells render immediately while data loads.
  - Used `next/form` for analytics threshold forms to keep fast, URL-backed GET updates.

<sup>Written for commit bb432b29056d6a1e05a1298949fce548404268e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

