### PR TITLE
feat(core): enroll users when courses start

### DIFF
--- a/apps/api/e2e/workflows-course-generation.test.ts
+++ b/apps/api/e2e/workflows-course-generation.test.ts
@@ -4,6 +4,7 @@ import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
 import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { createAuthenticatedApiContext } from "./helpers/auth";
 
 /**
@@ -158,6 +159,50 @@ test.describe("Course Generation Workflow API", () => {
     expect(body.message).toBe("Workflow started");
     expect(body.runId).toBeDefined();
     expect(typeof body.runId).toBe("string");
+
+    await apiContext.dispose();
+  });
+
+  test("enrolls the authenticated learner in the generated course", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const organization = await getAiOrganization();
+
+    const course = await courseFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId: organization.id,
+      slug: `e2e-enrolled-course-${uniqueId}`,
+      title: `E2E Enrolled Course ${uniqueId}`,
+    });
+
+    const coursePrompt = await coursePromptFixture({
+      canonicalTitle: course.title,
+      courseId: course.id,
+      generationStatus: "completed",
+    });
+
+    const { apiContext, user } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "course-enrollment",
+    });
+
+    const response = await apiContext.post("/v1/workflows/course-generation/trigger", {
+      data: { coursePromptId: coursePrompt.id },
+    });
+
+    expect(response.status()).toBe(200);
+
+    await expect(async () => {
+      const [courseUser, updatedCourse] = await Promise.all([
+        prisma.courseUser.findUnique({
+          where: { courseUser: { courseId: course.id, userId: user.id } },
+        }),
+        prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+      ]);
+
+      expect(courseUser).not.toBeNull();
+      expect(updatedCourse.userCount).toBe(1);
+    }).toPass({ timeout: 10_000 });
 
     await apiContext.dispose();
   });

--- a/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
+++ b/apps/api/src/app/v1/workflows/course-generation/trigger/route.ts
@@ -1,5 +1,6 @@
 import { errors } from "@/lib/api-errors";
 import { parseBody } from "@/lib/body-parser";
+import { getRequestUserId } from "@/lib/get-request-user-id";
 import { courseGenerationTriggerSchema } from "@/lib/openapi/schemas/workflows";
 import { courseGenerationWorkflow } from "@/workflows/course-generation/course-generation-workflow";
 import { getCoursePromptGenerationError } from "@zoonk/core/courses/prompt-generation";
@@ -14,9 +15,10 @@ export async function POST(request: NextRequest) {
     return errors.validation(parsed.error);
   }
 
-  const coursePrompt = await prisma.coursePrompt.findUnique({
-    where: { id: parsed.data.coursePromptId },
-  });
+  const [coursePrompt, userId] = await Promise.all([
+    prisma.coursePrompt.findUnique({ where: { id: parsed.data.coursePromptId } }),
+    getRequestUserId(request.headers),
+  ]);
 
   if (!coursePrompt) {
     return errors.notFound();
@@ -28,7 +30,9 @@ export async function POST(request: NextRequest) {
     return errors.badRequest(generationError);
   }
 
-  const run = await start(courseGenerationWorkflow, [parsed.data.coursePromptId]);
+  const run = await start(courseGenerationWorkflow, [
+    { coursePromptId: parsed.data.coursePromptId, userId },
+  ]);
 
   return NextResponse.json({ message: "Workflow started", runId: run.runId });
 }

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -21,6 +21,7 @@ import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
 import { courseCategoryFixture, courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
 import { normalizeString } from "@zoonk/utils/string";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { getOrCreateCourse } from "./_internal/get-or-create-course";
@@ -175,6 +176,11 @@ vi.mock("./_internal/get-or-create-course", async (importOriginal) => {
   };
 });
 
+/** Runs generation without enrollment for tests that cover course setup behavior. */
+function generateCourse(coursePromptId: string) {
+  return courseGenerationWorkflow({ coursePromptId, userId: null });
+}
+
 describe(courseGenerationWorkflow, () => {
   let organizationId: string;
 
@@ -187,9 +193,7 @@ describe(courseGenerationWorkflow, () => {
     it("returns when request not found", async () => {
       const nonExistentId = randomUUID();
 
-      await expect(courseGenerationWorkflow(nonExistentId)).rejects.toThrow(
-        "Course prompt not found",
-      );
+      await expect(generateCourse(nonExistentId)).rejects.toThrow("Course prompt not found");
 
       expect(generateCourseDescription).not.toHaveBeenCalled();
     });
@@ -217,7 +221,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "running",
       });
 
-      await courseGenerationWorkflow(request.id);
+      await generateCourse(request.id);
 
       const dbRequest = await prisma.coursePrompt.findUnique({ where: { id: request.id } });
 
@@ -257,7 +261,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "completed",
       });
 
-      await courseGenerationWorkflow(request.id);
+      await generateCourse(request.id);
 
       const dbRequest = await prisma.coursePrompt.findUnique({ where: { id: request.id } });
 
@@ -294,7 +298,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "pending",
       });
 
-      await courseGenerationWorkflow(request.id);
+      await generateCourse(request.id);
 
       const dbRequest = await prisma.coursePrompt.findUnique({ where: { id: request.id } });
 
@@ -321,7 +325,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "pending",
       });
 
-      await courseGenerationWorkflow(request.id);
+      await generateCourse(request.id);
 
       const dbRequest = await prisma.coursePrompt.findUnique({ where: { id: request.id } });
 
@@ -364,7 +368,7 @@ describe(courseGenerationWorkflow, () => {
           targetLanguage: "es",
         });
 
-        await expect(courseGenerationWorkflow(request.id)).rejects.toThrow(
+        await expect(generateCourse(request.id)).rejects.toThrow(
           "Recovered course does not match the prompt identity",
         );
 
@@ -384,6 +388,28 @@ describe(courseGenerationWorkflow, () => {
   });
 
   describe("happy path", () => {
+    it("enrolls the authenticated learner when generating a course", async () => {
+      const user = await userFixture();
+      const title = `Enrolled Course ${randomUUID()}`;
+      const slug = getCourseSlugForTitle({ language: "en", title });
+
+      const request = await coursePromptFixture({
+        canonicalTitle: title,
+        generationStatus: "pending",
+      });
+
+      await courseGenerationWorkflow({ coursePromptId: request.id, userId: user.id });
+
+      const course = await prisma.course.findFirstOrThrow({ where: { slug } });
+
+      const courseUser = await prisma.courseUser.findUnique({
+        where: { courseUser: { courseId: course.id, userId: user.id } },
+      });
+
+      expect(courseUser).not.toBeNull();
+      expect(course.userCount).toBe(1);
+    });
+
     it("creates an intro chapter without triggering chapter generation for core courses", async () => {
       vi.mocked(chapterGenerationWorkflow).mockClear();
 
@@ -395,7 +421,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "pending",
       });
 
-      await courseGenerationWorkflow(request.id);
+      await generateCourse(request.id);
 
       const course = await prisma.course.findFirstOrThrow({
         include: {
@@ -469,7 +495,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "pending",
       });
 
-      const workflow = courseGenerationWorkflow(request.id);
+      const workflow = generateCourse(request.id);
 
       try {
         await vi.waitFor(() => {
@@ -516,7 +542,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "pending",
       });
 
-      const workflow = courseGenerationWorkflow(request.id);
+      const workflow = generateCourse(request.id);
 
       try {
         await vi.waitFor(() => {
@@ -584,7 +610,7 @@ describe(courseGenerationWorkflow, () => {
         targetLanguage: "es",
       });
 
-      await courseGenerationWorkflow(request.id);
+      await generateCourse(request.id);
 
       const updatedRequest = await prisma.coursePrompt.findUniqueOrThrow({
         where: { id: request.id },
@@ -642,7 +668,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "failed",
       });
 
-      await courseGenerationWorkflow(request.id);
+      await generateCourse(request.id);
 
       const course = await prisma.course.findUnique({ where: { id: existingCourse.id } });
 
@@ -704,7 +730,7 @@ describe(courseGenerationWorkflow, () => {
         }),
       ]);
 
-      await courseGenerationWorkflow(request.id);
+      await generateCourse(request.id);
 
       expect(generateCourseDescription).not.toHaveBeenCalled();
       expect(generateCourseLandingPage).not.toHaveBeenCalled();
@@ -732,7 +758,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "pending",
       });
 
-      await expect(courseGenerationWorkflow(request.id)).rejects.toThrow();
+      await expect(generateCourse(request.id)).rejects.toThrow();
 
       const course = await prisma.course.findFirst({ where: { slug } });
 
@@ -760,7 +786,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "pending",
       });
 
-      await expect(courseGenerationWorkflow(request.id)).rejects.toThrow();
+      await expect(generateCourse(request.id)).rejects.toThrow();
 
       const dbRequest = await prisma.coursePrompt.findUnique({ where: { id: request.id } });
 
@@ -790,7 +816,7 @@ describe(courseGenerationWorkflow, () => {
         generationStatus: "pending",
       });
 
-      await expect(courseGenerationWorkflow(request.id)).resolves.toBeUndefined();
+      await expect(generateCourse(request.id)).resolves.toBeUndefined();
 
       const course = await prisma.course.findFirst({
         include: { chapters: { orderBy: { position: "asc" } } },

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -6,6 +6,7 @@ import { getWorkflowMetadata } from "workflow";
 import { getOrCreateCourse } from "./_internal/get-or-create-course";
 import { setupCourse } from "./_internal/setup-course";
 import { completeCourseSetupStep } from "./steps/complete-course-setup-step";
+import { enrollCourseUserStep } from "./steps/enroll-course-user-step";
 import { assertGeneratableCoursePrompt, getCoursePromptStep } from "./steps/get-course-prompt-step";
 import { handleCourseFailureStep } from "./steps/handle-failure-step";
 import { resolveCourseIdentityStep } from "./steps/resolve-course-identity-step";
@@ -78,7 +79,19 @@ async function startChapterImagesAndGenerateFirstLanguageChapter({
   }
 }
 
-export async function courseGenerationWorkflow(coursePromptId: string): Promise<void> {
+/**
+ * Generates or resumes a course and enrolls the authenticated requester once
+ * the workflow resolves the concrete course. Enrollment runs before completed
+ * or running courses return so reused courses are added to the learner's
+ * library too.
+ */
+export async function courseGenerationWorkflow({
+  coursePromptId,
+  userId,
+}: {
+  coursePromptId: string;
+  userId: string | null;
+}): Promise<void> {
   "use workflow";
 
   const { workflowRunId } = getWorkflowMetadata();
@@ -106,6 +119,10 @@ export async function courseGenerationWorkflow(coursePromptId: string): Promise<
 
     throw error;
   });
+
+  if (userId) {
+    await enrollCourseUserStep({ courseId: courseSetup.course.courseId, userId });
+  }
 
   if (courseSetup.status === "running") {
     return;

--- a/apps/api/src/workflows/course-generation/steps/enroll-course-user-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/enroll-course-user-step.ts
@@ -1,0 +1,17 @@
+import { enrollUserInCourse } from "@zoonk/core/courses/enroll-user";
+
+/**
+ * Enrolls the authenticated learner after the workflow has resolved a concrete
+ * course. The shared operation is idempotent because workflow steps may retry.
+ */
+export async function enrollCourseUserStep({
+  courseId,
+  userId,
+}: {
+  courseId: string;
+  userId: string;
+}): Promise<void> {
+  "use step";
+
+  await enrollUserInCourse({ courseId, userId });
+}

--- a/apps/main/e2e/lesson-start-tracking.test.ts
+++ b/apps/main/e2e/lesson-start-tracking.test.ts
@@ -77,7 +77,7 @@ async function createTestLesson() {
 
   const url = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`;
 
-  return { lesson, url };
+  return { course, lesson, url };
 }
 
 test.describe("Lesson Start Tracking", () => {
@@ -85,7 +85,7 @@ test.describe("Lesson Start Tracking", () => {
     baseURL,
     browser,
   }) => {
-    const [email, { lesson, url }] = await Promise.all([
+    const [email, { course, lesson, url }] = await Promise.all([
       createUniqueUser(baseURL!),
       createTestLesson(),
     ]);
@@ -96,24 +96,32 @@ test.describe("Lesson Start Tracking", () => {
     expect(user).not.toBeNull();
     const userId = user!.id;
 
-    const before = await prisma.lessonProgress.findUnique({
-      where: { userLesson: { lessonId: lesson.id, userId } },
-    });
+    const [progressBefore, courseUserBefore] = await Promise.all([
+      prisma.lessonProgress.findUnique({ where: { userLesson: { lessonId: lesson.id, userId } } }),
+      prisma.courseUser.findUnique({ where: { courseUser: { courseId: course.id, userId } } }),
+    ]);
 
-    expect(before).toBeNull();
+    expect(progressBefore).toBeNull();
+    expect(courseUserBefore).toBeNull();
 
     await page.goto(url);
     await page.waitForLoadState("networkidle");
 
     // after() runs asynchronously — use toPass retry pattern
     await expect(async () => {
-      const progress = await prisma.lessonProgress.findUnique({
-        where: { userLesson: { lessonId: lesson.id, userId } },
-      });
+      const [progress, courseUser, updatedCourse] = await Promise.all([
+        prisma.lessonProgress.findUnique({
+          where: { userLesson: { lessonId: lesson.id, userId } },
+        }),
+        prisma.courseUser.findUnique({ where: { courseUser: { courseId: course.id, userId } } }),
+        prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+      ]);
 
       expect(progress).not.toBeNull();
       expect(progress?.completedAt).toBeNull();
       expect(progress?.durationSeconds).toBeNull();
+      expect(courseUser).not.toBeNull();
+      expect(updatedCourse.userCount).toBe(1);
     }).toPass({ timeout: 5000 });
 
     await browserContext.close();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "./auth/subscription": "./src/auth/subscription.ts",
     "./auth/username-rules": "./src/auth/username-rules.ts",
     "./chapters/search": "./src/chapters/search-chapters.ts",
+    "./courses/enroll-user": "./src/courses/enroll-user-in-course.ts",
     "./courses/landing-page": "./src/courses/course-landing-page.ts",
     "./courses/prompt-generation": "./src/courses/course-prompt-generation.ts",
     "./courses/slug": "./src/courses/course-slug.ts",

--- a/packages/core/src/courses/enroll-user-in-course.test.ts
+++ b/packages/core/src/courses/enroll-user-in-course.test.ts
@@ -1,0 +1,42 @@
+import { prisma } from "@zoonk/db";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { describe, expect, it } from "vitest";
+import { enrollUserInCourse } from "./enroll-user-in-course";
+
+describe(enrollUserInCourse, () => {
+  it("creates the course enrollment and increments the user count", async () => {
+    const [course, user] = await Promise.all([courseFixture(), userFixture()]);
+
+    await enrollUserInCourse({ courseId: course.id, userId: user.id });
+
+    const [courseUser, updatedCourse] = await Promise.all([
+      prisma.courseUser.findUnique({
+        where: { courseUser: { courseId: course.id, userId: user.id } },
+      }),
+      prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+    ]);
+
+    expect(courseUser).not.toBeNull();
+    expect(updatedCourse.userCount).toBe(1);
+  });
+
+  it("creates one enrollment when called concurrently", async () => {
+    const [course, user] = await Promise.all([courseFixture(), userFixture()]);
+    const enrollment = { courseId: course.id, userId: user.id };
+
+    await Promise.all([
+      enrollUserInCourse(enrollment),
+      enrollUserInCourse(enrollment),
+      enrollUserInCourse(enrollment),
+    ]);
+
+    const [courseUsers, updatedCourse] = await Promise.all([
+      prisma.courseUser.findMany({ where: enrollment }),
+      prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+    ]);
+
+    expect(courseUsers).toHaveLength(1);
+    expect(updatedCourse.userCount).toBe(1);
+  });
+});

--- a/packages/core/src/courses/enroll-user-in-course.ts
+++ b/packages/core/src/courses/enroll-user-in-course.ts
@@ -1,0 +1,32 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+
+/**
+ * Keeps course membership and the catalog popularity count in sync. Lesson
+ * starts and course generation can race or retry, so this operation owns the
+ * transaction that creates the unique CourseUser row and increments the
+ * course's user count exactly once.
+ */
+export async function enrollUserInCourse({
+  courseId,
+  userId,
+}: {
+  courseId: string;
+  userId: string;
+}): Promise<void> {
+  await prisma.$transaction(async (transaction) => {
+    const { count } = await transaction.courseUser.createMany({
+      data: [{ courseId, userId }],
+      skipDuplicates: true,
+    });
+
+    if (count === 0) {
+      return;
+    }
+
+    await transaction.course.update({
+      data: { userCount: { increment: 1 } },
+      where: { id: courseId },
+    });
+  });
+}

--- a/packages/core/src/player/commands/start-lesson.test.ts
+++ b/packages/core/src/player/commands/start-lesson.test.ts
@@ -18,11 +18,12 @@ async function authenticateFixtureUser() {
 }
 
 describe(startLesson, () => {
+  let course: Awaited<ReturnType<typeof courseFixture>>;
   let lesson: Awaited<ReturnType<typeof lessonFixture>>;
 
   beforeAll(async () => {
     const org = await organizationFixture();
-    const course = await courseFixture({ organizationId: org.id });
+    course = await courseFixture({ organizationId: org.id });
     const chapter = await chapterFixture({ courseId: course.id, organizationId: org.id });
     lesson = await lessonFixture({ chapterId: chapter.id, kind: "quiz", organizationId: org.id });
   });
@@ -40,6 +41,21 @@ describe(startLesson, () => {
     expect(progress?.completedAt).toBeNull();
     expect(progress?.durationSeconds).toBeNull();
     expect(progress?.startedAt).toBeInstanceOf(Date);
+  });
+
+  it("enrolls the learner in the course when the lesson starts", async () => {
+    const userId = await authenticateFixtureUser();
+    const courseBefore = await prisma.course.findUniqueOrThrow({ where: { id: course.id } });
+
+    await startLesson(lesson.id);
+
+    const [courseUser, courseAfter] = await Promise.all([
+      prisma.courseUser.findUnique({ where: { courseUser: { courseId: course.id, userId } } }),
+      prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+    ]);
+
+    expect(courseUser).not.toBeNull();
+    expect(courseAfter.userCount).toBe(courseBefore.userCount + 1);
   });
 
   it("idempotent: second call preserves original startedAt", async () => {
@@ -62,15 +78,20 @@ describe(startLesson, () => {
 
   it("idempotent: concurrent calls create one progress row", async () => {
     const userId = await authenticateFixtureUser();
+    const courseBefore = await prisma.course.findUniqueOrThrow({ where: { id: course.id } });
 
     await Promise.all([startLesson(lesson.id), startLesson(lesson.id)]);
 
-    const progress = await prisma.lessonProgress.findMany({
-      where: { lessonId: lesson.id, userId },
-    });
+    const [progress, courseUsers, courseAfter] = await Promise.all([
+      prisma.lessonProgress.findMany({ where: { lessonId: lesson.id, userId } }),
+      prisma.courseUser.findMany({ where: { courseId: course.id, userId } }),
+      prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+    ]);
 
     expect(progress).toHaveLength(1);
     expect(progress[0]?.completedAt).toBeNull();
+    expect(courseUsers).toHaveLength(1);
+    expect(courseAfter.userCount).toBe(courseBefore.userCount + 1);
   });
 
   it("does not overwrite a completed record", async () => {

--- a/packages/core/src/player/commands/start-lesson.ts
+++ b/packages/core/src/player/commands/start-lesson.ts
@@ -1,12 +1,13 @@
 import "server-only";
 import { isPrismaUniqueConstraintError, prisma } from "@zoonk/db";
+import { enrollUserInCourse } from "../../courses/enroll-user-in-course";
 import { getSession } from "../../users/get-user-session";
 
 /**
- * The player shell calls this as soon as a learner opens a lesson so the
- * completion write can later distinguish "started" from "never seen". A
- * session-derived user id keeps this analytics write scoped to the current
- * learner, while the upsert preserves existing progress on repeat visits.
+ * Records that the current learner started a lesson and enrolls them in its
+ * course. Both writes are idempotent because lesson starts can be repeated or
+ * concurrent, while the session-derived user id keeps both operations scoped to
+ * the current learner.
  */
 export async function startLesson(lessonId: string): Promise<void> {
   const session = await getSession();
@@ -15,12 +16,22 @@ export async function startLesson(lessonId: string): Promise<void> {
     return;
   }
 
+  const userId = session.user.id;
+
   try {
-    await prisma.lessonProgress.upsert({
-      create: { lessonId, userId: session.user.id },
-      update: {},
-      where: { userLesson: { lessonId, userId: session.user.id } },
+    const lesson = await prisma.lesson.findUniqueOrThrow({
+      include: { chapter: true },
+      where: { id: lessonId },
     });
+
+    await Promise.all([
+      prisma.lessonProgress.upsert({
+        create: { lessonId, userId },
+        update: {},
+        where: { userLesson: { lessonId, userId } },
+      }),
+      enrollUserInCourse({ courseId: lesson.chapter.courseId, userId }),
+    ]);
   } catch (error) {
     if (isPrismaUniqueConstraintError(error)) {
       return;

--- a/packages/core/src/player/commands/submit-lesson-completion.test.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.test.ts
@@ -582,7 +582,7 @@ describe(submitLessonCompletion, () => {
     expect(result.newTotalBp).toBe(10);
   });
 
-  it("creates CourseUser and increments userCount on first lesson completion", async () => {
+  it("does not enroll the learner when completing a lesson", async () => {
     const user = await userFixture();
     const userId = user.id;
 
@@ -603,42 +603,10 @@ describe(submitLessonCompletion, () => {
       where: { courseUser: { courseId: course.id, userId } },
     });
 
-    expect(courseUser).not.toBeNull();
+    expect(courseUser).toBeNull();
 
     const courseAfter = await prisma.course.findUniqueOrThrow({ where: { id: course.id } });
-    expect(courseAfter.userCount).toBe(courseBefore.userCount + 1);
-  });
-
-  it("does not duplicate CourseUser or increment userCount on re-completion", async () => {
-    const user = await userFixture();
-    const userId = user.id;
-
-    const baseInput = {
-      durationSeconds: 10,
-      lessonId: lesson.id,
-
-      localDate: todayLocalDate(),
-      score: { brainPower: 10, correctCount: 1, energyDelta: 0.2, incorrectCount: 0 },
-      startedAt: new Date(Date.now() - 10_000),
-      stepResults: [stepResult(true)],
-      userId,
-    };
-
-    await submitLessonCompletion(baseInput);
-    const courseAfterFirst = await prisma.course.findUniqueOrThrow({ where: { id: course.id } });
-
-    await submitLessonCompletion(baseInput);
-    const courseAfterSecond = await prisma.course.findUniqueOrThrow({ where: { id: course.id } });
-
-    // userCount should not increment on second completion
-    expect(courseAfterSecond.userCount).toBe(courseAfterFirst.userCount);
-
-    // Only one CourseUser record should exist
-    const courseUsers = await prisma.courseUser.findMany({
-      where: { courseId: course.id, userId },
-    });
-
-    expect(courseUsers).toHaveLength(1);
+    expect(courseAfter.userCount).toBe(courseBefore.userCount);
   });
 
   it("1-day gap: no decay, no gap records", async () => {

--- a/packages/core/src/player/commands/submit-lesson-completion.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.ts
@@ -80,20 +80,7 @@ export async function submitLessonCompletion(input: {
       where: { completedAt: null, lessonId: input.lessonId, userId: input.userId },
     });
 
-    const { courseId } = await syncDurableCurriculumCompletion(tx, {
-      lessonId: input.lessonId,
-      userId: input.userId,
-    });
-
-    // CourseUser + userCount (only on first completion per course)
-    const { count } = await tx.courseUser.createMany({
-      data: [{ courseId, userId: input.userId }],
-      skipDuplicates: true,
-    });
-
-    if (count > 0) {
-      await tx.course.update({ data: { userCount: { increment: 1 } }, where: { id: courseId } });
-    }
+    await syncDurableCurriculumCompletion(tx, { lessonId: input.lessonId, userId: input.userId });
 
     // Find existing UserProgress to apply decay
     const existingProgress = await tx.userProgress.findUnique({ where: { userId: input.userId } });


### PR DESCRIPTION
Enrolls authenticated users when they start a lesson or generate a course. Keeps enrollment idempotent, updates course user counts atomically, and removes completion-time enrollment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically enroll authenticated learners when they start a lesson or trigger course generation. Enrollment is idempotent and updates course `userCount` atomically.

- **New Features**
  - Added `@zoonk/core/courses/enroll-user` to create `CourseUser` once and increment `userCount` in a transaction.
  - `@zoonk/core/player/commands/start-lesson` now enrolls the learner’s course on lesson open while keeping progress writes idempotent.
  - Course generation: the trigger route reads the requester `userId`, and `courseGenerationWorkflow` enrolls them via `enroll-course-user-step` once the course is resolved (including reused courses).
  - Removed enrollment from `@zoonk/core/player/commands/submit-lesson-completion` to avoid duplicate or late enrollments.

<sup>Written for commit 258438616c4dbfb13266f9182d4b4d9bffef38d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

