### PR TITLE
fix(main): use app locale for hydration-sensitive output

### DIFF
--- a/apps/main/e2e/courses.test.ts
+++ b/apps/main/e2e/courses.test.ts
@@ -177,4 +177,38 @@ test.describe("Courses Page - Locale", () => {
 
     await expect(page.getByRole("heading", { name: /explorar cursos/iu })).toBeVisible();
   });
+
+  test("sorts categories using the active app locale", async ({ browser }) => {
+    const browserContext = await browser.newContext({
+      locale: "cs-CZ",
+      viewport: { height: 720, width: 800 },
+    });
+
+    const page = await browserContext.newPage();
+    const hydrationErrors: Error[] = [];
+
+    page.on("pageerror", (error) => hydrationErrors.push(error));
+
+    try {
+      await page.goto("/de/courses");
+      await expect(page.getByRole("button", { name: "Scroll right" })).toBeVisible();
+      expect(hydrationErrors).toEqual([]);
+
+      const labels = await page
+        .getByRole("navigation", { name: "Kurskategorien" })
+        .getByRole("link")
+        .allTextContents();
+
+      const categoryLabels = labels.slice(1);
+      const germanCollator = new Intl.Collator("de");
+
+      const expectedLabels = categoryLabels.toSorted((first, second) =>
+        germanCollator.compare(first, second),
+      );
+
+      expect(categoryLabels).toStrictEqual(expectedLabels);
+    } finally {
+      await browserContext.close();
+    }
+  });
 });

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -230,6 +230,41 @@ test.describe("Generate Course Page", () => {
   });
 
   test.describe("Initial triggering state", () => {
+    test("hydrates localized progress values consistently", async ({ browser }) => {
+      const request = await coursePromptFixture({
+        canonicalTitle: "E2E Localized Progress",
+        generationStatus: "pending",
+        language: "de",
+      });
+
+      const browserContext = await browser.newContext({ locale: "de-DE" });
+      const localizedPage = await browserContext.newPage();
+      const hydrationErrors: Error[] = [];
+
+      localizedPage.on("pageerror", (error) => hydrationErrors.push(error));
+
+      await setupMockApis(localizedPage, {
+        statusDelayMs: 2500,
+        streamMessages: [{ status: "started", step: "getCoursePrompt" }],
+      });
+
+      const triggerRequest = localizedPage.waitForRequest(
+        (pageRequest) =>
+          pageRequest.method() === "POST" &&
+          pageRequest.url().includes("/v1/workflows/course-generation/trigger"),
+      );
+
+      try {
+        await localizedPage.goto(`/de/generate/course/${request.id}`);
+        await triggerRequest;
+        await expect(localizedPage.getByRole("progressbar")).toBeVisible();
+
+        expect(hydrationErrors).toEqual([]);
+      } finally {
+        await browserContext.close();
+      }
+    });
+
     test("shows active generation feedback while the workflow is still starting", async ({
       authenticatedPage,
     }) => {

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -548,6 +548,32 @@ test.describe("Lesson Player Page", () => {
     ).toBeVisible();
   });
 
+  test("formats lesson progress using the app locale", async ({ browser, withProgressUser }) => {
+    const { chapter, course, lesson, uniqueId } = await createTestLesson({
+      generationStatus: "completed",
+      stepCount: 2,
+    });
+
+    const browserContext = await browser.newContext({
+      locale: "en-US",
+      storageState: withProgressUser.storageState,
+    });
+
+    const page = await browserContext.newPage();
+
+    try {
+      await page.goto(`/de/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+      await expect(page.getByRole("heading", { name: `Step ${uniqueId} #0` })).toBeVisible();
+
+      await expect(page.getByRole("progressbar", { name: "Lektionsfortschritt" })).toHaveAttribute(
+        "aria-valuetext",
+        new Intl.NumberFormat("de", { style: "percent" }).format(0.5),
+      );
+    } finally {
+      await browserContext.close();
+    }
+  });
+
   test("authenticated users without subscription see upgrade CTA for later chapters", async ({
     authenticatedPage,
   }) => {

--- a/apps/main/e2e/level.test.ts
+++ b/apps/main/e2e/level.test.ts
@@ -10,16 +10,22 @@ import { expect, test } from "./fixtures";
 async function createLevelTestPage({
   baseURL,
   browser,
+  browserLocale,
   totalBrainPower,
 }: {
   baseURL: string;
   browser: Browser;
+  browserLocale?: string;
   totalBrainPower: bigint;
 }) {
   const user = await createE2EUser(baseURL, { orgRole: "member" });
   await userProgressFixture({ totalBrainPower, userId: user.id });
 
-  const browserContext = await browser.newContext({ storageState: user.storageState });
+  const browserContext = await browser.newContext({
+    locale: browserLocale,
+    storageState: user.storageState,
+  });
+
   const page = await browserContext.newPage();
 
   return { browserContext, page };
@@ -67,6 +73,30 @@ test.describe("Level Page", () => {
         await expect(page.getByRole("navigation", { name: /period selection/iu })).toHaveCount(0);
         await expect(page.getByRole("figure", { name: /brain power chart/iu })).toHaveCount(0);
         await expect(page.getByRole("article", { name: /highest bp/iu })).toHaveCount(0);
+      } finally {
+        await browserContext.close();
+      }
+    });
+
+    test("formats level progress using the app locale", async ({ baseURL, browser }) => {
+      const { browserContext, page } = await createLevelTestPage({
+        baseURL: baseURL!,
+        browser,
+        browserLocale: "en-US",
+        totalBrainPower: 15_000n,
+      });
+
+      try {
+        await page.goto("/de/level");
+
+        const levelProgress = page.getByRole("progressbar", {
+          name: /500 bp bis zum nächsten level/iu,
+        });
+
+        await expect(levelProgress).toHaveAttribute(
+          "aria-valuetext",
+          new Intl.NumberFormat("de", { style: "percent" }).format(0.5),
+        );
       } finally {
         await browserContext.close();
       }

--- a/apps/main/src/app/[lang]/(catalog)/courses/category-pills.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/courses/category-pills.tsx
@@ -6,7 +6,7 @@ import { buttonVariants } from "@zoonk/ui/components/button";
 import { HorizontalScroll, HorizontalScrollContent } from "@zoonk/ui/components/horizontal-scroll";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { type CourseCategory } from "@zoonk/utils/categories";
-import { useExtracted } from "next-intl";
+import { useExtracted, useLocale } from "next-intl";
 import { useSelectedLayoutSegment } from "next/navigation";
 
 export function CategoryPillsSkeleton() {
@@ -29,6 +29,7 @@ export function CategoryPills({
 }) {
   const segment = useSelectedLayoutSegment();
   const t = useExtracted();
+  const locale = useLocale();
 
   return (
     <HorizontalScroll>
@@ -45,7 +46,7 @@ export function CategoryPills({
         </Link>
 
         {categories
-          .toSorted((a, b) => a.label.localeCompare(b.label))
+          .toSorted((a, b) => a.label.localeCompare(b.label, locale))
           .map((category) => {
             const Icon = CATEGORY_ICONS[category.key];
 

--- a/apps/main/src/app/[lang]/(progress)/level/level-stats.tsx
+++ b/apps/main/src/app/[lang]/(progress)/level/level-stats.tsx
@@ -10,7 +10,7 @@ import {
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { cn } from "@zoonk/ui/lib/utils";
 import { formatWholeNumber } from "@zoonk/utils/number";
-import { getExtracted, getFormatter } from "next-intl/server";
+import { getExtracted, getFormatter, getLocale } from "next-intl/server";
 import { ProgressHeadline, ProgressHeadlineValue } from "../_components/progress-headline";
 
 /**
@@ -29,6 +29,7 @@ function getLevelProgressPercentage(currentBelt: BeltLevelDetails): number {
 export async function LevelStats({ currentBelt }: { currentBelt: BeltLevelDetails }) {
   const t = await getExtracted();
   const format = await getFormatter();
+  const locale = await getLocale();
 
   const beltLabel = await getBeltLabel({ color: currentBelt.color });
   const formattedBpPerLevel = formatWholeNumber({ format, value: currentBelt.bpPerLevel });
@@ -48,7 +49,7 @@ export async function LevelStats({ currentBelt }: { currentBelt: BeltLevelDetail
         </div>
       </ProgressHeadline>
 
-      <ProgressRoot className="gap-y-2" value={progressPercentage}>
+      <ProgressRoot className="gap-y-2" locale={locale} value={progressPercentage}>
         <ProgressLabel>
           {currentBelt.isMaxLevel
             ? t("Max level reached")

--- a/apps/main/src/components/generation/generation-progress.tsx
+++ b/apps/main/src/components/generation/generation-progress.tsx
@@ -5,6 +5,7 @@ import { Button } from "@zoonk/ui/components/button";
 import { Progress, ProgressLabel, ProgressValue } from "@zoonk/ui/components/progress";
 import { cn } from "@zoonk/ui/lib/utils";
 import { AlertCircleIcon, CheckIcon, type LucideIcon } from "lucide-react";
+import { useLocale } from "next-intl";
 import { type ReactNode, useEffect, useRef } from "react";
 
 type PhaseStatus = "pending" | "active" | "completed";
@@ -37,10 +38,17 @@ function GenerationTimelineTitle({ children }: { children: ReactNode }) {
   );
 }
 
+/**
+ * Uses the app locale for percentage formatting so the server and browser
+ * render identical progress text even when their default locales differ.
+ */
 function GenerationTimelineProgress({ label, value }: { label: string; value: number }) {
+  const locale = useLocale();
+
   return (
     <Progress
       className="**:data-[slot=progress-indicator]:duration-700 **:data-[slot=progress-indicator]:ease-out **:data-[slot=progress-track]:h-2"
+      locale={locale}
       value={value}
     >
       <ProgressLabel className="sr-only">{label}</ProgressLabel>

--- a/packages/player/src/components/player-progress-bar.tsx
+++ b/packages/player/src/components/player-progress-bar.tsx
@@ -2,20 +2,23 @@
 
 import { ProgressIndicator, ProgressRoot, ProgressTrack } from "@zoonk/ui/components/progress";
 import { cn } from "@zoonk/ui/lib/utils";
-import { useExtracted } from "next-intl";
+import { useExtracted, useLocale } from "next-intl";
 
+/** Uses the app locale so assistive progress text matches the lesson language. */
 export function PlayerProgressBar({
   className,
   value,
   ...props
 }: Omit<React.ComponentProps<"div">, "value"> & { value: number }) {
   const t = useExtracted();
+  const locale = useLocale();
 
   return (
     <ProgressRoot
       aria-label={t("Lesson progress")}
       className={cn("gap-0", className)}
       data-slot="player-progress-bar"
+      locale={locale}
       value={value}
       {...props}
     >


### PR DESCRIPTION
## Summary

- use the active app locale for generation, lesson, and level progress values
- sort course categories with the active app locale to keep server and client output consistent
- add focused E2E regressions for React hydration errors and localized accessible progress text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hydration mismatches by using the active app locale for progress text and category sorting. Keeps server and client renders identical and improves localized accessibility text.

- **Bug Fixes**
  - Format generation, lesson, and level progress with the app locale by passing `locale` to `Progress`/`ProgressRoot` (via `next-intl` `useLocale`/`getLocale`).
  - Sort course categories using the active locale to align SSR/CSR order.
  - Add E2E checks to prevent hydration errors and verify localized `aria-valuetext` in Generate Course, Level, Lesson Player, and Courses pages.

<sup>Written for commit 0dd8f0fa4bf8742a4a41a8077efdf53976981834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

