### PR TITLE
fix(main): highlight yearly subscription savings

### DIFF
--- a/apps/main/src/app/[lang]/(settings)/subscription/plus-purchase.tsx
+++ b/apps/main/src/app/[lang]/(settings)/subscription/plus-purchase.tsx
@@ -114,10 +114,12 @@ function AvailablePlusPurchase({
   const priceLabel = price ? formatPrice(price.amount, price.currency, locale) : null;
   const periodLabel = period === "monthly" ? t("per month") : t("per year");
 
-  const savingsLabel = yearlySavings
-    ? t("Save {amount} every year", {
-        amount: formatPrice(yearlySavings.amount, yearlySavings.currency, locale),
-      })
+  const yearlySavingsAmount = yearlySavings
+    ? formatPrice(yearlySavings.amount, yearlySavings.currency, locale)
+    : null;
+
+  const savingsLabel = yearlySavingsAmount
+    ? t("Save {amount} every year", { amount: yearlySavingsAmount })
     : null;
 
   /**
@@ -167,7 +169,7 @@ function AvailablePlusPurchase({
 
         <Button
           aria-pressed={period === "yearly"}
-          className="flex-1"
+          className="flex-1 gap-2"
           disabled={!yearlyPrice}
           onClick={() => setPeriod("yearly")}
           size="sm"
@@ -175,6 +177,14 @@ function AvailablePlusPurchase({
           variant={period === "yearly" ? "secondary" : "ghost"}
         >
           {t("Yearly")}
+          {yearlySavingsAmount && (
+            <>
+              <Badge aria-hidden="true" className="font-mono" variant="success">
+                −{yearlySavingsAmount}
+              </Badge>
+              <span className="sr-only">{savingsLabel}</span>
+            </>
+          )}
         </Button>
       </div>
 
@@ -188,9 +198,11 @@ function AvailablePlusPurchase({
           <p className="text-muted-foreground text-sm">{t("Price shown at checkout")}</p>
         )}
 
-        {period === "yearly" && savingsLabel && (
-          <p className="text-success text-sm font-medium">{savingsLabel}</p>
-        )}
+        <div className="min-h-5">
+          {period === "yearly" && savingsLabel && (
+            <p className="text-success text-sm font-medium">{savingsLabel}</p>
+          )}
+        </div>
       </div>
 
       {monthlyPrice && (


### PR DESCRIPTION
- Show verified yearly savings directly in the billing selector.
- Reserve stable space for the savings message so prices do not shift between billing periods.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Highlights yearly subscription savings in the billing selector and prevents layout shifts when switching billing periods. Adds a savings badge on the Yearly option with accessible text.

- **New Features**
  - Show a `−{amount}` savings badge on the Yearly button.
  - Add an SR-only label: “Save {amount} every year”.

- **Bug Fixes**
  - Reserve space for the savings message to avoid price/UI shifting between periods.

<sup>Written for commit aa5742b2d62731d38dd4a78307395c37288af3a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

