### PR TITLE
feat(admin): add course prompt and course editors

### DIFF
--- a/apps/admin/src/app/(private)/course-prompts/[id]/_actions/update-course-prompt.ts
+++ b/apps/admin/src/app/(private)/course-prompts/[id]/_actions/update-course-prompt.ts
@@ -1,0 +1,227 @@
+"use server";
+
+import { assertAdmin } from "@/lib/admin-guard";
+import { getCoursePromptGenerationError } from "@zoonk/core/courses/prompt-generation";
+import { CourseFormat, type CoursePrompt, CoursePromptIntent, prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { isUuid } from "@zoonk/utils/uuid";
+import { revalidatePath } from "next/cache";
+
+export type UpdateCoursePromptState = {
+  canEditGenerationStatus: boolean;
+  canonicalTitle: string;
+  courseFormat: CoursePrompt["courseFormat"];
+  error: string | null;
+  generationStatus: CoursePrompt["generationStatus"];
+  intent: CoursePrompt["intent"];
+  status: "idle" | "error" | "success";
+  submissionId: number;
+};
+
+type CoursePromptFormValues = {
+  canonicalTitle: string | null;
+  courseFormat: CoursePrompt["courseFormat"];
+  id: string;
+  intent: CoursePrompt["intent"];
+  requestedStatus: string | null;
+};
+
+/**
+ * Runtime enum validation prevents a handcrafted Server Action request from
+ * storing a classification value that was never offered by the edit form.
+ */
+function isCoursePromptIntent(value: string | null): value is CoursePrompt["intent"] {
+  return Boolean(value && Object.values(CoursePromptIntent).some((intent) => intent === value));
+}
+
+/**
+ * Optional course formats use an empty form value for null, while non-empty
+ * values must still be one of the database enum members.
+ */
+function isCourseFormat(value: string): value is NonNullable<CoursePrompt["courseFormat"]> {
+  return Object.values(CourseFormat).some((format) => format === value);
+}
+
+/**
+ * Converts the form's empty option to the database null value and leaves an
+ * invalid enum distinguishable from that intentional absence.
+ */
+function parseCourseFormat(value: string): CoursePrompt["courseFormat"] | undefined {
+  if (value === "") {
+    return null;
+  }
+
+  if (isCourseFormat(value)) {
+    return value;
+  }
+}
+
+/**
+ * Parses and validates the complete untrusted form payload before the action
+ * reads a prompt or starts constructing database update values.
+ */
+function parseCoursePromptFormValues(
+  formData: FormData,
+): { data: CoursePromptFormValues; error: null } | { data: null; error: string } {
+  const id = parseFormField(formData, "id");
+  const intent = parseFormField(formData, "intent");
+  const courseFormatValue = parseFormField(formData, "courseFormat");
+  const canonicalTitle = parseFormField(formData, "canonicalTitle") || null;
+  const requestedStatus = parseFormField(formData, "generationStatus");
+
+  if (!(isUuid(id) && isCoursePromptIntent(intent) && courseFormatValue !== null)) {
+    return { data: null, error: "Invalid course prompt fields." };
+  }
+
+  const courseFormat = parseCourseFormat(courseFormatValue);
+
+  if (courseFormat === undefined) {
+    return { data: null, error: "Invalid course format." };
+  }
+
+  if (requestedStatus !== null && requestedStatus !== "" && requestedStatus !== "pending") {
+    return { data: null, error: "Invalid generation status." };
+  }
+
+  return { data: { canonicalTitle, courseFormat, id, intent, requestedStatus }, error: null };
+}
+
+/**
+ * Admins may start generation only from the explicit "No generation" state.
+ * Existing workflow states belong to the workflow and cannot be reset here.
+ */
+function getGenerationStatus({
+  currentStatus,
+  requestedStatus,
+}: {
+  currentStatus: CoursePrompt["generationStatus"];
+  requestedStatus: string | null;
+}): CoursePrompt["generationStatus"] | undefined {
+  if (requestedStatus === null || requestedStatus === "") {
+    return currentStatus;
+  }
+
+  if (requestedStatus === "pending" && currentStatus === null) {
+    return "pending";
+  }
+}
+
+/**
+ * Failed submissions keep the values the admin just chose. A pending request
+ * remains editable when the stored prompt still has no workflow-owned status.
+ */
+function getSubmittedCoursePromptState({
+  currentStatus,
+  values,
+}: {
+  currentStatus: CoursePrompt["generationStatus"];
+  values: CoursePromptFormValues;
+}): Omit<UpdateCoursePromptState, "error" | "status" | "submissionId"> {
+  const generationStatus =
+    currentStatus === null && values.requestedStatus === "pending" ? "pending" : currentStatus;
+
+  return {
+    canEditGenerationStatus: currentStatus === null,
+    canonicalTitle: values.canonicalTitle ?? "",
+    courseFormat: values.courseFormat,
+    generationStatus,
+    intent: values.intent,
+  };
+}
+
+/**
+ * Updates the editable routing decision after re-authorizing and validating
+ * every submitted field. Successful saves return the persisted values so the
+ * form can confirm the change without navigating away or showing stale defaults.
+ */
+export async function updateCoursePromptAction(
+  previousState: UpdateCoursePromptState,
+  formData: FormData,
+): Promise<UpdateCoursePromptState> {
+  await assertAdmin();
+
+  const submissionId = previousState.submissionId + 1;
+  const parsedValues = parseCoursePromptFormValues(formData);
+
+  if (!parsedValues.data) {
+    return { ...previousState, error: parsedValues.error, status: "error", submissionId };
+  }
+
+  const values = parsedValues.data;
+  const { canonicalTitle, courseFormat, id, intent, requestedStatus } = values;
+
+  const { data: prompt, error: readError } = await safeAsync(() =>
+    prisma.coursePrompt.findUnique({ where: { id } }),
+  );
+
+  if (readError) {
+    return {
+      ...previousState,
+      error: "Could not load this course prompt. Please try again.",
+      status: "error",
+      submissionId,
+    };
+  }
+
+  if (!prompt) {
+    return { ...previousState, error: "Course prompt not found.", status: "error", submissionId };
+  }
+
+  const submittedState = getSubmittedCoursePromptState({
+    currentStatus: prompt.generationStatus,
+    values,
+  });
+
+  const generationStatus = getGenerationStatus({
+    currentStatus: prompt.generationStatus,
+    requestedStatus,
+  });
+
+  if (generationStatus === undefined) {
+    return {
+      ...submittedState,
+      error: "Only prompts with no generation can be moved to pending.",
+      status: "error",
+      submissionId,
+    };
+  }
+
+  const updatedPrompt = { ...prompt, canonicalTitle, courseFormat, generationStatus, intent };
+
+  if (requestedStatus === "pending") {
+    const generationError = getCoursePromptGenerationError(updatedPrompt);
+
+    if (generationError) {
+      return { ...submittedState, error: generationError, status: "error", submissionId };
+    }
+  }
+
+  const { error: updateError } = await safeAsync(() =>
+    prisma.coursePrompt.update({
+      data: { canonicalTitle, courseFormat, generationStatus, intent },
+      where: { id },
+    }),
+  );
+
+  if (updateError) {
+    return {
+      ...submittedState,
+      error: "Could not save this course prompt. Please try again.",
+      status: "error",
+      submissionId,
+    };
+  }
+
+  revalidatePath("/course-prompts");
+  revalidatePath(`/course-prompts/${id}`);
+
+  return {
+    ...submittedState,
+    canEditGenerationStatus: generationStatus === null,
+    error: null,
+    generationStatus,
+    status: "success",
+    submissionId,
+  };
+}

--- a/apps/admin/src/app/(private)/course-prompts/[id]/course-prompt-form.tsx
+++ b/apps/admin/src/app/(private)/course-prompts/[id]/course-prompt-form.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import {
+  AdminEditForm,
+  AdminEditFormActions,
+  AdminEditFormFeedback,
+} from "@/components/admin-edit-form";
+import { type CoursePrompt } from "@zoonk/db";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@zoonk/ui/components/field";
+import { Input } from "@zoonk/ui/components/input";
+import { NativeSelect, NativeSelectOption } from "@zoonk/ui/components/native-select";
+import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
+import { CheckIcon } from "lucide-react";
+import Link from "next/link";
+import { useActionState } from "react";
+import {
+  type UpdateCoursePromptState,
+  updateCoursePromptAction,
+} from "./_actions/update-course-prompt";
+
+/**
+ * Database enums use stable lowercase values, while the form presents them as
+ * human-readable labels without maintaining a second label map.
+ */
+function getOptionLabel(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * The prompt editor keeps the submitted text as read-only context and exposes
+ * only the classification fields admins are expected to correct.
+ */
+export function CoursePromptForm({
+  courseFormats,
+  intents,
+  prompt,
+}: {
+  courseFormats: NonNullable<CoursePrompt["courseFormat"]>[];
+  intents: CoursePrompt["intent"][];
+  prompt: Pick<
+    CoursePrompt,
+    "canonicalTitle" | "courseFormat" | "generationStatus" | "id" | "intent" | "language" | "prompt"
+  >;
+}) {
+  const [state, formAction] = useActionState(updateCoursePromptAction, {
+    canEditGenerationStatus: prompt.generationStatus === null,
+    canonicalTitle: prompt.canonicalTitle ?? "",
+    courseFormat: prompt.courseFormat,
+    error: null,
+    generationStatus: prompt.generationStatus,
+    intent: prompt.intent,
+    status: "idle",
+    submissionId: 0,
+  } satisfies UpdateCoursePromptState);
+
+  return (
+    <AdminEditForm action={formAction}>
+      <input name="id" type="hidden" value={prompt.id} />
+
+      <div className="border-b pb-6">
+        <p className="text-muted-foreground mb-1 text-sm">Submitted prompt</p>
+        <p className="leading-relaxed font-medium">{prompt.prompt}</p>
+        <p className="text-muted-foreground mt-1 text-xs uppercase">{prompt.language}</p>
+      </div>
+
+      <FieldGroup>
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="intent">Intent</FieldLabel>
+            <NativeSelect
+              className="w-full"
+              defaultValue={state.intent}
+              id="intent"
+              key={state.intent}
+              name="intent"
+            >
+              {intents.map((intent) => (
+                <NativeSelectOption key={intent} value={intent}>
+                  {getOptionLabel(intent)}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </FieldContent>
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="courseFormat">Course format</FieldLabel>
+            <NativeSelect
+              className="w-full"
+              defaultValue={state.courseFormat ?? ""}
+              id="courseFormat"
+              key={state.courseFormat ?? "no-course-format"}
+              name="courseFormat"
+            >
+              <NativeSelectOption value="">No course format</NativeSelectOption>
+              {courseFormats.map((courseFormat) => (
+                <NativeSelectOption key={courseFormat} value={courseFormat}>
+                  {getOptionLabel(courseFormat)}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </FieldContent>
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="canonicalTitle">Canonical title</FieldLabel>
+            <Input
+              defaultValue={state.canonicalTitle}
+              id="canonicalTitle"
+              key={state.canonicalTitle}
+              name="canonicalTitle"
+              placeholder="No canonical title"
+            />
+            <FieldDescription>
+              Leave blank when this prompt should not have a canonical title.
+            </FieldDescription>
+          </FieldContent>
+        </Field>
+
+        <GenerationStatusField
+          canEdit={state.canEditGenerationStatus}
+          generationStatus={state.generationStatus}
+        />
+      </FieldGroup>
+
+      <AdminEditFormFeedback
+        error={state.status === "error" ? state.error : null}
+        submissionId={state.submissionId}
+        successMessage={state.status === "success" ? "Course prompt updated successfully." : null}
+      />
+
+      <AdminEditFormActions>
+        <Link className={buttonVariants({ variant: "outline" })} href="/course-prompts">
+          Cancel
+        </Link>
+        <SubmitButton icon={<CheckIcon />}>Save changes</SubmitButton>
+      </AdminEditFormActions>
+    </AdminEditForm>
+  );
+}
+
+/**
+ * Null statuses are the only workflow state this editor can advance. Once a
+ * workflow owns the prompt, the current state stays visible but read-only.
+ */
+function GenerationStatusField({
+  canEdit,
+  generationStatus,
+}: {
+  canEdit: boolean;
+  generationStatus: CoursePrompt["generationStatus"];
+}) {
+  if (!canEdit) {
+    return (
+      <Field>
+        <FieldContent>
+          <FieldLabel htmlFor="generationStatus">Generation status</FieldLabel>
+          <Input
+            className="capitalize"
+            disabled
+            id="generationStatus"
+            value={generationStatus ?? "No generation"}
+          />
+          <FieldDescription>The generation workflow owns this status.</FieldDescription>
+        </FieldContent>
+      </Field>
+    );
+  }
+
+  return (
+    <Field>
+      <FieldContent>
+        <FieldLabel htmlFor="generationStatus">Generation status</FieldLabel>
+        <NativeSelect
+          className="w-full"
+          defaultValue={generationStatus ?? ""}
+          id="generationStatus"
+          key={generationStatus ?? "no-generation"}
+          name="generationStatus"
+        >
+          <NativeSelectOption value="">No generation</NativeSelectOption>
+          <NativeSelectOption value="pending">Pending</NativeSelectOption>
+        </NativeSelect>
+        <FieldDescription>
+          Pending requires a learn intent, canonical title, and supported core or language format.
+        </FieldDescription>
+      </FieldContent>
+    </Field>
+  );
+}

--- a/apps/admin/src/app/(private)/course-prompts/[id]/page.tsx
+++ b/apps/admin/src/app/(private)/course-prompts/[id]/page.tsx
@@ -1,0 +1,135 @@
+import {
+  AdminEditFormSkeleton,
+  AdminEditFormSkeletonActions,
+  AdminEditFormSkeletonField,
+} from "@/components/admin-edit-form";
+import { getCoursePrompt } from "@/data/course-prompts/get-course-prompt";
+import { CourseFormat, CoursePromptIntent } from "@zoonk/db";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@zoonk/ui/components/breadcrumb";
+import {
+  Container,
+  ContainerBody,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { isUuid } from "@zoonk/utils/uuid";
+import { type Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { CoursePromptForm } from "./course-prompt-form";
+
+export const metadata: Metadata = { title: "Edit Course Prompt" };
+export const prefetch = "allow-runtime";
+
+/**
+ * The list remains one click away while the current breadcrumb clearly marks
+ * this route as an editor rather than another prompt detail log.
+ */
+function CoursePromptBreadcrumb() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/course-prompts">Course Prompts</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Edit</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+/**
+ * The static edit shell renders immediately while the private prompt record is
+ * validated and loaded inside its Suspense boundary.
+ */
+export default function CoursePromptEditPage({ params }: PageProps<"/course-prompts/[id]">) {
+  return (
+    <Container>
+      <ContainerHeader variant="sidebar">
+        <ContainerHeaderGroup>
+          <CoursePromptBreadcrumb />
+          <ContainerTitle>Edit course prompt</ContainerTitle>
+          <ContainerDescription>
+            Correct its routing classification and generation eligibility.
+          </ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <Suspense fallback={<CoursePromptFormSkeleton />}>
+          <CoursePromptFormContent params={params} />
+        </Suspense>
+      </ContainerBody>
+    </Container>
+  );
+}
+
+/**
+ * Invalid identifiers and deleted prompts use the standard not-found boundary
+ * before any values are passed to the client-side form.
+ */
+async function CoursePromptFormContent({
+  params,
+}: Pick<PageProps<"/course-prompts/[id]">, "params">) {
+  const { id } = await params;
+
+  if (!isUuid(id)) {
+    notFound();
+  }
+
+  const prompt = await getCoursePrompt(id);
+
+  if (!prompt) {
+    notFound();
+  }
+
+  return (
+    <CoursePromptForm
+      courseFormats={Object.values(CourseFormat)}
+      intents={Object.values(CoursePromptIntent)}
+      prompt={{
+        canonicalTitle: prompt.canonicalTitle,
+        courseFormat: prompt.courseFormat,
+        generationStatus: prompt.generationStatus,
+        id: prompt.id,
+        intent: prompt.intent,
+        language: prompt.language,
+        prompt: prompt.prompt,
+      }}
+    />
+  );
+}
+
+/**
+ * Four field placeholders mirror intent, format, title, and generation status
+ * while the selected prompt is loading.
+ */
+function CoursePromptFormSkeleton() {
+  return (
+    <AdminEditFormSkeleton>
+      <div className="border-b pb-6">
+        <Skeleton className="mb-2 h-4 w-28" />
+        <Skeleton className="h-5 w-3/4" />
+        <Skeleton className="mt-2 h-3 w-8" />
+      </div>
+      <AdminEditFormSkeletonField />
+      <AdminEditFormSkeletonField />
+      <AdminEditFormSkeletonField />
+      <AdminEditFormSkeletonField />
+      <AdminEditFormSkeletonActions />
+    </AdminEditFormSkeleton>
+  );
+}

--- a/apps/admin/src/app/(private)/course-prompts/course-prompt-list.tsx
+++ b/apps/admin/src/app/(private)/course-prompts/course-prompt-list.tsx
@@ -15,6 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from "@zoonk/ui/components/table";
+import Link from "next/link";
 
 const TABLE_COLUMN_COUNT = 7;
 
@@ -178,8 +179,10 @@ function CoursePromptRow({ prompt }: { prompt: ListedCoursePrompt }) {
   return (
     <TableRow>
       <TableCell className="max-w-xl min-w-80 whitespace-normal">
-        <p className="font-medium">{prompt.prompt}</p>
-        <p className="text-muted-foreground text-xs uppercase">{prompt.language}</p>
+        <Link className="block" href={`/course-prompts/${prompt.id}`} prefetch>
+          <span className="font-medium">{prompt.prompt}</span>
+          <span className="text-muted-foreground block text-xs uppercase">{prompt.language}</span>
+        </Link>
       </TableCell>
       <TableCell>
         <Badge className="capitalize" variant="secondary">
@@ -206,7 +209,9 @@ function CoursePromptRow({ prompt }: { prompt: ListedCoursePrompt }) {
       </TableCell>
       <TableCell className="max-w-sm whitespace-normal">
         {prompt.course ? (
-          <span>{prompt.course.title}</span>
+          <Link href={`/courses/${prompt.course.id}`} prefetch>
+            {prompt.course.title}
+          </Link>
         ) : (
           <span className="text-muted-foreground">No linked course</span>
         )}

--- a/apps/admin/src/app/(private)/courses/[id]/_actions/update-course.ts
+++ b/apps/admin/src/app/(private)/courses/[id]/_actions/update-course.ts
@@ -1,0 +1,121 @@
+"use server";
+
+import { assertAdmin } from "@/lib/admin-guard";
+import { isPrismaUniqueConstraintError, prisma } from "@zoonk/db";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { normalizeString, toSlug } from "@zoonk/utils/string";
+import { isUuid } from "@zoonk/utils/uuid";
+import { revalidatePath } from "next/cache";
+
+export type UpdateCourseState = {
+  error: string | null;
+  slug: string;
+  status: "idle" | "error" | "success";
+  submissionId: number;
+  title: string;
+};
+
+/**
+ * An unchanged stored slug must remain byte-for-byte stable, including older
+ * values that may predate today's slug length rules. New input is normalized
+ * through the shared slug function before it is persisted.
+ */
+function getUpdatedSlug({
+  currentSlug,
+  submittedSlug,
+}: {
+  currentSlug: string;
+  submittedSlug: string;
+}) {
+  if (submittedSlug === currentSlug) {
+    return currentSlug;
+  }
+
+  return toSlug(submittedSlug);
+}
+
+/**
+ * Keeps a course's display title, normalized search title, and URL slug in sync
+ * while preserving the admin's ability to choose a slug independently.
+ */
+export async function updateCourseAction(
+  previousState: UpdateCourseState,
+  formData: FormData,
+): Promise<UpdateCourseState> {
+  await assertAdmin();
+
+  const submissionId = previousState.submissionId + 1;
+  const id = parseFormField(formData, "id");
+  const title = parseFormField(formData, "title");
+  const submittedSlug = parseFormField(formData, "slug");
+
+  if (!(isUuid(id) && title && submittedSlug)) {
+    return {
+      ...previousState,
+      error: "Title and slug are required.",
+      status: "error",
+      submissionId,
+    };
+  }
+
+  const submittedState = { slug: submittedSlug, title };
+
+  const { data: course, error: readError } = await safeAsync(() =>
+    prisma.course.findUnique({ where: { id } }),
+  );
+
+  if (readError) {
+    return {
+      ...submittedState,
+      error: "Could not load this course. Please try again.",
+      status: "error",
+      submissionId,
+    };
+  }
+
+  if (!course) {
+    return { ...submittedState, error: "Course not found.", status: "error", submissionId };
+  }
+
+  const slug = getUpdatedSlug({ currentSlug: course.slug, submittedSlug });
+
+  if (!slug) {
+    return {
+      ...submittedState,
+      error: "Enter a slug with at least one letter or number.",
+      status: "error",
+      submissionId,
+    };
+  }
+
+  const { error: updateError } = await safeAsync(() =>
+    prisma.course.update({
+      data: { normalizedTitle: normalizeString(title), slug, title },
+      where: { id },
+    }),
+  );
+
+  if (isPrismaUniqueConstraintError(updateError)) {
+    return {
+      ...submittedState,
+      error: "That slug is already used by another course with the same owner.",
+      status: "error",
+      submissionId,
+    };
+  }
+
+  if (updateError) {
+    return {
+      ...submittedState,
+      error: "Could not save this course. Please try again.",
+      status: "error",
+      submissionId,
+    };
+  }
+
+  revalidatePath("/courses");
+  revalidatePath(`/courses/${id}`);
+
+  return { error: null, slug, status: "success", submissionId, title };
+}

--- a/apps/admin/src/app/(private)/courses/[id]/course-form.tsx
+++ b/apps/admin/src/app/(private)/courses/[id]/course-form.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import {
+  AdminEditForm,
+  AdminEditFormActions,
+  AdminEditFormFeedback,
+} from "@/components/admin-edit-form";
+import { type Course } from "@zoonk/db";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@zoonk/ui/components/field";
+import { Input } from "@zoonk/ui/components/input";
+import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
+import { CheckIcon } from "lucide-react";
+import Link from "next/link";
+import { useActionState } from "react";
+import { type UpdateCourseState, updateCourseAction } from "./_actions/update-course";
+
+/**
+ * Course identity editing keeps title and slug together because the title is
+ * searchable while the slug is the public URL identity admins need to verify.
+ */
+export function CourseForm({ course }: { course: Pick<Course, "id" | "slug" | "title"> }) {
+  const [state, formAction] = useActionState(updateCourseAction, {
+    error: null,
+    slug: course.slug,
+    status: "idle",
+    submissionId: 0,
+    title: course.title,
+  } satisfies UpdateCourseState);
+
+  return (
+    <AdminEditForm action={formAction}>
+      <input name="id" type="hidden" value={course.id} />
+
+      <FieldGroup>
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="title">Title</FieldLabel>
+            <Input defaultValue={state.title} id="title" key={state.title} name="title" required />
+            <FieldDescription>The learner-facing course title and search label.</FieldDescription>
+          </FieldContent>
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="slug">Slug</FieldLabel>
+            <Input
+              autoCapitalize="none"
+              autoCorrect="off"
+              defaultValue={state.slug}
+              id="slug"
+              key={state.slug}
+              name="slug"
+              required
+              spellCheck={false}
+            />
+            <FieldDescription>
+              Used in course URLs. New values are normalized to a URL-safe slug when saved.
+            </FieldDescription>
+          </FieldContent>
+        </Field>
+      </FieldGroup>
+
+      <AdminEditFormFeedback
+        error={state.status === "error" ? state.error : null}
+        submissionId={state.submissionId}
+        successMessage={state.status === "success" ? "Course updated successfully." : null}
+      />
+
+      <AdminEditFormActions>
+        <Link className={buttonVariants({ variant: "outline" })} href="/courses">
+          Cancel
+        </Link>
+        <SubmitButton icon={<CheckIcon />}>Save changes</SubmitButton>
+      </AdminEditFormActions>
+    </AdminEditForm>
+  );
+}

--- a/apps/admin/src/app/(private)/courses/[id]/page.tsx
+++ b/apps/admin/src/app/(private)/courses/[id]/page.tsx
@@ -1,0 +1,110 @@
+import {
+  AdminEditFormSkeleton,
+  AdminEditFormSkeletonActions,
+  AdminEditFormSkeletonField,
+} from "@/components/admin-edit-form";
+import { getCourse } from "@/data/courses/get-course";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@zoonk/ui/components/breadcrumb";
+import {
+  Container,
+  ContainerBody,
+  ContainerDescription,
+  ContainerHeader,
+  ContainerHeaderGroup,
+  ContainerTitle,
+} from "@zoonk/ui/components/container";
+import { isUuid } from "@zoonk/utils/uuid";
+import { type Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { CourseForm } from "./course-form";
+
+export const metadata: Metadata = { title: "Edit Course" };
+export const prefetch = "allow-runtime";
+
+/**
+ * The course editor stays anchored to the catalog list through the same compact
+ * breadcrumb pattern used by other admin detail pages.
+ */
+function CourseBreadcrumb() {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/courses">Courses</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Edit</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}
+
+/**
+ * The static course edit shell streams the private record into a focused title
+ * and slug form without delaying navigation chrome.
+ */
+export default function CourseEditPage({ params }: PageProps<"/courses/[id]">) {
+  return (
+    <Container>
+      <ContainerHeader variant="sidebar">
+        <ContainerHeaderGroup>
+          <CourseBreadcrumb />
+          <ContainerTitle>Edit course</ContainerTitle>
+          <ContainerDescription>
+            Update the learner-facing title and course URL slug.
+          </ContainerDescription>
+        </ContainerHeaderGroup>
+      </ContainerHeader>
+
+      <ContainerBody>
+        <Suspense fallback={<CourseFormSkeleton />}>
+          <CourseFormContent params={params} />
+        </Suspense>
+      </ContainerBody>
+    </Container>
+  );
+}
+
+/**
+ * Only valid, existing course identifiers reach the form, keeping malformed
+ * URLs away from Prisma's UUID boundary.
+ */
+async function CourseFormContent({ params }: Pick<PageProps<"/courses/[id]">, "params">) {
+  const { id } = await params;
+
+  if (!isUuid(id)) {
+    notFound();
+  }
+
+  const course = await getCourse(id);
+
+  if (!course) {
+    notFound();
+  }
+
+  return <CourseForm course={{ id: course.id, slug: course.slug, title: course.title }} />;
+}
+
+/**
+ * Title and slug placeholders keep the form's final dimensions stable until
+ * the course record resolves.
+ */
+function CourseFormSkeleton() {
+  return (
+    <AdminEditFormSkeleton>
+      <AdminEditFormSkeletonField />
+      <AdminEditFormSkeletonField />
+      <AdminEditFormSkeletonActions />
+    </AdminEditFormSkeleton>
+  );
+}

--- a/apps/admin/src/app/(private)/courses/course-row.tsx
+++ b/apps/admin/src/app/(private)/courses/course-row.tsx
@@ -1,10 +1,20 @@
 import { type ListedCourse } from "@/data/courses/list-courses";
 import { TableCell, TableRow } from "@zoonk/ui/components/table";
+import Link from "next/link";
 
+/**
+ * The primary course identity links to its editor and keeps the current slug
+ * visible so admins can verify URL changes directly from the catalog list.
+ */
 export function CourseRow({ course }: { course: ListedCourse }) {
   return (
     <TableRow>
-      <TableCell className="font-medium">{course.title}</TableCell>
+      <TableCell>
+        <Link className="block" href={`/courses/${course.id}`} prefetch>
+          <span className="font-medium">{course.title}</span>
+          <span className="text-muted-foreground block text-xs">{course.slug}</span>
+        </Link>
+      </TableCell>
       <TableCell>{course.organization?.name ?? "—"}</TableCell>
       <TableCell className="uppercase">{course.language}</TableCell>
       <TableCell className="text-right tabular-nums">

--- a/apps/admin/src/components/admin-edit-form.tsx
+++ b/apps/admin/src/components/admin-edit-form.tsx
@@ -1,0 +1,74 @@
+import { FieldDynamicDescription, FieldError } from "@zoonk/ui/components/field";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { cn } from "@zoonk/ui/lib/utils";
+
+/**
+ * Admin edit pages share one restrained form width and rhythm so adding another
+ * record editor does not introduce a slightly different layout.
+ */
+export function AdminEditForm({ className, ...props }: React.ComponentProps<"form">) {
+  return <form className={cn("flex max-w-2xl flex-col gap-7", className)} {...props} />;
+}
+
+/**
+ * Secondary navigation and the primary save action stay grouped at the end of
+ * every admin edit form in the same visual order.
+ */
+export function AdminEditFormActions({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex items-center gap-2", className)} {...props} />;
+}
+
+/**
+ * Save feedback always reserves one line so a confirmation or validation error
+ * does not move the form actions when it appears.
+ */
+export function AdminEditFormFeedback({
+  error,
+  submissionId,
+  successMessage,
+}: {
+  error: string | null;
+  submissionId: number;
+  successMessage: string | null;
+}) {
+  return (
+    <div className="min-h-5">
+      <FieldDynamicDescription key={submissionId} successMessage={successMessage} />
+      {error && <FieldError>{error}</FieldError>}
+    </div>
+  );
+}
+
+/**
+ * The edit-page fallback reserves the same narrow column as the loaded form so
+ * dynamic record reads do not shift the surrounding admin layout.
+ */
+export function AdminEditFormSkeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return <div className={cn("flex max-w-2xl flex-col gap-7", className)} {...props} />;
+}
+
+/**
+ * A label and control placeholder mirror one standard admin form field while
+ * its private default value is loading.
+ */
+export function AdminEditFormSkeletonField() {
+  return (
+    <div className="flex flex-col gap-2">
+      <Skeleton className="h-4 w-28" />
+      <Skeleton className="h-9 w-full" />
+    </div>
+  );
+}
+
+/**
+ * Action placeholders preserve the final row without suggesting that loading
+ * controls can already be submitted.
+ */
+export function AdminEditFormSkeletonActions() {
+  return (
+    <div className="flex gap-2">
+      <Skeleton className="h-9 w-20 rounded-full" />
+      <Skeleton className="h-9 w-32 rounded-full" />
+    </div>
+  );
+}

--- a/apps/admin/src/data/course-prompts/get-course-prompt.ts
+++ b/apps/admin/src/data/course-prompts/get-course-prompt.ts
@@ -1,0 +1,11 @@
+import "server-only";
+import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { prisma } from "@zoonk/db";
+
+/**
+ * The editor reads the complete prompt row because classification fields are
+ * coupled to its language metadata and current generation state.
+ */
+export const getCoursePrompt = cacheAdminData((id: string) =>
+  prisma.coursePrompt.findUnique({ where: { id } }),
+);

--- a/apps/admin/src/data/courses/get-course.ts
+++ b/apps/admin/src/data/courses/get-course.ts
@@ -1,0 +1,11 @@
+import "server-only";
+import { cacheAdminData } from "@/data/_utils/admin-data-cache";
+import { prisma } from "@zoonk/db";
+
+/**
+ * Course editing only needs the model fields, so the detail query avoids
+ * loading curriculum relations that the title and slug form never renders.
+ */
+export const getCourse = cacheAdminData((id: string) =>
+  prisma.course.findUnique({ where: { id } }),
+);

--- a/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
@@ -1,8 +1,8 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
 import { courseGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
-import { getCoursePromptGenerationError } from "@/workflows/course-generation/_utils/course-prompt-validation";
 import { courseGenerationWorkflow } from "@/workflows/course-generation/course-generation-workflow";
+import { getCoursePromptGenerationError } from "@zoonk/core/courses/prompt-generation";
 import { prisma } from "@zoonk/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { start } from "workflow/api";

--- a/apps/api/src/workflows/course-generation/steps/get-course-prompt-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-prompt-step.ts
@@ -1,8 +1,8 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
+import { getCoursePromptGenerationError } from "@zoonk/core/courses/prompt-generation";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type CoursePrompt, type GenerationStatus, prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
-import { getCoursePromptGenerationError } from "../_utils/course-prompt-validation";
 
 type GeneratableCoursePromptBase = CoursePrompt & {
   canonicalTitle: string;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "./auth/username-rules": "./src/auth/username-rules.ts",
     "./chapters/search": "./src/chapters/search-chapters.ts",
     "./courses/landing-page": "./src/courses/course-landing-page.ts",
+    "./courses/prompt-generation": "./src/courses/course-prompt-generation.ts",
     "./courses/slug": "./src/courses/course-slug.ts",
     "./content/thumbnail": "./src/content/content-thumbnail.ts",
     "./courses/search": "./src/courses/search-courses.ts",

--- a/packages/core/src/courses/course-prompt-generation.test.ts
+++ b/packages/core/src/courses/course-prompt-generation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { getCoursePromptGenerationError } from "./course-prompt-generation";
+
+const generatableCorePrompt = {
+  canonicalTitle: "Linear Algebra",
+  courseFormat: "core" as const,
+  generationStatus: "pending" as const,
+  intent: "learn" as const,
+  language: "en",
+  targetLanguage: null,
+};
+
+describe(getCoursePromptGenerationError, () => {
+  it("accepts a pending learn prompt with a canonical title and core format", () => {
+    expect(getCoursePromptGenerationError(generatableCorePrompt)).toBeNull();
+  });
+
+  it.each([
+    ["missing canonical title", { ...generatableCorePrompt, canonicalTitle: null }],
+    ["unsupported format", { ...generatableCorePrompt, courseFormat: "question" as const }],
+    ["missing generation status", { ...generatableCorePrompt, generationStatus: null }],
+    ["unsupported intent", { ...generatableCorePrompt, intent: "question" as const }],
+  ])("rejects a prompt with %s", (_reason, prompt) => {
+    expect(getCoursePromptGenerationError(prompt)).toBe("Course prompt is not generatable");
+  });
+
+  it("rejects a language prompt whose source and target languages match", () => {
+    const prompt = {
+      ...generatableCorePrompt,
+      courseFormat: "language" as const,
+      targetLanguage: "en",
+    };
+
+    expect(getCoursePromptGenerationError(prompt)).toBe(
+      "Language course source and target languages must be different",
+    );
+  });
+});

--- a/packages/core/src/courses/course-prompt-generation.ts
+++ b/packages/core/src/courses/course-prompt-generation.ts
@@ -3,24 +3,28 @@ import { type CoursePrompt } from "@zoonk/db";
 const SAME_LANGUAGE_COURSE_ERROR = "Language course source and target languages must be different";
 const UNSUPPORTED_COURSE_PROMPT_ERROR = "Course prompt is not generatable";
 
+type CoursePromptGenerationInput = Pick<
+  CoursePrompt,
+  "canonicalTitle" | "courseFormat" | "generationStatus" | "intent" | "language" | "targetLanguage"
+>;
+
 /**
  * Language courses are only useful when the learner language and learned
- * language differ. The main app prevents selecting the current locale, but the
- * API and workflow need the same rule because prompts can be started outside
- * that page.
+ * language differ. Every entry point uses this shared check so an admin edit
+ * cannot create a prompt that the generation workflow must reject later.
  */
 function isSameLanguageCourseRequest(
-  prompt: Pick<CoursePrompt, "courseFormat" | "language" | "targetLanguage">,
+  prompt: Pick<CoursePromptGenerationInput, "courseFormat" | "language" | "targetLanguage">,
 ): boolean {
   return prompt.courseFormat === "language" && prompt.targetLanguage === prompt.language;
 }
 
 /**
  * Explains why a persisted prompt cannot enter course generation. The database
- * also stores redirect, waitlist, unsafe, and invalid language records, so the
- * API route and workflow step share this check before creating courses.
+ * also stores redirect, waitlist, unsafe, and invalid language records, so API
+ * callers and admin mutations must share this check before requesting generation.
  */
-export function getCoursePromptGenerationError(prompt: CoursePrompt): string | null {
+export function getCoursePromptGenerationError(prompt: CoursePromptGenerationInput): string | null {
   if (!(prompt.canonicalTitle && prompt.generationStatus)) {
     return UNSUPPORTED_COURSE_PROMPT_ERROR;
   }


### PR DESCRIPTION
## Summary

- add admin edit pages for course prompt classification, canonical titles, and generation status
- add admin editing for course titles and slugs
- keep saves inline with stable feedback and share course prompt generation validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds admin editors for course prompts and courses to update classification, generation status, titles, and slugs with inline save feedback. Centralizes course prompt generation validation in `@zoonk/core` and reuses it across API and workflows.

- New Features
  - Course Prompt editor: edit intent, course format, canonical title; allow switching generation only from “No generation” to “Pending” with validation and clear errors.
  - Course editor: edit title and slug; normalize new slugs; handle duplicate slug errors.
  - Lists: prompt rows link to the prompt editor; course rows link to the course editor and show the current slug.

- Refactors
  - Share generation validation via `@zoonk/core/courses/prompt-generation`; API trigger and workflow step now import it; added unit tests.
  - Introduced `AdminEditForm` primitives for consistent layout, skeletons, and feedback.
  - Revalidate list and detail routes after save to keep views up to date.

<sup>Written for commit 84c35f4d7cf83c45998fba5fa9897a005fb75136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

