### PR TITLE
feat(main): restore courses navigation

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -398,15 +398,12 @@ test.describe("Chapter Navbar - Mobile", () => {
 });
 
 test.describe("Chapter Navbar - Desktop", () => {
-  test("keeps catalog actions without the Courses link", async ({ page }) => {
+  test("keeps the full catalog navbar", async ({ page }) => {
     await page.goto(chapterUrl);
 
     const catalogNavbar = page.getByRole("navigation").first();
 
-    await expect(
-      catalogNavbar.getByRole("link", { exact: true, name: "Courses" }),
-    ).not.toBeVisible();
-
+    await expect(catalogNavbar.getByRole("link", { exact: true, name: "Courses" })).toBeVisible();
     await expect(catalogNavbar.getByRole("button", { name: /search/iu })).toBeVisible();
     await expect(catalogNavbar.getByRole("link", { name: /course page/iu })).not.toBeVisible();
     await expect(page.getByRole("main").getByRole("link", { name: courseTitle })).toBeVisible();

--- a/apps/main/e2e/command-palette.test.ts
+++ b/apps/main/e2e/command-palette.test.ts
@@ -201,13 +201,13 @@ test.describe("Command Palette - Unauthenticated", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible();
   });
 
-  test("shows Pages group with Home and start goals", async ({ page }) => {
+  test("shows Pages group with Home, Courses, and start goals", async ({ page }) => {
     await openCommandPalette(page);
 
     const dialog = page.getByRole("dialog");
     await expect(dialog.getByRole("group", { name: "Pages" })).toBeVisible();
     await expect(dialog.getByText(/home page/iu)).toBeVisible();
-    await expect(dialog.getByRole("option", { name: /^courses$/iu })).not.toBeVisible();
+    await expect(dialog.getByRole("option", { name: /^courses$/iu })).toBeVisible();
     await expect(dialog.getByText(/start a new course/iu)).toBeVisible();
     await expect(dialog.getByText(/speak a language/iu)).toBeVisible();
     await expect(dialog.getByText(/learn something/iu)).toBeVisible();
@@ -247,6 +247,18 @@ test.describe("Command Palette - Unauthenticated", () => {
 
     await expect(page).toHaveURL(/\/$/u);
     await expect(page.getByRole("heading", { name: "What's your goal?" })).toBeVisible();
+  });
+
+  test("selecting Courses shows courses content", async ({ page }) => {
+    await openCommandPalette(page);
+
+    await page
+      .getByRole("dialog")
+      .getByRole("option", { name: /^courses$/iu })
+      .click();
+
+    await expect(page).toHaveURL(/\/courses$/u);
+    await expect(page.getByRole("heading", { name: /explore courses/iu })).toBeVisible();
   });
 
   test("selecting Start a new course shows the goal picker", async ({ page }) => {
@@ -677,12 +689,12 @@ test.describe("Command Palette - Keyboard Navigation", () => {
     await expectActiveOption(page, /home page/iu);
 
     // Also wait for the second option to be present before navigating
-    const learnOption = dialog.getByRole("option", { name: /start a new course/iu });
-    await expect(learnOption).toBeVisible();
+    const coursesOption = dialog.getByRole("option", { name: /^courses$/iu });
+    await expect(coursesOption).toBeVisible();
 
-    // Press ArrowDown - "Start a new course" should now be selected
+    // Press ArrowDown - "Courses" should now be selected
     await page.keyboard.press("ArrowDown");
-    await expectActiveOption(page, /start a new course/iu);
+    await expectActiveOption(page, /^courses$/iu);
 
     // Press ArrowUp - "Home page" should be selected again
     await page.keyboard.press("ArrowUp");

--- a/apps/main/e2e/locale.test.ts
+++ b/apps/main/e2e/locale.test.ts
@@ -36,7 +36,7 @@ test.describe("Locale Behavior - English", () => {
 
     const nav = page.getByRole("navigation");
 
-    await expect(nav.getByRole("link", { exact: true, name: "Courses" })).not.toBeVisible();
+    await expect(nav.getByRole("link", { exact: true, name: "Courses" })).toBeVisible();
     await expect(nav.getByRole("link", { exact: true, name: "New course" })).toBeVisible();
 
     await expect(page).toHaveURL(/\/$/u);
@@ -58,7 +58,7 @@ test.describe("Locale Behavior - Portuguese", () => {
 
     const nav = page.getByRole("navigation");
 
-    await expect(nav.getByRole("link", { exact: true, name: "Cursos" })).not.toBeVisible();
+    await expect(nav.getByRole("link", { exact: true, name: "Cursos" })).toBeVisible();
     await expect(nav.getByRole("link", { exact: true, name: "Novo curso" })).toBeVisible();
 
     await expect(page).toHaveURL(/\/pt$/u);
@@ -99,6 +99,21 @@ test.describe("Locale Detection", () => {
 });
 
 test.describe("Locale Navigation", () => {
+  test("clicking courses navbar link keeps user in Portuguese", async ({ page }) => {
+    await setLocale(page, "pt");
+    await page.goto("/");
+
+    const coursesLink = page
+      .getByRole("navigation")
+      .getByRole("link", { exact: true, name: "Cursos" });
+
+    await expect(coursesLink).toHaveAttribute("href", "/pt/courses");
+    await coursesLink.click();
+
+    await expect(page).toHaveURL(/\/pt\/courses$/u);
+    await expect(page.getByRole("heading", { name: /explorar cursos/iu })).toBeVisible();
+  });
+
   test("clicking start navbar link keeps user in Portuguese", async ({ page }) => {
     await setLocale(page, "pt");
     await page.goto("/courses");

--- a/apps/main/e2e/navbar.test.ts
+++ b/apps/main/e2e/navbar.test.ts
@@ -24,15 +24,24 @@ test.describe("Navbar - Unauthenticated", () => {
     await expect(page.getByRole("heading", { name: "What's your goal?" })).toBeVisible();
   });
 
-  test("Courses page stays directly available without a navbar link", async ({ page }) => {
+  test("Courses link navigates to courses page", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "What's your goal?" })).toBeVisible();
+
+    await page.getByRole("navigation").getByRole("link", { exact: true, name: "Courses" }).click();
+
+    await expect(page).toHaveURL(/\/courses$/u);
+    await expect(page.getByRole("heading", { name: /explore courses/iu })).toBeVisible();
+  });
+
+  test("Courses link is active on courses page", async ({ page }) => {
     await page.goto("/courses");
 
     const coursesLink = page
       .getByRole("navigation")
       .getByRole("link", { exact: true, name: "Courses" });
 
-    await expect(page.getByRole("heading", { name: /explore courses/iu })).toBeVisible();
-    await expect(coursesLink).not.toBeVisible();
+    await expect(coursesLink).toHaveAttribute("aria-current", "page");
   });
 
   test("New course link is active on start page", async ({ page }) => {

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -70,6 +70,12 @@ msgid "Home page"
 msgstr "Startseite"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
+#: src/app/[lang]/(catalog)/_components/navbar-links.tsx
+msgctxt "R85gsW"
+msgid "Courses"
+msgstr "Kurse"
+
+#: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "jboh4c"
 msgid "Start a new course"
 msgstr "Neuen Kurs starten"
@@ -122,11 +128,6 @@ msgstr "Feedback & Support"
 msgctxt "SENRqu"
 msgid "Help"
 msgstr "Hilfe"
-
-#: src/app/[lang]/(catalog)/_components/command-palette.tsx
-msgctxt "R85gsW"
-msgid "Courses"
-msgstr "Kurse"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "Do1Pfd"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -70,6 +70,12 @@ msgid "Home page"
 msgstr "Home page"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
+#: src/app/[lang]/(catalog)/_components/navbar-links.tsx
+msgctxt "R85gsW"
+msgid "Courses"
+msgstr "Courses"
+
+#: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "jboh4c"
 msgid "Start a new course"
 msgstr "Start a new course"
@@ -122,11 +128,6 @@ msgstr "Feedback & Support"
 msgctxt "SENRqu"
 msgid "Help"
 msgstr "Help"
-
-#: src/app/[lang]/(catalog)/_components/command-palette.tsx
-msgctxt "R85gsW"
-msgid "Courses"
-msgstr "Courses"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "Do1Pfd"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -70,6 +70,12 @@ msgid "Home page"
 msgstr "Página de inicio"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
+#: src/app/[lang]/(catalog)/_components/navbar-links.tsx
+msgctxt "R85gsW"
+msgid "Courses"
+msgstr "Cursos"
+
+#: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "jboh4c"
 msgid "Start a new course"
 msgstr "Empezar un curso nuevo"
@@ -122,11 +128,6 @@ msgstr "Comentarios y ayuda"
 msgctxt "SENRqu"
 msgid "Help"
 msgstr "Ayuda"
-
-#: src/app/[lang]/(catalog)/_components/command-palette.tsx
-msgctxt "R85gsW"
-msgid "Courses"
-msgstr "Cursos"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "Do1Pfd"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -70,6 +70,12 @@ msgid "Home page"
 msgstr "Page d’accueil"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
+#: src/app/[lang]/(catalog)/_components/navbar-links.tsx
+msgctxt "R85gsW"
+msgid "Courses"
+msgstr "Cours"
+
+#: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "jboh4c"
 msgid "Start a new course"
 msgstr "Commencer un nouveau cours"
@@ -122,11 +128,6 @@ msgstr "Avis et aide"
 msgctxt "SENRqu"
 msgid "Help"
 msgstr "Aide"
-
-#: src/app/[lang]/(catalog)/_components/command-palette.tsx
-msgctxt "R85gsW"
-msgid "Courses"
-msgstr "Cours"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "Do1Pfd"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -70,6 +70,12 @@ msgid "Home page"
 msgstr "Página inicial"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
+#: src/app/[lang]/(catalog)/_components/navbar-links.tsx
+msgctxt "R85gsW"
+msgid "Courses"
+msgstr "Cursos"
+
+#: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "jboh4c"
 msgid "Start a new course"
 msgstr "Começar um novo curso"
@@ -122,11 +128,6 @@ msgstr "Sugestões e Suporte"
 msgctxt "SENRqu"
 msgid "Help"
 msgstr "Ajuda"
-
-#: src/app/[lang]/(catalog)/_components/command-palette.tsx
-msgctxt "R85gsW"
-msgid "Courses"
-msgstr "Cursos"
 
 #: src/app/[lang]/(catalog)/_components/command-palette.tsx
 msgctxt "Do1Pfd"

--- a/apps/main/src/app/[lang]/(catalog)/_components/command-palette.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/_components/command-palette.tsx
@@ -199,6 +199,11 @@ function usePaletteGroups({
         items: [
           createNavigationPaletteItem({ id: "home", label: t("Home page"), menu: getMenu("home") }),
           createNavigationPaletteItem({
+            id: "courses",
+            label: t("Courses"),
+            menu: getMenu("courses"),
+          }),
+          createNavigationPaletteItem({
             id: "start",
             label: t("Start a new course"),
             menu: getMenu("start"),

--- a/apps/main/src/app/[lang]/(catalog)/_components/navbar-links.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/_components/navbar-links.tsx
@@ -30,6 +30,7 @@ function getVariant(href: string, pathname: string): "outline" | "secondary" | "
 }
 
 const homeMenu = getMenu("home");
+const coursesMenu = getMenu("courses");
 const startMenu = getMenu("start");
 const MOBILE_CHAPTER_NAV_CLASS = "sm:hidden";
 const DESKTOP_CHAPTER_NAV_CLASS = "hidden sm:inline-flex";
@@ -76,6 +77,7 @@ export function NavbarLinksSkeleton() {
   return (
     <>
       <Skeleton className="size-9 rounded-full" />
+      <Skeleton className="size-9 rounded-full sm:h-9 sm:w-24" />
       <Skeleton className="size-9 rounded-full" />
       <Skeleton className="ml-auto size-9 rounded-full sm:h-9 sm:w-20" />
     </>
@@ -89,6 +91,7 @@ export function NavbarLinks({ isLoggedIn }: { isLoggedIn: boolean }) {
   const desktopClassName = mobileChapterNavTarget ? DESKTOP_CHAPTER_NAV_CLASS : undefined;
 
   const homeVariant = getVariant(homeMenu.url, pathname);
+  const coursesVariant = getVariant(coursesMenu.url, pathname);
   const startVariant = getVariant(startMenu.url, pathname);
 
   return (
@@ -105,6 +108,19 @@ export function NavbarLinks({ isLoggedIn }: { isLoggedIn: boolean }) {
       >
         <homeMenu.icon aria-hidden="true" />
         <span className="sr-only">{t("Home page")}</span>
+      </Link>
+
+      <Link
+        aria-current={coursesVariant === "default" ? "page" : undefined}
+        className={cn(
+          buttonVariants({ size: "adaptive", variant: coursesVariant }),
+          desktopClassName,
+        )}
+        href={coursesMenu.url}
+        prefetch
+      >
+        <coursesMenu.icon aria-hidden="true" />
+        <span className="sr-only sm:not-sr-only">{t("Courses")}</span>
       </Link>
 
       <CommandPalette className={desktopClassName} isLoggedIn={isLoggedIn} />

--- a/apps/main/src/lib/menu.ts
+++ b/apps/main/src/lib/menu.ts
@@ -19,6 +19,7 @@ import {
 
 const menu = {
   blog: { icon: Newspaper, url: "/blog" },
+  courses: { icon: LayoutGrid, url: "/courses" },
   energy: { icon: ZapIcon, url: "/energy" },
   home: { icon: Home, url: "/" },
   language: { icon: Languages, url: "/language" },


### PR DESCRIPTION
Restores the published Courses entry in the main navbar and command palette, including localized navigation behavior, active states, and browser coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Courses navigation across the app by adding a Courses link to the main navbar and Command Palette with localized labels, correct active state, and locale‑preserving routes. Updates i18n and e2e tests to cover the new behavior.

- **New Features**
  - Added Courses link to the navbar with icon, active `aria-current` on `/courses`, and skeleton; introduced `courses` in the `menu` config.
  - Added “Courses” to the Command Palette (Pages group) that navigates to `/courses` and works with keyboard selection.
  - Kept users in their current locale when navigating to Courses; added translations for de/en/es/fr/pt and updated e2e tests for navbar, command palette, and locale behavior.

<sup>Written for commit 183c0b2d1f9e2a1a6cae73ac77d8904e24157136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

