### PR TITLE
fix(main): warm language course cache during prefetch

### DIFF
--- a/apps/main/src/app/[lang]/(catalog)/start/speak/language-list-content.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/start/speak/language-list-content.tsx
@@ -1,6 +1,7 @@
 import { getCompletedLanguageCourseHrefs } from "@/data/courses/language-course";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { getExtracted } from "next-intl/server";
+import { lang } from "next/root-params";
 import { LanguageList } from "./language-list";
 import { getLanguageOptions } from "./language-options";
 
@@ -34,13 +35,13 @@ export function LanguageListSkeleton() {
 }
 
 /**
- * Resolves the URL locale and its completed-course destinations below the
+ * Resolves the request locale and its completed-course destinations below the
  * page's Suspense boundary so the picker heading remains in the shared shell.
+ * Reading the root parameter directly keeps it available during runtime-prefetch
+ * cache warming, where the full params promise is intentionally deferred.
  */
-export async function LanguageListContent({
-  params,
-}: Pick<PageProps<"/[lang]/start/speak">, "params">) {
-  const { lang: locale } = await params;
+export async function LanguageListContent() {
+  const locale = await lang();
   const t = await getExtracted({ locale });
   const completedLanguageCourseHrefs = await getCompletedLanguageCourseHrefs({ language: locale });
   const languages = getLanguageOptions({ completedLanguageCourseHrefs, locale });

--- a/apps/main/src/app/[lang]/(catalog)/start/speak/page.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/start/speak/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(): Promise<Metadata> {
  * Shows every TTS-supported language as a searchable list so learners can start
  * a controlled language course without going through open-ended prompting.
  */
-export default async function StartSpeak({ params }: PageProps<"/[lang]/start/speak">) {
+export default async function StartSpeak() {
   const t = await getExtracted();
 
   return (
@@ -36,7 +36,7 @@ export default async function StartSpeak({ params }: PageProps<"/[lang]/start/sp
       </StartSurfaceHeader>
 
       <Suspense fallback={<LanguageListSkeleton />}>
-        <LanguageListContent params={params} />
+        <LanguageListContent />
       </Suspense>
     </StartSurface>
   );


### PR DESCRIPTION
Resolve the language picker locale through Next's root-parameter API so its completed-course cache is reached during both runtime-prefetch prerender phases. Remove the obsolete params plumbing from the page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes locale resolution on the Start → Speak page by using `lang()` from `next/root-params`, ensuring the completed-course cache warms during runtime prefetch and prerender. This avoids cache misses and speeds up the first load.

- **Bug Fixes**
  - Read locale via `lang()` inside `LanguageListContent` instead of deferred `params`.
  - Removed `params` plumbing from `page.tsx` and child to keep Suspense stable and enable cache warming.

<sup>Written for commit d5138c8308186d5a13e4b98971a3f9b85b5f5455. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

