### PR TITLE
feat(main): show support form on page

### DIFF
--- a/apps/main/e2e/support.test.ts
+++ b/apps/main/e2e/support.test.ts
@@ -1,4 +1,3 @@
-import { openDialog } from "@zoonk/e2e/fixtures/dialog";
 import { mockFeedbackSubmission } from "./feedback";
 import { expect, test } from "./fixtures";
 
@@ -9,20 +8,18 @@ test.describe("Support page", () => {
     await expect(page.getByRole("heading", { name: /feedback & support/iu })).toBeVisible();
   });
 
-  test("shows page content with support options", async ({ page }) => {
-    await expect(page.getByRole("link", { name: /github discussions/iu })).toBeVisible();
-
-    await expect(page.getByRole("button", { name: /contact support/iu })).toBeVisible();
+  test("shows the contact form directly on the page", async ({ page }) => {
+    await expect(page.getByRole("link", { name: /github discussions/iu })).toHaveCount(0);
+    await expect(page.getByRole("textbox", { name: /email address/iu })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: /^message$/iu })).toBeVisible();
+    await expect(page.getByRole("button", { name: /send message/iu })).toBeVisible();
   });
 
   test("submit with valid data shows success message", async ({ page }) => {
     const feedbackSubmission = await mockFeedbackSubmission(page);
 
-    const supportButton = page.getByRole("button", { name: /contact support/iu });
-    const dialog = page.getByRole("dialog");
-    await openDialog(supportButton, dialog);
-    const emailInput = dialog.getByRole("textbox", { name: /email address/iu });
-    const messageInput = dialog.getByRole("textbox", { name: /^message$/iu });
+    const emailInput = page.getByRole("textbox", { name: /email address/iu });
+    const messageInput = page.getByRole("textbox", { name: /^message$/iu });
 
     await expect(emailInput).toBeEnabled();
     await expect(messageInput).toBeEnabled();
@@ -31,9 +28,9 @@ test.describe("Support page", () => {
     await emailInput.fill("test@example.com");
     await messageInput.click();
     await messageInput.fill("Test message");
-    await dialog.getByRole("button", { name: /send message/iu }).click();
+    await page.getByRole("button", { name: /send message/iu }).click();
 
-    await expect(dialog.getByText(/message sent successfully/iu)).toBeVisible();
+    await expect(page.getByText(/message sent successfully/iu)).toBeVisible();
 
     await expect(feedbackSubmission.requestBody).resolves.toStrictEqual({
       email: "test@example.com",
@@ -42,11 +39,8 @@ test.describe("Support page", () => {
   });
 
   test("submit with invalid email shows validation error", async ({ page }) => {
-    const supportButton = page.getByRole("button", { name: /contact support/iu });
-    const dialog = page.getByRole("dialog");
-    await openDialog(supportButton, dialog);
-    const emailInput = dialog.getByRole("textbox", { name: /email address/iu });
-    const messageInput = dialog.getByRole("textbox", { name: /^message$/iu });
+    const emailInput = page.getByRole("textbox", { name: /email address/iu });
+    const messageInput = page.getByRole("textbox", { name: /^message$/iu });
 
     await expect(emailInput).toBeEnabled();
     await expect(messageInput).toBeEnabled();
@@ -55,22 +49,14 @@ test.describe("Support page", () => {
     await emailInput.fill("invalid-email");
     await messageInput.click();
     await messageInput.fill("Test message");
-    await dialog.getByRole("button", { name: /send message/iu }).click();
+    await page.getByRole("button", { name: /send message/iu }).click();
 
-    // Browser validation prevents submission - verify semantically:
-    // 1. Dialog remains visible (form wasn't submitted)
-    await expect(dialog).toBeVisible();
-
-    // 2. Email input is focused (browser focuses invalid fields)
     await expect(emailInput).toBeFocused();
   });
 
   test("submit failure shows error message", async ({ page }) => {
-    const supportButton = page.getByRole("button", { name: /contact support/iu });
-    const dialog = page.getByRole("dialog");
-    await openDialog(supportButton, dialog);
-    const emailInput = dialog.getByRole("textbox", { name: /email address/iu });
-    const messageInput = dialog.getByRole("textbox", { name: /^message$/iu });
+    const emailInput = page.getByRole("textbox", { name: /email address/iu });
+    const messageInput = page.getByRole("textbox", { name: /^message$/iu });
 
     await expect(emailInput).toBeEnabled();
     await expect(messageInput).toBeEnabled();
@@ -81,9 +67,9 @@ test.describe("Support page", () => {
     // Whitespace passes HTML5 "required" but fails server-side when trimmed
     await messageInput.click();
     await messageInput.fill("   ");
-    await dialog.getByRole("button", { name: /send message/iu }).click();
+    await page.getByRole("button", { name: /send message/iu }).click();
 
-    await expect(dialog.getByText(/failed to send message/iu)).toBeVisible();
+    await expect(page.getByText(/failed to send message/iu)).toBeVisible();
   });
 });
 
@@ -94,11 +80,7 @@ test.describe("Support page - Authenticated", () => {
   }) => {
     await authenticatedPage.goto("/support");
 
-    const supportButton = authenticatedPage.getByRole("button", { name: /contact support/iu });
-    const dialog = authenticatedPage.getByRole("dialog");
-    await openDialog(supportButton, dialog);
-
-    const emailInput = dialog.getByRole("textbox", { name: /email address/iu });
+    const emailInput = authenticatedPage.getByRole("textbox", { name: /email address/iu });
 
     await expect(emailInput).toBeEnabled();
 

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -1631,26 +1631,6 @@ msgid "Share feedback, ask questions, or get help with your account and courses.
 msgstr "Teile Feedback, stelle Fragen oder erhalte Hilfe zu deinem Konto und deinen Kursen."
 
 #: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "dQIo6c"
-msgid "Email us at hello@zoonk.com"
-msgstr "Schreib uns an hello@zoonk.com"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "YdQxfw"
-msgid "Contact Support"
-msgstr "Support kontaktieren"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "cDAb4a"
-msgid "GitHub Discussions"
-msgstr "GitHub Discussions"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "7h49qt"
-msgid "Connect with the community and get answers"
-msgstr "Vernetze dich mit der Community und erhalte Antworten"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
 msgctxt "l1XTI5"
 msgid "Follow us"
 msgstr "Folge uns"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1631,26 +1631,6 @@ msgid "Share feedback, ask questions, or get help with your account and courses.
 msgstr "Share feedback, ask questions, or get help with your account and courses."
 
 #: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "dQIo6c"
-msgid "Email us at hello@zoonk.com"
-msgstr "Email us at hello@zoonk.com"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "YdQxfw"
-msgid "Contact Support"
-msgstr "Contact Support"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "cDAb4a"
-msgid "GitHub Discussions"
-msgstr "GitHub Discussions"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "7h49qt"
-msgid "Connect with the community and get answers"
-msgstr "Connect with the community and get answers"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
 msgctxt "l1XTI5"
 msgid "Follow us"
 msgstr "Follow us"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1631,26 +1631,6 @@ msgid "Share feedback, ask questions, or get help with your account and courses.
 msgstr "Comparte tu opinión, haz preguntas o recibe ayuda con tu cuenta y tus cursos."
 
 #: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "dQIo6c"
-msgid "Email us at hello@zoonk.com"
-msgstr "Escríbenos a contacto@zoonk.com"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "YdQxfw"
-msgid "Contact Support"
-msgstr "Contactar con soporte"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "cDAb4a"
-msgid "GitHub Discussions"
-msgstr "GitHub Discussions"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "7h49qt"
-msgid "Connect with the community and get answers"
-msgstr "Conecta con la comunidad y recibe respuestas"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
 msgctxt "l1XTI5"
 msgid "Follow us"
 msgstr "Síguenos"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -1631,26 +1631,6 @@ msgid "Share feedback, ask questions, or get help with your account and courses.
 msgstr "Partage tes retours, pose tes questions ou obtiens de l’aide pour ton compte et tes cours."
 
 #: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "dQIo6c"
-msgid "Email us at hello@zoonk.com"
-msgstr "Écris-nous à hello@zoonk.com"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "YdQxfw"
-msgid "Contact Support"
-msgstr "Contacter l’assistance"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "cDAb4a"
-msgid "GitHub Discussions"
-msgstr "Discussions GitHub"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "7h49qt"
-msgid "Connect with the community and get answers"
-msgstr "Échange avec la communauté et obtiens des réponses"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
 msgctxt "l1XTI5"
 msgid "Follow us"
 msgstr "Suis-nous"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1631,26 +1631,6 @@ msgid "Share feedback, ask questions, or get help with your account and courses.
 msgstr "Envie feedback, faça perguntas ou receba ajuda com sua conta e cursos."
 
 #: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "dQIo6c"
-msgid "Email us at hello@zoonk.com"
-msgstr "Envie um email para contato@zoonk.com"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "YdQxfw"
-msgid "Contact Support"
-msgstr "Falar com o suporte"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "cDAb4a"
-msgid "GitHub Discussions"
-msgstr "GitHub Discussions"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
-msgctxt "7h49qt"
-msgid "Connect with the community and get answers"
-msgstr "Converse com a comunidade e receba respostas"
-
-#: src/app/[lang]/(settings)/support/support-content.tsx
 msgctxt "l1XTI5"
 msgid "Follow us"
 msgstr "Siga a gente"

--- a/apps/main/src/app/[lang]/(settings)/support/support-content.tsx
+++ b/apps/main/src/app/[lang]/(settings)/support/support-content.tsx
@@ -1,4 +1,4 @@
-import { FeedbackDialog } from "@/components/feedback/feedback-dialog";
+import { ContactForm, ContactFormSkeleton } from "@/components/feedback/contact-form";
 import { getSession } from "@/data/users/get-session";
 import { getSocialProfiles } from "@/lib/social";
 import { buttonVariants } from "@zoonk/ui/components/button";
@@ -10,66 +10,23 @@ import {
   ContainerHeaderGroup,
   ContainerTitle,
 } from "@zoonk/ui/components/container";
-import {
-  Item,
-  ItemContent,
-  ItemDescription,
-  ItemGroup,
-  ItemMedia,
-  ItemSeparator,
-  ItemTitle,
-} from "@zoonk/ui/components/item";
-import { Mail, MessagesSquare } from "lucide-react";
+import { ItemSeparator } from "@zoonk/ui/components/item";
 import { getExtracted, getLocale } from "next-intl/server";
 import { Suspense } from "react";
 
-type ContactSupportItemProps = { description: string; disabled?: boolean; title: string };
-
 /**
- * Keeps the support row identical while session data resolves so the cold-path
- * fallback does not shift the surrounding static support content.
+ * Adds the signed-in learner's email without holding back the rest of the support page.
  */
-function ContactSupportItem({ description, disabled, title }: ContactSupportItemProps) {
-  return (
-    <Item
-      render={<button aria-busy={disabled || undefined} disabled={disabled} type="button" />}
-      size="sm"
-    >
-      <ItemMedia className="bg-muted size-10 rounded-full" variant="icon">
-        <Mail aria-hidden="true" />
-      </ItemMedia>
-
-      <ItemContent>
-        <ItemTitle>{title}</ItemTitle>
-        <ItemDescription>{description}</ItemDescription>
-      </ItemContent>
-    </Item>
-  );
-}
-
-/**
- * Adds the signed-in learner's email only after the private session cache has
- * resolved, leaving the rest of the support page available immediately.
- */
-async function ContactSupport(props: ContactSupportItemProps) {
+async function ContactSupport() {
   const session = await getSession();
 
-  return (
-    <FeedbackDialog defaultEmail={session?.user.email}>
-      <ContactSupportItem {...props} />
-    </FeedbackDialog>
-  );
+  return <ContactForm defaultEmail={session?.user.email} />;
 }
 
 export async function SupportContent() {
   const t = await getExtracted();
   const locale = await getLocale();
   const socials = getSocialProfiles(locale);
-
-  const contactSupportProps = {
-    description: t("Email us at hello@zoonk.com"),
-    title: t("Contact Support"),
-  };
 
   return (
     <Container>
@@ -82,32 +39,11 @@ export async function SupportContent() {
         </ContainerHeaderGroup>
       </ContainerHeader>
 
-      <ItemGroup>
-        <Item
-          render={
-            // oxlint-disable-next-line jsx-a11y/anchor-has-content -- render prop
-            <a
-              href="https://github.com/zoonk/zoonk/discussions"
-              rel="noopener noreferrer"
-              target="_blank"
-            />
-          }
-          size="sm"
-        >
-          <ItemMedia className="bg-muted size-10 rounded-full" variant="icon">
-            <MessagesSquare aria-hidden="true" />
-          </ItemMedia>
-
-          <ItemContent>
-            <ItemTitle>{t("GitHub Discussions")}</ItemTitle>
-            <ItemDescription>{t("Connect with the community and get answers")}</ItemDescription>
-          </ItemContent>
-        </Item>
-
-        <Suspense fallback={<ContactSupportItem {...contactSupportProps} disabled />}>
-          <ContactSupport {...contactSupportProps} />
+      <ContainerBody className="lg:max-w-md">
+        <Suspense fallback={<ContactFormSkeleton />}>
+          <ContactSupport />
         </Suspense>
-      </ItemGroup>
+      </ContainerBody>
 
       <ItemSeparator />
 

--- a/apps/main/src/components/feedback/contact-form.tsx
+++ b/apps/main/src/components/feedback/contact-form.tsx
@@ -9,6 +9,7 @@ import {
   FieldLabel,
 } from "@zoonk/ui/components/field";
 import { Input } from "@zoonk/ui/components/input";
+import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { Textarea } from "@zoonk/ui/components/textarea";
 import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
 import { useExtracted } from "next-intl";
@@ -75,5 +76,28 @@ export function ContactForm({ defaultEmail }: { defaultEmail?: string }) {
 
       <SubmitButton>{t("Send message")}</SubmitButton>
     </form>
+  );
+}
+
+/**
+ * Preserves the contact form's layout while the signed-in learner's email is loading.
+ */
+export function ContactFormSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-5 w-56 max-w-full" />
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-5 w-64 max-w-full" />
+      </div>
+
+      <Skeleton className="h-9 w-32" />
+    </div>
   );
 }


### PR DESCRIPTION
Shows the contact form directly on the support page, removes the GitHub Discussions option, and preserves authenticated email prefilling with a form-shaped loading state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the contact form directly on the Support page, removes GitHub Discussions, and preserves email prefilling with a form-shaped loading state.

- **New Features**
  - Inline `ContactForm` on `/support` using `Suspense` with `ContactFormSkeleton`.
  - Prefills email for signed-in users without delaying page render.

- **Refactors**
  - Replaced dialog flow (`FeedbackDialog`) and removed the GitHub Discussions option; deleted related i18n strings.
  - Updated e2e tests to use the inline form and assert success/error states on the page.

<sup>Written for commit 9e5fd6b792ce18c62a5eddd6fe82f941a722dc50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

