### PR TITLE
feat(core): generate all regular course formats

### DIFF
--- a/apps/api/e2e/course-prompts-and-generation-resources.test.ts
+++ b/apps/api/e2e/course-prompts-and-generation-resources.test.ts
@@ -24,12 +24,14 @@ test.describe("Course prompt and generation resources API", () => {
     await prisma.$disconnect();
   });
 
-  test("resolves a cached topic prompt into a route-neutral generation target", async () => {
+  test("resolves a cached coding prompt into a route-neutral generation target", async () => {
     const uniqueId = randomUUID();
     const prompt = `Learn focused API design ${uniqueId}`;
 
     const coursePrompt = await coursePromptFixture({
       canonicalTitle: `Focused API design ${uniqueId}`,
+      courseFormat: "coding",
+      generationStatus: null,
       language: "en",
       normalizedPrompt: normalizeString(prompt),
       prompt,
@@ -47,6 +49,10 @@ test.describe("Course prompt and generation resources API", () => {
       coursePromptId: coursePrompt.id,
       kind: "generation",
     });
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: coursePrompt.id } }),
+    ).resolves.toMatchObject({ courseFormat: "coding", generationStatus: "pending" });
 
     await apiContext.dispose();
   });

--- a/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
@@ -104,6 +104,55 @@ describe(getOrCreateCourse, () => {
     expect(updatedRequest.generationRunId).toBe(winningWorkflowRunId);
   });
 
+  it("recovers the same-slug course when its regular format differs", async () => {
+    const title = `Cross Format Collision ${randomUUID()}`;
+    const language = "en";
+    const slug = getCourseSlugForTitle({ language, title });
+    const winningWorkflowRunId = `winning-run-${randomUUID()}`;
+
+    const existingCourse = await courseFixture({
+      format: "core",
+      generationRunId: winningWorkflowRunId,
+      generationStatus: "running",
+      language,
+      organizationId,
+      slug,
+      title,
+    });
+
+    const request = await generatableCoursePromptFixture({
+      canonicalTitle: title,
+      courseFormat: "instrument",
+      language,
+    });
+
+    assertGeneratableCoursePrompt(request);
+
+    const result = await getOrCreateCourse({
+      coursePromptId: request.id,
+      existingCourse: null,
+      prompt: request,
+      workflowRunId: `run-${randomUUID()}`,
+    });
+
+    expect(result.status).toBe("running");
+    expect(result.course).toMatchObject({ courseId: existingCourse.id, format: "core" });
+
+    const [courses, updatedRequest] = await Promise.all([
+      prisma.course.findMany({ where: { organizationId, slug } }),
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: request.id } }),
+    ]);
+
+    expect(courses).toHaveLength(1);
+
+    expect(updatedRequest).toMatchObject({
+      courseFormat: "instrument",
+      courseId: existingCourse.id,
+      generationRunId: winningWorkflowRunId,
+      generationStatus: "running",
+    });
+  });
+
   it("continues a running course owned by the same workflow run", async () => {
     const title = `Retried Course ${randomUUID()}`;
     const language = "en";
@@ -143,7 +192,6 @@ describe(getOrCreateCourse, () => {
   });
 
   it.each([
-    { courseFormat: "core", courseLanguage: "en", courseTargetLanguage: null, mismatch: "format" },
     {
       courseFormat: "language",
       courseLanguage: "pt",

--- a/apps/api/src/workflows/course-generation/_internal/introduction-course-setup.ts
+++ b/apps/api/src/workflows/course-generation/_internal/introduction-course-setup.ts
@@ -11,12 +11,10 @@ import { addIntroductionChapterStep } from "../steps/add-introduction-chapter-st
 import { completeIntroductionChapterStep } from "../steps/complete-introduction-chapter-step";
 import { completeIntroductionLessonStep } from "../steps/complete-introduction-lesson-step";
 import { getIntroductionLessonsStep } from "../steps/get-introduction-lessons-step";
-import { type CourseContext } from "../steps/initialize-course-step";
+import { type CourseContext, type RegularCourseContext } from "../steps/initialize-course-step";
 import { startIntroductionLessonsStep } from "../steps/start-introduction-lessons-step";
 
 const INITIAL_LESSON_GENERATION_TARGET_COUNT = 3;
-
-type IntroductionCourseContext = Extract<CourseContext, { format: "core" }>;
 
 /**
  * Keeps the intro chapter helper scoped to regular courses even if a future
@@ -26,8 +24,8 @@ type IntroductionCourseContext = Extract<CourseContext, { format: "core" }>;
  */
 function assertIntroductionCourseContext(
   course: CourseContext,
-): asserts course is IntroductionCourseContext {
-  if (course.format !== "core") {
+): asserts course is RegularCourseContext {
+  if (course.format === "language") {
     throw new Error("Introduction chapters are only generated for regular courses.");
   }
 }

--- a/apps/api/src/workflows/course-generation/_utils/course-identity-validation.ts
+++ b/apps/api/src/workflows/course-generation/_utils/course-identity-validation.ts
@@ -1,11 +1,12 @@
+import { getCompatibleCourseFormats } from "@zoonk/core/courses/prompt-generation";
 import { type Course } from "@zoonk/db";
 import { FatalError } from "workflow";
 import { type GeneratableCoursePrompt } from "../steps/get-course-prompt-step";
 
 /**
  * Prevents cached, classified, or unique-conflict matches from linking a prompt
- * to a different generation identity. Format is authoritative, while source
- * and target languages are the dependent values that must match it exactly.
+ * to a different generation identity. Formats that share the regular course
+ * pipeline are compatible, while source and target languages must still match.
  */
 export function assertCourseMatchesPromptIdentity({
   course,
@@ -15,7 +16,7 @@ export function assertCourseMatchesPromptIdentity({
   prompt: GeneratableCoursePrompt;
 }): void {
   const matchesPrompt =
-    course.format === prompt.courseFormat &&
+    getCompatibleCourseFormats(prompt.courseFormat).includes(course.format) &&
     course.language === prompt.language &&
     course.targetLanguage === prompt.targetLanguage;
 

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -410,74 +410,80 @@ describe(courseGenerationWorkflow, () => {
       expect(course.userCount).toBe(1);
     });
 
-    it("creates an intro chapter without triggering chapter generation for core courses", async () => {
-      vi.mocked(chapterGenerationWorkflow).mockClear();
+    it.each(["coding", "core", "instrument", "practical"] as const)(
+      "creates an intro chapter without triggering chapter generation for %s courses",
+      async (courseFormat) => {
+        vi.mocked(chapterGenerationWorkflow).mockClear();
 
-      const title = `Intro Chapter Course ${randomUUID()}`;
-      const slug = getCourseSlugForTitle({ language: "en", title });
+        const title = `Intro Chapter ${courseFormat} Course ${randomUUID()}`;
+        const slug = getCourseSlugForTitle({ language: "en", title });
 
-      const request = await coursePromptFixture({
-        canonicalTitle: title,
-        generationStatus: "pending",
-      });
+        const request = await coursePromptFixture({
+          canonicalTitle: title,
+          courseFormat,
+          generationStatus: "pending",
+        });
 
-      await generateCourse(request.id);
+        await generateCourse(request.id);
 
-      const course = await prisma.course.findFirstOrThrow({
-        include: {
-          chapters: {
-            include: { lessons: { orderBy: { position: "asc" } } },
-            orderBy: { position: "asc" },
+        const course = await prisma.course.findFirstOrThrow({
+          include: {
+            chapters: {
+              include: { lessons: { orderBy: { position: "asc" } } },
+              orderBy: { position: "asc" },
+            },
           },
-        },
-        where: { slug },
-      });
+          where: { slug },
+        });
 
-      const introductionChapter = course.chapters[0]!;
-      expect(introductionChapter.generationStatus).toBe("completed");
-      expect(introductionChapter.title).toBe("A quick guide to the field");
+        expect(course.format).toBe(courseFormat);
 
-      expect(introductionChapter.lessons.map((lesson) => lesson.kind)).toStrictEqual([
-        "explanation",
-        "quiz",
-        "practice",
-        "explanation",
-        "quiz",
-        "practice",
-        "explanation",
-        "quiz",
-        "practice",
-        "review",
-      ]);
+        const introductionChapter = course.chapters[0]!;
+        expect(introductionChapter.generationStatus).toBe("completed");
+        expect(introductionChapter.title).toBe("A quick guide to the field");
 
-      expect(introductionChapter.imageUrl).toBeNull();
+        expect(introductionChapter.lessons.map((lesson) => lesson.kind)).toStrictEqual([
+          "explanation",
+          "quiz",
+          "practice",
+          "explanation",
+          "quiz",
+          "practice",
+          "explanation",
+          "quiz",
+          "practice",
+          "review",
+        ]);
 
-      const firstMainChapter = course.chapters[1]!;
-      expect(firstMainChapter.position).toBe(1);
-      expect(firstMainChapter.title).toBe("Chapter 1");
-      expect(firstMainChapter.imageUrl).toBeNull();
+        expect(introductionChapter.imageUrl).toBeNull();
 
-      const thirdChapter = course.chapters[2]!;
-      expect(thirdChapter.position).toBe(2);
-      expect(thirdChapter.title).toBe("Chapter 2");
+        const firstMainChapter = course.chapters[1]!;
+        expect(firstMainChapter.position).toBe(1);
+        expect(firstMainChapter.title).toBe("Chapter 1");
+        expect(firstMainChapter.imageUrl).toBeNull();
 
-      const firstLesson = introductionChapter.lessons[0]!;
-      const secondLesson = introductionChapter.lessons[1]!;
-      const thirdLesson = introductionChapter.lessons[2]!;
+        const thirdChapter = course.chapters[2]!;
+        expect(thirdChapter.position).toBe(2);
+        expect(thirdChapter.title).toBe("Chapter 2");
 
-      expect(lessonGenerationWorkflow).toHaveBeenCalledWith(firstLesson.id);
-      expect(startMock).toHaveBeenCalledWith(lessonGenerationWorkflow, [secondLesson.id]);
-      expect(startMock).toHaveBeenCalledWith(lessonGenerationWorkflow, [thirdLesson.id]);
+        const firstLesson = introductionChapter.lessons[0]!;
+        const secondLesson = introductionChapter.lessons[1]!;
+        const thirdLesson = introductionChapter.lessons[2]!;
 
-      expect(startMock).toHaveBeenCalledWith(chapterImagesWorkflow, [course.id]);
+        expect(lessonGenerationWorkflow).toHaveBeenCalledWith(firstLesson.id);
+        expect(startMock).toHaveBeenCalledWith(lessonGenerationWorkflow, [secondLesson.id]);
+        expect(startMock).toHaveBeenCalledWith(lessonGenerationWorkflow, [thirdLesson.id]);
 
-      expect(generateCourseIntroduction).toHaveBeenCalledWith({
-        courseTitle: title,
-        language: "en",
-      });
+        expect(startMock).toHaveBeenCalledWith(chapterImagesWorkflow, [course.id]);
 
-      expect(chapterGenerationWorkflow).not.toHaveBeenCalled();
-    });
+        expect(generateCourseIntroduction).toHaveBeenCalledWith({
+          courseTitle: title,
+          language: "en",
+        });
+
+        expect(chapterGenerationWorkflow).not.toHaveBeenCalled();
+      },
+    );
 
     it("starts the first intro lesson before the main course setup finishes", async () => {
       startMock.mockClear();

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -54,7 +54,7 @@ async function startChapterImagesWithoutFailingCourse(courseId: string): Promise
 
 /**
  * Starts the optional image workflow for every course and generates the first
- * chapter only for language courses. Core courses already generate their
+ * chapter only for language courses. Regular courses already generate their
  * introduction lessons during setup, so they no longer need another chapter
  * workflow to start automatically.
  */

--- a/apps/api/src/workflows/course-generation/steps/add-introduction-chapter-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-introduction-chapter-step.test.ts
@@ -6,7 +6,7 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { addIntroductionChapterStep } from "./add-introduction-chapter-step";
-import { type CourseContext } from "./initialize-course-step";
+import { type RegularCourseContext } from "./initialize-course-step";
 
 describe(addIntroductionChapterStep, () => {
   let organizationId: string;
@@ -23,7 +23,7 @@ describe(addIntroductionChapterStep, () => {
   /**
    * Builds the regular-course context required by the intro chapter step. The
    * step intentionally excludes language courses, so every caller should pass a
-   * context with the core format and its null target language.
+   * context with a regular format and its null target language.
    */
   function getCourseContext(course: Awaited<ReturnType<typeof courseFixture>>) {
     return {
@@ -34,7 +34,7 @@ describe(addIntroductionChapterStep, () => {
       language: course.language,
       organizationId,
       targetLanguage: null,
-    } satisfies Extract<CourseContext, { format: "core" }>;
+    } satisfies RegularCourseContext;
   }
 
   it("creates a published running introduction chapter at position zero", async () => {

--- a/apps/api/src/workflows/course-generation/steps/add-introduction-chapter-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/add-introduction-chapter-step.ts
@@ -3,10 +3,9 @@ import { type CourseIntroductionSchema } from "@zoonk/ai/tasks/courses/introduct
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type Chapter, isPrismaUniqueConstraintError, prisma } from "@zoonk/db";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
-import { type CourseContext } from "./initialize-course-step";
+import { type RegularCourseContext } from "./initialize-course-step";
 
 type IntroductionChapterPlan = CourseIntroductionSchema["chapter"];
-type CoreCourseContext = Extract<CourseContext, { format: "core" }>;
 
 /**
  * Loads the reserved intro shell by structural position. Regular courses use
@@ -53,7 +52,7 @@ async function createIntroductionChapter({
   course,
   plan,
 }: {
-  course: CoreCourseContext;
+  course: RegularCourseContext;
   plan: IntroductionChapterPlan;
 }): Promise<Chapter> {
   try {
@@ -85,7 +84,7 @@ async function getOrCreateIntroductionChapter({
   course,
   plan,
 }: {
-  course: CoreCourseContext;
+  course: RegularCourseContext;
   plan: IntroductionChapterPlan;
 }): Promise<Chapter> {
   const existingChapter = await getExistingIntroductionChapter(course.courseId);
@@ -106,7 +105,7 @@ export async function addIntroductionChapterStep({
   course,
   plan,
 }: {
-  course: CoreCourseContext;
+  course: RegularCourseContext;
   plan: IntroductionChapterPlan;
 }): Promise<Chapter> {
   "use step";

--- a/apps/api/src/workflows/course-generation/steps/generate-introduction-chapter-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-introduction-chapter-step.test.ts
@@ -1,7 +1,7 @@
 import { getStreamedEvents } from "@/workflows/_test-utils/parse-stream-events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { generateIntroductionChapterStep } from "./generate-introduction-chapter-step";
-import { type CourseContext } from "./initialize-course-step";
+import { type RegularCourseContext } from "./initialize-course-step";
 
 const { generateCourseIntroductionMock } = vi.hoisted(() => ({
   generateCourseIntroductionMock: vi.fn(),
@@ -19,7 +19,7 @@ const course = {
   language: "en",
   organizationId: "org-1",
   targetLanguage: null,
-} satisfies Extract<CourseContext, { format: "core" }>;
+} satisfies RegularCourseContext;
 
 describe(generateIntroductionChapterStep, () => {
   beforeEach(() => {

--- a/apps/api/src/workflows/course-generation/steps/generate-introduction-chapter-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/generate-introduction-chapter-step.ts
@@ -4,9 +4,7 @@ import {
   generateCourseIntroduction,
 } from "@zoonk/ai/tasks/courses/introduction";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
-import { type CourseContext } from "./initialize-course-step";
-
-type CoreCourseContext = Extract<CourseContext, { format: "core" }>;
+import { type RegularCourseContext } from "./initialize-course-step";
 
 /**
  * Generates the fixed first chapter separately from the full curriculum
@@ -15,7 +13,7 @@ type CoreCourseContext = Extract<CourseContext, { format: "core" }>;
  * different goals.
  */
 export async function generateIntroductionChapterStep(
-  course: CoreCourseContext,
+  course: RegularCourseContext,
 ): Promise<CourseIntroductionSchema> {
   "use step";
 

--- a/apps/api/src/workflows/course-generation/steps/get-course-prompt-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-prompt-step.ts
@@ -1,5 +1,8 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
-import { getCoursePromptGenerationError } from "@zoonk/core/courses/prompt-generation";
+import {
+  type RegularCourseFormat,
+  getCoursePromptGenerationError,
+} from "@zoonk/core/courses/prompt-generation";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type CoursePrompt, type GenerationStatus, prisma } from "@zoonk/db";
 import { FatalError } from "workflow";
@@ -11,13 +14,13 @@ type GeneratableCoursePromptBase = CoursePrompt & {
 };
 
 export type GeneratableCoursePrompt =
-  | (GeneratableCoursePromptBase & { courseFormat: "core"; targetLanguage: null })
+  | (GeneratableCoursePromptBase & { courseFormat: RegularCourseFormat; targetLanguage: null })
   | (GeneratableCoursePromptBase & { courseFormat: "language"; targetLanguage: string });
 
 /**
- * Narrows persisted routing decisions to the subset the course workflow can
- * generate today. Redirect-only, waitlist, and unsafe prompts are valid admin
- * records but invalid workflow inputs.
+ * Narrows persisted routing decisions to the regular and language formats the
+ * course workflow can generate. Redirect-only, waitlist, and unsafe prompts
+ * are valid admin records but invalid workflow inputs.
  */
 export function assertGeneratableCoursePrompt(
   prompt: CoursePrompt,

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
@@ -1,4 +1,8 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
+import {
+  type RegularCourseFormat,
+  isRegularCourseFormat,
+} from "@zoonk/core/courses/prompt-generation";
 import { getCourseSlugForTitle } from "@zoonk/core/courses/slug";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import {
@@ -26,8 +30,13 @@ type CourseContextBase = {
   organizationId: string;
 };
 
+export type RegularCourseContext = CourseContextBase & {
+  format: RegularCourseFormat;
+  targetLanguage: null;
+};
+
 export type CourseContext =
-  | (CourseContextBase & { format: "core"; targetLanguage: null })
+  | RegularCourseContext
   | (CourseContextBase & { format: "language"; targetLanguage: string });
 
 export type InitializedCourse = { course: CourseContext; existing: ExistingCourseContent | null };
@@ -56,8 +65,8 @@ export function getCourseContext({
     organizationId,
   };
 
-  if (course.format === "core" && course.targetLanguage === null) {
-    return { ...context, format: "core", targetLanguage: null };
+  if (isRegularCourseFormat(course.format) && course.targetLanguage === null) {
+    return { ...context, format: course.format, targetLanguage: null };
   }
 
   if (

--- a/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.test.ts
@@ -96,6 +96,34 @@ describe(resolveCourseIdentityStep, () => {
     expect(resolveCourseIdentity).not.toHaveBeenCalled();
   });
 
+  it("returns and stores an exact-slug course with a different regular format", async () => {
+    const title = `Existing Cross Format Course ${randomUUID()}`;
+    const slug = getCourseSlugForTitle({ language: "en", title });
+
+    const [course, request] = await Promise.all([
+      courseFixture({ format: "core", organizationId, slug, title }),
+      generatableCoursePromptFixture({
+        canonicalTitle: title,
+        courseFormat: "coding",
+        language: "en",
+      }),
+    ]);
+
+    assertGeneratableCoursePrompt(request);
+
+    const result = await resolveCourseIdentityStep(request);
+
+    const linkedRequest = await prisma.coursePrompt.findUniqueOrThrow({
+      where: { id: request.id },
+    });
+
+    expect(result?.id).toBe(course.id);
+    expect(result?.format).toBe("core");
+    expect(linkedRequest).toMatchObject({ courseFormat: "coding", courseId: course.id });
+    expect(generateCourseIdentitySearchQueries).not.toHaveBeenCalled();
+    expect(resolveCourseIdentity).not.toHaveBeenCalled();
+  });
+
   it("uses AI classification to link semantically equivalent course titles", async () => {
     const [course, request] = await Promise.all([
       courseFixture({

--- a/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.ts
@@ -134,7 +134,7 @@ function getCourseIdentityWhere(request: GeneratableCoursePrompt): CourseWhereIn
 /**
  * Combines format identity with the amount of fuzzy title search each format
  * needs. A language target is already the complete reusable-course identity,
- * while core courses still need at least one usable title or alias clause.
+ * while regular courses still need at least one usable title or alias clause.
  */
 function getCandidateSearchWhere({
   request,

--- a/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.ts
@@ -5,6 +5,7 @@ import {
   resolveCourseIdentity,
 } from "@zoonk/ai/tasks/courses/identity";
 import { generateCourseIdentitySearchQueries } from "@zoonk/ai/tasks/courses/identity-search";
+import { getCompatibleCourseFormats } from "@zoonk/core/courses/prompt-generation";
 import { getCourseSlugForTitle } from "@zoonk/core/courses/slug";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type CourseGetPayload, getAiGenerationCourseWhere, prisma } from "@zoonk/db";
@@ -125,7 +126,7 @@ function getCandidateWhereClauses({
  */
 function getCourseIdentityWhere(request: GeneratableCoursePrompt): CourseWhereInput {
   return {
-    format: request.courseFormat,
+    format: { in: getCompatibleCourseFormats(request.courseFormat) },
     language: request.language,
     targetLanguage: request.targetLanguage,
   };

--- a/apps/main/src/app/[lang]/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
@@ -25,8 +25,8 @@ function renderHighlightedTitle(chunks: React.ReactNode) {
 }
 
 /**
- * Shows the waitlist state for prompt intents and reusable course formats that are
- * intentionally recognized before their dedicated learning workflows exist.
+ * Shows the waitlist state for prompt intents that are intentionally recognized
+ * before their dedicated learning workflows exist.
  */
 async function WaitlistedCoursePrompt({
   prompt,

--- a/packages/core/src/courses/_utils/course-prompt-reusable-course.ts
+++ b/packages/core/src/courses/_utils/course-prompt-reusable-course.ts
@@ -5,6 +5,7 @@ import {
   getAiGenerationCourseWhere,
   prisma,
 } from "@zoonk/db";
+import { getCompatibleCourseFormats } from "../course-prompt-generation";
 import { getCourseSlugForTitle } from "../course-slug";
 import { type CoursePromptWithCourse } from "./course-prompt-types";
 
@@ -28,7 +29,7 @@ async function findCompletedReusableCourse({
 
   return prisma.course.findFirst({
     where: getAiGenerationCourseWhere({
-      format,
+      format: { in: getCompatibleCourseFormats(format) },
       generationStatus: "completed",
       isPublished: true,
       language,

--- a/packages/core/src/courses/_utils/course-prompt-reusable-course.ts
+++ b/packages/core/src/courses/_utils/course-prompt-reusable-course.ts
@@ -1,4 +1,10 @@
-import { type Course, type CoursePrompt, getAiGenerationCourseWhere, prisma } from "@zoonk/db";
+import {
+  type Course,
+  type CourseFormat,
+  type CoursePrompt,
+  getAiGenerationCourseWhere,
+  prisma,
+} from "@zoonk/db";
 import { getCourseSlugForTitle } from "../course-slug";
 import { type CoursePromptWithCourse } from "./course-prompt-types";
 
@@ -10,9 +16,11 @@ export type ReusableCourse = Pick<Course, "id" | "slug">;
  * generation only when the exact generated course identity already exists.
  */
 async function findCompletedReusableCourse({
+  format,
   language,
   title,
 }: {
+  format: CourseFormat;
   language: string;
   title: string;
 }): Promise<Course | null> {
@@ -20,7 +28,7 @@ async function findCompletedReusableCourse({
 
   return prisma.course.findFirst({
     where: getAiGenerationCourseWhere({
-      format: "core",
+      format,
       generationStatus: "completed",
       isPublished: true,
       language,
@@ -79,11 +87,15 @@ async function getReusableCourseForPrompt(prompt: CoursePromptWithCourse): Promi
     return linkedCourse;
   }
 
-  if (!prompt.canonicalTitle) {
+  if (!(prompt.canonicalTitle && prompt.courseFormat)) {
     return null;
   }
 
-  return findCompletedReusableCourse({ language: prompt.language, title: prompt.canonicalTitle });
+  return findCompletedReusableCourse({
+    format: prompt.courseFormat,
+    language: prompt.language,
+    title: prompt.canonicalTitle,
+  });
 }
 
 /**

--- a/packages/core/src/courses/course-prompt-generation.test.ts
+++ b/packages/core/src/courses/course-prompt-generation.test.ts
@@ -11,9 +11,12 @@ const generatableCorePrompt = {
 };
 
 describe(getCoursePromptGenerationError, () => {
-  it("accepts a pending learn prompt with a canonical title and core format", () => {
-    expect(getCoursePromptGenerationError(generatableCorePrompt)).toBeNull();
-  });
+  it.each(["coding", "core", "instrument", "practical"] as const)(
+    "accepts a pending learn prompt with a canonical title and %s format",
+    (courseFormat) => {
+      expect(getCoursePromptGenerationError({ ...generatableCorePrompt, courseFormat })).toBeNull();
+    },
+  );
 
   it.each([
     ["missing canonical title", { ...generatableCorePrompt, canonicalTitle: null }],

--- a/packages/core/src/courses/course-prompt-generation.ts
+++ b/packages/core/src/courses/course-prompt-generation.ts
@@ -29,6 +29,19 @@ export function isRegularCourseFormat(
 }
 
 /**
+ * Treats every format that uses the regular generation pipeline as the same
+ * reusable course identity. Other formats keep their exact stored identity so
+ * language and future format-specific workflows remain isolated.
+ */
+export function getCompatibleCourseFormats(courseFormat: CourseFormat): CourseFormat[] {
+  if (isRegularCourseFormat(courseFormat)) {
+    return [...REGULAR_COURSE_FORMATS];
+  }
+
+  return [courseFormat];
+}
+
+/**
  * Language courses are only useful when the learner language and learned
  * language differ. Every entry point uses this shared check so an admin edit
  * cannot create a prompt that the generation workflow must reject later.

--- a/packages/core/src/courses/course-prompt-generation.ts
+++ b/packages/core/src/courses/course-prompt-generation.ts
@@ -1,12 +1,32 @@
-import { type CoursePrompt } from "@zoonk/db";
+import { type CourseFormat, type CoursePrompt } from "@zoonk/db";
 
 const SAME_LANGUAGE_COURSE_ERROR = "Language course source and target languages must be different";
 const UNSUPPORTED_COURSE_PROMPT_ERROR = "Course prompt is not generatable";
+
+const REGULAR_COURSE_FORMATS = [
+  "coding",
+  "core",
+  "instrument",
+  "practical",
+] as const satisfies readonly CourseFormat[];
+
+export type RegularCourseFormat = (typeof REGULAR_COURSE_FORMATS)[number];
 
 type CoursePromptGenerationInput = Pick<
   CoursePrompt,
   "canonicalTitle" | "courseFormat" | "generationStatus" | "intent" | "language" | "targetLanguage"
 >;
+
+/**
+ * Identifies formats that use the regular course pipeline. Keeping this rule in
+ * Core lets routing and Workflow agree on generation support while preserving
+ * the classified format on the prompt and generated course.
+ */
+export function isRegularCourseFormat(
+  courseFormat: CourseFormat | null,
+): courseFormat is RegularCourseFormat {
+  return REGULAR_COURSE_FORMATS.some((format) => format === courseFormat);
+}
 
 /**
  * Language courses are only useful when the learner language and learned
@@ -33,7 +53,7 @@ export function getCoursePromptGenerationError(prompt: CoursePromptGenerationInp
     return UNSUPPORTED_COURSE_PROMPT_ERROR;
   }
 
-  if (prompt.courseFormat === "core") {
+  if (isRegularCourseFormat(prompt.courseFormat)) {
     return prompt.targetLanguage === null ? null : UNSUPPORTED_COURSE_PROMPT_ERROR;
   }
 

--- a/packages/core/src/courses/get-course-prompt-generation.ts
+++ b/packages/core/src/courses/get-course-prompt-generation.ts
@@ -9,7 +9,7 @@ export type CoursePromptGenerationCompletionKind = "course" | "introductionLesso
 /**
  * Resolves the route-neutral destination that becomes available while a course
  * prompt is generating. Language courses wait for the complete curriculum,
- * while core courses become usable as soon as their published intro lesson
+ * while regular courses become usable as soon as their published intro lesson
  * exists.
  */
 async function getCoursePromptGenerationTarget({

--- a/packages/core/src/courses/resolve-course-prompt.test.ts
+++ b/packages/core/src/courses/resolve-course-prompt.test.ts
@@ -187,6 +187,30 @@ describe("course-prompt", () => {
     });
   });
 
+  it("reuses an existing course with the same slug regardless of regular format", async () => {
+    const prompt = `existing practical topic ${randomUUID()}`;
+    const title = `Existing Practical Course ${randomUUID().slice(0, 8)}`;
+    const course = await createCompletedAiCourse({ language: "en", title });
+    mockPromptTasks({ courseFormat: "practical", title });
+
+    const result = await resolveCoursePrompt({ language: "en", prompt });
+
+    expectCourseResult(result);
+    expect(result.course).toStrictEqual({ id: course.id, slug: course.slug });
+
+    const storedPrompt = await prisma.coursePrompt.findUniqueOrThrow({
+      where: {
+        languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
+      },
+    });
+
+    expect(storedPrompt).toMatchObject({
+      courseFormat: "practical",
+      courseId: course.id,
+      generationStatus: "completed",
+    });
+  });
+
   it("uses a cached reusable prompt without calling model tasks", async () => {
     const prompt = `cached topic ${randomUUID()}`;
 

--- a/packages/core/src/courses/resolve-course-prompt.test.ts
+++ b/packages/core/src/courses/resolve-course-prompt.test.ts
@@ -211,6 +211,40 @@ describe("course-prompt", () => {
     expect(titleSpy).not.toHaveBeenCalled();
   });
 
+  it.each(["coding", "instrument", "practical"] as const)(
+    "enables generation for a cached %s prompt that was previously waitlisted",
+    async (courseFormat) => {
+      const prompt = `cached ${courseFormat} topic ${randomUUID()}`;
+
+      const cached = await coursePromptFixture({
+        canonicalTitle: `Cached ${courseFormat} Course ${randomUUID()}`,
+        courseFormat,
+        generationStatus: null,
+        normalizedPrompt: normalizeString(prompt),
+        prompt,
+      });
+
+      const intentSpy = vi.spyOn(intentTask, "classifyCourseIntent");
+      const personalizationSpy = vi.spyOn(personalizationTask, "classifyCoursePersonalization");
+      const courseFormatSpy = vi.spyOn(formatTask, "classifyCourseFormat");
+      const titleSpy = vi.spyOn(canonicalTitleTask, "generateCanonicalCourseTitle");
+
+      const result = await resolveCoursePrompt({ language: "en", prompt });
+
+      expectGenerateResult(result);
+      expect(result.prompt.id).toBe(cached.id);
+
+      await expect(
+        prisma.coursePrompt.findUniqueOrThrow({ where: { id: cached.id } }),
+      ).resolves.toMatchObject({ courseFormat, generationStatus: "pending" });
+
+      expect(intentSpy).not.toHaveBeenCalled();
+      expect(personalizationSpy).not.toHaveBeenCalled();
+      expect(courseFormatSpy).not.toHaveBeenCalled();
+      expect(titleSpy).not.toHaveBeenCalled();
+    },
+  );
+
   it("redirects cached reusable prompts to an existing reusable course without model tasks", async () => {
     const prompt = `cached existing topic ${randomUUID()}`;
     const title = `Cached Existing Course ${randomUUID().slice(0, 8)}`;
@@ -392,19 +426,16 @@ describe("course-prompt", () => {
     { courseFormat: "instrument" },
     { courseFormat: "practical" },
   ] as const)(
-    "persists waitlist state for learn $courseFormat prompts",
+    "creates a generatable prompt while preserving the $courseFormat format",
     async ({ courseFormat }) => {
       const prompt = `${courseFormat} prompt ${randomUUID()}`;
-      const title = `Unsupported ${courseFormat} ${randomUUID()}`;
+      const title = `${courseFormat} course ${randomUUID()}`;
       mockPromptTasks({ courseFormat, title });
 
       const result = await resolveCoursePrompt({ language: "en", prompt });
 
-      expect(result).toStrictEqual({
-        kind: "unsupported",
-        prompt: { courseFormat, intent: "learn" },
-        title,
-      });
+      expectGenerateResult(result);
+      expect(result.prompt).toMatchObject({ canonicalTitle: title, courseFormat, intent: "learn" });
 
       const storedPrompt = await prisma.coursePrompt.findUnique({
         where: {
@@ -415,7 +446,7 @@ describe("course-prompt", () => {
       expect(storedPrompt).toMatchObject({
         canonicalTitle: title,
         courseFormat,
-        generationStatus: null,
+        generationStatus: "pending",
         intent: "learn",
       });
     },

--- a/packages/core/src/courses/resolve-course-prompt.ts
+++ b/packages/core/src/courses/resolve-course-prompt.ts
@@ -10,6 +10,7 @@ import { normalizeString } from "@zoonk/utils/string";
 import { getReusableCourseForCoursePrompt } from "./_utils/course-prompt-reusable-course";
 import { type CoursePromptWithCourse } from "./_utils/course-prompt-types";
 import { COURSE_LANGUAGE_MAX_LENGTH, COURSE_PROMPT_MAX_LENGTH } from "./course-prompt-contract";
+import { isRegularCourseFormat } from "./course-prompt-generation";
 
 type PromptIntent = CoursePrompt["intent"];
 type PersistedCourseFormat = CoursePrompt["courseFormat"];
@@ -83,7 +84,7 @@ async function findCachedCoursePrompt({
 }
 
 /**
- * Keeps the supported-generation check in one place. `core` courses use the
+ * Keeps the supported-generation check in one place. Regular formats use the
  * current course workflow, while language prompts only generate after the
  * dedicated language start flow has stored a concrete target language.
  */
@@ -96,11 +97,27 @@ function canGenerateCoursePrompt({
     return false;
   }
 
-  if (courseFormat === "core") {
+  if (isRegularCourseFormat(courseFormat)) {
     return true;
   }
 
   return courseFormat === "language" && Boolean(targetLanguage);
+}
+
+/**
+ * Promotes legacy waitlist rows when their format becomes generatable. The
+ * conditional update cannot replace a newer running or completed status when
+ * two visits or a workflow start race with this cached resolution.
+ */
+async function enableCoursePromptGeneration(prompt: CoursePrompt): Promise<void> {
+  if (prompt.generationStatus !== null) {
+    return;
+  }
+
+  await prisma.coursePrompt.updateMany({
+    data: { generationStatus: "pending" },
+    where: { generationStatus: null, id: prompt.id },
+  });
 }
 
 /**
@@ -111,7 +128,7 @@ function canGenerateCoursePrompt({
 async function getCoursePromptResolution(
   prompt: CoursePromptWithCourse,
 ): Promise<CoursePromptResolution> {
-  if (prompt.intent === "learn" && prompt.courseFormat === "core") {
+  if (prompt.intent === "learn" && isRegularCourseFormat(prompt.courseFormat)) {
     const course = await getReusableCourseForCoursePrompt(prompt);
 
     if (course) {
@@ -120,6 +137,8 @@ async function getCoursePromptResolution(
   }
 
   if (canGenerateCoursePrompt(prompt)) {
+    await enableCoursePromptGeneration(prompt);
+
     return {
       kind: "generate",
       prompt: {
@@ -257,8 +276,8 @@ async function upsertCoursePrompt({
 
 /**
  * Builds the persisted prompt fields for a newly classified prompt. Keeping the
- * mapper separate makes the launch limitation explicit: only shared-learning
- * core and concrete language prompts are sent to generation today.
+ * mapper separate makes the generation boundary explicit: shared regular
+ * formats and concrete language prompts are sent to generation today.
  */
 function getClassifiedCoursePromptInput({
   courseFormat,


### PR DESCRIPTION
## Summary

- route coding, instrument, and practical prompts through regular course generation
- preserve each classified format and enable previously waitlisted prompts on revisit
- extend workflow and public API coverage for the new generation paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate all regular course formats—coding, core, instrument, and practical—through the intro‑first pipeline. Regular formats are treated as compatible for course reuse and identity while preserving the classified format; previously waitlisted prompts now start generating on revisit. Language courses are unchanged.

- **New Features**
  - Route coding, instrument, and practical learn prompts through the regular generation path.
  - Promote cached prompts from waitlisted to pending on revisit; show the route‑neutral generation target once the intro lesson exists for regular courses.
  - Reuse existing courses across compatible regular formats by slug/title; link to the existing course while keeping the prompt’s classified format.

- **Refactors**
  - Added `RegularCourseFormat`, `isRegularCourseFormat`, and `RegularCourseContext`; replaced core‑only checks with regular format checks.
  - Guarded intro helpers against language courses and kept chapter images optional; do not auto‑start chapter generation for regular courses (intro lessons already start).

<sup>Written for commit 25a011ecc61f1807c8547367144e6279b106dfc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

