### PR TITLE
fix(ai): normalize generated practice options

### DIFF
--- a/packages/ai/src/tasks/lessons/core/_utils/normalize-practice-options.ts
+++ b/packages/ai/src/tasks/lessons/core/_utils/normalize-practice-options.ts
@@ -1,0 +1,85 @@
+export const practiceOptionLimit = 4;
+
+type PracticeOption = { feedback: string; isCorrect: boolean; text: string };
+
+/**
+ * Ignores surrounding model whitespace when comparing visible answer labels
+ * without changing meaningful capitalization or internal spacing.
+ */
+function getComparableOptionText(text: string): string {
+  return text.trim();
+}
+
+/**
+ * Keeps one copy of a repeated answer. When the model disagrees about whether
+ * identical labels are correct, the correct copy preserves the answer rather
+ * than accidentally turning the normalized question into an impossible one.
+ * Whitespace-only labels have no preferred copy because they should be removed.
+ */
+function shouldKeepOption({
+  option,
+  options,
+}: {
+  option: PracticeOption;
+  options: readonly PracticeOption[];
+}): boolean {
+  const comparableText = getComparableOptionText(option.text);
+
+  if (!comparableText) {
+    return false;
+  }
+
+  const repeatedOptions = options.filter(
+    (candidate) => getComparableOptionText(candidate.text) === comparableText,
+  );
+
+  const [firstOption] = repeatedOptions;
+  const preferredOption = repeatedOptions.find((candidate) => candidate.isCorrect);
+
+  return preferredOption ? option === preferredOption : option === firstOption;
+}
+
+/**
+ * Reduces extra distinct options only when there is one unambiguous correct
+ * answer. Ambiguous generations stay unchanged so the caller can reject them
+ * instead of silently inventing which answer should be correct.
+ */
+function limitPracticeOptions<Option extends PracticeOption>(options: Option[]): Option[] {
+  if (options.length <= practiceOptionLimit) {
+    return options;
+  }
+
+  const correctOptions = options.filter((option) => option.isCorrect);
+  const [correctOption] = correctOptions;
+
+  if (!correctOption || correctOptions.length !== 1) {
+    return options;
+  }
+
+  const retainedOptions = new Set([
+    correctOption,
+    ...options.filter((option) => !option.isCorrect).slice(0, practiceOptionLimit - 1),
+  ]);
+
+  return options.filter((option) => retainedOptions.has(option));
+}
+
+/**
+ * Repairs model output that contains blank, repeated, or extra practice
+ * answers while preserving the generated copy and the only correct answer.
+ */
+export function normalizePracticeOptions<Option extends PracticeOption>(
+  options: readonly Option[],
+): Option[] {
+  const trimmedOptions = options.map((option) => ({
+    ...option,
+    feedback: option.feedback.trim(),
+    text: option.text.trim(),
+  }));
+
+  const uniqueOptions = trimmedOptions.filter((option) =>
+    shouldKeepOption({ option, options: trimmedOptions }),
+  );
+
+  return limitPracticeOptions(uniqueOptions);
+}

--- a/packages/ai/src/tasks/lessons/core/_utils/normalize-practice-options.ts
+++ b/packages/ai/src/tasks/lessons/core/_utils/normalize-practice-options.ts
@@ -11,9 +11,18 @@ function getComparableOptionText(text: string): string {
 }
 
 /**
+ * Prefers duplicate options that can explain the result after submission.
+ */
+function hasVisibleFeedback(option: PracticeOption): boolean {
+  return option.feedback.length > 0;
+}
+
+/**
  * Keeps one copy of a repeated answer. When the model disagrees about whether
  * identical labels are correct, the correct copy preserves the answer rather
  * than accidentally turning the normalized question into an impossible one.
+ * Among copies with the same correctness, usable feedback wins so normalization
+ * does not discard a complete option in favor of one the final schema rejects.
  * Whitespace-only labels have no preferred copy because they should be removed.
  */
 function shouldKeepOption({
@@ -33,10 +42,14 @@ function shouldKeepOption({
     (candidate) => getComparableOptionText(candidate.text) === comparableText,
   );
 
-  const [firstOption] = repeatedOptions;
-  const preferredOption = repeatedOptions.find((candidate) => candidate.isCorrect);
+  const correctOptions = repeatedOptions.filter((candidate) => candidate.isCorrect);
+  const equallyCorrectOptions = correctOptions.length > 0 ? correctOptions : repeatedOptions;
 
-  return preferredOption ? option === preferredOption : option === firstOption;
+  const preferredOption =
+    equallyCorrectOptions.find((candidate) => hasVisibleFeedback(candidate)) ??
+    equallyCorrectOptions[0];
+
+  return option === preferredOption;
 }
 
 /**

--- a/packages/ai/src/tasks/lessons/core/lesson-practice.test.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.test.ts
@@ -28,11 +28,11 @@ describe(generateLessonPractice, () => {
             dialogue: "Apply the contract rule.",
             imagePrompt: "A rental contract beside a broken pipe.",
             options: [
-              { feedback: "Correct.", isCorrect: true, text: "Contact the owner" },
+              { feedback: "", isCorrect: true, text: "Contact the owner" },
               { feedback: "Not supported.", isCorrect: false, text: "Charge the tenant" },
               { feedback: "Not supported.", isCorrect: false, text: "Split the cost" },
               { feedback: "Not supported.", isCorrect: false, text: "Ignore the clause" },
-              { feedback: "Also correct.", isCorrect: true, text: "Contact the owner" },
+              { feedback: "Correct.", isCorrect: true, text: "Contact the owner" },
             ],
             question: "Who should arrange the repair?",
           },
@@ -62,10 +62,10 @@ describe(generateLessonPractice, () => {
 
     expect(result.data.situations.map((situation) => situation.options)).toStrictEqual([
       [
-        { feedback: "Correct.", isCorrect: true, text: "Contact the owner" },
         { feedback: "Not supported.", isCorrect: false, text: "Charge the tenant" },
         { feedback: "Not supported.", isCorrect: false, text: "Split the cost" },
         { feedback: "Not supported.", isCorrect: false, text: "Ignore the clause" },
+        { feedback: "Correct.", isCorrect: true, text: "Contact the owner" },
       ],
       [
         { feedback: "Correct.", isCorrect: true, text: "Match labels" },

--- a/packages/ai/src/tasks/lessons/core/lesson-practice.test.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.test.ts
@@ -1,0 +1,114 @@
+import { generateText } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateLessonPractice } from "./lesson-practice";
+import type * as Ai from "ai";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("./lesson-practice.prompt.md", () => ({ default: "{{FEEDBACK}}" }));
+vi.mock("../_utils/lesson-feedback.prompt.md", () => ({ default: "Feedback guidance" }));
+vi.mock("../_utils/lesson-rich-text.prompt.md", () => ({ default: "Rich text guidance" }));
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof Ai>();
+
+  return { ...actual, generateText: vi.fn() };
+});
+
+describe(generateLessonPractice, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes blank and duplicate options from generated practice situations", async () => {
+    vi.mocked(generateText).mockResolvedValueOnce({
+      output: {
+        situations: [
+          {
+            dialogue: "Apply the contract rule.",
+            imagePrompt: "A rental contract beside a broken pipe.",
+            options: [
+              { feedback: "Correct.", isCorrect: true, text: "Contact the owner" },
+              { feedback: "Not supported.", isCorrect: false, text: "Charge the tenant" },
+              { feedback: "Not supported.", isCorrect: false, text: "Split the cost" },
+              { feedback: "Not supported.", isCorrect: false, text: "Ignore the clause" },
+              { feedback: "Also correct.", isCorrect: true, text: "Contact the owner" },
+            ],
+            question: "Who should arrange the repair?",
+          },
+          {
+            dialogue: "Give the robot a precise instruction.",
+            imagePrompt: "A robot beside labeled shelves.",
+            options: [
+              { feedback: "Correct.", isCorrect: true, text: "Match labels" },
+              { feedback: "Too vague.", isCorrect: false, text: "Make it neat" },
+              { feedback: "Too vague.", isCorrect: false, text: "Use common sense" },
+              { feedback: "Too vague.", isCorrect: false, text: "Make it look right" },
+              { feedback: "", isCorrect: false, text: "   " },
+            ],
+            question: "Which instruction is precise?",
+          },
+        ],
+      },
+      usage: {},
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    const result = await generateLessonPractice({
+      chapterTitle: "Rules",
+      courseTitle: "Reasoning",
+      language: "en",
+      lesson: { description: "Apply explicit rules.", title: "Using rules" },
+    });
+
+    expect(result.data.situations.map((situation) => situation.options)).toStrictEqual([
+      [
+        { feedback: "Correct.", isCorrect: true, text: "Contact the owner" },
+        { feedback: "Not supported.", isCorrect: false, text: "Charge the tenant" },
+        { feedback: "Not supported.", isCorrect: false, text: "Split the cost" },
+        { feedback: "Not supported.", isCorrect: false, text: "Ignore the clause" },
+      ],
+      [
+        { feedback: "Correct.", isCorrect: true, text: "Match labels" },
+        { feedback: "Too vague.", isCorrect: false, text: "Make it neat" },
+        { feedback: "Too vague.", isCorrect: false, text: "Use common sense" },
+        { feedback: "Too vague.", isCorrect: false, text: "Make it look right" },
+      ],
+    ]);
+  });
+
+  it("keeps the correct answer when limiting extra distinct options", async () => {
+    vi.mocked(generateText).mockResolvedValueOnce({
+      output: {
+        situations: [
+          {
+            dialogue: "Choose the precise instruction.",
+            imagePrompt: "A robot beside labeled shelves.",
+            options: [
+              { feedback: "Too vague.", isCorrect: false, text: "Make it neat" },
+              { feedback: "Too vague.", isCorrect: false, text: "Use common sense" },
+              { feedback: "Too vague.", isCorrect: false, text: "Make it look right" },
+              { feedback: "Too vague.", isCorrect: false, text: "Put them away" },
+              { feedback: "Correct.", isCorrect: true, text: "Match the labels" },
+            ],
+            question: "Which instruction can the robot follow?",
+          },
+        ],
+      },
+      usage: {},
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    const result = await generateLessonPractice({
+      chapterTitle: "Algorithms",
+      courseTitle: "Computer Science",
+      language: "en",
+      lesson: { description: "Write precise instructions.", title: "Algorithms" },
+    });
+
+    expect(result.data.situations[0]?.options).toStrictEqual([
+      { feedback: "Too vague.", isCorrect: false, text: "Make it neat" },
+      { feedback: "Too vague.", isCorrect: false, text: "Use common sense" },
+      { feedback: "Too vague.", isCorrect: false, text: "Make it look right" },
+      { feedback: "Correct.", isCorrect: true, text: "Match the labels" },
+    ]);
+  });
+});

--- a/packages/ai/src/tasks/lessons/core/lesson-practice.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.ts
@@ -6,6 +6,7 @@ import { getPromptLanguageName } from "../../_utils/prompt-language";
 import { insertLessonFeedbackPrompt } from "../_utils/append-lesson-feedback-prompt";
 import { appendLessonRichTextPrompt } from "../_utils/append-lesson-rich-text-prompt";
 import { type SourceLesson, formatSourceLessonForPrompt } from "../_utils/source-lessons";
+import { normalizePracticeOptions, practiceOptionLimit } from "./_utils/normalize-practice-options";
 import baseSystemPrompt from "./lesson-practice.prompt.md";
 
 const defaultModel = "openai/gpt-5.6-sol";
@@ -18,6 +19,11 @@ const practiceOptionSchema = z.object({
   text: z.string(),
 });
 
+const normalizedPracticeOptionSchema = practiceOptionSchema.extend({
+  feedback: z.string().trim().min(1),
+  text: z.string().trim().min(1),
+});
+
 const practiceSituationSchema = z.object({
   dialogue: z.string(),
   imagePrompt: z.string(),
@@ -25,9 +31,29 @@ const practiceSituationSchema = z.object({
   question: z.string(),
 });
 
-const schema = z.object({ situations: z.array(practiceSituationSchema).min(1) });
+/**
+ * Practice questions are only safe to publish when one visible answer is
+ * marked correct. Normalization can remove duplicate correct copies, but it
+ * must not guess between distinct answers that the model marked as correct.
+ */
+function hasExactlyOneCorrectOption(situation: z.infer<typeof practiceSituationSchema>): boolean {
+  return situation.options.filter((option) => option.isCorrect).length === 1;
+}
 
-export type LessonPracticeSchema = z.infer<typeof schema>;
+const generatedPracticeSchema = z.object({ situations: z.array(practiceSituationSchema).min(1) });
+
+const normalizedPracticeSituationSchema = practiceSituationSchema
+  .extend({ options: z.array(normalizedPracticeOptionSchema).length(practiceOptionLimit) })
+  .refine(hasExactlyOneCorrectOption, {
+    message: "Practice situations must have exactly one correct option",
+    path: ["options"],
+  });
+
+const normalizedPracticeSchema = z.object({
+  situations: z.array(normalizedPracticeSituationSchema).min(1),
+});
+
+export type LessonPracticeSchema = z.infer<typeof normalizedPracticeSchema>;
 
 export type LessonPracticeParams = {
   chapterTitle: string;
@@ -38,6 +64,22 @@ export type LessonPracticeParams = {
   useFallback?: boolean;
   reasoning?: Reasoning;
 };
+
+/**
+ * Repairs structurally usable model output before enforcing the practice
+ * contract. This lets blank, repeated, or extra distractors be removed without
+ * failing the whole lesson while still rejecting questions that remain unsafe.
+ */
+function normalizePracticeOutput(
+  output: z.infer<typeof generatedPracticeSchema>,
+): LessonPracticeSchema {
+  return normalizedPracticeSchema.parse({
+    situations: output.situations.map((situation) => ({
+      ...situation,
+      options: normalizePracticeOptions(situation.options),
+    })),
+  });
+}
 
 export async function generateLessonPractice({
   chapterTitle,
@@ -63,11 +105,11 @@ export async function generateLessonPractice({
   const { output, usage } = await generateText({
     instructions: systemPrompt,
     model,
-    output: Output.object({ schema }),
+    output: Output.object({ schema: generatedPracticeSchema }),
     prompt: userPrompt,
     providerOptions,
     reasoning,
   });
 
-  return { data: output, systemPrompt, usage, userPrompt };
+  return { data: normalizePracticeOutput(output), systemPrompt, usage, userPrompt };
 }


### PR DESCRIPTION
## Summary

- normalize blank, duplicate, and excess practice options before validation
- preserve the correct answer when generated output can be repaired safely
- add regression coverage for malformed option sets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes generated practice options to drop blanks and duplicates, cap to 4 choices, and keep the correct answer so lessons stay valid. Validates the normalized result to require exactly one correct option and non-empty labels.

- **Bug Fixes**
  - Added `normalizePracticeOptions` to trim fields, drop blank/duplicate labels (prefer the copy with feedback and preserve the correct one), and limit via `practiceOptionLimit` (4) only when one correct answer exists.
  - Updated `generateLessonPractice` to parse with a generated schema, normalize output via `normalizePracticeOutput`, then validate a normalized schema requiring 4 options, exactly one correct, and non-empty trimmed `text`/`feedback`.
  - Added regression tests for malformed sets, duplicate labels with conflicting correctness, blank entries, and preserving the correct answer when limiting options.

<sup>Written for commit efc166a13424d044525d5737bceb36c3c91867ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

