### PR TITLE
feat(main): add category course creation cta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - When writing comments, use `/** ... */` for functions, so we can get JSDoc tooltips
 - When refactoring code, double check if the remaining or replaced logic still makes sense. For example, it's pointless to just reassign a type or const like `type ExistingCourse = Course` or `const existingCourse = course`. Just use the original type or const instead of creating an alias that adds no value
 - Never move independent async work out of an existing Promise.all because it can create a waterfall. Preserving or increasing parallelism is required, even if one branch does not use every result. Treat newly serialized async reads as a performance regression unless there is a concrete dependency between them. You should always avoid waterfalls
+- Do not store an unawaited promise solely to overlap async operations (for example, `const valuePromise = load(); ...; const value = await valuePromise`). Prefer a direct `await`. Only introduce explicit concurrency when it has a demonstrated benefit and can be expressed clearly with `Promise.all`
 - Run browser-launching test commands such as Playwright, Cypress, Puppeteer, Selenium, or repository E2E scripts with escalated sandbox permissions on the first attempt. Chromium-based browsers require Mach services that are blocked by the workspace sandbox, so do not first run these commands inside the sandbox; send the exact command to Auto-review for approval instead
 
 ## Prisma Queries

--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -89,6 +89,17 @@ test.describe("Courses Page - Basic", () => {
 
     await expect(page.getByRole("heading", { level: 1, name: course.title })).toBeVisible();
   });
+
+  test("empty category lets users create a course about that category", async ({ page }) => {
+    await page.goto("/courses/law");
+
+    const createCourseLink = page.getByRole("link", { name: "Create a course about Law" });
+
+    await expect(createCourseLink).toBeVisible();
+    await createCourseLink.click();
+
+    await expect(page).toHaveURL(/\/start\/learn$/u);
+  });
 });
 
 test.describe("Courses Page - Infinite Loading", () => {

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -477,14 +477,19 @@ msgid "All"
 msgstr "Alle"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+msgctxt "zJxO2f"
+msgid "No courses"
+msgstr "Keine Kurse"
+
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "Wc7aau"
 msgid "No courses available yet."
 msgstr "Noch keine Kurse verfügbar."
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-msgctxt "zJxO2f"
-msgid "No courses"
-msgstr "Keine Kurse"
+msgctxt "qm3Qo4"
+msgid "Create a course about {category}"
+msgstr "Erstelle einen Kurs über {category}"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "T0mfNV"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -477,14 +477,19 @@ msgid "All"
 msgstr "All"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+msgctxt "zJxO2f"
+msgid "No courses"
+msgstr "No courses"
+
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "Wc7aau"
 msgid "No courses available yet."
 msgstr "No courses available yet."
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-msgctxt "zJxO2f"
-msgid "No courses"
-msgstr "No courses"
+msgctxt "qm3Qo4"
+msgid "Create a course about {category}"
+msgstr "Create a course about {category}"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "T0mfNV"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -477,14 +477,19 @@ msgid "All"
 msgstr "Todo"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+msgctxt "zJxO2f"
+msgid "No courses"
+msgstr "No hay cursos"
+
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "Wc7aau"
 msgid "No courses available yet."
 msgstr "Todavía no hay cursos disponibles."
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-msgctxt "zJxO2f"
-msgid "No courses"
-msgstr "No hay cursos"
+msgctxt "qm3Qo4"
+msgid "Create a course about {category}"
+msgstr "Crea un curso sobre {category}"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "T0mfNV"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -477,14 +477,19 @@ msgid "All"
 msgstr "Tout"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+msgctxt "zJxO2f"
+msgid "No courses"
+msgstr "Aucun cours"
+
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "Wc7aau"
 msgid "No courses available yet."
 msgstr "Aucun cours disponible pour le moment."
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-msgctxt "zJxO2f"
-msgid "No courses"
-msgstr "Aucun cours"
+msgctxt "qm3Qo4"
+msgid "Create a course about {category}"
+msgstr "Créer un cours sur {category}"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "T0mfNV"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -477,14 +477,19 @@ msgid "All"
 msgstr "Todos"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+msgctxt "zJxO2f"
+msgid "No courses"
+msgstr "Nenhum curso"
+
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "Wc7aau"
 msgid "No courses available yet."
 msgstr "Ainda não há cursos disponíveis."
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-msgctxt "zJxO2f"
-msgid "No courses"
-msgstr "Nenhum curso"
+msgctxt "qm3Qo4"
+msgid "Create a course about {category}"
+msgstr "Criar um curso sobre {category}"
 
 #: src/app/[lang]/(catalog)/courses/course-list-client.tsx
 msgctxt "T0mfNV"

--- a/apps/main/src/app/[lang]/(catalog)/courses/[category]/page.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/courses/[category]/page.tsx
@@ -1,6 +1,6 @@
 import { CatalogGridSkeleton } from "@/components/catalog/catalog-skeletons";
 import { LIST_COURSES_LIMIT, listCourses } from "@/data/courses/list-courses";
-import { getCategoryHeader, getCategoryMeta } from "@/lib/categories/category";
+import { getCategoryHeader, getCategoryLabel, getCategoryMeta } from "@/lib/categories/category";
 import { getLocalizedUrl } from "@/lib/metadata/localized-url";
 import {
   Container,
@@ -48,10 +48,11 @@ async function CategoryCourseListContent({ params }: CategoryParamsProps) {
 
   const locale = await getLocale();
   const courses = await listCourses({ category, language: locale });
+  const categoryLabel = await getCategoryLabel(category);
 
   return (
     <CourseListClient
-      category={category}
+      category={{ key: category, label: categoryLabel }}
       initialCourses={courses}
       language={locale}
       limit={LIST_COURSES_LIMIT}

--- a/apps/main/src/app/[lang]/(catalog)/courses/course-list-client.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/courses/course-list-client.tsx
@@ -3,7 +3,16 @@
 import { CatalogGridContent, CatalogGridItem } from "@/components/catalog/catalog-grid";
 import { CatalogGridImage } from "@/components/catalog/catalog-grid-image";
 import { type CourseWithOrg } from "@/data/courses/list-courses";
-import { Button } from "@zoonk/ui/components/button";
+import { Link } from "@/i18n/navigation";
+import { Button, buttonVariants } from "@zoonk/ui/components/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@zoonk/ui/components/empty";
 import {
   GridGroup,
   GridItemContent,
@@ -12,11 +21,12 @@ import {
   GridItemTitle,
 } from "@zoonk/ui/components/grid";
 import { useInfiniteList } from "@zoonk/ui/hooks/infinite-list";
-import { EmptyView } from "@zoonk/ui/patterns/empty";
 import { type CourseCategory } from "@zoonk/utils/categories";
-import { Loader2Icon, NotebookPenIcon, RefreshCwIcon } from "lucide-react";
+import { Loader2Icon, NotebookPenIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
 import { useExtracted } from "next-intl";
 import { loadMoreCourses } from "./actions";
+
+type CourseListCategory = { key: CourseCategory; label: string };
 
 /**
  * Course discovery should use the same playful tile language as curriculum
@@ -52,7 +62,7 @@ export function CourseListClient({
   language,
   limit,
 }: {
-  category?: CourseCategory;
+  category?: CourseListCategory;
   initialCourses: CourseWithOrg[];
   language: string;
   limit: number;
@@ -66,7 +76,8 @@ export function CourseListClient({
     retry,
     sentryRef,
   } = useInfiniteList<CourseWithOrg>({
-    fetchMore: (cursor) => loadMoreCourses({ category, cursor: String(cursor), language }),
+    fetchMore: (cursor) =>
+      loadMoreCourses({ category: category?.key, cursor: String(cursor), language }),
     getKey: (course) => course.id,
     initialItems: initialCourses,
     limit,
@@ -74,11 +85,34 @@ export function CourseListClient({
 
   if (courses.length === 0) {
     return (
-      <EmptyView
-        description={t("No courses available yet.")}
-        icon={NotebookPenIcon}
-        title={t("No courses")}
-      />
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <NotebookPenIcon aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>{t("No courses")}</EmptyTitle>
+          <EmptyDescription>{t("No courses available yet.")}</EmptyDescription>
+        </EmptyHeader>
+
+        {category && (
+          <EmptyContent>
+            <Link
+              className={buttonVariants({
+                className:
+                  "h-auto min-h-9 max-w-full whitespace-normal py-2 text-center leading-snug",
+                variant: "outline",
+              })}
+              href="/start/learn"
+              prefetch
+            >
+              <PlusIcon aria-hidden="true" />
+              <span className="min-w-0 wrap-break-word">
+                {t("Create a course about {category}", { category: category.label })}
+              </span>
+            </Link>
+          </EmptyContent>
+        )}
+      </Empty>
     );
   }
 

--- a/apps/main/src/lib/categories/category.ts
+++ b/apps/main/src/lib/categories/category.ts
@@ -24,7 +24,11 @@ export async function getCategories(): Promise<CategoryInfo[]> {
   ];
 }
 
-async function getCategoryLabel(category: CourseCategory): Promise<string> {
+/**
+ * Resolves route category slugs to their translated display labels so UI copy
+ * never exposes internal values such as "tech" instead of "Technology".
+ */
+export async function getCategoryLabel(category: CourseCategory): Promise<string> {
   const categories = await getCategories();
 
   return categories.find((cat) => cat.key === category)?.label ?? "";


### PR DESCRIPTION
Adds a localized course-creation CTA to empty category pages and routes learners to /start/learn. Includes E2E coverage, generated translations, and the direct-await guidance in AGENTS.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a localized “Create a course” CTA to empty category pages that routes learners to /start/learn. Encourages course creation when a category has no content.

- **New Features**
  - Show empty state with CTA: “Create a course about {category}” linking to /start/learn.
  - Resolve translated category labels via `getCategoryLabel`; client now receives `{ key, label }`.
  - Add i18n strings for en, es, fr, de, pt and update empty-state copy.
  - Add E2E test for CTA visibility and navigation; update `AGENTS.md` with direct-await guidance.

<sup>Written for commit d1f363b7a41b440fe9df1af46429649b0d273f8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

