### PR TITLE
fix(player): clarify keyboard shortcut hints

### DIFF
--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -53,9 +53,9 @@ msgid "Word bank"
 msgstr "Wortschatz"
 
 #: src/components/choice-step-layout.tsx
-msgctxt "qjehBi"
-msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
-msgstr "Drücke <kbd>{shortcut}</kbd>, um diese Antwort auszuwählen."
+msgctxt "usfevO"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Tastenkürzel: Drücke <kbd>{shortcut}</kbd>, um diese Antwort auszuwählen."
 
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
@@ -339,9 +339,9 @@ msgid "Play pronunciation"
 msgstr "Aussprache abspielen"
 
 #: src/components/play-audio-button.tsx
-msgctxt "XHsJo3"
-msgid "Press <kbd>{shortcut}</kbd> to play audio."
-msgstr "Drücke <kbd>{shortcut}</kbd>, um das Audio abzuspielen."
+msgctxt "RPYE-D"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Tastenkürzel: Drücke <kbd>{shortcut}</kbd>, um das Audio abzuspielen."
 
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
@@ -400,21 +400,21 @@ msgid "Check"
 msgstr "Prüfen"
 
 #: src/components/step-action-button.tsx
-msgctxt "2VjMZp"
-msgid "Press <kbd>Enter</kbd> to check your answer."
-msgstr "Drücke <kbd>Enter</kbd>, um deine Antwort zu prüfen."
+msgctxt "ZnWuU7"
+msgid "Keyboard shortcut: press <kbd>Enter</kbd> to check your answer."
+msgstr "Tastenkürzel: Drücke <kbd>Enter</kbd>, um deine Antwort zu prüfen."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "XHEfA9"
-msgid "Press <kbd>←</kbd> to go back."
-msgstr "Drücke <kbd>←</kbd>, um zurückzugehen."
+msgctxt "kp9T44"
+msgid "Keyboard shortcut: press <kbd>←</kbd> to go back."
+msgstr "Tastenkürzel: Drücke <kbd>←</kbd>, um zurückzugehen."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "nvVP6A"
-msgid "Press <kbd>→</kbd> to continue."
-msgstr "Drücke <kbd>→</kbd>, um fortzufahren."
+msgctxt "egQWyS"
+msgid "Keyboard shortcut: press <kbd>→</kbd> to continue."
+msgstr "Tastenkürzel: Drücke <kbd>→</kbd>, um fortzufahren."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -53,9 +53,9 @@ msgid "Word bank"
 msgstr "Word bank"
 
 #: src/components/choice-step-layout.tsx
-msgctxt "qjehBi"
-msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
-msgstr "Press <kbd>{shortcut}</kbd> to choose this answer."
+msgctxt "usfevO"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Keyboard shortcut: press <kbd>{shortcut}</kbd> to choose this answer."
 
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
@@ -339,9 +339,9 @@ msgid "Play pronunciation"
 msgstr "Play pronunciation"
 
 #: src/components/play-audio-button.tsx
-msgctxt "XHsJo3"
-msgid "Press <kbd>{shortcut}</kbd> to play audio."
-msgstr "Press <kbd>{shortcut}</kbd> to play audio."
+msgctxt "RPYE-D"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Keyboard shortcut: press <kbd>{shortcut}</kbd> to play audio."
 
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
@@ -400,21 +400,21 @@ msgid "Check"
 msgstr "Check"
 
 #: src/components/step-action-button.tsx
-msgctxt "2VjMZp"
-msgid "Press <kbd>Enter</kbd> to check your answer."
-msgstr "Press <kbd>Enter</kbd> to check your answer."
+msgctxt "ZnWuU7"
+msgid "Keyboard shortcut: press <kbd>Enter</kbd> to check your answer."
+msgstr "Keyboard shortcut: press <kbd>Enter</kbd> to check your answer."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "XHEfA9"
-msgid "Press <kbd>←</kbd> to go back."
-msgstr "Press <kbd>←</kbd> to go back."
+msgctxt "kp9T44"
+msgid "Keyboard shortcut: press <kbd>←</kbd> to go back."
+msgstr "Keyboard shortcut: press <kbd>←</kbd> to go back."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "nvVP6A"
-msgid "Press <kbd>→</kbd> to continue."
-msgstr "Press <kbd>→</kbd> to continue."
+msgctxt "egQWyS"
+msgid "Keyboard shortcut: press <kbd>→</kbd> to continue."
+msgstr "Keyboard shortcut: press <kbd>→</kbd> to continue."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -53,9 +53,9 @@ msgid "Word bank"
 msgstr "Banco de palabras"
 
 #: src/components/choice-step-layout.tsx
-msgctxt "qjehBi"
-msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
-msgstr "Presiona <kbd>{shortcut}</kbd> para elegir esta respuesta."
+msgctxt "usfevO"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Atajo de teclado: presiona <kbd>{shortcut}</kbd> para elegir esta respuesta."
 
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
@@ -339,9 +339,9 @@ msgid "Play pronunciation"
 msgstr "Reproducir pronunciación"
 
 #: src/components/play-audio-button.tsx
-msgctxt "XHsJo3"
-msgid "Press <kbd>{shortcut}</kbd> to play audio."
-msgstr "Presiona <kbd>{shortcut}</kbd> para reproducir el audio."
+msgctxt "RPYE-D"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Atajo de teclado: presiona <kbd>{shortcut}</kbd> para reproducir el audio."
 
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
@@ -400,21 +400,21 @@ msgid "Check"
 msgstr "Revisar"
 
 #: src/components/step-action-button.tsx
-msgctxt "2VjMZp"
-msgid "Press <kbd>Enter</kbd> to check your answer."
-msgstr "Presiona <kbd>Enter</kbd> para comprobar tu respuesta."
+msgctxt "ZnWuU7"
+msgid "Keyboard shortcut: press <kbd>Enter</kbd> to check your answer."
+msgstr "Atajo de teclado: presiona <kbd>Enter</kbd> para comprobar tu respuesta."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "XHEfA9"
-msgid "Press <kbd>←</kbd> to go back."
-msgstr "Presiona <kbd>←</kbd> para volver."
+msgctxt "kp9T44"
+msgid "Keyboard shortcut: press <kbd>←</kbd> to go back."
+msgstr "Atajo de teclado: presiona <kbd>←</kbd> para volver."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "nvVP6A"
-msgid "Press <kbd>→</kbd> to continue."
-msgstr "Presiona <kbd>→</kbd> para continuar."
+msgctxt "egQWyS"
+msgid "Keyboard shortcut: press <kbd>→</kbd> to continue."
+msgstr "Atajo de teclado: presiona <kbd>→</kbd> para continuar."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -53,9 +53,9 @@ msgid "Word bank"
 msgstr "Banque de mots"
 
 #: src/components/choice-step-layout.tsx
-msgctxt "qjehBi"
-msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
-msgstr "Appuie sur <kbd>{shortcut}</kbd> pour choisir cette réponse."
+msgctxt "usfevO"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Raccourci clavier : appuie sur <kbd>{shortcut}</kbd> pour choisir cette réponse."
 
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
@@ -339,9 +339,9 @@ msgid "Play pronunciation"
 msgstr "Écouter la prononciation"
 
 #: src/components/play-audio-button.tsx
-msgctxt "XHsJo3"
-msgid "Press <kbd>{shortcut}</kbd> to play audio."
-msgstr "Appuie sur <kbd>{shortcut}</kbd> pour écouter l’audio."
+msgctxt "RPYE-D"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Raccourci clavier : appuie sur <kbd>{shortcut}</kbd> pour lancer l’audio."
 
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
@@ -400,21 +400,21 @@ msgid "Check"
 msgstr "Vérifier"
 
 #: src/components/step-action-button.tsx
-msgctxt "2VjMZp"
-msgid "Press <kbd>Enter</kbd> to check your answer."
-msgstr "Appuie sur <kbd>Entrée</kbd> pour vérifier ta réponse."
+msgctxt "ZnWuU7"
+msgid "Keyboard shortcut: press <kbd>Enter</kbd> to check your answer."
+msgstr "Raccourci clavier : appuie sur <kbd>Entrée</kbd> pour vérifier ta réponse."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "XHEfA9"
-msgid "Press <kbd>←</kbd> to go back."
-msgstr "Appuie sur <kbd>←</kbd> pour revenir en arrière."
+msgctxt "kp9T44"
+msgid "Keyboard shortcut: press <kbd>←</kbd> to go back."
+msgstr "Raccourci clavier : appuie sur <kbd>←</kbd> pour revenir en arrière."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "nvVP6A"
-msgid "Press <kbd>→</kbd> to continue."
-msgstr "Appuie sur <kbd>→</kbd> pour continuer."
+msgctxt "egQWyS"
+msgid "Keyboard shortcut: press <kbd>→</kbd> to continue."
+msgstr "Raccourci clavier : appuie sur <kbd>→</kbd> pour continuer."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -53,9 +53,9 @@ msgid "Word bank"
 msgstr "Banco de palavras"
 
 #: src/components/choice-step-layout.tsx
-msgctxt "qjehBi"
-msgid "Press <kbd>{shortcut}</kbd> to choose this answer."
-msgstr "Pressione <kbd>{shortcut}</kbd> para escolher esta resposta."
+msgctxt "usfevO"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to choose this answer."
+msgstr "Atalho de teclado: pressione <kbd>{shortcut}</kbd> para escolher esta resposta."
 
 #: src/components/completion-auth-branch.tsx
 msgctxt "E2sGaF"
@@ -339,9 +339,9 @@ msgid "Play pronunciation"
 msgstr "Ouvir pronúncia"
 
 #: src/components/play-audio-button.tsx
-msgctxt "XHsJo3"
-msgid "Press <kbd>{shortcut}</kbd> to play audio."
-msgstr "Pressione <kbd>{shortcut}</kbd> para ouvir o áudio."
+msgctxt "RPYE-D"
+msgid "Keyboard shortcut: press <kbd>{shortcut}</kbd> to play audio."
+msgstr "Atalho de teclado: pressione <kbd>{shortcut}</kbd> para tocar o áudio."
 
 #: src/components/player-choice-scene.tsx
 msgctxt "akd-cv"
@@ -400,21 +400,21 @@ msgid "Check"
 msgstr "Conferir"
 
 #: src/components/step-action-button.tsx
-msgctxt "2VjMZp"
-msgid "Press <kbd>Enter</kbd> to check your answer."
-msgstr "Pressione <kbd>Enter</kbd> para conferir sua resposta."
+msgctxt "ZnWuU7"
+msgid "Keyboard shortcut: press <kbd>Enter</kbd> to check your answer."
+msgstr "Atalho de teclado: pressione <kbd>Enter</kbd> para conferir sua resposta."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "XHEfA9"
-msgid "Press <kbd>←</kbd> to go back."
-msgstr "Pressione <kbd>←</kbd> para voltar."
+msgctxt "kp9T44"
+msgid "Keyboard shortcut: press <kbd>←</kbd> to go back."
+msgstr "Atalho de teclado: pressione <kbd>←</kbd> para voltar."
 
 #: src/components/step-navigation-button-group.tsx
 #: src/components/swipe-navigable-step-layout.tsx
-msgctxt "nvVP6A"
-msgid "Press <kbd>→</kbd> to continue."
-msgstr "Pressione <kbd>→</kbd> para continuar."
+msgctxt "egQWyS"
+msgid "Keyboard shortcut: press <kbd>→</kbd> to continue."
+msgstr "Atalho de teclado: pressione <kbd>→</kbd> para continuar."
 
 #: src/components/step-navigation-button-group.tsx
 msgctxt "JJNc3c"

--- a/packages/player/src/components/choice-step-layout.tsx
+++ b/packages/player/src/components/choice-step-layout.tsx
@@ -69,7 +69,7 @@ function ChoiceStepLayoutContent({
     showPlayerShortcutHint({
       event,
       hint: "multipleChoiceNumber",
-      message: t.rich("Press <kbd>{shortcut}</kbd> to choose this answer.", {
+      message: t.rich("Keyboard shortcut: press <kbd>{shortcut}</kbd> to choose this answer.", {
         kbd: renderPlayerShortcutHintKey,
         shortcut,
       }),

--- a/packages/player/src/components/play-audio-button.tsx
+++ b/packages/player/src/components/play-audio-button.tsx
@@ -88,7 +88,7 @@ export function PlayAudioButton({
       showPlayerShortcutHint({
         event,
         hint: "promptAudio",
-        message: t.rich("Press <kbd>{shortcut}</kbd> to play audio.", {
+        message: t.rich("Keyboard shortcut: press <kbd>{shortcut}</kbd> to play audio.", {
           kbd: renderPlayerShortcutHintKey,
           shortcut: keyboardShortcut.toUpperCase(),
         }),

--- a/packages/player/src/components/step-action-button.tsx
+++ b/packages/player/src/components/step-action-button.tsx
@@ -48,7 +48,7 @@ export function StepActionButton({
       showPlayerShortcutHint({
         event,
         hint: "checkAnswer",
-        message: t.rich("Press <kbd>Enter</kbd> to check your answer.", {
+        message: t.rich("Keyboard shortcut: press <kbd>Enter</kbd> to check your answer.", {
           kbd: renderPlayerShortcutHintKey,
         }),
       });

--- a/packages/player/src/components/step-navigation-button-group.tsx
+++ b/packages/player/src/components/step-navigation-button-group.tsx
@@ -35,7 +35,9 @@ export function StepNavigationButtonGroup({
     showPlayerShortcutHint({
       event,
       hint: "navigatePrevious",
-      message: t.rich("Press <kbd>←</kbd> to go back.", { kbd: renderPlayerShortcutHintKey }),
+      message: t.rich("Keyboard shortcut: press <kbd>←</kbd> to go back.", {
+        kbd: renderPlayerShortcutHintKey,
+      }),
     });
   }
 
@@ -47,7 +49,9 @@ export function StepNavigationButtonGroup({
     showPlayerShortcutHint({
       event,
       hint: "navigateNext",
-      message: t.rich("Press <kbd>→</kbd> to continue.", { kbd: renderPlayerShortcutHintKey }),
+      message: t.rich("Keyboard shortcut: press <kbd>→</kbd> to continue.", {
+        kbd: renderPlayerShortcutHintKey,
+      }),
     });
   }
 

--- a/packages/player/src/components/swipe-navigable-step-layout.tsx
+++ b/packages/player/src/components/swipe-navigable-step-layout.tsx
@@ -108,7 +108,7 @@ function DesktopNavigationToolbar({
             aria-label={t("Previous step")}
             aria-keyshortcuts="ArrowLeft"
             hint="navigatePrevious"
-            hintMessage={t.rich("Press <kbd>←</kbd> to go back.", {
+            hintMessage={t.rich("Keyboard shortcut: press <kbd>←</kbd> to go back.", {
               kbd: renderPlayerShortcutHintKey,
             })}
             onClick={onNavigatePrev}
@@ -131,7 +131,7 @@ function DesktopNavigationToolbar({
           aria-label={t("Next step")}
           aria-keyshortcuts="ArrowRight"
           hint="navigateNext"
-          hintMessage={t.rich("Press <kbd>→</kbd> to continue.", {
+          hintMessage={t.rich("Keyboard shortcut: press <kbd>→</kbd> to continue.", {
             kbd: renderPlayerShortcutHintKey,
           })}
           onClick={onNavigateNext}


### PR DESCRIPTION
Clarifies player shortcut toasts by explicitly labeling them as keyboard shortcuts. Updates the translated player catalogs for the revised copy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified player shortcut toasts by labeling them as keyboard shortcuts across answer selection, audio playback, navigation, and check actions. Updated strings in `packages/player` and refreshed translations (en, de, es, fr, pt).

<sup>Written for commit 2c83134af193944ef65cf94e5e35ab93a60a7f8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

