### PR TITLE
fix(main): center progress navbar on wide screens

### DIFF
--- a/apps/main/src/app/[lang]/(progress)/_components/progress-navbar.tsx
+++ b/apps/main/src/app/[lang]/(progress)/_components/progress-navbar.tsx
@@ -12,7 +12,7 @@ export async function ProgressNavbar() {
   return (
     <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 pt-4 backdrop-blur">
       <HorizontalScroll>
-        <HorizontalScrollContent>
+        <HorizontalScrollContent className="lg:justify-center">
           <Link className={buttonVariants({ size: "icon", variant: "outline" })} href="/" prefetch>
             <HomeIcon aria-hidden="true" />
             <span className="sr-only">{t("Home page")}</span>
@@ -28,7 +28,7 @@ export async function ProgressNavbar() {
 export function ProgressNavbarSkeleton() {
   return (
     <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 pt-4 backdrop-blur">
-      <div className="flex gap-2 px-4">
+      <div className="flex gap-2 px-4 lg:justify-center">
         <Skeleton className="size-9 rounded-md" />
         <Skeleton className="h-9 w-24 rounded-md" />
         <Skeleton className="h-9 w-20 rounded-md" />

--- a/apps/main/src/app/[lang]/(progress)/_components/progress-navbar.tsx
+++ b/apps/main/src/app/[lang]/(progress)/_components/progress-navbar.tsx
@@ -12,7 +12,7 @@ export async function ProgressNavbar() {
   return (
     <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 pt-4 backdrop-blur">
       <HorizontalScroll>
-        <HorizontalScrollContent className="lg:justify-center">
+        <HorizontalScrollContent className="justify-center">
           <Link className={buttonVariants({ size: "icon", variant: "outline" })} href="/" prefetch>
             <HomeIcon aria-hidden="true" />
             <span className="sr-only">{t("Home page")}</span>
@@ -28,7 +28,7 @@ export async function ProgressNavbar() {
 export function ProgressNavbarSkeleton() {
   return (
     <nav className="bg-background/95 supports-backdrop-filter:bg-background/60 sticky top-0 z-10 pt-4 backdrop-blur">
-      <div className="flex gap-2 px-4 lg:justify-center">
+      <div className="flex justify-center gap-2 px-4">
         <Skeleton className="size-9 rounded-md" />
         <Skeleton className="h-9 w-24 rounded-md" />
         <Skeleton className="h-9 w-20 rounded-md" />


### PR DESCRIPTION
Centers the progress navbar on wide screens while preserving full-width horizontal scrolling on smaller screens. Keeps the loading skeleton aligned with the final navbar.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always center the progress navbar across all screen sizes while preserving horizontal scrolling. Updates the loading skeleton to match the centered layout.

<sup>Written for commit dbcfb3af9155aae0baf1a56e42627d2c37fcaaa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

