### PR TITLE
fix(main): show all user courses

### DIFF
--- a/apps/main/src/data/courses/list-user-courses.test.ts
+++ b/apps/main/src/data/courses/list-user-courses.test.ts
@@ -1,40 +1,11 @@
 import { ErrorCode } from "@/lib/app-error";
 import { prisma } from "@zoonk/db";
 import { signInAs } from "@zoonk/testing/fixtures/auth";
-import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture, courseUserFixture } from "@zoonk/testing/fixtures/courses";
-import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeAll, describe, expect, it } from "vitest";
 import { listUserCourses } from "./list-user-courses";
-
-/**
- * My Courses is backed by completed lesson progress, so tests create the
- * smallest real course tree that can prove whether a course belongs in that
- * list instead of relying on the CourseUser row alone.
- */
-async function createCourseWithLesson({
-  organizationId,
-  userId,
-}: {
-  organizationId: string | null;
-  userId?: string;
-}) {
-  const course = await courseFixture({ isPublished: true, organizationId, userId });
-  const chapter = await chapterFixture({ courseId: course.id, isPublished: true, organizationId });
-  const lesson = await lessonFixture({ chapterId: chapter.id, isPublished: true, organizationId });
-
-  return { course, lesson };
-}
-
-/**
- * A course only belongs in My Courses after a learner finishes a lesson, so
- * tests call this helper whenever they need a course to satisfy that contract.
- */
-async function completeLessonForUser({ lessonId, userId }: { lessonId: string; userId: string }) {
-  return lessonProgressFixture({ completedAt: new Date(), durationSeconds: 60, lessonId, userId });
-}
 
 describe("unauthenticated users", () => {
   it("returns Unauthorized", async () => {
@@ -66,13 +37,10 @@ describe("authenticated users", () => {
     expect(result.data).toStrictEqual([]);
   });
 
-  it("returns courses where the user completed a lesson", async () => {
-    const { course, lesson } = await createCourseWithLesson({ organizationId: organization.id });
+  it("includes courses where the user has not completed a lesson", async () => {
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
 
-    await Promise.all([
-      courseUserFixture({ courseId: course.id, userId: user.id }),
-      completeLessonForUser({ lessonId: lesson.id, userId: user.id }),
-    ]);
+    await courseUserFixture({ courseId: course.id, userId: user.id });
 
     const result = await listUserCourses(headers);
 
@@ -81,37 +49,13 @@ describe("authenticated users", () => {
     expect(result.data?.some((item) => item.id === course.id)).toBe(true);
   });
 
-  it("excludes courses where the user started but did not complete a lesson", async () => {
-    const testUser = await userFixture();
-    const testHeaders = await signInAs(testUser.email, testUser.password);
-    const { course, lesson } = await createCourseWithLesson({ organizationId: organization.id });
-
-    await Promise.all([
-      courseUserFixture({ courseId: course.id, userId: testUser.id }),
-      lessonProgressFixture({
-        completedAt: null,
-        durationSeconds: null,
-        lessonId: lesson.id,
-        userId: testUser.id,
-      }),
-    ]);
-
-    const result = await listUserCourses(testHeaders);
-
-    expect(result.error).toBeNull();
-    expect(result.data?.some((item) => item.id === course.id)).toBe(false);
-  });
-
   it("includes the organization in the response", async () => {
     const testUser = await userFixture();
     const testHeaders = await signInAs(testUser.email, testUser.password);
 
-    const { course, lesson } = await createCourseWithLesson({ organizationId: organization.id });
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
 
-    await Promise.all([
-      courseUserFixture({ courseId: course.id, userId: testUser.id }),
-      completeLessonForUser({ lessonId: lesson.id, userId: testUser.id }),
-    ]);
+    await courseUserFixture({ courseId: course.id, userId: testUser.id });
 
     const result = await listUserCourses(testHeaders);
 
@@ -128,13 +72,11 @@ describe("authenticated users", () => {
     const testUser = await userFixture();
     const testHeaders = await signInAs(testUser.email, testUser.password);
 
-    const [data1, data2, data3] = await Promise.all([
-      createCourseWithLesson({ organizationId: organization.id }),
-      createCourseWithLesson({ organizationId: organization.id }),
-      createCourseWithLesson({ organizationId: organization.id }),
+    const [course1, course2, course3] = await Promise.all([
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
     ]);
-
-    const [course1, course2, course3] = [data1.course, data2.course, data3.course];
 
     // Create course users with specific timestamps
     const now = new Date();
@@ -148,12 +90,6 @@ describe("authenticated users", () => {
         { courseId: course3.id, startedAt: oneHourAgo, userId: testUser.id },
       ],
     });
-
-    await Promise.all(
-      [data1, data2, data3].map((data) =>
-        completeLessonForUser({ lessonId: data.lesson.id, userId: testUser.id }),
-      ),
-    );
 
     const result = await listUserCourses(testHeaders);
 
@@ -173,18 +109,14 @@ describe("authenticated users", () => {
       organizationFixture({ kind: "school" }),
     ]);
 
-    const [brandData, schoolData] = await Promise.all([
-      createCourseWithLesson({ organizationId: brandOrg.id }),
-      createCourseWithLesson({ organizationId: schoolOrg.id }),
+    const [brandCourse, schoolCourse] = await Promise.all([
+      courseFixture({ isPublished: true, organizationId: brandOrg.id }),
+      courseFixture({ isPublished: true, organizationId: schoolOrg.id }),
     ]);
-
-    const [brandCourse, schoolCourse] = [brandData.course, schoolData.course];
 
     await Promise.all([
       courseUserFixture({ courseId: brandCourse.id, userId: testUser.id }),
       courseUserFixture({ courseId: schoolCourse.id, userId: testUser.id }),
-      completeLessonForUser({ lessonId: brandData.lesson.id, userId: testUser.id }),
-      completeLessonForUser({ lessonId: schoolData.lesson.id, userId: testUser.id }),
     ]);
 
     const result = await listUserCourses(testHeaders);
@@ -198,15 +130,13 @@ describe("authenticated users", () => {
     const testUser = await userFixture();
     const testHeaders = await signInAs(testUser.email, testUser.password);
 
-    const { course: personalCourse, lesson } = await createCourseWithLesson({
+    const personalCourse = await courseFixture({
+      isPublished: true,
       organizationId: null,
       userId: testUser.id,
     });
 
-    await Promise.all([
-      courseUserFixture({ courseId: personalCourse.id, userId: testUser.id }),
-      completeLessonForUser({ lessonId: lesson.id, userId: testUser.id }),
-    ]);
+    await courseUserFixture({ courseId: personalCourse.id, userId: testUser.id });
 
     const result = await listUserCourses(testHeaders);
 
@@ -219,18 +149,14 @@ describe("authenticated users", () => {
 
     const testHeaders = await signInAs(testUser.email, testUser.password);
 
-    const [otherUserData, testUserData] = await Promise.all([
-      createCourseWithLesson({ organizationId: organization.id }),
-      createCourseWithLesson({ organizationId: organization.id }),
+    const [otherUserCourse, testUserCourse] = await Promise.all([
+      courseFixture({ isPublished: true, organizationId: organization.id }),
+      courseFixture({ isPublished: true, organizationId: organization.id }),
     ]);
-
-    const [otherUserCourse, testUserCourse] = [otherUserData.course, testUserData.course];
 
     await Promise.all([
       courseUserFixture({ courseId: otherUserCourse.id, userId: otherUser.id }),
       courseUserFixture({ courseId: testUserCourse.id, userId: testUser.id }),
-      completeLessonForUser({ lessonId: otherUserData.lesson.id, userId: otherUser.id }),
-      completeLessonForUser({ lessonId: testUserData.lesson.id, userId: testUser.id }),
     ]);
 
     const result = await listUserCourses(testHeaders);

--- a/apps/main/src/data/courses/list-user-courses.ts
+++ b/apps/main/src/data/courses/list-user-courses.ts
@@ -8,25 +8,8 @@ import { cache } from "react";
 type UserCourse = Course & { organization: Organization | null };
 
 /**
- * My Courses is a resume surface, not raw start history. Opening a lesson
- * creates a lesson_progress row with completedAt null, so the list must require
- * at least one completed lesson in the same course before showing it.
- */
-function getCompletedUserCourseWhere({ userId }: { userId: string }) {
-  return {
-    course: {
-      OR: [{ organization: { kind: "brand" } }, { organizationId: null }],
-      chapters: {
-        some: { lessons: { some: { progress: { some: { completedAt: { not: null }, userId } } } } },
-      },
-    },
-    userId,
-  };
-}
-
-/**
- * The My Courses page only shows courses where the learner has real completion
- * progress, while preserving the existing course metadata needed by the list UI.
+ * The My Courses page lists every main-app course associated with the learner
+ * through CourseUser, including courses where they have not completed a lesson.
  */
 export const listUserCourses = cache(
   async (headers?: Headers): Promise<SafeReturn<UserCourse[]>> => {
@@ -42,7 +25,10 @@ export const listUserCourses = cache(
       prisma.courseUser.findMany({
         include: { course: { include: { organization: true } } },
         orderBy: { startedAt: "desc" },
-        where: getCompletedUserCourseWhere({ userId }),
+        where: {
+          course: { OR: [{ organization: { kind: "brand" } }, { organizationId: null }] },
+          userId,
+        },
       }),
     );
 


### PR DESCRIPTION
Show every main-app course associated through CourseUser without requiring completed lesson progress. Simplify the integration coverage around CourseUser as the source of truth.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show all main-app courses linked to a learner via `CourseUser`, not only those with completed lessons. Fixes missing courses in My Courses while keeping sorting and org data intact.

- **Bug Fixes**
  - Use `CourseUser` as the source of truth instead of requiring completed lesson progress.
  - Return brand and personal courses only; keep `startedAt` ordering and include `organization`.

- **Refactors**
  - Simplified tests by removing lesson/chapter/progress setup and related helpers.
  - Updated assertions to validate inclusion without completion requirements.

<sup>Written for commit c861245eb64d8df724452ff6dc60068c27444db7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

