### PR TITLE
fix(main): hide generation exit after completion

### DIFF
--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -230,6 +230,7 @@ test.describe("Generate Chapter Page - With Subscription", () => {
 
     await expect(authenticatedPage.getByText(/your lessons are ready/iu)).toBeVisible();
     await expect(authenticatedPage.getByText(/taking you to your chapter/iu)).toBeVisible();
+    expect(await authenticatedPage.getByRole("link", { name: /back to course/iu }).count()).toBe(0);
 
     await authenticatedPage.waitForURL(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`, {
       timeout: 10_000,

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -421,6 +421,9 @@ test.describe("Generate Course Page", () => {
 
       await authenticatedPage.goto(`/generate/course/${request.id}`);
 
+      await expect(authenticatedPage.getByText(/taking you to your first lesson/iu)).toBeVisible();
+      expect(await authenticatedPage.getByRole("link", { name: /back home/iu }).count()).toBe(0);
+
       await authenticatedPage.waitForURL(`/b/ai/c/${introLessonTarget}`, { timeout: 10_000 });
     });
 

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -458,6 +458,10 @@ test.describe("Generate Lesson Page - With Subscription", () => {
     await expect(authenticatedPage.getByText(/your lesson is ready/iu)).toBeVisible();
     await expect(authenticatedPage.getByText(/taking you to your lesson/iu)).toBeVisible();
 
+    expect(await authenticatedPage.getByRole("link", { name: /back to chapter/iu }).count()).toBe(
+      0,
+    );
+
     await authenticatedPage.waitForURL(
       new RegExp(`/b/${AI_ORG_SLUG}/c/.+/ch/.+/l/${lesson.slug}`, "u"),
       { timeout: 10_000 },

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -1802,10 +1802,9 @@ msgid "Taking you to your course..."
 msgstr "Wir leiten dich zu deinem Kurs weiter…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
-#: src/app/[lang]/generate/l/[id]/generation-client.tsx
-msgctxt "T2TGxR"
-msgid "Taking you to your lesson..."
-msgstr "Deine Lektion öffnen..."
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Deine erste Lektion wird gleich geöffnet…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"
@@ -2021,6 +2020,11 @@ msgstr "Lektion {title} erstellen"
 msgctxt "3vY0Zu"
 msgid "This usually takes 1-2 minutes"
 msgstr "Das dauert normalerweise 1–2 Minuten"
+
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
+msgstr "Deine Lektion öffnen..."
 
 #: src/app/[lang]/generate/l/[id]/phase-thinking-generators/content.ts
 msgctxt "cVoRCh"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1802,10 +1802,9 @@ msgid "Taking you to your course..."
 msgstr "Taking you to your course..."
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
-#: src/app/[lang]/generate/l/[id]/generation-client.tsx
-msgctxt "T2TGxR"
-msgid "Taking you to your lesson..."
-msgstr "Taking you to your lesson..."
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Taking you to your first lesson…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"
@@ -2021,6 +2020,11 @@ msgstr "Creating the {title} lesson"
 msgctxt "3vY0Zu"
 msgid "This usually takes 1-2 minutes"
 msgstr "This usually takes 1-2 minutes"
+
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
+msgstr "Taking you to your lesson..."
 
 #: src/app/[lang]/generate/l/[id]/phase-thinking-generators/content.ts
 msgctxt "cVoRCh"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1802,10 +1802,9 @@ msgid "Taking you to your course..."
 msgstr "Te llevamos a tu curso…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
-#: src/app/[lang]/generate/l/[id]/generation-client.tsx
-msgctxt "T2TGxR"
-msgid "Taking you to your lesson..."
-msgstr "Te llevamos a tu lección…"
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Te llevamos a tu primera lección…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"
@@ -2021,6 +2020,11 @@ msgstr "Creando la lección {title}"
 msgctxt "3vY0Zu"
 msgid "This usually takes 1-2 minutes"
 msgstr "Esto suele tardar 1-2 minutos"
+
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
+msgstr "Te llevamos a tu lección…"
 
 #: src/app/[lang]/generate/l/[id]/phase-thinking-generators/content.ts
 msgctxt "cVoRCh"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -1802,10 +1802,9 @@ msgid "Taking you to your course..."
 msgstr "On t’emmène vers ton cours…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
-#: src/app/[lang]/generate/l/[id]/generation-client.tsx
-msgctxt "T2TGxR"
-msgid "Taking you to your lesson..."
-msgstr "On t’emmène vers ta leçon…"
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Direction ta première leçon…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"
@@ -2021,6 +2020,11 @@ msgstr "Création de la leçon {title}"
 msgctxt "3vY0Zu"
 msgid "This usually takes 1-2 minutes"
 msgstr "Cela prend généralement 1 à 2 minutes"
+
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
+msgstr "On t’emmène vers ta leçon…"
 
 #: src/app/[lang]/generate/l/[id]/phase-thinking-generators/content.ts
 msgctxt "cVoRCh"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1802,10 +1802,9 @@ msgid "Taking you to your course..."
 msgstr "Te levando para o seu curso…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
-#: src/app/[lang]/generate/l/[id]/generation-client.tsx
-msgctxt "T2TGxR"
-msgid "Taking you to your lesson..."
-msgstr "Te levando para a sua aula…"
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Te levando para sua primeira aula…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"
@@ -2021,6 +2020,11 @@ msgstr "Criando a aula {title}"
 msgctxt "3vY0Zu"
 msgid "This usually takes 1-2 minutes"
 msgstr "Isso costuma levar de 1 a 2 minutos"
+
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
+msgctxt "T2TGxR"
+msgid "Taking you to your lesson..."
+msgstr "Te levando para a sua aula…"
 
 #: src/app/[lang]/generate/l/[id]/phase-thinking-generators/content.ts
 msgctxt "cVoRCh"

--- a/apps/main/src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
@@ -64,10 +64,11 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
             generationRunId={chapter.generationRunId}
             initialStatus={initialStatus}
             invalidateContent={invalidateGeneratedChapter}
-          />
-          <GenerationExitLink href={backHref} shortcut="Esc" width="content">
-            {backLabel}
-          </GenerationExitLink>
+          >
+            <GenerationExitLink href={backHref} shortcut="Esc" width="content">
+              {backLabel}
+            </GenerationExitLink>
+          </GenerationClient>
         </SubscriptionGate>
       </ContainerBody>
     </Container>

--- a/apps/main/src/app/[lang]/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/[lang]/generate/ch/[id]/generation-client.tsx
@@ -20,12 +20,14 @@ import { CHAPTER_COMPLETION_STEP, type ChapterWorkflowStepName } from "@zoonk/co
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { API_URL } from "@zoonk/utils/url";
 import { useExtracted } from "next-intl";
+import { type ReactNode } from "react";
 import { useGenerationPhases } from "./use-generation-phases";
 
 export function GenerationClient({
   chapterId,
   chapterSlug,
   chapterTitle,
+  children,
   courseSlug,
   generationRunId,
   initialStatus,
@@ -34,6 +36,7 @@ export function GenerationClient({
   chapterId: string;
   chapterSlug: string;
   chapterTitle: string;
+  children: ReactNode;
   courseSlug: string;
   generationRunId: string | null;
   initialStatus: GenerationStatus;
@@ -85,31 +88,34 @@ export function GenerationClient({
 
   if (isActive) {
     return (
-      <GenerationTimeline>
-        <GenerationTimelineHeader>
-          <GenerationTimelineTitle>
-            {t("Creating the {title} chapter", { title: chapterTitle })}
-          </GenerationTimelineTitle>
-          <GenerationTimelineSubtitle>
-            {t("This usually takes about a minute")}
-          </GenerationTimelineSubtitle>
-          <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
-        </GenerationTimelineHeader>
+      <>
+        <GenerationTimeline>
+          <GenerationTimelineHeader>
+            <GenerationTimelineTitle>
+              {t("Creating the {title} chapter", { title: chapterTitle })}
+            </GenerationTimelineTitle>
+            <GenerationTimelineSubtitle>
+              {t("This usually takes about a minute")}
+            </GenerationTimelineSubtitle>
+            <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
+          </GenerationTimelineHeader>
 
-        <GenerationTimelineSteps>
-          {phases.map((phase, index) => (
-            <GenerationTimelineStep
-              detail={thinkingMessages[phase.name]}
-              icon={phase.icon}
-              isLast={index === phases.length - 1}
-              key={phase.name}
-              status={phase.status}
-            >
-              {phase.label}
-            </GenerationTimelineStep>
-          ))}
-        </GenerationTimelineSteps>
-      </GenerationTimeline>
+          <GenerationTimelineSteps>
+            {phases.map((phase, index) => (
+              <GenerationTimelineStep
+                detail={thinkingMessages[phase.name]}
+                icon={phase.icon}
+                isLast={index === phases.length - 1}
+                key={phase.name}
+                status={phase.status}
+              >
+                {phase.label}
+              </GenerationTimelineStep>
+            ))}
+          </GenerationTimelineSteps>
+        </GenerationTimeline>
+        {children}
+      </>
     );
   }
 
@@ -123,13 +129,16 @@ export function GenerationClient({
 
   if (generation.status === "error") {
     return (
-      <WorkflowGenerationError
-        error={generation.error}
-        errorKind={generation.errorKind}
-        onRetry={generation.retry}
-      />
+      <>
+        <WorkflowGenerationError
+          error={generation.error}
+          errorKind={generation.errorKind}
+          onRetry={generation.retry}
+        />
+        {children}
+      </>
     );
   }
 
-  return null;
+  return children;
 }

--- a/apps/main/src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
+++ b/apps/main/src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
@@ -91,10 +91,11 @@ export async function GenerateCoursePromptContent({
           generationStatus={request.generationStatus}
           isLanguageCourse={isLanguageCourse}
           requestId={id}
-        />
-        <GenerationExitLink href="/" width="content">
-          {t("Back home")}
-        </GenerationExitLink>
+        >
+          <GenerationExitLink href="/" width="content">
+            {t("Back home")}
+          </GenerationExitLink>
+        </GenerationClient>
       </ContainerBody>
     </Container>
   );

--- a/apps/main/src/app/[lang]/generate/course/[id]/generation-client.tsx
+++ b/apps/main/src/app/[lang]/generate/course/[id]/generation-client.tsx
@@ -25,6 +25,7 @@ import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { API_URL } from "@zoonk/utils/url";
 import { useExtracted } from "next-intl";
+import { type ReactNode } from "react";
 import { invalidateGeneratedCourse } from "./invalidate-generated-course";
 import { useGenerationPhases } from "./use-generation-phases";
 
@@ -46,6 +47,7 @@ function getCourseGenerationCompletionStep({
 }
 
 export function GenerationClient({
+  children,
   courseSlug,
   courseTitle,
   generationRunId,
@@ -54,6 +56,7 @@ export function GenerationClient({
   linkedCourseSlug,
   requestId,
 }: {
+  children: ReactNode;
   courseSlug: string;
   courseTitle: string;
   generationRunId: string | null;
@@ -110,7 +113,7 @@ export function GenerationClient({
 
   const completedSubtitle = isLanguageCourse
     ? t("Taking you to your course...")
-    : t("Taking you to your lesson...");
+    : t("Taking you to your first lesson…");
 
   useCompletionRedirect({
     beforeRedirect: () => invalidateGeneratedCourse(redirectHref),
@@ -120,31 +123,34 @@ export function GenerationClient({
 
   if (isActive) {
     return (
-      <GenerationTimeline>
-        <GenerationTimelineHeader>
-          <GenerationTimelineTitle>
-            {t("Creating the {title} course", { title: courseTitle })}
-          </GenerationTimelineTitle>
-          <GenerationTimelineSubtitle>
-            {t("This usually takes about 2 minutes")}
-          </GenerationTimelineSubtitle>
-          <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
-        </GenerationTimelineHeader>
+      <>
+        <GenerationTimeline>
+          <GenerationTimelineHeader>
+            <GenerationTimelineTitle>
+              {t("Creating the {title} course", { title: courseTitle })}
+            </GenerationTimelineTitle>
+            <GenerationTimelineSubtitle>
+              {t("This usually takes about 2 minutes")}
+            </GenerationTimelineSubtitle>
+            <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
+          </GenerationTimelineHeader>
 
-        <GenerationTimelineSteps>
-          {phases.map((phase, index) => (
-            <GenerationTimelineStep
-              detail={thinkingMessages[phase.name]}
-              icon={phase.icon}
-              isLast={index === phases.length - 1}
-              key={phase.name}
-              status={phase.status}
-            >
-              {phase.label}
-            </GenerationTimelineStep>
-          ))}
-        </GenerationTimelineSteps>
-      </GenerationTimeline>
+          <GenerationTimelineSteps>
+            {phases.map((phase, index) => (
+              <GenerationTimelineStep
+                detail={thinkingMessages[phase.name]}
+                icon={phase.icon}
+                isLast={index === phases.length - 1}
+                key={phase.name}
+                status={phase.status}
+              >
+                {phase.label}
+              </GenerationTimelineStep>
+            ))}
+          </GenerationTimelineSteps>
+        </GenerationTimeline>
+        {children}
+      </>
     );
   }
 
@@ -158,13 +164,16 @@ export function GenerationClient({
 
   if (generation.status === "error") {
     return (
-      <WorkflowGenerationError
-        error={generation.error}
-        errorKind={generation.errorKind}
-        onRetry={generation.retry}
-      />
+      <>
+        <WorkflowGenerationError
+          error={generation.error}
+          errorKind={generation.errorKind}
+          onRetry={generation.retry}
+        />
+        {children}
+      </>
     );
   }
 
-  return null;
+  return children;
 }

--- a/apps/main/src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
@@ -101,22 +101,21 @@ export async function GenerateLessonContent({
     lesson.generationStatus !== "completed" && isGeneratedCompanionLessonKind(lesson.kind) ? (
       <GeneratedCompanionRedirect lesson={lesson} locale={locale} />
     ) : (
-      <>
-        <GenerationClient
-          chapterSlug={lesson.chapter.slug}
-          courseSlug={lesson.chapter.course.slug}
-          generationRunId={lesson.generationRunId}
-          initialStatus={initialStatus}
-          invalidateContent={invalidateGeneratedLesson}
-          lessonId={id}
-          lessonKind={lesson.kind}
-          lessonSlug={lesson.slug}
-          lessonTitle={lessonMeta.title}
-        />
+      <GenerationClient
+        chapterSlug={lesson.chapter.slug}
+        courseSlug={lesson.chapter.course.slug}
+        generationRunId={lesson.generationRunId}
+        initialStatus={initialStatus}
+        invalidateContent={invalidateGeneratedLesson}
+        lessonId={id}
+        lessonKind={lesson.kind}
+        lessonSlug={lesson.slug}
+        lessonTitle={lessonMeta.title}
+      >
         <GenerationExitLink href={backHref} shortcut="Esc" width="content">
           {backLabel}
         </GenerationExitLink>
-      </>
+      </GenerationClient>
     );
 
   return (

--- a/apps/main/src/app/[lang]/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/[lang]/generate/l/[id]/generation-client.tsx
@@ -20,11 +20,13 @@ import { LESSON_COMPLETION_STEP, type LessonStepName } from "@zoonk/core/workflo
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { API_URL } from "@zoonk/utils/url";
 import { useExtracted } from "next-intl";
+import { type ReactNode } from "react";
 import { type GeneratedLessonKind } from "./generation-phase-config";
 import { useGenerationPhases } from "./use-generation-phases";
 
 export function GenerationClient({
   chapterSlug,
+  children,
   courseSlug,
   generationRunId,
   initialStatus,
@@ -35,6 +37,7 @@ export function GenerationClient({
   lessonTitle,
 }: {
   chapterSlug: string;
+  children: ReactNode;
   courseSlug: string;
   generationRunId: string | null;
   initialStatus: GenerationStatus;
@@ -91,31 +94,34 @@ export function GenerationClient({
 
   if (isActive) {
     return (
-      <GenerationTimeline>
-        <GenerationTimelineHeader>
-          <GenerationTimelineTitle>
-            {t("Creating the {title} lesson", { title: lessonTitle })}
-          </GenerationTimelineTitle>
-          <GenerationTimelineSubtitle>
-            {t("This usually takes 1-2 minutes")}
-          </GenerationTimelineSubtitle>
-          <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
-        </GenerationTimelineHeader>
+      <>
+        <GenerationTimeline>
+          <GenerationTimelineHeader>
+            <GenerationTimelineTitle>
+              {t("Creating the {title} lesson", { title: lessonTitle })}
+            </GenerationTimelineTitle>
+            <GenerationTimelineSubtitle>
+              {t("This usually takes 1-2 minutes")}
+            </GenerationTimelineSubtitle>
+            <GenerationTimelineProgress label={t("Progress")} value={displayProgress} />
+          </GenerationTimelineHeader>
 
-        <GenerationTimelineSteps>
-          {phases.map((phase, index) => (
-            <GenerationTimelineStep
-              detail={thinkingMessages[phase.name]}
-              icon={phase.icon}
-              isLast={index === phases.length - 1}
-              key={phase.name}
-              status={phase.status}
-            >
-              {phase.label}
-            </GenerationTimelineStep>
-          ))}
-        </GenerationTimelineSteps>
-      </GenerationTimeline>
+          <GenerationTimelineSteps>
+            {phases.map((phase, index) => (
+              <GenerationTimelineStep
+                detail={thinkingMessages[phase.name]}
+                icon={phase.icon}
+                isLast={index === phases.length - 1}
+                key={phase.name}
+                status={phase.status}
+              >
+                {phase.label}
+              </GenerationTimelineStep>
+            ))}
+          </GenerationTimelineSteps>
+        </GenerationTimeline>
+        {children}
+      </>
     );
   }
 
@@ -129,13 +135,16 @@ export function GenerationClient({
 
   if (generation.status === "error") {
     return (
-      <WorkflowGenerationError
-        error={generation.error}
-        errorKind={generation.errorKind}
-        onRetry={generation.retry}
-      />
+      <>
+        <WorkflowGenerationError
+          error={generation.error}
+          errorKind={generation.errorKind}
+          onRetry={generation.retry}
+        />
+        {children}
+      </>
     );
   }
 
-  return null;
+  return children;
 }


### PR DESCRIPTION
Hides generation exit links while the completion confirmation is shown. Clarifies that regular course generation redirects learners to their first lesson, with translated copy and focused E2E coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide generation exit links while the completion confirmation is shown, so learners don’t click away during auto-redirects. Also clarifies course redirects with “Taking you to your first lesson…” and adds focused E2E coverage.

- **Bug Fixes**
  - Render `GenerationExitLink` as children of `GenerationClient` so links show during active/error states but are hidden during completion confirmation (lesson/chapter/course).
  - Update copy for course completion to “Taking you to your first lesson…” and localize in `en.po`, `de.po`, `es.po`, `fr.po`, `pt.po`.
  - Strengthen E2E tests to assert the new copy and that exit links are hidden during completion.

<sup>Written for commit 7b3092edf4feb2e32a214992b16b0579826ca67b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

