### PR TITLE
feat(player): improve milestone messaging

### DIFF
--- a/apps/main/e2e/energy.test.ts
+++ b/apps/main/e2e/energy.test.ts
@@ -74,8 +74,6 @@ test.describe("Energy Page", () => {
         await expect(fullEnergyCard).toContainText("1 day");
         await expect(energyChart).toBeVisible();
         await expect(recordedEnergyDay).toBeVisible();
-        await recordedEnergyDay.hover();
-        await expect(page.getByText(/^50% energy on /iu)).toBeVisible();
 
         await expect(energyChart.getByRole("button", { name: /^100% energy on /iu })).toHaveCount(
           0,

--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -80,9 +80,9 @@ msgid "New daily best"
 msgstr "Neuer Tagesrekord"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "VaM8Q9"
-msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
-msgstr "Du hast heute {brainPower} BP erreicht, deine höchste Brain Power an einem Tag. Lern jeden Tag weiter, um einen neuen Rekord zu setzen."
+msgctxt "0TbCx0"
+msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
+msgstr "Du hast heute {brainPower} BP verdient, mehr als an jedem anderen Tag. Weiter so—deine Mühe wird sich auszahlen."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -90,9 +90,9 @@ msgid "Max Energy!"
 msgstr "Maximale Energie!"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "Fo6YtA"
-msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
-msgstr "Glückwunsch! Du hast maximale Energie erreicht. Übe jeden Tag, um deine Energie bei 100% zu halten."
+msgctxt "WwRCBI"
+msgid "You've been learning regularly and answering accurately. Stay consistent to keep your Energy at 100%."
+msgstr "Du lernst regelmäßig und beantwortest Fragen richtig. Bleib dran, damit deine Energie bei 100 % bleibt."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "J89SkG"
@@ -100,9 +100,9 @@ msgid "{percentage} Energy"
 msgstr "{percentage} Energie"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "3Jd-mJ"
-msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
-msgstr "Dein Einsatz zahlt sich aus. Schließe jeden Tag Lektionen ab, um deine Energie zu steigern."
+msgctxt "pQ9XJb"
+msgid "You're building good momentum. Learning regularly and getting answers right will keep your Energy moving up."
+msgstr "Du kommst gut voran. Wenn du regelmäßig lernst und Fragen richtig beantwortest, steigt deine Energie weiter."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "5YVYKd"
@@ -115,9 +115,9 @@ msgid "{days} days of max Energy"
 msgstr "{days} Tage volle Energie"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "cIxpmv"
-msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
-msgstr "Wow, was für eine unglaubliche Ausdauer! Lern weiter jeden Tag, damit deine Energie bei 100% bleibt."
+msgctxt "wl6CDc"
+msgid "You're building real consistency. Learning every day helps keep your mind active and improve your performance."
+msgstr "Du bleibst richtig gut dran. Tägliches Lernen hält deinen Geist aktiv und hilft dir, dich zu verbessern."
 
 #: src/components/completion-learning-days-milestone.tsx
 msgctxt "SIXtG5"
@@ -125,9 +125,9 @@ msgid "{days} learning days"
 msgstr "{days} Lerntage"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "hjXoGI"
-msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
-msgstr "Du hast an {days} verschiedenen Tagen Lektionen abgeschlossen. Wenn du oft übst, kannst du dir das Gelernte besser merken."
+msgctxt "_M8z1y"
+msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
+msgstr "Lernen wird für dich zur Gewohnheit. Regelmäßiges Üben hilft dir, dir mehr von dem zu merken, was du lernst."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -145,19 +145,9 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# Stunde gelernt} other {# Stunden gelernt}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "WcAhMT"
-msgid "You can learn a lot by practicing for a few minutes a day."
-msgstr "Du kannst viel lernen, wenn du täglich ein paar Minuten übst."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "LzEQnT"
-msgid "That's a full day of focused practice."
-msgstr "Das ist ein ganzer Tag konzentriertes Üben."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "PpK3hX"
-msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
-msgstr "Das sind mehr als {days, plural, one {# voller Tag} other {# volle Tage}} konzentriertes Üben."
+msgctxt "YYZPzp"
+msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
+msgstr "Die ganze Zeit, die du mit Lernen verbringst, zahlt sich aus. Selbst kurze, regelmäßige Einheiten helfen dir, neue Ideen im Gedächtnis zu behalten."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -165,19 +155,19 @@ msgid "Level achieved"
 msgstr "Level erreicht"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Ar7dNY"
-msgid "You reached a new level: {belt}, level {level}. Congrats!"
-msgstr "Du hast ein neues Level erreicht: {belt}, Level {level}. Glückwunsch!"
+msgctxt "WheDiX"
+msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
+msgstr "Deine Mühe zahlt sich aus—du hast {belt}, Level {level}, erreicht. Weiter so—jede Lektion steigert deine Brain Power."
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Bk6B6r"
-msgid "Almost there"
-msgstr "Fast geschafft"
+msgctxt "VfEqvB"
+msgid "Halfway there"
+msgstr "Halb geschafft"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "b7ZoLo"
-msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
-msgstr "Dein Wissen wächst. Schließe {count, plural, one {noch # Lektion} other {noch # Lektionen}} ab, um {belt}, Level {level}, zu erreichen."
+msgctxt "LrDO2N"
+msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more lesson will get you there} other {# more lessons will get you there}}."
+msgstr "Du bist auf halbem Weg zu {belt}, Level {level}. {count, plural, one {Noch eine Lektion, dann hast du es geschafft} other {Noch # Lektionen, dann hast du es geschafft}}."
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "DiIkZH"
@@ -200,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} ist dein bester Tag"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "PTQ0ah"
-msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
-msgstr "An {day} hast du normalerweise {percentage} der Antworten richtig – dein bester Durchschnitt in dieser Woche."
+msgctxt "bim3gG"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
+msgstr "Du erreichst im Schnitt {percentage} {day, select, sunday {sonntags} monday {montags} tuesday {dienstags} wednesday {mittwochs} thursday {donnerstags} friday {freitags} saturday {samstags} other {an deinem besten Tag}}, mehr als an jedem anderen Tag. Überlege, was dann besonders gut funktioniert—vielleicht kannst du es die ganze Woche über nutzen."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -80,9 +80,9 @@ msgid "New daily best"
 msgstr "New daily best"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "VaM8Q9"
-msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
-msgstr "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
+msgctxt "0TbCx0"
+msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
+msgstr "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -90,9 +90,9 @@ msgid "Max Energy!"
 msgstr "Max Energy!"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "Fo6YtA"
-msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
-msgstr "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
+msgctxt "WwRCBI"
+msgid "You've been learning regularly and answering accurately. Stay consistent to keep your Energy at 100%."
+msgstr "You've been learning regularly and answering accurately. Stay consistent to keep your Energy at 100%."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "J89SkG"
@@ -100,9 +100,9 @@ msgid "{percentage} Energy"
 msgstr "{percentage} Energy"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "3Jd-mJ"
-msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
-msgstr "Your effort is paying off. Complete lessons every day to increase your Energy."
+msgctxt "pQ9XJb"
+msgid "You're building good momentum. Learning regularly and getting answers right will keep your Energy moving up."
+msgstr "You're building good momentum. Learning regularly and getting answers right will keep your Energy moving up."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "5YVYKd"
@@ -115,9 +115,9 @@ msgid "{days} days of max Energy"
 msgstr "{days} days of max Energy"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "cIxpmv"
-msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
-msgstr "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
+msgctxt "wl6CDc"
+msgid "You're building real consistency. Learning every day helps keep your mind active and improve your performance."
+msgstr "You're building real consistency. Learning every day helps keep your mind active and improve your performance."
 
 #: src/components/completion-learning-days-milestone.tsx
 msgctxt "SIXtG5"
@@ -125,9 +125,9 @@ msgid "{days} learning days"
 msgstr "{days} learning days"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "hjXoGI"
-msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
-msgstr "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
+msgctxt "_M8z1y"
+msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
+msgstr "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -145,19 +145,9 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "WcAhMT"
-msgid "You can learn a lot by practicing for a few minutes a day."
-msgstr "You can learn a lot by practicing for a few minutes a day."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "LzEQnT"
-msgid "That's a full day of focused practice."
-msgstr "That's a full day of focused practice."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "PpK3hX"
-msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
-msgstr "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
+msgctxt "YYZPzp"
+msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
+msgstr "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -165,19 +155,19 @@ msgid "Level achieved"
 msgstr "Level achieved"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Ar7dNY"
-msgid "You reached a new level: {belt}, level {level}. Congrats!"
-msgstr "You reached a new level: {belt}, level {level}. Congrats!"
+msgctxt "WheDiX"
+msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
+msgstr "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Bk6B6r"
-msgid "Almost there"
-msgstr "Almost there"
+msgctxt "VfEqvB"
+msgid "Halfway there"
+msgstr "Halfway there"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "b7ZoLo"
-msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
-msgstr "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
+msgctxt "LrDO2N"
+msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more lesson will get you there} other {# more lessons will get you there}}."
+msgstr "You're halfway to {belt}, level {level}. {count, plural, one {One more lesson will get you there} other {# more lessons will get you there}}."
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "DiIkZH"
@@ -200,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} is your best day"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "PTQ0ah"
-msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
-msgstr "You usually get {percentage} of answers right on {day}, your highest average of the week."
+msgctxt "bim3gG"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
+msgstr "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -80,9 +80,9 @@ msgid "New daily best"
 msgstr "Nuevo récord diario"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "VaM8Q9"
-msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
-msgstr "Hoy alcanzaste {brainPower} PM, tu mayor Poder Mental en un solo día. Sigue estudiando cada día para marcar un nuevo récord."
+msgctxt "0TbCx0"
+msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
+msgstr "Hoy ganaste {brainPower} PM, más que cualquier otro día. Sigue así: este esfuerzo dará sus frutos."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -90,9 +90,9 @@ msgid "Max Energy!"
 msgstr "¡Energía al máximo!"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "Fo6YtA"
-msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
-msgstr "¡Felicidades! Alcanzaste el máximo de Energía. Sigue practicando cada día para mantener tu Energía al 100 %."
+msgctxt "WwRCBI"
+msgid "You've been learning regularly and answering accurately. Stay consistent to keep your Energy at 100%."
+msgstr "Has estudiado con regularidad y respondido correctamente. Mantén el ritmo para conservar tu Energía al 100 %."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "J89SkG"
@@ -100,9 +100,9 @@ msgid "{percentage} Energy"
 msgstr "{percentage} de Energía"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "3Jd-mJ"
-msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
-msgstr "Tu esfuerzo está dando resultado. Completa lecciones cada día para aumentar tu Energía."
+msgctxt "pQ9XJb"
+msgid "You're building good momentum. Learning regularly and getting answers right will keep your Energy moving up."
+msgstr "Estás avanzando a buen ritmo. Estudiar con regularidad y acertar las respuestas hará que tu Energía siga aumentando."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "5YVYKd"
@@ -115,9 +115,9 @@ msgid "{days} days of max Energy"
 msgstr "{days} días de Energía al máximo"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "cIxpmv"
-msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
-msgstr "¡Guau, qué constancia tan increíble! Sigue estudiando cada día para mantener tu Energía al 100 %."
+msgctxt "wl6CDc"
+msgid "You're building real consistency. Learning every day helps keep your mind active and improve your performance."
+msgstr "Estás logrando una gran constancia. Estudiar todos los días mantiene tu mente activa y te ayuda a mejorar tu rendimiento."
 
 #: src/components/completion-learning-days-milestone.tsx
 msgctxt "SIXtG5"
@@ -125,9 +125,9 @@ msgid "{days} learning days"
 msgstr "{days} días de estudio"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "hjXoGI"
-msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
-msgstr "Completaste lecciones en {days} días diferentes. Practicar a menudo te ayuda a recordar lo que aprendes."
+msgctxt "_M8z1y"
+msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
+msgstr "El estudio ya forma parte de tu rutina. Practicar con regularidad te ayuda a recordar mejor lo que aprendes."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -145,19 +145,9 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# hora de estudio} other {# horas de estudio}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "WcAhMT"
-msgid "You can learn a lot by practicing for a few minutes a day."
-msgstr "Puedes aprender mucho practicando unos minutos al día."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "LzEQnT"
-msgid "That's a full day of focused practice."
-msgstr "Eso es un día completo de práctica concentrada."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "PpK3hX"
-msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
-msgstr "Eso es más de {days, plural, one {# día completo} other {# días completos}} de práctica concentrada."
+msgctxt "YYZPzp"
+msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
+msgstr "Todo el tiempo que dedicas al estudio suma. Incluso las sesiones cortas y frecuentes ayudan a que las ideas nuevas se queden contigo."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -165,19 +155,19 @@ msgid "Level achieved"
 msgstr "Nivel alcanzado"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Ar7dNY"
-msgid "You reached a new level: {belt}, level {level}. Congrats!"
-msgstr "Alcanzaste un nuevo nivel: {belt}, nivel {level}. ¡Felicidades!"
+msgctxt "WheDiX"
+msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
+msgstr "Tu esfuerzo está dando frutos: alcanzaste {belt}, nivel {level}. Sigue así: cada lección aumenta tu Poder Mental."
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Bk6B6r"
-msgid "Almost there"
-msgstr "Ya casi"
+msgctxt "VfEqvB"
+msgid "Halfway there"
+msgstr "Ya estás a mitad de camino"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "b7ZoLo"
-msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
-msgstr "Tu conocimiento está creciendo. Completa {count, plural, one {# lección más} other {# lecciones más}} para llegar a {belt}, nivel {level}."
+msgctxt "LrDO2N"
+msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more lesson will get you there} other {# more lessons will get you there}}."
+msgstr "Ya recorriste la mitad del camino hacia {belt}, nivel {level}. {count, plural, one {Una lección más y llegarás} other {# lecciones más y llegarás}}."
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "DiIkZH"
@@ -200,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} es tu mejor día"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "PTQ0ah"
-msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
-msgstr "Sueles acertar el {percentage} de las respuestas los {day}, tu promedio más alto de la semana."
+msgctxt "bim3gG"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
+msgstr "Tu promedio es de {percentage} {day, select, sunday {los domingos} monday {los lunes} tuesday {los martes} wednesday {los miércoles} thursday {los jueves} friday {los viernes} saturday {los sábados} other {en tu mejor día}}, mejor que cualquier otro día. Piensa en qué funciona bien ese día: quizá puedas aplicarlo durante toda la semana."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -80,9 +80,9 @@ msgid "New daily best"
 msgstr "Nouveau record du jour"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "VaM8Q9"
-msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
-msgstr "Tu as atteint {brainPower} PM aujourd’hui, ta plus grande Puissance Mentale en une seule journée. Continue à apprendre chaque jour pour battre ton record."
+msgctxt "0TbCx0"
+msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
+msgstr "Tu as gagné {brainPower} PM aujourd’hui, plus que n’importe quel autre jour. Continue comme ça : tes efforts porteront leurs fruits."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -90,9 +90,9 @@ msgid "Max Energy!"
 msgstr "Énergie au max !"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "Fo6YtA"
-msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
-msgstr "Bravo ! Tu as atteint le maximum d’Énergie. Continue à t’entraîner chaque jour pour garder ton Énergie à 100 %."
+msgctxt "WwRCBI"
+msgid "You've been learning regularly and answering accurately. Stay consistent to keep your Energy at 100%."
+msgstr "Tu apprends régulièrement et donnes de bonnes réponses. Garde ce rythme pour maintenir ton Énergie à 100 %."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "J89SkG"
@@ -100,9 +100,9 @@ msgid "{percentage} Energy"
 msgstr "{percentage} Énergie"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "3Jd-mJ"
-msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
-msgstr "Tes efforts paient. Termine des leçons chaque jour pour augmenter ton Énergie."
+msgctxt "pQ9XJb"
+msgid "You're building good momentum. Learning regularly and getting answers right will keep your Energy moving up."
+msgstr "Tu es sur une bonne lancée. Apprends régulièrement et donne de bonnes réponses pour continuer à faire monter ton Énergie."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "5YVYKd"
@@ -115,9 +115,9 @@ msgid "{days} days of max Energy"
 msgstr "{days} jours d’Énergie au max"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "cIxpmv"
-msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
-msgstr "Waouh, quelle régularité incroyable ! Continue à étudier chaque jour pour garder ton Énergie à 100 %."
+msgctxt "wl6CDc"
+msgid "You're building real consistency. Learning every day helps keep your mind active and improve your performance."
+msgstr "Tu deviens vraiment régulier. Apprendre chaque jour aide à garder l’esprit actif et à progresser."
 
 #: src/components/completion-learning-days-milestone.tsx
 msgctxt "SIXtG5"
@@ -125,9 +125,9 @@ msgid "{days} learning days"
 msgstr "{days} jours d’apprentissage"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "hjXoGI"
-msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
-msgstr "Tu as terminé des leçons sur {days} jours différents. T’entraîner souvent t’aide à retenir ce que tu apprends."
+msgctxt "_M8z1y"
+msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
+msgstr "Apprendre fait désormais partie de tes habitudes. T’entraîner régulièrement t’aide à mieux retenir ce que tu apprends."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -145,19 +145,9 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# heure d’apprentissage} other {# heures d’apprentissage}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "WcAhMT"
-msgid "You can learn a lot by practicing for a few minutes a day."
-msgstr "Tu peux apprendre beaucoup en t’entraînant quelques minutes par jour."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "LzEQnT"
-msgid "That's a full day of focused practice."
-msgstr "C’est une journée complète d’entraînement concentré."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "PpK3hX"
-msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
-msgstr "C’est plus de {days, plural, one {# journée complète} other {# journées complètes}} d’entraînement concentré."
+msgctxt "YYZPzp"
+msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
+msgstr "Tout ce temps passé à apprendre finit par compter. Même de courtes sessions régulières peuvent t’aider à retenir de nouvelles idées."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -165,19 +155,19 @@ msgid "Level achieved"
 msgstr "Niveau atteint"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Ar7dNY"
-msgid "You reached a new level: {belt}, level {level}. Congrats!"
-msgstr "Tu as atteint un nouveau niveau : {belt}, niveau {level}. Bravo !"
+msgctxt "WheDiX"
+msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
+msgstr "Tes efforts portent leurs fruits : tu as atteint {belt}, niveau {level}. Continue comme ça : chaque leçon augmente ta Puissance Mentale."
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Bk6B6r"
-msgid "Almost there"
-msgstr "Presque"
+msgctxt "VfEqvB"
+msgid "Halfway there"
+msgstr "À mi-chemin"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "b7ZoLo"
-msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
-msgstr "Tes connaissances progressent. Termine encore {count, plural, one {# leçon} other {# leçons}} pour atteindre {belt}, niveau {level}."
+msgctxt "LrDO2N"
+msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more lesson will get you there} other {# more lessons will get you there}}."
+msgstr "Tu es à mi-chemin de {belt}, niveau {level}. {count, plural, one {Encore une leçon et tu y seras} other {Encore # leçons et tu y seras}}."
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "DiIkZH"
@@ -200,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} est ton meilleur jour"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "PTQ0ah"
-msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
-msgstr "Tu obtiens généralement {percentage} de bonnes réponses le {day}, ta meilleure moyenne de la semaine."
+msgctxt "bim3gG"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
+msgstr "Tu obtiens en moyenne {percentage} {day, select, sunday {le dimanche} monday {le lundi} tuesday {le mardi} wednesday {le mercredi} thursday {le jeudi} friday {le vendredi} saturday {le samedi} other {lors de ton meilleur jour}}, plus que n’importe quel autre jour. Réfléchis à ce qui fonctionne bien ce jour-là : tu pourras peut-être t’en servir toute la semaine."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -80,9 +80,9 @@ msgid "New daily best"
 msgstr "Novo recorde diário"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "VaM8Q9"
-msgid "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best."
-msgstr "Você chegou a {brainPower} PM hoje, seu maior Poder Mental em um só dia. Continue estudando todos os dias para bater esse recorde."
+msgctxt "0TbCx0"
+msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
+msgstr "Você ganhou {brainPower} PM hoje, mais do que em qualquer outro dia. Continue assim — esse esforço vai valer a pena."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -90,9 +90,9 @@ msgid "Max Energy!"
 msgstr "Energia máxima!"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "Fo6YtA"
-msgid "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%."
-msgstr "Parabéns! Você chegou à Energia máxima. Continue praticando todos os dias para manter sua Energia em 100%."
+msgctxt "WwRCBI"
+msgid "You've been learning regularly and answering accurately. Stay consistent to keep your Energy at 100%."
+msgstr "Você tem estudado com frequência e acertado as respostas. Mantenha a constância para deixar sua Energia em 100%."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "J89SkG"
@@ -100,9 +100,9 @@ msgid "{percentage} Energy"
 msgstr "{percentage} de Energia"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "3Jd-mJ"
-msgid "Your effort is paying off. Complete lessons every day to increase your Energy."
-msgstr "Seu esforço está dando resultado. Complete aulas todos os dias para aumentar sua Energia."
+msgctxt "pQ9XJb"
+msgid "You're building good momentum. Learning regularly and getting answers right will keep your Energy moving up."
+msgstr "Você está pegando um bom ritmo. Estudar com frequência e acertar as respostas vai continuar aumentando sua Energia."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "5YVYKd"
@@ -115,9 +115,9 @@ msgid "{days} days of max Energy"
 msgstr "{days} dias de Energia máxima"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "cIxpmv"
-msgid "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%."
-msgstr "Uau, que consistência incrível! Continue estudando todos os dias para manter sua Energia em 100%."
+msgctxt "wl6CDc"
+msgid "You're building real consistency. Learning every day helps keep your mind active and improve your performance."
+msgstr "Você está criando uma rotina de verdade. Estudar todos os dias ajuda a manter a mente ativa e melhorar seu desempenho."
 
 #: src/components/completion-learning-days-milestone.tsx
 msgctxt "SIXtG5"
@@ -125,9 +125,9 @@ msgid "{days} learning days"
 msgstr "{days} dias de estudo"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "hjXoGI"
-msgid "You've completed lessons on {days} different days. Practicing often helps you remember what you learn."
-msgstr "Você completou aulas em {days} dias diferentes. Praticar com frequência te ajuda a lembrar o que você aprende."
+msgctxt "_M8z1y"
+msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
+msgstr "O estudo está virando parte da sua rotina. Praticar com frequência te ajuda a lembrar melhor o que aprendeu."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -145,19 +145,9 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# hora de estudo} other {# horas de estudo}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "WcAhMT"
-msgid "You can learn a lot by practicing for a few minutes a day."
-msgstr "Você pode aprender muito praticando por alguns minutos por dia."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "LzEQnT"
-msgid "That's a full day of focused practice."
-msgstr "Isso é um dia inteiro de prática focada."
-
-#: src/components/completion-learning-time-milestone.tsx
-msgctxt "PpK3hX"
-msgid "That's more than {days, plural, one {# full day} other {# full days}} of focused practice."
-msgstr "Isso é mais de {days, plural, one {# dia inteiro} other {# dias inteiros}} de prática focada."
+msgctxt "YYZPzp"
+msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
+msgstr "Todo esse tempo de estudo faz diferença. Mesmo sessões curtas e frequentes ajudam a fixar novas ideias."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -165,19 +155,19 @@ msgid "Level achieved"
 msgstr "Nível alcançado"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Ar7dNY"
-msgid "You reached a new level: {belt}, level {level}. Congrats!"
-msgstr "Você chegou a um novo nível: {belt}, nível {level}. Parabéns!"
+msgctxt "WheDiX"
+msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
+msgstr "Seu esforço está valendo a pena — você chegou à {belt}, nível {level}. Continue assim — cada aula aumenta seu Poder Mental."
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "Bk6B6r"
-msgid "Almost there"
-msgstr "Quase lá"
+msgctxt "VfEqvB"
+msgid "Halfway there"
+msgstr "Você já chegou à metade"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "b7ZoLo"
-msgid "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}."
-msgstr "Seu conhecimento está crescendo. Complete {count, plural, one {mais # aula} other {mais # aulas}} para chegar a {belt}, nível {level}."
+msgctxt "LrDO2N"
+msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more lesson will get you there} other {# more lessons will get you there}}."
+msgstr "Você está na metade do caminho para chegar à {belt}, nível {level}. {count, plural, one {Só falta mais uma aula} other {Só faltam mais # aulas}}."
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "DiIkZH"
@@ -200,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} é seu melhor dia"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "PTQ0ah"
-msgid "You usually get {percentage} of answers right on {day}, your highest average of the week."
-msgstr "Você costuma acertar {percentage} das respostas em {day}, sua maior média da semana."
+msgctxt "bim3gG"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
+msgstr "Sua média é de {percentage} {day, select, sunday {aos domingos} monday {às segundas-feiras} tuesday {às terças-feiras} wednesday {às quartas-feiras} thursday {às quintas-feiras} friday {às sextas-feiras} saturday {aos sábados} other {no seu melhor dia}}, melhor do que em qualquer outro dia. Pense no que dá certo nesse dia — talvez você possa usar isso durante toda a semana."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -163,10 +163,8 @@ describe("player browser integration: completion", () => {
 
     const milestoneScreen = page.getByRole("status");
 
-    await expect.element(milestoneScreen.getByText(/level achieved/iu)).toBeInTheDocument();
-
     await expect
-      .element(milestoneScreen.getByText(/you reached a new level/iu))
+      .element(milestoneScreen.getByRole("heading", { name: /level achieved/iu }))
       .toBeInTheDocument();
 
     await expect
@@ -197,9 +195,9 @@ describe("player browser integration: completion", () => {
 
     const milestoneScreen = page.getByRole("status");
 
-    await expect.element(milestoneScreen.getByText(/almost there/iu)).toBeInTheDocument();
-
-    await expect.element(milestoneScreen.getByText(/complete/iu)).toBeInTheDocument();
+    await expect
+      .element(milestoneScreen.getByRole("heading", { name: /halfway there/iu }))
+      .toBeInTheDocument();
 
     await milestoneScreen.getByRole("button", { name: /continue/iu }).click();
 
@@ -219,9 +217,9 @@ describe("player browser integration: completion", () => {
 
     const milestoneScreen = page.getByRole("status");
 
-    await expect.element(milestoneScreen.getByText(/10% energy/iu)).toBeInTheDocument();
-
-    await expect.element(milestoneScreen.getByText(/effort is paying off/iu)).toBeInTheDocument();
+    await expect
+      .element(milestoneScreen.getByRole("heading", { name: /10% energy/iu }))
+      .toBeInTheDocument();
 
     await expect
       .element(milestoneScreen.getByRole("link", { name: /learn about energy/iu }))
@@ -296,9 +294,9 @@ describe("player browser integration: completion", () => {
 
     const milestoneScreen = page.getByRole("status");
 
-    await expect.element(milestoneScreen.getByText(/5 learning days/iu)).toBeInTheDocument();
-
-    await expect.element(milestoneScreen.getByText(/different days/iu)).toBeInTheDocument();
+    await expect
+      .element(milestoneScreen.getByRole("heading", { name: /5 learning days/iu }))
+      .toBeInTheDocument();
 
     await expect
       .element(milestoneScreen.getByRole("link", { name: /learn about levels/iu }))
@@ -327,10 +325,8 @@ describe("player browser integration: completion", () => {
 
     const milestoneScreen = page.getByRole("status");
 
-    await expect.element(milestoneScreen.getByText(/is your best day/iu)).toBeInTheDocument();
-
     await expect
-      .element(milestoneScreen.getByText(/you usually get .* of answers right/iu))
+      .element(milestoneScreen.getByRole("heading", { name: /is your best day/iu }))
       .toBeInTheDocument();
 
     await expect

--- a/packages/player/src/components/completion-brain-power-milestone.tsx
+++ b/packages/player/src/components/completion-brain-power-milestone.tsx
@@ -29,7 +29,7 @@ export function BrainPowerMilestoneCopy({ milestone }: { milestone: BrainPowerMi
       <CompletionMilestoneTitle>{t("New daily best")}</CompletionMilestoneTitle>
       <PlayerSupportingText>
         {t(
-          "You reached {brainPower} BP today, your highest Brain Power in a single day. Keep learning every day to set a new best.",
+          "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off.",
           { brainPower: formattedBrainPower },
         )}
       </PlayerSupportingText>

--- a/packages/player/src/components/completion-energy-milestone.tsx
+++ b/packages/player/src/components/completion-energy-milestone.tsx
@@ -33,7 +33,7 @@ function EnergyThresholdCopy({
         <CompletionMilestoneTitle>{t("Max Energy!")}</CompletionMilestoneTitle>
         <PlayerSupportingText>
           {t(
-            "Congrats! You reached max Energy. Keep practicing every day to keep your Energy at 100%.",
+            "You've been learning regularly and answering accurately. Stay consistent to keep your Energy at 100%.",
           )}
         </PlayerSupportingText>
       </>
@@ -48,7 +48,9 @@ function EnergyThresholdCopy({
         })}
       </CompletionMilestoneTitle>
       <PlayerSupportingText>
-        {t("Your effort is paying off. Complete lessons every day to increase your Energy.")}
+        {t(
+          "You're building good momentum. Learning regularly and getting answers right will keep your Energy moving up.",
+        )}
       </PlayerSupportingText>
     </>
   );
@@ -82,7 +84,7 @@ function FullEnergyDaysCopy({
       <FullEnergyDaysTitle days={milestone.days} />
       <PlayerSupportingText>
         {t(
-          "Wow, what incredible consistency! Keep studying every day to keep your Energy at 100%.",
+          "You're building real consistency. Learning every day helps keep your mind active and improve your performance.",
         )}
       </PlayerSupportingText>
     </>

--- a/packages/player/src/components/completion-learning-days-milestone.tsx
+++ b/packages/player/src/components/completion-learning-days-milestone.tsx
@@ -39,8 +39,7 @@ export function LearningDaysMilestoneCopy({ milestone }: { milestone: LearningDa
       </CompletionMilestoneTitle>
       <PlayerSupportingText>
         {t(
-          "You've completed lessons on {days} different days. Practicing often helps you remember what you learn.",
-          { days: formattedDays },
+          "You're making learning part of your routine. Regular practice helps you remember more of what you learn.",
         )}
       </PlayerSupportingText>
     </>

--- a/packages/player/src/components/completion-learning-time-milestone.tsx
+++ b/packages/player/src/components/completion-learning-time-milestone.tsx
@@ -61,34 +61,16 @@ function LearningTimeMilestoneTitle({ seconds }: { seconds: number }) {
 }
 
 /**
- * Adds the day equivalent once the learner reaches 24 hours, matching the
- * progress-page idea that long learning time is easier to feel in full days.
+ * Connects accumulated learning time to the value of regular practice without
+ * repeating the duration already shown in the milestone title.
  */
-function LearningTimeMilestoneDescription({ seconds }: { seconds: number }) {
+function LearningTimeMilestoneDescription() {
   const t = useExtracted();
-  const hours = Math.round(seconds / SECONDS_PER_MINUTE / MINUTES_PER_HOUR);
-
-  if (hours < HOURS_PER_DAY) {
-    return (
-      <PlayerSupportingText>
-        {t("You can learn a lot by practicing for a few minutes a day.")}
-      </PlayerSupportingText>
-    );
-  }
-
-  if (hours === HOURS_PER_DAY) {
-    return (
-      <PlayerSupportingText>{t("That's a full day of focused practice.")}</PlayerSupportingText>
-    );
-  }
-
-  const fullDays = Math.floor(hours / HOURS_PER_DAY);
 
   return (
     <PlayerSupportingText>
       {t(
-        "That's more than {days, plural, one {# full day} other {# full days}} of focused practice.",
-        { days: fullDays },
+        "All that time spent learning adds up. Even short, regular sessions can help new ideas stick.",
       )}
     </PlayerSupportingText>
   );
@@ -102,7 +84,7 @@ export function LearningTimeMilestoneCopy({ milestone }: { milestone: LearningTi
   return (
     <>
       <LearningTimeMilestoneTitle seconds={milestone.seconds} />
-      <LearningTimeMilestoneDescription seconds={milestone.seconds} />
+      <LearningTimeMilestoneDescription />
     </>
   );
 }

--- a/packages/player/src/components/completion-level-milestone.tsx
+++ b/packages/player/src/components/completion-level-milestone.tsx
@@ -35,10 +35,10 @@ function AchievedLevelCopy({
     <>
       <CompletionMilestoneTitle>{t("Level achieved")}</CompletionMilestoneTitle>
       <PlayerSupportingText>
-        {t("You reached a new level: {belt}, level {level}. Congrats!", {
-          belt: beltLabel,
-          level: String(milestone.belt.level),
-        })}
+        {t(
+          "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power.",
+          { belt: beltLabel, level: String(milestone.belt.level) },
+        )}
       </PlayerSupportingText>
     </>
   );
@@ -54,10 +54,10 @@ function HalfwayLevelCopy({
 
   return (
     <>
-      <CompletionMilestoneTitle>{t("Almost there")}</CompletionMilestoneTitle>
+      <CompletionMilestoneTitle>{t("Halfway there")}</CompletionMilestoneTitle>
       <PlayerSupportingText>
         {t(
-          "Your knowledge is growing. Complete {count, plural, one {# more lesson} other {# more lessons}} to reach {belt}, level {level}.",
+          "You're halfway to {belt}, level {level}. {count, plural, one {One more lesson will get you there} other {# more lessons will get you there}}.",
           {
             belt: beltLabel,
             count: milestone.remainingLessons,

--- a/packages/player/src/components/completion-milestone-shell.tsx
+++ b/packages/player/src/components/completion-milestone-shell.tsx
@@ -53,7 +53,10 @@ export function CompletionMilestoneMark({
 export function CompletionMilestoneCopy({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      className={cn("flex max-w-md flex-col items-center gap-3 text-center", className)}
+      className={cn(
+        "flex max-w-md flex-col items-center gap-3 text-center text-balance",
+        className,
+      )}
       data-slot="completion-milestone-copy"
       {...props}
     />
@@ -71,7 +74,7 @@ export function CompletionMilestoneTitle({
 }: React.ComponentProps<"h2">) {
   return (
     <h2
-      className={cn("text-3xl font-semibold tracking-tight sm:text-4xl", className)}
+      className={cn("text-3xl font-semibold tracking-tight text-pretty sm:text-4xl", className)}
       data-slot="completion-milestone-title"
       {...props}
     >

--- a/packages/player/src/components/completion-patterns-milestone.tsx
+++ b/packages/player/src/components/completion-patterns-milestone.tsx
@@ -10,6 +10,18 @@ import { PlayerSupportingText } from "./player-supporting-text";
 
 type PatternsMilestone = Extract<PlayerCompletionMilestone, { kind: "patterns" }>;
 
+const WEEKDAY_KEYS = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+] as const;
+
+type WeekdayKey = (typeof WEEKDAY_KEYS)[number] | "other";
+
 /**
  * Patterns milestones use a trophy mark because this screen highlights the
  * learner's strongest weekday for answer accuracy.
@@ -35,6 +47,14 @@ function getWeekdayName({ dayOfWeek, locale }: { dayOfWeek: number; locale: stri
 }
 
 /**
+ * Passes a stable weekday enum into ICU messages so each translation can keep
+ * weekday-specific prepositions and articles inside its own select branches.
+ */
+function getWeekdayKey(dayOfWeek: number): WeekdayKey {
+  return WEEKDAY_KEYS[dayOfWeek] ?? "other";
+}
+
+/**
  * Names the learner's best weekday and repeats the Patterns-page percentage so
  * the milestone feels connected to the page it links to.
  */
@@ -43,6 +63,7 @@ export function PatternsMilestoneCopy({ milestone }: { milestone: PatternsMilest
   const format = useFormatter();
   const locale = useLocale();
   const dayName = getWeekdayName({ dayOfWeek: milestone.dayOfWeek, locale });
+  const weekdayKey = getWeekdayKey(milestone.dayOfWeek);
   const formattedScore = formatMetricPercent({ format, value: milestone.score });
 
   return (
@@ -52,8 +73,8 @@ export function PatternsMilestoneCopy({ milestone }: { milestone: PatternsMilest
       </CompletionMilestoneTitle>
       <PlayerSupportingText>
         {t(
-          "You usually get {percentage} of answers right on {day}, your highest average of the week.",
-          { day: dayName, percentage: formattedScore },
+          "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week.",
+          { day: weekdayKey, percentage: formattedScore },
         )}
       </PlayerSupportingText>
     </>


### PR DESCRIPTION
## Summary

- improve milestone descriptions with clearer, encouraging explanations
- apply balanced title and description wrapping across milestone screens
- make best-day wording locale-aware and align completion browser coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved player milestone copy for clarity and encouragement, with locale‑aware best‑day messaging. Refined text wrapping and updated tests to assert headings for better semantics.

- **New Features**
  - Rewrote messages for Brain Power, Energy, Learning Days/Time, and Level milestones.
  - Changed “Almost there” to “Halfway there” with explicit remaining‑lesson guidance.
  - Best‑day patterns now use ICU select with weekday keys for locale‑accurate phrasing.
  - Updated translations for `en`, `de`, `es`, `fr`, and `pt`.

- **Refactors**
  - Applied `text-balance` and `text-pretty` to milestone copy and titles for better wrapping.
  - Updated completion tests to assert headings and removed a brittle hover assertion in the Energy e2e.

<sup>Written for commit dcc63c733ba4e9030cfff61d98fd8ecd622456b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

