### PR TITLE
fix(main): reveal active progress pill

### DIFF
--- a/apps/main/e2e/energy.test.ts
+++ b/apps/main/e2e/energy.test.ts
@@ -1,3 +1,4 @@
+import { type Page } from "@playwright/test";
 import { prisma } from "@zoonk/db";
 import { createE2EUser } from "@zoonk/e2e/fixtures/users";
 import { dailyProgressFixtureMany, userProgressFixture } from "@zoonk/testing/fixtures/progress";
@@ -37,6 +38,27 @@ function getStableEnergyTimeZone(): string {
 }
 
 const ENERGY_TIME_ZONE = getStableEnergyTimeZone();
+
+/**
+ * Records the requested scroll behavior while preserving the browser's native
+ * scrolling so the test can verify both the animation contract and the final
+ * visible state.
+ */
+async function recordScrollIntoViewBehavior(page: Page) {
+  await page.addInitScript(() => {
+    // oxlint-disable-next-line typescript/unbound-method -- The wrapper must preserve the native DOM method before replacing it.
+    const nativeScrollIntoView = Element.prototype.scrollIntoView;
+
+    Element.prototype.scrollIntoView = function scrollIntoView(
+      options?: boolean | ScrollIntoViewOptions,
+    ) {
+      const behavior = typeof options === "object" ? options.behavior : undefined;
+
+      Reflect.set(globalThis, "progressScrollBehavior", behavior);
+      nativeScrollIntoView.call(this, options);
+    };
+  });
+}
 
 /**
  * Creates sparse authoritative activity days so the Energy page must derive
@@ -96,6 +118,41 @@ test.describe("Energy Page", () => {
       await expect(navigationLinks.nth(3)).toHaveAccessibleName("Patterns");
       await expect(navigationLinks.nth(4)).toHaveAccessibleName("Level");
       await expect(navigationLinks.nth(5)).toHaveAccessibleName("Energy");
+    });
+
+    test("smoothly reveals the active pill on a direct mobile visit", async ({
+      browser,
+      withProgressUser,
+    }) => {
+      const browserContext = await browser.newContext({
+        storageState: withProgressUser.storageState,
+        viewport: { height: 812, width: 375 },
+      });
+
+      const energyPage = await browserContext.newPage();
+
+      try {
+        await recordScrollIntoViewBehavior(energyPage);
+        await energyPage.goto("/energy");
+
+        const energyLink = energyPage.getByRole("link", { name: "Energy" });
+
+        await expect(energyLink).toHaveAttribute("aria-current", "page");
+
+        await expect
+          .poll(() =>
+            energyPage.evaluate(() => {
+              const behavior: unknown = Reflect.get(globalThis, "progressScrollBehavior");
+
+              return typeof behavior === "string" ? behavior : null;
+            }),
+          )
+          .toBe("smooth");
+
+        await expect(energyLink).toBeInViewport({ ratio: 1 });
+      } finally {
+        await browserContext.close();
+      }
     });
 
     test("shows the Energy calendar and all-time metrics without date controls", async ({

--- a/apps/main/src/app/[lang]/(progress)/_components/metric-pills.tsx
+++ b/apps/main/src/app/[lang]/(progress)/_components/metric-pills.tsx
@@ -5,10 +5,18 @@ import { getMenu } from "@/lib/menu";
 import { buttonVariants } from "@zoonk/ui/components/button";
 import { useExtracted } from "next-intl";
 import { useSelectedLayoutSegment } from "next/navigation";
+import { useEffect, useRef } from "react";
 
+/** Preserves the reveal without animating for users who reduce motion. */
+function getMetricPillScrollBehavior(): ScrollBehavior {
+  return globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth";
+}
+
+/** Keeps the selected progress metric visible when its route opens. */
 export function MetricPillLinks() {
   const segment = useSelectedLayoutSegment();
   const t = useExtracted();
+  const activeLinkRef = useRef<HTMLAnchorElement>(null);
 
   const items = [
     { label: t("Activity"), segment: "activity", ...getMenu("activity") },
@@ -17,6 +25,14 @@ export function MetricPillLinks() {
     { label: t("Level"), segment: "level", ...getMenu("level") },
     { label: t("Energy"), segment: "energy", ...getMenu("energy") },
   ];
+
+  useEffect(() => {
+    activeLinkRef.current?.scrollIntoView({
+      behavior: getMetricPillScrollBehavior(),
+      block: "nearest",
+      inline: "center",
+    });
+  }, [segment]);
 
   return items.map((item) => (
     <Link
@@ -28,6 +44,7 @@ export function MetricPillLinks() {
       href={item.url}
       key={item.segment}
       prefetch
+      ref={segment === item.segment ? activeLinkRef : undefined}
     >
       <item.icon aria-hidden className="size-4" />
       {item.label}


### PR DESCRIPTION
Smoothly reveals the active progress pill on direct mobile visits and respects reduced-motion preferences. Adds E2E coverage for the mobile Energy route.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smoothly scrolls the active progress pill into view on direct mobile visits. Respects reduced-motion preferences and adds E2E coverage for the mobile Energy route.

- **Bug Fixes**
  - Scroll the active pill into view on route load; uses `prefers-reduced-motion` to switch between smooth and instant.
  - Adds a mobile E2E test for Energy that verifies smooth scrolling and full visibility of the active pill.

<sup>Written for commit 26a93c840c2179e52617a8b256689859a0fcd95f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

