### PR TITLE
feat(main): index public lesson pages

### DIFF
--- a/apps/main/e2e/continue-lesson-link.test.ts
+++ b/apps/main/e2e/continue-lesson-link.test.ts
@@ -296,12 +296,10 @@ test.describe("Continue Lesson Link", () => {
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page.getByText(/create this lesson/iu)).toBeVisible();
+    const createLessonLink = page.getByRole("link", { name: /create lesson/iu });
 
-    await expect(page.getByRole("link", { name: /create lesson/iu })).toHaveAttribute(
-      "href",
-      `/generate/l/${lesson.id}`,
-    );
+    await expect(createLessonLink).toBeVisible();
+    await expect(createLessonLink).toHaveAttribute("href", `/generate/l/${lesson.id}`);
   });
 
   test("course page falls back to first chapter when no playable step data", async ({ page }) => {

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -82,6 +82,20 @@ async function continueWithoutSaving(page: Page) {
 }
 
 /**
+ * Lesson metadata streams after the initial document, so SEO assertions need
+ * to poll the rendered head instead of reading it immediately after navigation.
+ */
+async function expectRobotsMeta({ page, value }: { page: Page; value: string }) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.querySelector<HTMLMetaElement>("meta[name='robots']")?.content ?? "",
+      ),
+    )
+    .toBe(value);
+}
+
+/**
  * Practice lessons can be generated from explanation metadata before those
  * explanations finish generating, so the player empty state should point at
  * the practice lesson itself instead of sending learners to an explanation row.
@@ -90,6 +104,7 @@ async function createPracticeWithPendingExplanation() {
   const org = await getAiOrganization();
 
   const uniqueId = randomUUID().slice(0, 8);
+  const sourceTitle = `E2E Blocked Player Explanation ${uniqueId}`;
 
   const course = await courseFixture({
     isPublished: true,
@@ -115,21 +130,22 @@ async function createPracticeWithPendingExplanation() {
       organizationId: org.id,
       position: 0,
       slug: `e2e-blocked-player-explanation-${uniqueId}`,
-      title: `E2E Blocked Player Explanation ${uniqueId}`,
+      title: sourceTitle,
     }),
     lessonFixture({
       chapterId: chapter.id,
+      description: null,
       generationStatus: "pending",
       isPublished: true,
       kind: "practice",
       organizationId: org.id,
       position: 1,
       slug: `e2e-blocked-player-practice-${uniqueId}`,
-      title: `E2E Blocked Player Practice ${uniqueId}`,
+      title: null,
     }),
   ]);
 
-  return { chapter, course, practice };
+  return { chapter, course, practice, sourceTitle };
 }
 
 async function createPendingCompanionLesson({
@@ -234,13 +250,14 @@ async function createEmptyReviewLesson() {
     }),
     lessonFixture({
       chapterId: chapter.id,
+      description: null,
       generationStatus: "completed",
       isPublished: true,
       kind: "review",
       organizationId: org.id,
       position: 1,
       slug: `e2e-review-empty-review-${uniqueId}`,
-      title: `E2E Review Empty Review ${uniqueId}`,
+      title: null,
     }),
   ]);
 
@@ -545,17 +562,17 @@ test.describe("Lesson Player Page", () => {
 
     await authenticatedPage.goto(lessonHref);
 
-    await expect(authenticatedPage.getByText(/unlock the rest of this course/iu)).toBeVisible();
-
     await expect(
-      authenticatedPage.getByText(/you.ve reached your free lesson limit/iu),
+      authenticatedPage.getByRole("heading", { level: 1, name: lessonTitle }),
     ).toBeVisible();
 
-    await expect(authenticatedPage.getByRole("heading", { name: lessonTitle })).not.toBeVisible();
+    await expect(authenticatedPage.getByText(`E2E lesson description ${uniqueId}`)).toBeVisible();
 
     await expect(
-      authenticatedPage.getByText(`E2E lesson description ${uniqueId}`),
-    ).not.toBeVisible();
+      authenticatedPage.getByText(
+        "You’ve reached your free lesson limit. Upgrade for unlimited lessons",
+      ),
+    ).toBeVisible();
 
     const backLink = authenticatedPage.getByRole("link", { name: /back to chapter/iu });
     const upgradeLink = authenticatedPage.getByRole("link", { name: /upgrade/iu });
@@ -603,12 +620,21 @@ test.describe("Lesson Player Page", () => {
   });
 
   test("pending lessons show the create state and link details", async ({ page }) => {
-    const { lesson, chapter, course } = await createTestLesson({ generationStatus: "pending" });
+    const { lesson, chapter, course, lessonTitle, uniqueId } = await createTestLesson({
+      generationStatus: "pending",
+    });
 
     await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page.getByText(/create this lesson/iu)).toBeVisible();
-    await expect(page.getByText(/create it to start learning/iu)).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1, name: lessonTitle })).toBeVisible();
+    await expect(page.getByText(`E2E lesson description ${uniqueId}`)).toBeVisible();
+
+    await expect(
+      page.getByText(
+        "This lesson is part of the course, but it hasn't been created yet. Create it to start learning.",
+      ),
+    ).toBeVisible();
+
     const generateLink = page.getByRole("link", { name: /create lesson/iu });
 
     await expect(generateLink).toBeVisible();
@@ -643,11 +669,19 @@ test.describe("Lesson Player Page", () => {
   test("pending practice lessons link to their own generation page", async ({
     authenticatedPage,
   }) => {
-    const { chapter, course, practice } = await createPracticeWithPendingExplanation();
+    const { chapter, course, practice, sourceTitle } = await createPracticeWithPendingExplanation();
 
     await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${practice.slug}`);
 
-    await expect(authenticatedPage.getByText("Create this lesson")).toBeVisible();
+    await expect(
+      authenticatedPage.getByRole("heading", { level: 1, name: sourceTitle }),
+    ).toBeVisible();
+
+    await expect(
+      authenticatedPage.getByText(
+        `Apply ${sourceTitle} through a visual real-world problem with short decisions.`,
+      ),
+    ).toBeVisible();
 
     await expect(
       authenticatedPage.getByText(
@@ -695,7 +729,18 @@ test.describe("Lesson Player Page", () => {
 
     await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${review.slug}`);
 
-    await expect(authenticatedPage.getByText("Create lessons before reviewing")).toBeVisible();
+    await expect(authenticatedPage).toHaveTitle(new RegExp(`${chapter.title} Review`, "u"));
+    await expectRobotsMeta({ page: authenticatedPage, value: "index, follow" });
+
+    await expect(
+      authenticatedPage.getByRole("heading", { level: 1, name: chapter.title }),
+    ).toBeVisible();
+
+    await expect(
+      authenticatedPage.getByText(
+        `Review everything you learned about ${chapter.title} with a comprehensive quiz.`,
+      ),
+    ).toBeVisible();
 
     await expect(
       authenticatedPage.getByText(
@@ -797,7 +842,14 @@ test.describe("Lesson Player Page", () => {
 
     await page.goto(`/b/${org.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page.getByText(/create this lesson/iu)).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1, name: lesson.title! })).toBeVisible();
+
+    await expect(
+      page.getByText(
+        "This lesson is part of the course, but it hasn't been created yet. Create it to start learning.",
+      ),
+    ).toBeVisible();
+
     await expect(page.getByRole("link", { name: /create lesson/iu })).not.toBeVisible();
   });
 
@@ -822,17 +874,27 @@ test.describe("Lesson Player Page", () => {
     await expect(page.getByText(/not found|404/iu)).toBeVisible();
   });
 
-  test("page title contains lesson title", async ({ page }) => {
-    const { chapter, course, lesson, lessonTitle } = await createTestLesson({
+  test("uses stored lesson metadata and permits indexing", async ({ page }) => {
+    const { chapter, course, lesson, lessonTitle, uniqueId } = await createTestLesson({
       generationStatus: "completed",
     });
 
-    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    await page.goto(`/pt/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page).toHaveTitle(new RegExp(lessonTitle, "u"));
+    await expect(page).toHaveTitle(new RegExp(`Explicação sobre ${lessonTitle}`, "u"));
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => document.querySelector<HTMLMetaElement>("meta[name='description']")?.content ?? "",
+        ),
+      )
+      .toBe(`E2E lesson description ${uniqueId}`);
+
+    await expectRobotsMeta({ page, value: "index, follow" });
   });
 
-  test("page title describes lessons without a stored title", async ({ authenticatedPage }) => {
+  test("page title uses the source topic for an indexable companion lesson", async ({ page }) => {
     const org = await getAiOrganization();
     const uniqueId = randomUUID().slice(0, 8);
 
@@ -851,34 +913,69 @@ test.describe("Lesson Player Page", () => {
       title: `E2E Titleless Chapter ${uniqueId}`,
     });
 
-    const lesson = await lessonFixture({
-      chapterId: chapter.id,
+    const sourceTitle = `E2E Source Topic ${uniqueId}`;
+
+    const [sourceLesson, lesson] = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        organizationId: org.id,
+        position: 0,
+        slug: `e2e-source-explanation-${uniqueId}`,
+        title: sourceTitle,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        description: null,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "quiz",
+        organizationId: org.id,
+        position: 1,
+        slug: `e2e-titleless-quiz-${uniqueId}`,
+        title: null,
+      }),
+    ]);
+
+    await Promise.all([
+      stepFixture({
+        content: {
+          text: `Source explanation step ${uniqueId}`,
+          title: `Source explanation ${uniqueId}`,
+          variant: "text",
+        },
+        isPublished: true,
+        lessonId: sourceLesson.id,
+      }),
+      stepFixture({
+        content: {
+          text: `Titleless quiz step ${uniqueId}`,
+          title: `Titleless quiz ${uniqueId}`,
+          variant: "text",
+        },
+        isPublished: true,
+        lessonId: lesson.id,
+      }),
+    ]);
+
+    await page.goto(`/pt/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+
+    await expect(page).toHaveTitle(new RegExp(`Quiz sobre ${sourceTitle}`, "u"));
+
+    await expect(page).not.toHaveTitle(/Quiz Quiz/u);
+  });
+
+  test("permits indexing for lessons in later chapters", async ({ page }) => {
+    const { chapter, course, lesson } = await createTestLesson({
+      chapterPosition: 1,
       generationStatus: "completed",
-      isPublished: true,
-      kind: "quiz",
-      organizationId: org.id,
-      position: 2,
-      slug: `e2e-titleless-quiz-${uniqueId}`,
-      title: null,
     });
 
-    await stepFixture({
-      content: {
-        text: `Titleless quiz step ${uniqueId}`,
-        title: `Titleless quiz ${uniqueId}`,
-        variant: "text",
-      },
-      isPublished: true,
-      lessonId: lesson.id,
-    });
+    await page.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await authenticatedPage.goto(`/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
-
-    await expect(authenticatedPage).toHaveTitle(
-      new RegExp(`${chapter.title} Quiz ${lesson.position + 1}`, "u"),
-    );
-
-    await expect(authenticatedPage).not.toHaveTitle(/Quiz Quiz/u);
+    await expectRobotsMeta({ page, value: "index, follow" });
   });
 
   test("unpublished lesson shows 404 page", async ({ page }) => {

--- a/apps/main/e2e/sitemap.test.ts
+++ b/apps/main/e2e/sitemap.test.ts
@@ -1,5 +1,39 @@
+import { randomUUID } from "node:crypto";
 import { getBaseURL } from "@zoonk/e2e/fixtures/base-url";
+import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { expect, test } from "./fixtures";
+
+/**
+ * Checks each generated lesson sitemap page because a new fixture may sort
+ * after the first 5,000 lesson URLs in a long-lived E2E database.
+ */
+async function lessonSitemapContainsUrl({
+  expectedUrl,
+  page = 0,
+}: {
+  expectedUrl: string;
+  page?: number;
+}): Promise<boolean> {
+  const response = await fetch(`${getBaseURL()}/sitemaps/lessons/sitemap/${page}.xml`);
+  expect(response.status).toBe(200);
+
+  const body = await response.text();
+  expect(body).toContain("<urlset");
+
+  if (body.includes(expectedUrl)) {
+    return true;
+  }
+
+  if (!body.includes("<url>")) {
+    return false;
+  }
+
+  return lessonSitemapContainsUrl({ expectedUrl, page: page + 1 });
+}
 
 test.describe("robots.txt", () => {
   test("disallows private pages", async () => {
@@ -13,7 +47,7 @@ test.describe("robots.txt", () => {
     expect(body).toContain("Disallow: /generate/");
     expect(body).toContain("Disallow: /*/generate/");
     expect(body).toContain("Disallow: /*/p/");
-    expect(body).toContain("Sitemap:");
+    expect(body).toContain("Sitemap: https://www.zoonk.com/sitemaps/lessons/sitemap/0.xml");
   });
 });
 
@@ -38,5 +72,43 @@ test.describe("course sitemaps", () => {
 
     const body = await response.text();
     expect(body).toContain("<urlset");
+  });
+});
+
+test.describe("lesson sitemaps", () => {
+  test("returns canonical URLs for indexable lessons", async () => {
+    const uniqueId = randomUUID().slice(0, 8);
+    const organization = await getAiOrganization();
+
+    const course = await courseFixture({
+      isPublished: true,
+      language: "pt-BR",
+      organizationId: organization.id,
+      slug: `e2e-sitemap-course-${uniqueId}`,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+      slug: `e2e-sitemap-chapter-${uniqueId}`,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      description: `E2E sitemap lesson description ${uniqueId}`,
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId: organization.id,
+      slug: `e2e-sitemap-lesson-${uniqueId}`,
+      title: `E2E Sitemap Lesson ${uniqueId}`,
+    });
+
+    await stepFixture({ isPublished: true, lessonId: lesson.id });
+
+    const expectedUrl = `<loc>https://www.zoonk.com/pt/b/${organization.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}</loc>`;
+    expect(await lessonSitemapContainsUrl({ expectedUrl })).toBe(true);
   });
 });

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -1708,11 +1708,6 @@ msgid "Follow us"
 msgstr "Folge uns"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgctxt "rCpmYD"
-msgid "Create this lesson"
-msgstr "Diese Lektion erstellen"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 msgctxt "AtnLyn"
 msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "Diese Lektion ist Teil des Kurses, wurde aber noch nicht erstellt. Erstelle sie, um mit dem Lernen zu beginnen."
@@ -1731,19 +1726,10 @@ msgid "Back to chapter"
 msgstr "Zurück zum Kapitel"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgctxt "ZnMcrz"
-msgid "Unlock the rest of this course"
-msgstr "Den Rest dieses Kurses freischalten"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "A_uNk-"
-msgid "Create lessons before reviewing"
-msgstr "Erstelle Lektionen, bevor du mit der Überprüfung beginnst"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "Qy4EsI"
-msgid "Nothing to review yet"
-msgstr "Noch nichts zu wiederholen"
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
+msgstr "Du hast dein Limit für kostenlose Lektionen erreicht. Upgrade für unbegrenzte Lektionen"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2788,11 +2774,6 @@ msgid "Upgrade to create"
 msgstr "Zum Erstellen upgraden"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "Du hast dein Limit für kostenlose Lektionen erreicht. Upgrade für unbegrenzte Lektionen"
-
-#: src/components/subscription/upgrade-cta.tsx
 msgctxt "0h_lPM"
 msgid "Upgrade"
 msgstr "Upgrade"
@@ -3063,11 +3044,11 @@ msgid "Learn new words in {topic} with flashcards — see each word, its transla
 msgstr "Lerne neue Wörter in {topic} mit Karteikarten — sieh jedes Wort, seine Übersetzung und die Aussprache."
 
 #: src/lib/lessons.ts
-msgctxt "oCxmX9"
-msgid "{chapter} {kind} {position}"
-msgstr "{chapter} {kind} {position}"
+msgctxt "PhpBBE"
+msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} explanation {Explanation} grammar {Grammar} listening {Listening} practice {Practice} quiz {Quiz} reading {Reading} review {Review} translation {Translation} tutorial {Tutorial} vocabulary {Vocabulary} other {Lesson}} {position}"
+msgstr "{chapter}: {kind, select, alphabet {Alphabet} custom {Eigene Lektion} explanation {Erklärung} grammar {Grammatik} listening {Hören} practice {Übung} quiz {Quiz} reading {Lesen} review {Wiederholung} translation {Übersetzung} tutorial {Tutorial} vocabulary {Wortschatz} other {Lektion}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "qHbgYB"
-msgid "{lesson} - {course}"
-msgstr "{lesson} - {course}"
+msgctxt "EuLBDj"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
+msgstr "{kind, select, alphabet {Alphabet: {lesson}} custom {Eigene Lektion: {lesson}} explanation {Erklärung zu {lesson}} grammar {Grammatik: {lesson}} listening {Hörübung: {lesson}} practice {Übung zu {lesson}} quiz {Quiz zu {lesson}} reading {Leseübung: {lesson}} review {Wiederholung zu {lesson}} translation {Übersetzung von {lesson}} tutorial {Tutorial zu {lesson}} vocabulary {Wortschatz: {lesson}} other {{lesson}}} – {course}"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1708,11 +1708,6 @@ msgid "Follow us"
 msgstr "Follow us"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgctxt "rCpmYD"
-msgid "Create this lesson"
-msgstr "Create this lesson"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 msgctxt "AtnLyn"
 msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
@@ -1731,19 +1726,10 @@ msgid "Back to chapter"
 msgstr "Back to chapter"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgctxt "ZnMcrz"
-msgid "Unlock the rest of this course"
-msgstr "Unlock the rest of this course"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "A_uNk-"
-msgid "Create lessons before reviewing"
-msgstr "Create lessons before reviewing"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "Qy4EsI"
-msgid "Nothing to review yet"
-msgstr "Nothing to review yet"
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
+msgstr "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2788,11 +2774,6 @@ msgid "Upgrade to create"
 msgstr "Upgrade to create"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-
-#: src/components/subscription/upgrade-cta.tsx
 msgctxt "0h_lPM"
 msgid "Upgrade"
 msgstr "Upgrade"
@@ -3063,11 +3044,11 @@ msgid "Learn new words in {topic} with flashcards — see each word, its transla
 msgstr "Learn new words in {topic} with flashcards — see each word, its translation, and pronunciation."
 
 #: src/lib/lessons.ts
-msgctxt "oCxmX9"
-msgid "{chapter} {kind} {position}"
-msgstr "{chapter} {kind} {position}"
+msgctxt "PhpBBE"
+msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} explanation {Explanation} grammar {Grammar} listening {Listening} practice {Practice} quiz {Quiz} reading {Reading} review {Review} translation {Translation} tutorial {Tutorial} vocabulary {Vocabulary} other {Lesson}} {position}"
+msgstr "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} explanation {Explanation} grammar {Grammar} listening {Listening} practice {Practice} quiz {Quiz} reading {Reading} review {Review} translation {Translation} tutorial {Tutorial} vocabulary {Vocabulary} other {Lesson}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "qHbgYB"
-msgid "{lesson} - {course}"
-msgstr "{lesson} - {course}"
+msgctxt "EuLBDj"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
+msgstr "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1708,11 +1708,6 @@ msgid "Follow us"
 msgstr "Síguenos"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgctxt "rCpmYD"
-msgid "Create this lesson"
-msgstr "Crear esta lección"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 msgctxt "AtnLyn"
 msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "Esta lección forma parte del curso, pero aún no se ha creado. Créala para empezar a estudiar."
@@ -1731,19 +1726,10 @@ msgid "Back to chapter"
 msgstr "Volver al capítulo"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgctxt "ZnMcrz"
-msgid "Unlock the rest of this course"
-msgstr "Desbloquea el resto de este curso"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "A_uNk-"
-msgid "Create lessons before reviewing"
-msgstr "Crea lecciones antes de revisar"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "Qy4EsI"
-msgid "Nothing to review yet"
-msgstr "Aún no hay nada para repasar"
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
+msgstr "Llegaste al límite de lecciones gratis. Mejora tu plan para tener lecciones ilimitadas"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2788,11 +2774,6 @@ msgid "Upgrade to create"
 msgstr "Mejora tu plan para crear"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "Llegaste al límite de lecciones gratis. Mejora tu plan para tener lecciones ilimitadas"
-
-#: src/components/subscription/upgrade-cta.tsx
 msgctxt "0h_lPM"
 msgid "Upgrade"
 msgstr "Mejorar plan"
@@ -3063,11 +3044,11 @@ msgid "Learn new words in {topic} with flashcards — see each word, its transla
 msgstr "Aprende palabras nuevas de {topic} con tarjetas: ve cada palabra, su traducción y su pronunciación."
 
 #: src/lib/lessons.ts
-msgctxt "oCxmX9"
-msgid "{chapter} {kind} {position}"
-msgstr "{kind} {chapter} {position}"
+msgctxt "PhpBBE"
+msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} explanation {Explanation} grammar {Grammar} listening {Listening} practice {Practice} quiz {Quiz} reading {Reading} review {Review} translation {Translation} tutorial {Tutorial} vocabulary {Vocabulary} other {Lesson}} {position}"
+msgstr "{chapter}: {kind, select, alphabet {Alfabeto} custom {Lección personalizada} explanation {Explicación} grammar {Gramática} listening {Escucha} practice {Práctica} quiz {Cuestionario} reading {Lectura} review {Repaso} translation {Traducción} tutorial {Tutorial} vocabulary {Vocabulario} other {Lección}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "qHbgYB"
-msgid "{lesson} - {course}"
-msgstr "{lesson} - {course}"
+msgctxt "EuLBDj"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
+msgstr "{kind, select, alphabet {Alfabeto: {lesson}} custom {Lección personalizada: {lesson}} explanation {Explicación sobre {lesson}} grammar {Gramática: {lesson}} listening {Práctica de escucha: {lesson}} practice {Práctica de {lesson}} quiz {Quiz sobre {lesson}} reading {Práctica de lectura: {lesson}} review {Repaso de {lesson}} translation {Traducción de {lesson}} tutorial {Tutorial sobre {lesson}} vocabulary {Vocabulario: {lesson}} other {{lesson}}} - {course}"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -1708,11 +1708,6 @@ msgid "Follow us"
 msgstr "Suis-nous"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgctxt "rCpmYD"
-msgid "Create this lesson"
-msgstr "Créer cette leçon"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 msgctxt "AtnLyn"
 msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "Cette leçon fait partie du cours, mais elle n’a pas encore été créée. Crée-la pour commencer à apprendre."
@@ -1731,19 +1726,10 @@ msgid "Back to chapter"
 msgstr "Retour au chapitre"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgctxt "ZnMcrz"
-msgid "Unlock the rest of this course"
-msgstr "Déverrouiller le reste de ce cours"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "A_uNk-"
-msgid "Create lessons before reviewing"
-msgstr "Crée les leçons avant de les réviser"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "Qy4EsI"
-msgid "Nothing to review yet"
-msgstr "Rien à réviser pour l’instant"
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
+msgstr "Tu as atteint ta limite de leçons gratuites. Passe à l’offre supérieure pour des leçons illimitées"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2788,11 +2774,6 @@ msgid "Upgrade to create"
 msgstr "Passe à l’offre supérieure pour créer"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "Tu as atteint ta limite de leçons gratuites. Passe à l’offre supérieure pour des leçons illimitées"
-
-#: src/components/subscription/upgrade-cta.tsx
 msgctxt "0h_lPM"
 msgid "Upgrade"
 msgstr "Passer à l’offre supérieure"
@@ -3063,11 +3044,11 @@ msgid "Learn new words in {topic} with flashcards — see each word, its transla
 msgstr "Apprends de nouveaux mots en {topic} avec des cartes mémoire — vois chaque mot, sa traduction et sa prononciation."
 
 #: src/lib/lessons.ts
-msgctxt "oCxmX9"
-msgid "{chapter} {kind} {position}"
-msgstr "{chapter} {kind} {position}"
+msgctxt "PhpBBE"
+msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} explanation {Explanation} grammar {Grammar} listening {Listening} practice {Practice} quiz {Quiz} reading {Reading} review {Review} translation {Translation} tutorial {Tutorial} vocabulary {Vocabulary} other {Lesson}} {position}"
+msgstr "{chapter} : {kind, select, alphabet {Alphabet} custom {Leçon personnalisée} explanation {Explication} grammar {Grammaire} listening {Écoute} practice {Entraînement} quiz {Quiz} reading {Lecture} review {Révision} translation {Traduction} tutorial {Tutoriel} vocabulary {Vocabulaire} other {Leçon}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "qHbgYB"
-msgid "{lesson} - {course}"
-msgstr "{lesson} - {course}"
+msgctxt "EuLBDj"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
+msgstr "{kind, select, alphabet {Alphabet : {lesson}} custom {Leçon personnalisée : {lesson}} explanation {Explication de {lesson}} grammar {Grammaire : {lesson}} listening {Exercice d’écoute : {lesson}} practice {Entraînement sur {lesson}} quiz {Quiz sur {lesson}} reading {Exercice de lecture : {lesson}} review {Révision de {lesson}} translation {Traduction de {lesson}} tutorial {Tutoriel sur {lesson}} vocabulary {Vocabulaire : {lesson}} other {{lesson}}} - {course}"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1708,11 +1708,6 @@ msgid "Follow us"
 msgstr "Siga a gente"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
-msgctxt "rCpmYD"
-msgid "Create this lesson"
-msgstr "Criar esta aula"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 msgctxt "AtnLyn"
 msgid "This lesson is part of the course, but it hasn't been created yet. Create it to start learning."
 msgstr "Esta aula faz parte do curso, mas ainda não foi criada. Crie ela para começar a estudar."
@@ -1731,19 +1726,10 @@ msgid "Back to chapter"
 msgstr "Voltar ao capítulo"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-msgctxt "ZnMcrz"
-msgid "Unlock the rest of this course"
-msgstr "Desbloquear o resto deste curso"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "A_uNk-"
-msgid "Create lessons before reviewing"
-msgstr "Crie as aulas antes de revisar"
-
-#: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
-msgctxt "Qy4EsI"
-msgid "Nothing to review yet"
-msgstr "Nada para revisar ainda"
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "ZMU6iN"
+msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
+msgstr "Você atingiu o limite de aulas grátis. Faça upgrade para ter aulas ilimitadas"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2788,11 +2774,6 @@ msgid "Upgrade to create"
 msgstr "Faça upgrade para criar"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "Você atingiu o limite de aulas grátis. Faça upgrade para ter aulas ilimitadas"
-
-#: src/components/subscription/upgrade-cta.tsx
 msgctxt "0h_lPM"
 msgid "Upgrade"
 msgstr "Fazer upgrade"
@@ -3063,11 +3044,11 @@ msgid "Learn new words in {topic} with flashcards — see each word, its transla
 msgstr "Aprenda palavras novas em {topic} com flashcards — veja cada palavra, a tradução e a pronúncia."
 
 #: src/lib/lessons.ts
-msgctxt "oCxmX9"
-msgid "{chapter} {kind} {position}"
-msgstr "{kind} {chapter} {position}"
+msgctxt "PhpBBE"
+msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} explanation {Explanation} grammar {Grammar} listening {Listening} practice {Practice} quiz {Quiz} reading {Reading} review {Review} translation {Translation} tutorial {Tutorial} vocabulary {Vocabulary} other {Lesson}} {position}"
+msgstr "{chapter}: {kind, select, alphabet {Alfabeto} custom {Aula personalizada} explanation {Explicação} grammar {Gramática} listening {Escuta} practice {Prática} quiz {Quiz} reading {Leitura} review {Revisão} translation {Tradução} tutorial {Tutorial} vocabulary {Vocabulário} other {Aula}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "qHbgYB"
-msgid "{lesson} - {course}"
-msgstr "{lesson} - {course}"
+msgctxt "EuLBDj"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
+msgstr "{kind, select, alphabet {Alfabeto: {lesson}} custom {Aula personalizada: {lesson}} explanation {Explicação sobre {lesson}} grammar {Gramática: {lesson}} listening {Prática de escuta: {lesson}} practice {Prática de {lesson}} quiz {Quiz sobre {lesson}} reading {Prática de leitura: {lesson}} review {Revisão de {lesson}} translation {Tradução de {lesson}} tutorial {Tutorial sobre {lesson}} vocabulary {Vocabulário: {lesson}} other {{lesson}}} - {course}"

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
@@ -1,25 +1,25 @@
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import { GenerationShortcutLink } from "@/components/generation/generation-shortcut-link";
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@zoonk/ui/components/empty";
+import { Empty, EmptyContent } from "@zoonk/ui/components/empty";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
+import { LessonSummaryStatus } from "./lesson-summary";
 
+/**
+ * Keeps lesson context visible while offering generation only when the current
+ * organization and lesson type support creating the missing content.
+ */
 export async function LessonNotGenerated({
   brandSlug,
   chapterSlug,
+  children,
   courseSlug,
   generationLessonId,
 }: {
   brandSlug: string;
   chapterSlug: string;
+  children: React.ReactNode;
   courseSlug: string;
   generationLessonId?: string | null;
 }) {
@@ -29,21 +29,15 @@ export async function LessonNotGenerated({
 
   return (
     <Empty className="border-0">
-      <EmptyHeader align="start">
-        <EmptyMedia variant="icon">
-          <SparklesIcon />
-        </EmptyMedia>
+      {children}
 
-        <EmptyTitle>{t("Create this lesson")}</EmptyTitle>
-
-        <EmptyDescription>
+      <EmptyContent align="stretch">
+        <LessonSummaryStatus>
           {t(
             "This lesson is part of the course, but it hasn't been created yet. Create it to start learning.",
           )}
-        </EmptyDescription>
-      </EmptyHeader>
+        </LessonSummaryStatus>
 
-      <EmptyContent align="stretch">
         {canGenerateLesson && generationLessonId && (
           <GenerationShortcutLink
             href={`/generate/l/${generationLessonId}`}

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-summary.tsx
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-summary.tsx
@@ -8,7 +8,7 @@ import { cn } from "@zoonk/ui/lib/utils";
  * Groups the lesson name and description as the primary page context without
  * adding a card or decorative container around the unavailable state.
  */
-export function LessonSummary({ children, className, ...props }: React.ComponentProps<"header">) {
+function LessonSummary({ children, className, ...props }: React.ComponentProps<"header">) {
   return (
     <header
       className={cn("flex w-full max-w-sm flex-col items-start gap-2 text-left", className)}
@@ -24,7 +24,7 @@ export function LessonSummary({ children, className, ...props }: React.Component
  * Gives unavailable lesson pages one semantic page heading so people and
  * crawlers encounter the lesson topic before the access or generation action.
  */
-export function LessonSummaryTitle({ children, className, ...props }: React.ComponentProps<"h1">) {
+function LessonSummaryTitle({ children, className, ...props }: React.ComponentProps<"h1">) {
   return (
     <h1
       className={cn("text-xl leading-tight font-semibold tracking-tight text-pretty", className)}
@@ -40,11 +40,7 @@ export function LessonSummaryTitle({ children, className, ...props }: React.Comp
  * Keeps authored or derived lesson details visually quieter than the title
  * while remaining readable enough to explain what the lesson will teach.
  */
-export function LessonSummaryDescription({
-  children,
-  className,
-  ...props
-}: React.ComponentProps<"p">) {
+function LessonSummaryDescription({ children, className, ...props }: React.ComponentProps<"p">) {
   return (
     <p
       className={cn("text-muted-foreground text-sm/relaxed text-pretty", className)}

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-summary.tsx
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-summary.tsx
@@ -1,0 +1,95 @@
+import "server-only";
+import { type CatalogLesson } from "@/data/lessons/get-lesson";
+import { getLessonSeoSource } from "@/data/lessons/get-lesson-seo-source";
+import { getLessonPageMeta } from "@/lib/lessons";
+import { cn } from "@zoonk/ui/lib/utils";
+
+/**
+ * Groups the lesson name and description as the primary page context without
+ * adding a card or decorative container around the unavailable state.
+ */
+export function LessonSummary({ children, className, ...props }: React.ComponentProps<"header">) {
+  return (
+    <header
+      className={cn("flex w-full max-w-sm flex-col items-start gap-2 text-left", className)}
+      data-slot="lesson-summary"
+      {...props}
+    >
+      {children}
+    </header>
+  );
+}
+
+/**
+ * Gives unavailable lesson pages one semantic page heading so people and
+ * crawlers encounter the lesson topic before the access or generation action.
+ */
+export function LessonSummaryTitle({ children, className, ...props }: React.ComponentProps<"h1">) {
+  return (
+    <h1
+      className={cn("text-xl leading-tight font-semibold tracking-tight text-pretty", className)}
+      data-slot="lesson-summary-title"
+      {...props}
+    >
+      {children}
+    </h1>
+  );
+}
+
+/**
+ * Keeps authored or derived lesson details visually quieter than the title
+ * while remaining readable enough to explain what the lesson will teach.
+ */
+export function LessonSummaryDescription({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn("text-muted-foreground text-sm/relaxed text-pretty", className)}
+      data-slot="lesson-summary-description"
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * Separates a temporary availability message from the durable lesson
+ * description, so the page explains the current action without muddying SEO
+ * copy or turning the state into a second prominent heading.
+ */
+export function LessonSummaryStatus({ children, className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn(
+        "text-muted-foreground w-full max-w-sm text-left text-sm/relaxed text-pretty",
+        className,
+      )}
+      data-slot="lesson-summary-status"
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * Loads source-aware lesson copy only for unavailable states, keeping normal
+ * player routes free of the extra companion lookup while giving every blocked
+ * page the same semantic summary.
+ */
+export async function LessonPageSummary({ lesson }: { lesson: CatalogLesson }) {
+  const sourceLesson = await getLessonSeoSource(lesson);
+  const sourceTitle = sourceLesson?.title?.trim() || null;
+  const lessonMeta = await getLessonPageMeta({ lesson, sourceTitle });
+
+  return (
+    <LessonSummary>
+      <LessonSummaryTitle>{lessonMeta.title}</LessonSummaryTitle>
+      <LessonSummaryDescription>{lessonMeta.description}</LessonSummaryDescription>
+    </LessonSummary>
+  );
+}

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -2,6 +2,7 @@ import { GeneratedCourseCacheRefresher } from "@/components/catalog/generated-co
 import { UpgradeCTA } from "@/components/subscription/upgrade-cta";
 import { listCourseChapters } from "@/data/chapters/list-course-chapters";
 import { type CatalogLesson, getLesson as getCatalogLesson } from "@/data/lessons/get-lesson";
+import { getLessonSeoSource } from "@/data/lessons/get-lesson-seo-source";
 import { getNextLessonInCourse } from "@/data/lessons/get-next-lesson-in-course";
 import { listChapterLessons } from "@/data/lessons/list-chapter-lessons";
 import { getPlayerProgressSnapshot } from "@/data/progress/get-player-progress-snapshot";
@@ -9,6 +10,7 @@ import { hasActiveSubscription } from "@/data/subscriptions/get-active-subscript
 import { getSession } from "@/data/users/get-session";
 import { redirect } from "@/i18n/navigation";
 import { getLessonDisplayMeta, getLessonSeoMeta } from "@/lib/lessons";
+import { isLessonSeoIndexable } from "@/lib/lessons/seo";
 import { getLocalizedUrl } from "@/lib/metadata/localized-url";
 import { getLessonAccessRequirement } from "@zoonk/core/lessons/access";
 import { isStandaloneGeneratedLessonKind } from "@zoonk/core/lessons/generated-companion-kinds";
@@ -34,6 +36,7 @@ import {
 import { LessonNotGenerated } from "./lesson-not-generated";
 import { LessonPlayerClient } from "./lesson-player-client";
 import { buildLessonProgressMeta, getNextChapterTarget } from "./lesson-player-model";
+import { LessonPageSummary, LessonSummaryStatus } from "./lesson-summary";
 import { ReviewLessonEmpty } from "./review-lesson-empty";
 
 type Props = PageProps<"/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]">;
@@ -100,11 +103,13 @@ async function getLessonAccessGate({
   return (
     <Container className="min-h-dvh" variant="narrow">
       <ContainerBody className="justify-center sm:flex-1">
-        <UpgradeCTA
-          backHref={backHref}
-          backLabel={t("Back to chapter")}
-          title={t("Unlock the rest of this course")}
-        />
+        <UpgradeCTA backHref={backHref} backLabel={t("Back to chapter")}>
+          <LessonPageSummary lesson={lesson} />
+
+          <LessonSummaryStatus>
+            {t("You’ve reached your free lesson limit. Upgrade for unlimited lessons")}
+          </LessonSummaryStatus>
+        </UpgradeCTA>
       </ContainerBody>
     </Container>
   );
@@ -163,15 +168,26 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return {};
   }
 
+  const sourceLesson = await getLessonSeoSource(lessonShell);
+  const sourceTitle = sourceLesson?.title?.trim() || null;
+
   return {
-    ...(await getLessonSeoMeta(lessonShell)),
+    ...(await getLessonSeoMeta({ lesson: lessonShell, sourceTitle })),
     alternates: {
       canonical: getLocalizedUrl({
         href: `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
         language: lessonShell.chapter.course.language,
       }),
     },
-    robots: { follow: true, index: false },
+    robots: {
+      follow: true,
+      index: isLessonSeoIndexable({
+        description: lessonShell.description,
+        kind: lessonShell.kind,
+        sourceTitle,
+        title: lessonShell.title,
+      }),
+    },
   };
 }
 
@@ -244,7 +260,9 @@ async function LessonContent({ params }: Pick<Props, "params">) {
           chapterSlug={chapterSlug}
           courseSlug={courseSlug}
           generationLessonId={generationLessonId}
-        />
+        >
+          <LessonPageSummary lesson={lessonShell} />
+        </LessonNotGenerated>
       </main>
     );
   }
@@ -255,7 +273,9 @@ async function LessonContent({ params }: Pick<Props, "params">) {
 
     return (
       <main className="flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center p-4">
-        <ReviewLessonEmpty generationLessonId={generationLessonId} />
+        <ReviewLessonEmpty generationLessonId={generationLessonId}>
+          <LessonPageSummary lesson={lessonShell} />
+        </ReviewLessonEmpty>
       </main>
     );
   }

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
@@ -1,22 +1,18 @@
 import { GenerationShortcutLink } from "@/components/generation/generation-shortcut-link";
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@zoonk/ui/components/empty";
-import { BookOpenCheckIcon, SparklesIcon } from "lucide-react";
+import { Empty, EmptyContent } from "@zoonk/ui/components/empty";
+import { SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
+import { LessonSummaryStatus } from "./lesson-summary";
 
 /**
  * Replaces the misleading zero-step completion screen for review lessons with
  * a concrete next action when earlier generated lessons still need content.
  */
 export async function ReviewLessonEmpty({
+  children,
   generationLessonId,
 }: {
+  children: React.ReactNode;
   generationLessonId: string | null;
 }) {
   const t = await getExtracted();
@@ -24,26 +20,16 @@ export async function ReviewLessonEmpty({
 
   return (
     <Empty className="border-0">
-      <EmptyHeader align="start">
-        <EmptyMedia variant="icon">
-          <BookOpenCheckIcon />
-        </EmptyMedia>
+      {children}
 
-        <EmptyTitle>
-          {isWaitingForGeneration
-            ? t("Create lessons before reviewing")
-            : t("Nothing to review yet")}
-        </EmptyTitle>
-
-        <EmptyDescription>
+      <EmptyContent align="stretch">
+        <LessonSummaryStatus>
           {isWaitingForGeneration
             ? t("Review unlocks after the earlier lessons in this chapter have been created.")
             : t("There are no practice questions to review yet.")}
-        </EmptyDescription>
-      </EmptyHeader>
+        </LessonSummaryStatus>
 
-      {generationLessonId && (
-        <EmptyContent align="stretch">
+        {generationLessonId && (
           <GenerationShortcutLink
             href={`/generate/l/${generationLessonId}`}
             prefetch={false}
@@ -54,8 +40,8 @@ export async function ReviewLessonEmpty({
             <SparklesIcon data-icon="inline-start" />
             {t("Create lesson")}
           </GenerationShortcutLink>
-        </EmptyContent>
-      )}
+        )}
+      </EmptyContent>
     </Empty>
   );
 }

--- a/apps/main/src/app/robots.ts
+++ b/apps/main/src/app/robots.ts
@@ -12,6 +12,7 @@ export default function robots(): MetadataRoute.Robots {
       `${SITE_URL}/sitemap.xml`,
       `${SITE_URL}/sitemaps/courses/sitemap/0.xml`,
       `${SITE_URL}/sitemaps/chapters/sitemap/0.xml`,
+      `${SITE_URL}/sitemaps/lessons/sitemap/0.xml`,
     ],
   };
 }

--- a/apps/main/src/app/sitemaps/lessons/sitemap.ts
+++ b/apps/main/src/app/sitemaps/lessons/sitemap.ts
@@ -1,0 +1,32 @@
+import { SITEMAP_BATCH_SIZE } from "@/data/sitemaps/courses";
+import { countSitemapLessons, listSitemapLessons } from "@/data/sitemaps/lessons";
+import { getLocalizedUrl } from "@/lib/metadata/localized-url";
+import { type MetadataRoute } from "next";
+
+/**
+ * Allocates at least one lesson sitemap so the robots entry remains valid even
+ * before a deployment has any indexable lesson rows.
+ */
+export async function generateSitemaps() {
+  const count = await countSitemapLessons();
+  const pages = Math.ceil(count / SITEMAP_BATCH_SIZE);
+  return Array.from({ length: Math.max(pages, 1) }, (_, i) => ({ id: i }));
+}
+
+/**
+ * Serializes one batch of canonical, locale-aware public lesson URLs.
+ */
+export default async function sitemap(props: {
+  id: Promise<string>;
+}): Promise<MetadataRoute.Sitemap> {
+  const id = Number(await props.id);
+  const lessons = await listSitemapLessons(id);
+
+  return lessons.map(({ brandSlug, chapterSlug, courseSlug, language, lessonSlug, updatedAt }) => ({
+    lastModified: updatedAt,
+    url: getLocalizedUrl({
+      href: `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
+      language,
+    }),
+  }));
+}

--- a/apps/main/src/components/subscription/upgrade-cta.tsx
+++ b/apps/main/src/components/subscription/upgrade-cta.tsx
@@ -12,16 +12,19 @@ import { SparklesIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import { SubscriptionGateTracker } from "./subscription-gate-tracker";
 
+/**
+ * Preserves one tracked subscription action while allowing a calling page to
+ * provide durable context that is more useful than the generic generation
+ * limit message.
+ */
 export async function UpgradeCTA<Href extends string>({
   backHref,
   backLabel,
-  description,
-  title,
+  children,
 }: {
   backHref: AppRoute<Href>;
   backLabel: string;
-  description?: string;
-  title?: string;
+  children?: React.ReactNode;
 }) {
   const t = await getExtracted();
 
@@ -29,17 +32,19 @@ export async function UpgradeCTA<Href extends string>({
     <Empty className="border-0">
       <SubscriptionGateTracker />
 
-      <EmptyHeader align="start">
-        <EmptyMedia variant="icon">
-          <SparklesIcon />
-        </EmptyMedia>
+      {children ?? (
+        <EmptyHeader align="start">
+          <EmptyMedia variant="icon">
+            <SparklesIcon />
+          </EmptyMedia>
 
-        <EmptyTitle>{title ?? t("Upgrade to create")}</EmptyTitle>
+          <EmptyTitle>{t("Upgrade to create")}</EmptyTitle>
 
-        <EmptyDescription>
-          {description ?? t("You’ve reached your free lesson limit. Upgrade for unlimited lessons")}
-        </EmptyDescription>
-      </EmptyHeader>
+          <EmptyDescription>
+            {t("You’ve reached your free lesson limit. Upgrade for unlimited lessons")}
+          </EmptyDescription>
+        </EmptyHeader>
+      )}
 
       <EmptyContent align="stretch">
         <GenerationShortcutLink href={backHref} prefetch shortcut="Esc" variant="outline">

--- a/apps/main/src/data/lessons/get-lesson-seo-source.test.ts
+++ b/apps/main/src/data/lessons/get-lesson-seo-source.test.ts
@@ -1,0 +1,76 @@
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, it } from "vitest";
+import { getLessonSeoSource } from "./get-lesson-seo-source";
+
+describe(getLessonSeoSource, () => {
+  it("finds the nearest authored topic for generated companion metadata", async () => {
+    const organization = await organizationFixture({ kind: "brand" });
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    const [firstExplanation, secondExplanation, quiz, practice, vocabulary, translation] =
+      await Promise.all([
+        lessonFixture({
+          chapterId: chapter.id,
+          isPublished: true,
+          kind: "explanation",
+          organizationId: organization.id,
+          position: 0,
+          title: "First topic",
+        }),
+        lessonFixture({
+          chapterId: chapter.id,
+          isPublished: true,
+          kind: "explanation",
+          organizationId: organization.id,
+          position: 3,
+          title: "Second topic",
+        }),
+        lessonFixture({
+          chapterId: chapter.id,
+          isPublished: true,
+          kind: "quiz",
+          organizationId: organization.id,
+          position: 4,
+          title: null,
+        }),
+        lessonFixture({
+          chapterId: chapter.id,
+          isPublished: true,
+          kind: "practice",
+          organizationId: organization.id,
+          position: 5,
+          title: null,
+        }),
+        lessonFixture({
+          chapterId: chapter.id,
+          isPublished: true,
+          kind: "vocabulary",
+          organizationId: organization.id,
+          position: 6,
+          title: "Vocabulary topic",
+        }),
+        lessonFixture({
+          chapterId: chapter.id,
+          isPublished: true,
+          kind: "translation",
+          organizationId: organization.id,
+          position: 7,
+          title: null,
+        }),
+      ]);
+
+    await expect(getLessonSeoSource(quiz)).resolves.toMatchObject({ id: secondExplanation.id });
+    await expect(getLessonSeoSource(practice)).resolves.toMatchObject({ id: secondExplanation.id });
+    await expect(getLessonSeoSource(translation)).resolves.toMatchObject({ id: vocabulary.id });
+    await expect(getLessonSeoSource(firstExplanation)).resolves.toBeNull();
+  });
+});

--- a/apps/main/src/data/lessons/get-lesson-seo-source.ts
+++ b/apps/main/src/data/lessons/get-lesson-seo-source.ts
@@ -1,0 +1,27 @@
+import "server-only";
+import { getLessonSeoSourceKind } from "@/lib/lessons/seo";
+import { type Lesson, getPublishedLessonWhere, prisma } from "@zoonk/db";
+
+/**
+ * Finds the authored lesson that gives a generated companion its SEO topic.
+ * Chapter generation stores companions immediately after their source group,
+ * so the nearest earlier lesson of the owning kind is the exact source for
+ * quiz, practice, and translation metadata.
+ */
+export async function getLessonSeoSource(
+  lesson: Pick<Lesson, "chapterId" | "kind" | "position">,
+): Promise<Lesson | null> {
+  const sourceKind = getLessonSeoSourceKind(lesson.kind);
+
+  if (!sourceKind) {
+    return null;
+  }
+
+  return prisma.lesson.findFirst({
+    orderBy: { position: "desc" },
+    where: getPublishedLessonWhere({
+      chapterWhere: { id: lesson.chapterId },
+      lessonWhere: { kind: sourceKind, position: { lt: lesson.position }, title: { not: "" } },
+    }),
+  });
+}

--- a/apps/main/src/data/sitemaps/lessons.test.ts
+++ b/apps/main/src/data/sitemaps/lessons.test.ts
@@ -1,0 +1,226 @@
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, it } from "vitest";
+import { SITEMAP_BATCH_SIZE } from "./courses";
+import { countSitemapLessons, listSitemapLessons } from "./lessons";
+
+/**
+ * Returns the final sitemap page index for the shared integration database.
+ */
+function lastPage(count: number): number {
+  return Math.max(Math.ceil(count / SITEMAP_BATCH_SIZE) - 1, 0);
+}
+
+/**
+ * Reads the final two pages because adding a newly indexable lesson kind can
+ * move the pagination boundary across fixtures created in the same test.
+ */
+async function listLatestSitemapLessons(count: number) {
+  const finalPage = lastPage(count);
+  const firstPage = Math.max(finalPage - 1, 0);
+  const pages = Array.from({ length: finalPage - firstPage + 1 }, (_, index) => firstPage + index);
+  const lessons = await Promise.all(pages.map((page) => listSitemapLessons(page)));
+
+  return lessons.flat();
+}
+
+describe(listSitemapLessons, () => {
+  it("includes authored lessons and identifiable single-source companions", async () => {
+    const organization = await organizationFixture({ kind: "brand" });
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId: organization.id,
+      position: 0,
+    });
+
+    const lessons = await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        description: "Authored explanation description",
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "explanation",
+        organizationId: organization.id,
+        position: 0,
+        title: "Authored explanation",
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        description: null,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "quiz",
+        organizationId: organization.id,
+        position: 1,
+        title: null,
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        description: "Authored vocabulary description",
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "vocabulary",
+        organizationId: organization.id,
+        position: 2,
+        title: "Authored vocabulary",
+      }),
+      lessonFixture({
+        chapterId: chapter.id,
+        description: null,
+        generationStatus: "completed",
+        isPublished: true,
+        kind: "translation",
+        organizationId: organization.id,
+        position: 3,
+        title: null,
+      }),
+    ]);
+
+    const count = await countSitemapLessons();
+    const sitemapLessons = await listLatestSitemapLessons(count);
+    const sitemapSlugs = sitemapLessons.map((lesson) => lesson.lessonSlug);
+
+    expect(sitemapSlugs).toStrictEqual(
+      expect.arrayContaining(lessons.map((lesson) => lesson.slug)),
+    );
+  });
+
+  it("uses metadata rather than generation or chapter state", async () => {
+    const organization = await organizationFixture({ kind: "brand" });
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
+    const [firstChapter, gatedChapter] = await Promise.all([
+      chapterFixture({
+        courseId: course.id,
+        generationStatus: "pending",
+        isPublished: true,
+        organizationId: organization.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: course.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: organization.id,
+        position: 1,
+      }),
+    ]);
+
+    const [pendingLesson, reviewLesson, readingLesson, gatedLesson, untitledLesson] =
+      await Promise.all([
+        lessonFixture({
+          chapterId: firstChapter.id,
+          generationStatus: "pending",
+          isPublished: true,
+          organizationId: organization.id,
+          position: 0,
+        }),
+        lessonFixture({
+          chapterId: firstChapter.id,
+          description: null,
+          generationStatus: "completed",
+          isPublished: true,
+          kind: "review",
+          organizationId: organization.id,
+          position: 1,
+          title: null,
+        }),
+        lessonFixture({
+          chapterId: firstChapter.id,
+          generationStatus: "completed",
+          isPublished: true,
+          kind: "reading",
+          organizationId: organization.id,
+          position: 2,
+          title: null,
+        }),
+        lessonFixture({
+          chapterId: gatedChapter.id,
+          generationStatus: "completed",
+          isPublished: true,
+          organizationId: organization.id,
+          position: 0,
+        }),
+        lessonFixture({
+          chapterId: firstChapter.id,
+          description: null,
+          generationStatus: "completed",
+          isPublished: true,
+          organizationId: organization.id,
+          position: 3,
+          title: null,
+        }),
+      ]);
+
+    const includedLessons = [pendingLesson, reviewLesson, gatedLesson];
+    const excludedLessons = [readingLesson, untitledLesson];
+
+    const count = await countSitemapLessons();
+    const sitemapLessons = await listLatestSitemapLessons(count);
+    const sitemapSlugs = sitemapLessons.map((lesson) => lesson.lessonSlug);
+
+    expect(sitemapSlugs).toStrictEqual(
+      expect.arrayContaining(includedLessons.map((lesson) => lesson.slug)),
+    );
+
+    for (const lesson of excludedLessons) {
+      expect(sitemapSlugs).not.toContain(lesson.slug);
+    }
+  });
+
+  it("excludes lessons outside the published brand catalog", async () => {
+    const [brandOrganization, personalOrganization] = await Promise.all([
+      organizationFixture({ kind: "brand" }),
+      organizationFixture({ kind: "personal" }),
+    ]);
+
+    const [unpublishedCourse, personalCourse] = await Promise.all([
+      courseFixture({ isPublished: false, organizationId: brandOrganization.id }),
+      courseFixture({ isPublished: true, organizationId: personalOrganization.id }),
+    ]);
+
+    const [unpublishedChapter, personalChapter] = await Promise.all([
+      chapterFixture({
+        courseId: unpublishedCourse.id,
+        isPublished: true,
+        organizationId: brandOrganization.id,
+        position: 0,
+      }),
+      chapterFixture({
+        courseId: personalCourse.id,
+        isPublished: true,
+        organizationId: personalOrganization.id,
+        position: 0,
+      }),
+    ]);
+
+    const lessons = await Promise.all([
+      lessonFixture({
+        chapterId: unpublishedChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: brandOrganization.id,
+      }),
+      lessonFixture({
+        chapterId: personalChapter.id,
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId: personalOrganization.id,
+      }),
+    ]);
+
+    const count = await countSitemapLessons();
+    const sitemapLessons = await listLatestSitemapLessons(count);
+    const sitemapSlugs = sitemapLessons.map((lesson) => lesson.lessonSlug);
+
+    for (const lesson of lessons) {
+      expect(sitemapSlugs).not.toContain(lesson.slug);
+    }
+  });
+});

--- a/apps/main/src/data/sitemaps/lessons.ts
+++ b/apps/main/src/data/sitemaps/lessons.ts
@@ -1,0 +1,91 @@
+import "server-only";
+import {
+  INDEXABLE_AUTHORED_LESSON_KINDS,
+  INDEXABLE_CHAPTER_LESSON_KIND,
+  INDEXABLE_EXPLANATION_COMPANION_LESSON_KINDS,
+} from "@/lib/lessons/seo";
+import { getPublishedLessonWhere, prisma } from "@zoonk/db";
+import { SITEMAP_BATCH_SIZE } from "./courses";
+
+/**
+ * Keeps the lesson sitemap aligned with the route's indexing policy. Published
+ * authored rows need their own metadata. Single-source companions need an
+ * authored lesson in the same chapter, and the chapter-level review uses the
+ * chapter title. Reading and listening stay excluded because they span several
+ * topics without standalone metadata.
+ */
+function getSitemapLessonWhere() {
+  return {
+    AND: [
+      getPublishedLessonWhere({ courseWhere: { organization: { kind: "brand" } } }),
+      {
+        OR: [
+          {
+            description: { not: "" },
+            kind: { in: [...INDEXABLE_AUTHORED_LESSON_KINDS] },
+            title: { not: "" },
+          },
+          {
+            chapter: {
+              lessons: {
+                some: { isPublished: true, kind: "explanation" as const, title: { not: "" } },
+              },
+            },
+            kind: { in: [...INDEXABLE_EXPLANATION_COMPANION_LESSON_KINDS] },
+          },
+          {
+            chapter: {
+              lessons: {
+                some: { isPublished: true, kind: "vocabulary" as const, title: { not: "" } },
+              },
+            },
+            kind: "translation" as const,
+          },
+          { kind: INDEXABLE_CHAPTER_LESSON_KIND },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Counts every lesson URL that satisfies the same metadata policy used by the
+ * lesson page's robots metadata.
+ */
+export async function countSitemapLessons(): Promise<number> {
+  return prisma.lesson.count({ where: getSitemapLessonWhere() });
+}
+
+/**
+ * Returns one deterministic sitemap page with the full public lesson route
+ * hierarchy and the course language used by the canonical URL.
+ */
+export async function listSitemapLessons(
+  page: number,
+): Promise<
+  {
+    brandSlug: string;
+    chapterSlug: string;
+    courseSlug: string;
+    language: string;
+    lessonSlug: string;
+    updatedAt: Date;
+  }[]
+> {
+  const lessons = await prisma.lesson.findMany({
+    include: { chapter: { include: { course: { include: { organization: true } } } } },
+    orderBy: { id: "asc" },
+    skip: page * SITEMAP_BATCH_SIZE,
+    take: SITEMAP_BATCH_SIZE,
+    where: getSitemapLessonWhere(),
+  });
+
+  return lessons.map((lesson) => ({
+    brandSlug: lesson.chapter.course.organization?.slug ?? "",
+    chapterSlug: lesson.chapter.slug,
+    courseSlug: lesson.chapter.course.slug,
+    language: lesson.chapter.course.language,
+    lessonSlug: lesson.slug,
+    updatedAt: lesson.updatedAt,
+  }));
+}

--- a/apps/main/src/lib/lessons.ts
+++ b/apps/main/src/lib/lessons.ts
@@ -117,17 +117,29 @@ async function getSeoDescription(kind: LessonKind, topic: string): Promise<strin
   return descriptions[kind];
 }
 
-export async function getLessonSeoMeta(
-  lesson: LessonSeoInput,
-): Promise<{ title: string; description: string }> {
-  const title = await getSeoTitle({ lesson });
+/**
+ * Chooses the topic a learner would use to identify a lesson. Generated
+ * companions inherit their source lesson, while the single review lesson uses
+ * its chapter because review rows intentionally store no title.
+ */
+function getLessonTopic({
+  lesson,
+  sourceTitle,
+}: {
+  lesson: LessonSeoInput;
+  sourceTitle: string | null;
+}): string | null {
+  const lessonTitle = lesson.title?.trim();
 
-  const description = await getSeoLessonDescription({
-    lesson,
-    lessonTitle: lesson.title ?? lesson.chapter.title,
-  });
+  if (lessonTitle) {
+    return lessonTitle;
+  }
 
-  return { description, title };
+  if (sourceTitle?.trim()) {
+    return sourceTitle.trim();
+  }
+
+  return lesson.kind === "review" ? lesson.chapter.title : null;
 }
 
 /**
@@ -145,21 +157,35 @@ async function getUntitledLessonSeoTitle({
   kind: LessonKind;
   position: number;
 }) {
-  const labels = await getLessonKindLabels();
   const t = await getExtracted();
 
-  return t("{chapter} {kind} {position}", {
-    chapter: chapterTitle,
-    kind: labels[kind],
-    position: String(position + 1),
-  });
+  return t(
+    "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} explanation {Explanation} grammar {Grammar} listening {Listening} practice {Practice} quiz {Quiz} reading {Reading} review {Review} translation {Translation} tutorial {Tutorial} vocabulary {Vocabulary} other {Lesson}} {position}",
+    { chapter: chapterTitle, kind, position: String(position + 1) },
+  );
 }
 
-async function getSeoTitle({ lesson }: { lesson: LessonSeoInput }): Promise<string> {
-  if (lesson.title) {
+/**
+ * Uses the lesson kind to give every titled page a natural, localized browser
+ * title. Generated companions use their source topic, while authored lessons
+ * use their own stored title.
+ */
+async function getSeoTitle({
+  lesson,
+  sourceTitle,
+}: {
+  lesson: LessonSeoInput;
+  sourceTitle: string | null;
+}): Promise<string> {
+  const lessonTopic = getLessonTopic({ lesson, sourceTitle });
+
+  if (lessonTopic) {
     const t = await getExtracted();
 
-    return t("{lesson} - {course}", { course: lesson.chapter.course.title, lesson: lesson.title });
+    return t(
+      "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}",
+      { course: lesson.chapter.course.title, kind: lesson.kind, lesson: lessonTopic },
+    );
   }
 
   return getUntitledLessonSeoTitle({
@@ -169,6 +195,63 @@ async function getSeoTitle({ lesson }: { lesson: LessonSeoInput }): Promise<stri
   });
 }
 
+/**
+ * Provides useful visible copy before lesson content is available. Authored
+ * lessons keep their exact title, while structural lessons use the closest
+ * authored source topic so learners know what the page will cover.
+ */
+export async function getLessonPageMeta({
+  lesson,
+  sourceTitle,
+}: {
+  lesson: LessonSeoInput;
+  sourceTitle: string | null;
+}): Promise<LessonDisplayMeta> {
+  const lessonTopic = getLessonTopic({ lesson, sourceTitle });
+
+  const title =
+    lessonTopic ??
+    (await getUntitledLessonSeoTitle({
+      chapterTitle: lesson.chapter.title,
+      kind: lesson.kind,
+      position: lesson.position,
+    }));
+
+  const description = await getSeoLessonDescription({
+    lesson,
+    lessonTitle: lessonTopic ?? lesson.chapter.title,
+  });
+
+  return { description, title };
+}
+
+/**
+ * Builds accurate search metadata from authored lesson copy and, for generated
+ * companions, the specific source topic that owns their interactive content.
+ */
+export async function getLessonSeoMeta({
+  lesson,
+  sourceTitle,
+}: {
+  lesson: LessonSeoInput;
+  sourceTitle: string | null;
+}): Promise<{ title: string; description: string }> {
+  const lessonTopic = getLessonTopic({ lesson, sourceTitle });
+  const title = await getSeoTitle({ lesson, sourceTitle });
+
+  const description = await getSeoLessonDescription({
+    lesson,
+    lessonTitle: lessonTopic ?? lesson.chapter.title,
+  });
+
+  return { description, title };
+}
+
+/**
+ * Prefers the stored description for authored content and only generates
+ * kind-specific copy for structural companion rows that intentionally store no
+ * description.
+ */
 async function getSeoLessonDescription({
   lesson,
   lessonTitle,
@@ -176,7 +259,7 @@ async function getSeoLessonDescription({
   lesson: { kind: LessonKind; description: string | null };
   lessonTitle: string;
 }): Promise<string> {
-  if (lesson.kind === "custom" && lesson.description) {
+  if (lesson.description) {
     return lesson.description;
   }
 

--- a/apps/main/src/lib/lessons/seo.test.ts
+++ b/apps/main/src/lib/lessons/seo.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isLessonSeoIndexable } from "./seo";
+
+const indexableLesson = {
+  description: "A specific lesson description",
+  kind: "explanation",
+  sourceTitle: null,
+  title: "A specific lesson title",
+} as const;
+
+describe(isLessonSeoIndexable, () => {
+  it("indexes substantive authored lessons, companions, and chapter reviews", () => {
+    expect(isLessonSeoIndexable(indexableLesson)).toBe(true);
+
+    expect(
+      isLessonSeoIndexable({
+        ...indexableLesson,
+        description: null,
+        kind: "quiz",
+        sourceTitle: "A specific lesson title",
+        title: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      isLessonSeoIndexable({ ...indexableLesson, description: null, kind: "review", title: null }),
+    ).toBe(true);
+  });
+
+  it("does not index multi-source lesson kinds without a standalone topic", () => {
+    expect(isLessonSeoIndexable({ ...indexableLesson, kind: "reading" })).toBe(false);
+    expect(isLessonSeoIndexable({ ...indexableLesson, kind: "listening" })).toBe(false);
+  });
+
+  it("does not index pages without identifiable metadata", () => {
+    expect(isLessonSeoIndexable({ ...indexableLesson, description: null })).toBe(false);
+    expect(isLessonSeoIndexable({ ...indexableLesson, title: null })).toBe(false);
+
+    expect(
+      isLessonSeoIndexable({
+        ...indexableLesson,
+        description: null,
+        kind: "practice",
+        sourceTitle: null,
+        title: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/main/src/lib/lessons/seo.ts
+++ b/apps/main/src/lib/lessons/seo.ts
@@ -1,0 +1,76 @@
+import { type LessonKind } from "@zoonk/db";
+
+export const INDEXABLE_CHAPTER_LESSON_KIND = "review" as const satisfies LessonKind;
+
+export const INDEXABLE_AUTHORED_LESSON_KINDS = [
+  "alphabet",
+  "custom",
+  "explanation",
+  "grammar",
+  "tutorial",
+  "vocabulary",
+] as const satisfies readonly LessonKind[];
+
+export const INDEXABLE_EXPLANATION_COMPANION_LESSON_KINDS = [
+  "practice",
+  "quiz",
+] as const satisfies readonly LessonKind[];
+
+const INDEXABLE_COMPANION_LESSON_KINDS = [
+  ...INDEXABLE_EXPLANATION_COMPANION_LESSON_KINDS,
+  "translation",
+] as const satisfies readonly LessonKind[];
+
+const INDEXABLE_AUTHORED_LESSON_KIND_SET = new Set<LessonKind>(INDEXABLE_AUTHORED_LESSON_KINDS);
+
+const INDEXABLE_COMPANION_LESSON_KIND_SET = new Set<LessonKind>(INDEXABLE_COMPANION_LESSON_KINDS);
+
+/**
+ * Companion lesson metadata should name the authored topic that actually
+ * produced its content. Quiz and practice rows follow an explanation, while a
+ * translation row follows the vocabulary lesson whose words it reuses.
+ */
+export function getLessonSeoSourceKind(kind: LessonKind): LessonKind | null {
+  if (kind === "practice" || kind === "quiz") {
+    return "explanation";
+  }
+
+  if (kind === "translation") {
+    return "vocabulary";
+  }
+
+  return null;
+}
+
+/**
+ * Authored lessons need their own title and description, while single-source
+ * companions need the source title that makes their metadata specific. A
+ * chapter has one review lesson, so its chapter title provides a unique topic.
+ * Reading and listening can combine several vocabulary lessons, so those kinds
+ * remain out of the index until they have an accurate standalone topic.
+ */
+export function isLessonSeoIndexable({
+  description,
+  kind,
+  sourceTitle,
+  title,
+}: {
+  description: string | null;
+  kind: LessonKind;
+  sourceTitle: string | null;
+  title: string | null;
+}): boolean {
+  if (kind === INDEXABLE_CHAPTER_LESSON_KIND) {
+    return true;
+  }
+
+  if (INDEXABLE_COMPANION_LESSON_KIND_SET.has(kind)) {
+    return Boolean(sourceTitle?.trim());
+  }
+
+  return (
+    INDEXABLE_AUTHORED_LESSON_KIND_SET.has(kind) &&
+    Boolean(title?.trim()) &&
+    Boolean(description?.trim())
+  );
+}


### PR DESCRIPTION
## Summary

- add localized, source-aware metadata and indexing rules for meaningful public lesson pages
- publish eligible lesson URLs through a paginated sitemap and robots discovery
- show useful lesson context in unavailable and subscription-gated states while keeping the required action clear
- cover lesson SEO policy, source resolution, sitemap output, and browser flows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indexes public lesson pages with localized, kind-aware titles/descriptions and ships a paginated, locale-aware lesson sitemap. Blocked lesson pages now show the lesson context first, with one clear next action.

- **New Features**
  - Added lesson sitemap at `/sitemaps/lessons/sitemap/[id].xml`, linked in `robots.txt`; emits canonical, locale-aware URLs.
  - Centralized index policy via `isLessonSeoIndexable`: authored lessons need title+description; single-source companions (quiz/practice from explanation, translation from vocabulary) need a source topic; chapter review is indexable; reading/listening remain excluded. Robots meta now reflects this.
  - Localized SEO: titles include lesson kind and course; companions use their source topic; review uses the chapter; descriptions prefer stored copy or generate kind-specific text.
  - Blocked/gated states render a semantic summary (title + description) plus a focused status message; `UpgradeCTA` shows the same summary.

- **Refactors**
  - `UpgradeCTA` accepts `children`; message keys consolidated across locales.
  - Introduced `LessonSummary` and `LessonPageSummary` and integrated into pending/gated/review views.
  - Added `getLessonSeoSource`, `getLessonPageMeta`, and `isLessonSeoIndexable`; `generateMetadata` and lesson sitemaps now compute canonical URLs and indexing per locale using the same rules.
  - Expanded E2E and unit tests for localized titles, robots meta, and sitemap pagination.

<sup>Written for commit 351ae4e13126c7d136795cc2143aad36cb98f63e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

