### PR TITLE
fix(main): improve subscription gate copy

### DIFF
--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -167,9 +167,9 @@ test.describe("Generate Chapter Page - Unauthenticated", () => {
     const { chapter } = await createPendingChapter(1);
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByText(/^upgrade to create$/iu)).toBeVisible();
+    await expect(page.getByText(/^keep learning with plus$/iu)).toBeVisible();
 
-    const upgradeLink = page.getByRole("link", { name: /upgrade/iu });
+    const upgradeLink = page.getByRole("link", { name: /get zoonk plus/iu });
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
@@ -180,9 +180,9 @@ test.describe("Generate Chapter Page - No Subscription", () => {
     const { chapter } = await createPendingChapter(1);
     await authenticatedPage.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(authenticatedPage.getByText(/^upgrade to create$/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^keep learning with plus$/iu)).toBeVisible();
 
-    const upgradeLink = authenticatedPage.getByRole("link", { name: /upgrade/iu });
+    const upgradeLink = authenticatedPage.getByRole("link", { name: /get zoonk plus/iu });
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
@@ -204,7 +204,7 @@ test.describe("Generate Chapter Page - No Subscription", () => {
 
     await authenticatedPage.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(authenticatedPage.getByText(/^upgrade to create$/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^keep learning with plus$/iu)).toBeVisible();
   });
 });
 
@@ -526,7 +526,7 @@ test.describe("Generate Chapter Page - First Chapter Free", () => {
 
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByText(/^upgrade to create$/iu)).toHaveCount(0);
+    await expect(page.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
     await expect(page.getByRole("heading", { name: chapter.title })).toBeVisible();
   });
 
@@ -542,7 +542,7 @@ test.describe("Generate Chapter Page - First Chapter Free", () => {
 
     await authenticatedPage.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(authenticatedPage.getByText(/^upgrade to create$/iu)).toHaveCount(0);
+    await expect(authenticatedPage.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
     await expect(authenticatedPage.getByRole("heading", { name: chapter.title })).toBeVisible();
   });
 });
@@ -577,8 +577,13 @@ test.describe("Generate Chapter Page - Running Later Chapter Requires Subscripti
 
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByText(/^upgrade to create$/iu)).toBeVisible();
-    await expect(page.getByText(/you.ve reached your free lesson limit/iu)).toBeVisible();
+    await expect(page.getByText(/^keep learning with plus$/iu)).toBeVisible();
+
+    await expect(
+      page.getByText(
+        "Plus gives you unlimited courses and lessons for whatever you want to learn.",
+      ),
+    ).toBeVisible();
   });
 });
 

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -298,10 +298,15 @@ test.describe("Generate Lesson Page - Unauthenticated", () => {
     const { lesson } = await createPendingLesson({ chapterPosition: 1 });
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByText(/^upgrade to create$/iu)).toBeVisible();
-    await expect(page.getByText(/you.ve reached your free lesson limit/iu)).toBeVisible();
+    await expect(page.getByText(/^keep learning with plus$/iu)).toBeVisible();
 
-    const upgradeLink = page.getByRole("link", { name: /upgrade/iu });
+    await expect(
+      page.getByText(
+        "Plus gives you unlimited courses and lessons for whatever you want to learn.",
+      ),
+    ).toBeVisible();
+
+    const upgradeLink = page.getByRole("link", { name: /get zoonk plus/iu });
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
@@ -312,9 +317,9 @@ test.describe("Generate Lesson Page - No Subscription", () => {
     const { lesson } = await createPendingLesson({ chapterPosition: 1 });
     await authenticatedPage.goto(`/generate/l/${lesson.id}`);
 
-    await expect(authenticatedPage.getByText(/^upgrade to create$/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^keep learning with plus$/iu)).toBeVisible();
 
-    const upgradeLink = authenticatedPage.getByRole("link", { name: /upgrade/iu });
+    const upgradeLink = authenticatedPage.getByRole("link", { name: /get zoonk plus/iu });
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });
@@ -333,7 +338,7 @@ test.describe("Generate Lesson Page - No Subscription", () => {
 
     await authenticatedPage.goto(`/generate/l/${lesson.id}`);
 
-    await expect(authenticatedPage.getByText(/^upgrade to create$/iu)).toBeVisible();
+    await expect(authenticatedPage.getByText(/^keep learning with plus$/iu)).toBeVisible();
   });
 });
 
@@ -350,7 +355,7 @@ test.describe("Generate Lesson Page - First Chapter Free", () => {
 
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByText(/^upgrade to create$/iu)).toHaveCount(0);
+    await expect(page.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
 
     await expect(page.getByRole("heading", { name: lesson.title ?? "" })).toBeVisible();
   });
@@ -367,7 +372,7 @@ test.describe("Generate Lesson Page - First Chapter Free", () => {
 
     await authenticatedPage.goto(`/generate/l/${lesson.id}`);
 
-    await expect(authenticatedPage.getByText(/^upgrade to create$/iu)).toHaveCount(0);
+    await expect(authenticatedPage.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
 
     await expect(
       authenticatedPage.getByRole("heading", { name: lesson.title ?? "" }),
@@ -600,7 +605,7 @@ test.describe("Generate Lesson Page - Running Later Lesson Requires Subscription
 
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByText(/^upgrade to create$/iu)).toBeVisible();
+    await expect(page.getByText(/^keep learning with plus$/iu)).toBeVisible();
   });
 });
 

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -568,14 +568,10 @@ test.describe("Lesson Player Page", () => {
 
     await expect(authenticatedPage.getByText(`E2E lesson description ${uniqueId}`)).toBeVisible();
 
-    await expect(
-      authenticatedPage.getByText(
-        "You’ve reached your free lesson limit. Upgrade for unlimited lessons",
-      ),
-    ).toBeVisible();
+    await expect(authenticatedPage.getByText("This lesson is included with Plus.")).toBeVisible();
 
     const backLink = authenticatedPage.getByRole("link", { name: /back to chapter/iu });
-    const upgradeLink = authenticatedPage.getByRole("link", { name: /upgrade/iu });
+    const upgradeLink = authenticatedPage.getByRole("link", { name: /get zoonk plus/iu });
 
     await expect(backLink).toBeVisible();
     await expect(backLink.getByText(/^Esc$/u)).toBeVisible();
@@ -594,7 +590,8 @@ test.describe("Lesson Player Page", () => {
     });
 
     await authenticatedPage.goto(lessonHref);
-    await expect(authenticatedPage.getByRole("link", { name: /upgrade/iu })).toBeVisible();
+
+    await expect(authenticatedPage.getByRole("link", { name: /get zoonk plus/iu })).toBeVisible();
 
     await pressShortcutAndWaitForUrl({
       expectedUrl: "/subscription",

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -1668,10 +1668,9 @@ msgid "Back to chapter"
 msgstr "Zurück zum Kapitel"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "Du hast dein Limit für kostenlose Lektionen erreicht. Upgrade für unbegrenzte Lektionen"
+msgctxt "qmXr1f"
+msgid "This lesson is included with Plus."
+msgstr "Mit Plus ist diese Lektion enthalten."
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2711,14 +2710,19 @@ msgid "Learning time"
 msgstr "Lernzeit"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "IS_YjO"
-msgid "Upgrade to create"
-msgstr "Zum Erstellen upgraden"
+msgctxt "NU-lfu"
+msgid "Keep learning with Plus"
+msgstr "Mit Plus weiterlernen"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "0h_lPM"
-msgid "Upgrade"
-msgstr "Upgrade"
+msgctxt "X4sblx"
+msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
+msgstr "Mit Plus erhältst du unbegrenzten Zugriff auf Kurse und Lektionen zu allem, was du lernen möchtest."
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Zoonk Plus holen"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1668,10 +1668,9 @@ msgid "Back to chapter"
 msgstr "Back to chapter"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
+msgctxt "qmXr1f"
+msgid "This lesson is included with Plus."
+msgstr "This lesson is included with Plus."
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2711,14 +2710,19 @@ msgid "Learning time"
 msgstr "Learning time"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "IS_YjO"
-msgid "Upgrade to create"
-msgstr "Upgrade to create"
+msgctxt "NU-lfu"
+msgid "Keep learning with Plus"
+msgstr "Keep learning with Plus"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "0h_lPM"
-msgid "Upgrade"
-msgstr "Upgrade"
+msgctxt "X4sblx"
+msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
+msgstr "Plus gives you unlimited courses and lessons for whatever you want to learn."
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Get Zoonk Plus"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1668,10 +1668,9 @@ msgid "Back to chapter"
 msgstr "Volver al capítulo"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "Llegaste al límite de lecciones gratis. Mejora tu plan para tener lecciones ilimitadas"
+msgctxt "qmXr1f"
+msgid "This lesson is included with Plus."
+msgstr "Esta lección está incluida con Plus."
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2711,14 +2710,19 @@ msgid "Learning time"
 msgstr "Tiempo de estudio"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "IS_YjO"
-msgid "Upgrade to create"
-msgstr "Mejora tu plan para crear"
+msgctxt "NU-lfu"
+msgid "Keep learning with Plus"
+msgstr "Sigue estudiando con Plus"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "0h_lPM"
-msgid "Upgrade"
-msgstr "Mejorar plan"
+msgctxt "X4sblx"
+msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
+msgstr "Plus te ofrece cursos y lecciones ilimitados sobre lo que quieras aprender."
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Obtén Zoonk Plus"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -1668,10 +1668,9 @@ msgid "Back to chapter"
 msgstr "Retour au chapitre"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "Tu as atteint ta limite de leçons gratuites. Passe à l’offre supérieure pour des leçons illimitées"
+msgctxt "qmXr1f"
+msgid "This lesson is included with Plus."
+msgstr "Cette leçon est incluse avec Plus."
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2711,14 +2710,19 @@ msgid "Learning time"
 msgstr "Temps d’apprentissage"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "IS_YjO"
-msgid "Upgrade to create"
-msgstr "Passe à l’offre supérieure pour créer"
+msgctxt "NU-lfu"
+msgid "Keep learning with Plus"
+msgstr "Continue d’apprendre avec Plus"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "0h_lPM"
-msgid "Upgrade"
-msgstr "Passer à l’offre supérieure"
+msgctxt "X4sblx"
+msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
+msgstr "Plus te donne accès à des cours et des leçons en illimité sur tout ce que tu veux apprendre."
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Passe à Zoonk Plus"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1668,10 +1668,9 @@ msgid "Back to chapter"
 msgstr "Voltar ao capítulo"
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "ZMU6iN"
-msgid "You’ve reached your free lesson limit. Upgrade for unlimited lessons"
-msgstr "Você atingiu o limite de aulas grátis. Faça upgrade para ter aulas ilimitadas"
+msgctxt "qmXr1f"
+msgid "This lesson is included with Plus."
+msgstr "Esta aula está incluída no Plus."
 
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/review-lesson-empty.tsx
 msgctxt "4w9Y_P"
@@ -2711,14 +2710,19 @@ msgid "Learning time"
 msgstr "Tempo de estudo"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "IS_YjO"
-msgid "Upgrade to create"
-msgstr "Faça upgrade para criar"
+msgctxt "NU-lfu"
+msgid "Keep learning with Plus"
+msgstr "Continue estudando com o Plus"
 
 #: src/components/subscription/upgrade-cta.tsx
-msgctxt "0h_lPM"
-msgid "Upgrade"
-msgstr "Fazer upgrade"
+msgctxt "X4sblx"
+msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
+msgstr "Com o Plus, você tem cursos e aulas ilimitados sobre o que quiser aprender."
+
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Assine o Zoonk Plus"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -106,9 +106,7 @@ async function getLessonAccessGate({
         <UpgradeCTA backHref={backHref} backLabel={t("Back to chapter")}>
           <LessonPageSummary lesson={lesson} />
 
-          <LessonSummaryStatus>
-            {t("You’ve reached your free lesson limit. Upgrade for unlimited lessons")}
-          </LessonSummaryStatus>
+          <LessonSummaryStatus>{t("This lesson is included with Plus.")}</LessonSummaryStatus>
         </UpgradeCTA>
       </ContainerBody>
     </Container>

--- a/apps/main/src/components/subscription/subscription-gate.tsx
+++ b/apps/main/src/components/subscription/subscription-gate.tsx
@@ -4,8 +4,8 @@ import { type AppRoute } from "@/i18n/navigation";
 import { UpgradeCTA } from "./upgrade-cta";
 
 /**
- * Keeps generation pages on one subscription check and one upgrade message, so
- * chapter and lesson generation explain the free limit consistently.
+ * Keeps generation pages on one subscription check and one Plus message, so
+ * chapter and lesson generation present the offer consistently.
  */
 export async function SubscriptionGate<Href extends string>({
   backHref,

--- a/apps/main/src/components/subscription/upgrade-cta.tsx
+++ b/apps/main/src/components/subscription/upgrade-cta.tsx
@@ -14,8 +14,7 @@ import { SubscriptionGateTracker } from "./subscription-gate-tracker";
 
 /**
  * Preserves one tracked subscription action while allowing a calling page to
- * provide durable context that is more useful than the generic generation
- * limit message.
+ * provide durable context that is more useful than the generic Plus message.
  */
 export async function UpgradeCTA<Href extends string>({
   backHref,
@@ -38,10 +37,10 @@ export async function UpgradeCTA<Href extends string>({
             <SparklesIcon />
           </EmptyMedia>
 
-          <EmptyTitle>{t("Upgrade to create")}</EmptyTitle>
+          <EmptyTitle>{t("Keep learning with Plus")}</EmptyTitle>
 
           <EmptyDescription>
-            {t("You’ve reached your free lesson limit. Upgrade for unlimited lessons")}
+            {t("Plus gives you unlimited courses and lessons for whatever you want to learn.")}
           </EmptyDescription>
         </EmptyHeader>
       )}
@@ -52,7 +51,7 @@ export async function UpgradeCTA<Href extends string>({
         </GenerationShortcutLink>
 
         <GenerationShortcutLink href="/subscription" prefetch shortcut="Enter">
-          {t("Upgrade")}
+          {t("Get Zoonk Plus")}
         </GenerationShortcutLink>
       </EmptyContent>
     </Empty>


### PR DESCRIPTION
## Summary

- reframe subscription gates around continued learning and Plus benefits
- update lesson-specific copy, translations, and E2E expectations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reframed subscription gate copy to focus on Zoonk Plus benefits and removed “free limit” language for a clearer, more inviting CTA. Updated generate lesson/chapter and lesson player pages to show “Keep learning with Plus”, “Plus gives you unlimited courses and lessons for whatever you want to learn.”, “Get Zoonk Plus”, and “This lesson is included with Plus.”, with synced E2E tests and translations (en, de, es, fr, pt).

<sup>Written for commit 9a9466cc97e6ff13ef02479697ce5b2241a9d80e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

