### PR TITLE
feat(main): allow removing courses from my courses

### DIFF
--- a/apps/api/e2e/current-learning.test.ts
+++ b/apps/api/e2e/current-learning.test.ts
@@ -1,4 +1,5 @@
 import { request } from "@playwright/test";
+import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture, courseUserFixture } from "@zoonk/testing/fixtures/courses";
@@ -10,13 +11,16 @@ test.describe("Current learner catalog API", () => {
   test("requires authentication for learner-owned resources", async () => {
     const apiContext = await request.newContext({ baseURL: process.env.E2E_BASE_URL });
 
-    const [coursesResponse, continuationsResponse, visibilityResponse] = await Promise.all([
-      apiContext.get("/v1/me/courses"),
-      apiContext.get("/v1/me/course-continuations"),
-      apiContext.get("/v1/me/lesson-visibility"),
-    ]);
+    const [coursesResponse, removeCourseResponse, continuationsResponse, visibilityResponse] =
+      await Promise.all([
+        apiContext.get("/v1/me/courses"),
+        apiContext.delete("/v1/me/courses/00000000-0000-4000-8000-000000000001"),
+        apiContext.get("/v1/me/course-continuations"),
+        apiContext.get("/v1/me/lesson-visibility"),
+      ]);
 
     expect(coursesResponse.status()).toBe(401);
+    expect(removeCourseResponse.status()).toBe(401);
     expect(continuationsResponse.status()).toBe(401);
     expect(visibilityResponse.status()).toBe(401);
 
@@ -72,6 +76,48 @@ test.describe("Current learner catalog API", () => {
     expect(secondBody.pagination).toEqual({ hasMore: false, nextCursor: null });
 
     await Promise.all([apiContext.dispose(), otherUser.apiContext.dispose()]);
+  });
+
+  test("removes a course from the learner's library without clearing progress", async () => {
+    const baseURL = process.env.E2E_BASE_URL ?? "";
+
+    const { apiContext, user } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "remove-course",
+    });
+
+    const organization = await organizationFixture({ kind: "brand" });
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+    const chapter = await chapterFixture({ courseId: course.id, organizationId: organization.id });
+    const lesson = await lessonFixture({ chapterId: chapter.id, organizationId: organization.id });
+
+    const [, lessonProgress] = await Promise.all([
+      courseUserFixture({ courseId: course.id, userId: user.id }),
+      lessonProgressFixture({
+        completedAt: new Date(),
+        durationSeconds: 60,
+        lessonId: lesson.id,
+        userId: user.id,
+      }),
+    ]);
+
+    const response = await apiContext.delete(`/v1/me/courses/${course.id}`);
+
+    expect(response.status()).toBe(204);
+
+    const [courseUser, preservedProgress, updatedCourse] = await Promise.all([
+      prisma.courseUser.findUnique({
+        where: { courseUser: { courseId: course.id, userId: user.id } },
+      }),
+      prisma.lessonProgress.findUnique({ where: { id: lessonProgress.id } }),
+      prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+    ]);
+
+    expect(courseUser).toBeNull();
+    expect(preservedProgress).not.toBeNull();
+    expect(updatedCourse.userCount).toBe(0);
+
+    await apiContext.dispose();
   });
 
   test("returns the learner's bounded continuation resources", async () => {

--- a/apps/api/src/app/v1/me/courses/[courseId]/route.ts
+++ b/apps/api/src/app/v1/me/courses/[courseId]/route.ts
@@ -1,0 +1,28 @@
+import { errors } from "@/lib/api-errors";
+import { withApiErrorBoundary } from "@/lib/api-handler";
+import { coursePathParamsSchema } from "@/lib/openapi/schemas/paths";
+import { parsePathParams } from "@/lib/path-params";
+import { removeCurrentUserCourse } from "@zoonk/core/courses/remove-current-user";
+import { NextResponse } from "next/server";
+
+/**
+ * Removes one course from the authenticated learner's library while Core keeps
+ * progress data intact and derives the acting user from the trusted session.
+ */
+async function removeCourse(_request: Request, context: RouteContext<"/v1/me/courses/[courseId]">) {
+  const parsed = parsePathParams({ params: await context.params, schema: coursePathParamsSchema });
+
+  if (!parsed.success) {
+    return errors.validation(parsed.error);
+  }
+
+  const result = await removeCurrentUserCourse({ courseId: parsed.data.courseId });
+
+  if (!result) {
+    return errors.unauthorized();
+  }
+
+  return new NextResponse(null, { status: 204 });
+}
+
+export const DELETE = withApiErrorBoundary(removeCourse);

--- a/apps/api/src/lib/openapi/document.test.ts
+++ b/apps/api/src/lib/openapi/document.test.ts
@@ -23,7 +23,7 @@ import {
 
 const UUID = "00000000-0000-4000-8000-000000000001";
 const ISO_DATE = "2026-07-25T12:00:00.000Z";
-const DOCUMENTED_METHODS = ["get", "patch", "post"] as const;
+const DOCUMENTED_METHODS = ["delete", "get", "patch", "post"] as const;
 
 const CANONICAL_OPERATIONS = [
   { method: "get", operationId: "searchCatalog", path: "/catalog/search" },
@@ -35,6 +35,7 @@ const CANONICAL_OPERATIONS = [
   { method: "get", operationId: "getLesson", path: "/lessons/{lessonId}" },
   { method: "get", operationId: "listLanguageCourses", path: "/language-courses" },
   { method: "get", operationId: "listCurrentUserCourses", path: "/me/courses" },
+  { method: "delete", operationId: "removeCurrentUserCourse", path: "/me/courses/{courseId}" },
   {
     method: "get",
     operationId: "listCurrentUserCourseContinuations",
@@ -97,6 +98,7 @@ const operationContractSchema = z
 
 const pathItemContractSchema = z
   .object({
+    delete: operationContractSchema.optional(),
     get: operationContractSchema.optional(),
     patch: operationContractSchema.optional(),
     post: operationContractSchema.optional(),

--- a/apps/api/src/lib/openapi/paths/current-learning.ts
+++ b/apps/api/src/lib/openapi/paths/current-learning.ts
@@ -5,6 +5,7 @@ import {
   lessonVisibilitySchema,
   lessonVisibilityUpdateSchema,
 } from "../schemas/current-learning";
+import { coursePathParamsSchema } from "../schemas/paths";
 import { badRequestResponse, forbiddenResponse, unauthorizedResponse } from "../schemas/responses";
 import { AUTHENTICATED_SECURITY } from "../security";
 
@@ -38,6 +39,21 @@ export const currentLearningPaths = {
       },
       security: AUTHENTICATED_SECURITY,
       summary: "List current user's courses",
+      tags: ["Courses"],
+    },
+  },
+  "/me/courses/{courseId}": {
+    delete: {
+      operationId: "removeCurrentUserCourse",
+      requestParams: { path: coursePathParamsSchema },
+      responses: {
+        "204": { description: "Course removed from learner library" },
+        "400": badRequestResponse,
+        "401": unauthorizedResponse,
+        "403": forbiddenResponse,
+      },
+      security: AUTHENTICATED_SECURITY,
+      summary: "Remove a course from the current user's library",
       tags: ["Courses"],
     },
   },

--- a/apps/main/e2e/my-courses.test.ts
+++ b/apps/main/e2e/my-courses.test.ts
@@ -1,3 +1,9 @@
+import { prisma } from "@zoonk/db";
+import { createE2EUser } from "@zoonk/e2e/fixtures/users";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture, courseUserFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { expect, test } from "./fixtures";
 
 test.describe("My Courses", () => {
@@ -38,5 +44,63 @@ test.describe("My Courses", () => {
     await expect(
       userWithoutProgress.getByRole("heading", { name: "What's your goal?" }),
     ).toBeVisible();
+  });
+
+  test("removes a course from the list without clearing progress", async ({ baseURL, browser }) => {
+    const [user, organization] = await Promise.all([
+      createE2EUser(baseURL!),
+      organizationFixture({ kind: "brand" }),
+    ]);
+
+    const course = await courseFixture({
+      isPublished: true,
+      organizationId: organization.id,
+      title: `Course to remove ${user.id}`,
+    });
+
+    const chapter = await chapterFixture({ courseId: course.id, organizationId: organization.id });
+
+    const lesson = await lessonFixture({ chapterId: chapter.id, organizationId: organization.id });
+
+    const [, lessonProgress] = await Promise.all([
+      courseUserFixture({ courseId: course.id, userId: user.id }),
+      lessonProgressFixture({
+        completedAt: new Date(),
+        durationSeconds: 60,
+        lessonId: lesson.id,
+        userId: user.id,
+      }),
+    ]);
+
+    const browserContext = await browser.newContext({ storageState: user.storageState });
+    const page = await browserContext.newPage();
+
+    await page.goto("/my");
+
+    await expect(page.getByRole("link", { name: course.title })).toBeVisible();
+    await page.getByRole("button", { name: `More options for ${course.title}` }).click();
+    await page.getByRole("menuitem", { name: "Remove from My Courses" }).click();
+
+    const confirmation = page.getByRole("alertdialog", { name: `Remove ${course.title}?` });
+
+    await expect(confirmation).toContainText("Your progress will be kept.");
+    await confirmation.getByRole("button", { name: "Remove course" }).click();
+    await expect(page.getByRole("link", { name: course.title })).toHaveCount(0);
+
+    await expect(async () => {
+      const [courseUser, preservedProgress, updatedCourse] = await Promise.all([
+        prisma.courseUser.findUnique({
+          where: { courseUser: { courseId: course.id, userId: user.id } },
+        }),
+        prisma.lessonProgress.findUnique({ where: { id: lessonProgress.id } }),
+        prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+      ]);
+
+      expect(courseUser).toBeNull();
+      expect(preservedProgress).not.toBeNull();
+      expect(updatedCourse.userCount).toBe(0);
+    }).toPass({ timeout: 10_000 });
+
+    await browserContext.close();
   });
 });

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -545,6 +545,47 @@ msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Mach dort weiter, wo du aufgehört hast"
 
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "zfUTRh"
+msgid "More options for {courseTitle}"
+msgstr "Weitere Optionen für {courseTitle}"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "M9_kBE"
+msgid "Remove from My Courses"
+msgstr "Aus „Meine Kurse“ entfernen"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "SZ0Rgi"
+msgid "Remove {courseTitle}?"
+msgstr "{courseTitle} entfernen?"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RGYckE"
+msgid "The course will disappear from My Courses. Your progress will be kept."
+msgstr "Der Kurs wird nicht mehr unter „Meine Kurse“ angezeigt. Dein Fortschritt bleibt erhalten."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "xjTT7H"
+msgid "We couldn't remove this course. Please try again."
+msgstr "Dieser Kurs konnte nicht entfernt werden. Bitte versuche es erneut."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RC2XA4"
+msgid "Removing..."
+msgstr "Wird entfernt…"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "D4eTra"
+msgid "Remove course"
+msgstr "Kurs entfernen"
+
 #: src/app/[lang]/(catalog)/my/user-course-list.tsx
 msgctxt "BDHWkf"
 msgid "No courses yet"
@@ -684,11 +725,6 @@ msgstr "Wir suchen den besten Weg, dir zu helfen"
 msgctxt "1A36NM"
 msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "Wir prüfen dein Lernziel. Das kann ein paar Sekunden dauern."
-
-#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Abbrechen"
 
 #: src/app/[lang]/(catalog)/start/learn/[prompt]/page.tsx
 msgctxt "CaU_nf"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -545,6 +545,47 @@ msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Continue where you left off"
 
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "zfUTRh"
+msgid "More options for {courseTitle}"
+msgstr "More options for {courseTitle}"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "M9_kBE"
+msgid "Remove from My Courses"
+msgstr "Remove from My Courses"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "SZ0Rgi"
+msgid "Remove {courseTitle}?"
+msgstr "Remove {courseTitle}?"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RGYckE"
+msgid "The course will disappear from My Courses. Your progress will be kept."
+msgstr "The course will disappear from My Courses. Your progress will be kept."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "xjTT7H"
+msgid "We couldn't remove this course. Please try again."
+msgstr "We couldn't remove this course. Please try again."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Cancel"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RC2XA4"
+msgid "Removing..."
+msgstr "Removing..."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "D4eTra"
+msgid "Remove course"
+msgstr "Remove course"
+
 #: src/app/[lang]/(catalog)/my/user-course-list.tsx
 msgctxt "BDHWkf"
 msgid "No courses yet"
@@ -684,11 +725,6 @@ msgstr "Finding the best way to help"
 msgctxt "1A36NM"
 msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "We're checking your learning goal. This may take a few seconds."
-
-#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Cancel"
 
 #: src/app/[lang]/(catalog)/start/learn/[prompt]/page.tsx
 msgctxt "CaU_nf"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -545,6 +545,47 @@ msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Continúa donde lo dejaste"
 
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "zfUTRh"
+msgid "More options for {courseTitle}"
+msgstr "Más opciones para {courseTitle}"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "M9_kBE"
+msgid "Remove from My Courses"
+msgstr "Quitar de Mis cursos"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "SZ0Rgi"
+msgid "Remove {courseTitle}?"
+msgstr "¿Quitar {courseTitle}?"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RGYckE"
+msgid "The course will disappear from My Courses. Your progress will be kept."
+msgstr "El curso desaparecerá de Mis cursos. Tu progreso se conservará."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "xjTT7H"
+msgid "We couldn't remove this course. Please try again."
+msgstr "No pudimos quitar este curso. Inténtalo de nuevo."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RC2XA4"
+msgid "Removing..."
+msgstr "Quitando…"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "D4eTra"
+msgid "Remove course"
+msgstr "Quitar curso"
+
 #: src/app/[lang]/(catalog)/my/user-course-list.tsx
 msgctxt "BDHWkf"
 msgid "No courses yet"
@@ -684,11 +725,6 @@ msgstr "Buscando la mejor forma de ayudarte"
 msgctxt "1A36NM"
 msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "Estamos revisando tu objetivo de estudio. Esto puede tardar unos segundos."
-
-#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Cancelar"
 
 #: src/app/[lang]/(catalog)/start/learn/[prompt]/page.tsx
 msgctxt "CaU_nf"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -545,6 +545,47 @@ msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Reprends là où tu t'es arrêté"
 
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "zfUTRh"
+msgid "More options for {courseTitle}"
+msgstr "Plus d’options pour {courseTitle}"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "M9_kBE"
+msgid "Remove from My Courses"
+msgstr "Retirer de Mes cours"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "SZ0Rgi"
+msgid "Remove {courseTitle}?"
+msgstr "Retirer {courseTitle} ?"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RGYckE"
+msgid "The course will disappear from My Courses. Your progress will be kept."
+msgstr "Le cours disparaîtra de Mes cours. Ta progression sera conservée."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "xjTT7H"
+msgid "We couldn't remove this course. Please try again."
+msgstr "Impossible de retirer ce cours. Réessaie."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Annuler"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RC2XA4"
+msgid "Removing..."
+msgstr "Retrait…"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "D4eTra"
+msgid "Remove course"
+msgstr "Retirer le cours"
+
 #: src/app/[lang]/(catalog)/my/user-course-list.tsx
 msgctxt "BDHWkf"
 msgid "No courses yet"
@@ -684,11 +725,6 @@ msgstr "Nous cherchons la meilleure façon de t'aider"
 msgctxt "1A36NM"
 msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "Nous vérifions ton objectif d'apprentissage. Cela peut prendre quelques secondes."
-
-#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Annuler"
 
 #: src/app/[lang]/(catalog)/start/learn/[prompt]/page.tsx
 msgctxt "CaU_nf"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -545,6 +545,47 @@ msgctxt "Dr13kE"
 msgid "Continue where you left off"
 msgstr "Continue de onde parou"
 
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "zfUTRh"
+msgid "More options for {courseTitle}"
+msgstr "Mais opções para {courseTitle}"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "M9_kBE"
+msgid "Remove from My Courses"
+msgstr "Remover dos meus cursos"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "SZ0Rgi"
+msgid "Remove {courseTitle}?"
+msgstr "Remover {courseTitle}?"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RGYckE"
+msgid "The course will disappear from My Courses. Your progress will be kept."
+msgstr "O curso vai desaparecer de Meus cursos. Seu progresso será mantido."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "xjTT7H"
+msgid "We couldn't remove this course. Please try again."
+msgstr "Não foi possível remover este curso. Tente novamente."
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
+msgctxt "47FYwb"
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "RC2XA4"
+msgid "Removing..."
+msgstr "Removendo…"
+
+#: src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+msgctxt "D4eTra"
+msgid "Remove course"
+msgstr "Remover curso"
+
 #: src/app/[lang]/(catalog)/my/user-course-list.tsx
 msgctxt "BDHWkf"
 msgid "No courses yet"
@@ -684,11 +725,6 @@ msgstr "Buscando a melhor forma de ajudar"
 msgctxt "1A36NM"
 msgid "We're checking your learning goal. This may take a few seconds."
 msgstr "A gente está analisando sua meta de estudo. Isso pode levar alguns segundos."
-
-#: src/app/[lang]/(catalog)/start/learn/[prompt]/course-start-fallback.tsx
-msgctxt "47FYwb"
-msgid "Cancel"
-msgstr "Cancelar"
 
 #: src/app/[lang]/(catalog)/start/learn/[prompt]/page.tsx
 msgctxt "CaU_nf"

--- a/apps/main/src/app/[lang]/(catalog)/my/actions.ts
+++ b/apps/main/src/app/[lang]/(catalog)/my/actions.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { removeCurrentUserCourse } from "@zoonk/core/courses/remove-current-user";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { logError } from "@zoonk/utils/logger";
+import { isUuid } from "@zoonk/utils/uuid";
+import { revalidatePath } from "next/cache";
+
+export type RemoveCurrentUserCourseState = { status: "error" | "idle" | "success" };
+
+/**
+ * Adapts the My Courses confirmation form to the shared authenticated Core
+ * mutation, then refreshes this delivery surface so the removed row disappears.
+ */
+export async function removeCurrentUserCourseAction(
+  _previousState: RemoveCurrentUserCourseState,
+  formData: FormData,
+): Promise<RemoveCurrentUserCourseState> {
+  const courseId = parseFormField(formData, "courseId");
+
+  if (!courseId || !isUuid(courseId)) {
+    return { status: "error" as const };
+  }
+
+  const { data: result, error } = await safeAsync(() => removeCurrentUserCourse({ courseId }));
+
+  if (error || !result) {
+    logError("Error removing current user course:", error);
+    return { status: "error" as const };
+  }
+
+  revalidatePath("/[lang]/(catalog)/my", "page");
+  return { status: "success" as const };
+}

--- a/apps/main/src/app/[lang]/(catalog)/my/remove-course-menu.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/my/remove-course-menu.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@zoonk/ui/components/alert-dialog";
+import { Button } from "@zoonk/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@zoonk/ui/components/dropdown-menu";
+import { Spinner } from "@zoonk/ui/components/spinner";
+import { EllipsisIcon, ListXIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
+import { useActionState } from "react";
+import { type RemoveCurrentUserCourseState, removeCurrentUserCourseAction } from "./actions";
+
+const INITIAL_REMOVE_COURSE_STATE: RemoveCurrentUserCourseState = { status: "idle" };
+
+/**
+ * Keeps the destructive library action behind a familiar overflow menu and
+ * explains the progress-preservation contract before the learner confirms it.
+ */
+export function RemoveCourseMenu({
+  courseId,
+  courseTitle,
+}: {
+  courseId: string;
+  courseTitle: string;
+}) {
+  const t = useExtracted();
+
+  const [state, formAction, isPending] = useActionState(
+    removeCurrentUserCourseAction,
+    INITIAL_REMOVE_COURSE_STATE,
+  );
+
+  return (
+    <AlertDialog>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          aria-label={t("More options for {courseTitle}", { courseTitle })}
+          render={<Button size="icon-sm" variant="ghost" />}
+        >
+          <EllipsisIcon aria-hidden="true" />
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align="end" className="w-56">
+          <AlertDialogTrigger
+            nativeButton={false}
+            render={<DropdownMenuItem variant="destructive" />}
+            role="menuitem"
+          >
+            <ListXIcon aria-hidden="true" />
+            {t("Remove from My Courses")}
+          </AlertDialogTrigger>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("Remove {courseTitle}?", { courseTitle })}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("The course will disappear from My Courses. Your progress will be kept.")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {state.status === "error" && (
+          <p className="text-destructive text-sm" role="alert">
+            {t("We couldn't remove this course. Please try again.")}
+          </p>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>{t("Cancel")}</AlertDialogCancel>
+
+          <form action={formAction} className="contents">
+            <input name="courseId" type="hidden" value={courseId} />
+            <AlertDialogAction disabled={isPending} type="submit" variant="destructive">
+              {isPending && <Spinner />}
+              {isPending ? t("Removing...") : t("Remove course")}
+            </AlertDialogAction>
+          </form>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/main/src/app/[lang]/(catalog)/my/user-course-list.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/my/user-course-list.tsx
@@ -12,6 +12,7 @@ import {
 import {
   ListGroup,
   ListItem,
+  ListItemActions,
   ListItemContent,
   ListItemDescription,
   ListItemIcon,
@@ -22,6 +23,7 @@ import {
 import { NotebookPenIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
 import Image from "next/image";
+import { RemoveCourseMenu } from "./remove-course-menu";
 
 export async function UserCourseList() {
   const t = await getExtracted();
@@ -50,24 +52,31 @@ export async function UserCourseList() {
   return (
     <ListGroup>
       {courses.map((course) => (
-        <ListItem
-          key={course.id}
-          render={<Link href={`/b/${course.organization?.slug}/c/${course.slug}`} prefetch />}
-        >
-          {course.imageUrl ? (
-            <ListItemImage>
-              <Image alt={course.title} height={64} src={course.imageUrl} width={64} />
-            </ListItemImage>
-          ) : (
-            <ListItemIcon>
-              <NotebookPenIcon aria-hidden="true" className="text-muted-foreground/80 size-6" />
-            </ListItemIcon>
-          )}
+        <ListItem className="gap-0 p-0" key={course.id}>
+          <Link
+            className="focus-visible:ring-ring/50 hover:bg-muted flex min-w-0 flex-1 items-center gap-3.5 rounded-2xl px-4 py-2.5 transition-colors outline-none focus-visible:ring-[3px]"
+            href={`/b/${course.organization?.slug}/c/${course.slug}`}
+            prefetch
+          >
+            {course.imageUrl ? (
+              <ListItemImage>
+                <Image alt={course.title} height={64} src={course.imageUrl} width={64} />
+              </ListItemImage>
+            ) : (
+              <ListItemIcon>
+                <NotebookPenIcon aria-hidden="true" className="text-muted-foreground/80 size-6" />
+              </ListItemIcon>
+            )}
 
-          <ListItemContent>
-            <ListItemTitle>{course.title}</ListItemTitle>
-            <ListItemDescription>{course.description}</ListItemDescription>
-          </ListItemContent>
+            <ListItemContent>
+              <ListItemTitle>{course.title}</ListItemTitle>
+              <ListItemDescription>{course.description}</ListItemDescription>
+            </ListItemContent>
+          </Link>
+
+          <ListItemActions className="pr-3">
+            <RemoveCourseMenu courseId={course.id} courseTitle={course.title} />
+          </ListItemActions>
         </ListItem>
       ))}
     </ListGroup>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "./courses/list": "./src/courses/list-courses.ts",
     "./courses/prompt-contract": "./src/courses/course-prompt-contract.ts",
     "./courses/prompt-generation": "./src/courses/course-prompt-generation.ts",
+    "./courses/remove-current-user": "./src/courses/remove-current-user-course.ts",
     "./courses/resolve-prompt": "./src/courses/resolve-course-prompt.ts",
     "./courses/slug": "./src/courses/course-slug.ts",
     "./content/thumbnail": "./src/content/content-thumbnail.ts",

--- a/packages/core/src/courses/remove-current-user-course.test.ts
+++ b/packages/core/src/courses/remove-current-user-course.test.ts
@@ -1,0 +1,94 @@
+import { prisma } from "@zoonk/db";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture, courseUserFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture, lessonProgressFixture } from "@zoonk/testing/fixtures/lessons";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { revalidateTag } from "next/cache";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockSession } from "../_test-utils/mock-session";
+import { COURSE_LIST_CACHE_TAG, getCourseCacheTag, getUserProgressCacheTag } from "../cache/tags";
+import { removeCurrentUserCourse } from "./remove-current-user-course";
+
+vi.mock("../users/get-session", () => ({ getSession: vi.fn() }));
+
+describe(removeCurrentUserCourse, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession(null);
+  });
+
+  it("does not remove course membership for a guest", async () => {
+    const [course, user] = await Promise.all([courseFixture(), userFixture()]);
+    await courseUserFixture({ courseId: course.id, userId: user.id });
+
+    await expect(removeCurrentUserCourse({ courseId: course.id })).resolves.toBeNull();
+
+    await expect(
+      prisma.courseUser.findUnique({
+        where: { courseUser: { courseId: course.id, userId: user.id } },
+      }),
+    ).resolves.not.toBeNull();
+  });
+
+  it("removes only library membership while preserving learning progress", async () => {
+    const [course, otherUser, user] = await Promise.all([
+      courseFixture(),
+      userFixture(),
+      userFixture(),
+    ]);
+
+    const chapter = await chapterFixture({ courseId: course.id });
+    const lesson = await lessonFixture({ chapterId: chapter.id });
+
+    const [lessonProgress] = await Promise.all([
+      lessonProgressFixture({
+        completedAt: new Date(),
+        durationSeconds: 90,
+        lessonId: lesson.id,
+        userId: user.id,
+      }),
+      courseUserFixture({ courseId: course.id, userId: otherUser.id }),
+      courseUserFixture({ courseId: course.id, userId: user.id }),
+    ]);
+
+    mockSession(user.id);
+
+    await expect(removeCurrentUserCourse({ courseId: course.id })).resolves.toStrictEqual({
+      removed: true,
+    });
+
+    const [courseUser, otherCourseUser, preservedProgress, updatedCourse] = await Promise.all([
+      prisma.courseUser.findUnique({
+        where: { courseUser: { courseId: course.id, userId: user.id } },
+      }),
+      prisma.courseUser.findUnique({
+        where: { courseUser: { courseId: course.id, userId: otherUser.id } },
+      }),
+      prisma.lessonProgress.findUnique({ where: { id: lessonProgress.id } }),
+      prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+    ]);
+
+    expect(courseUser).toBeNull();
+    expect(otherCourseUser).not.toBeNull();
+    expect(preservedProgress).not.toBeNull();
+    expect(updatedCourse.userCount).toBe(1);
+    expect(revalidateTag).toHaveBeenCalledWith(COURSE_LIST_CACHE_TAG, { expire: 0 });
+    expect(revalidateTag).toHaveBeenCalledWith(getCourseCacheTag(course.id), { expire: 0 });
+    expect(revalidateTag).toHaveBeenCalledWith(getUserProgressCacheTag(user.id), { expire: 0 });
+  });
+
+  it("does not change the course when the learner is not enrolled", async () => {
+    const [course, user] = await Promise.all([courseFixture(), userFixture()]);
+    mockSession(user.id);
+
+    await expect(removeCurrentUserCourse({ courseId: course.id })).resolves.toStrictEqual({
+      removed: false,
+    });
+
+    await expect(
+      prisma.course.findUniqueOrThrow({ where: { id: course.id } }),
+    ).resolves.toMatchObject({ userCount: 0 });
+
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/courses/remove-current-user-course.ts
+++ b/packages/core/src/courses/remove-current-user-course.ts
@@ -1,0 +1,58 @@
+import "server-only";
+import { prisma } from "@zoonk/db";
+import { isUuid } from "@zoonk/utils/uuid";
+import { revalidateTag } from "next/cache";
+import { COURSE_LIST_CACHE_TAG, getCourseCacheTag, getUserProgressCacheTag } from "../cache/tags";
+import { getSession } from "../users/get-session";
+
+/**
+ * Deletes one learner's library membership and updates the course popularity
+ * count in the same transaction. Progress lives in separate tables and is
+ * intentionally outside this operation so learners can resume if they rejoin.
+ */
+async function removeCourseMembership({ courseId, userId }: { courseId: string; userId: string }) {
+  return prisma.$transaction(async (transaction) => {
+    const { count } = await transaction.courseUser.deleteMany({ where: { courseId, userId } });
+
+    if (count === 0) {
+      return false;
+    }
+
+    await transaction.course.update({
+      data: { userCount: { decrement: 1 } },
+      where: { id: courseId },
+    });
+
+    return true;
+  });
+}
+
+/**
+ * Removes a course from the authenticated learner's library without accepting
+ * an acting user ID. Missing memberships are idempotent, while a null result
+ * tells delivery adapters that the request was unauthenticated.
+ */
+export async function removeCurrentUserCourse({ courseId }: { courseId: string }) {
+  const session = await getSession();
+
+  if (!session) {
+    return null;
+  }
+
+  if (!isUuid(courseId)) {
+    return { removed: false };
+  }
+
+  const userId = session.user.id;
+  const removed = await removeCourseMembership({ courseId, userId });
+
+  if (!removed) {
+    return { removed: false };
+  }
+
+  revalidateTag(COURSE_LIST_CACHE_TAG, { expire: 0 });
+  revalidateTag(getCourseCacheTag(courseId), { expire: 0 });
+  revalidateTag(getUserProgressCacheTag(userId), { expire: 0 });
+
+  return { removed: true };
+}

--- a/packages/ui/src/components/list.tsx
+++ b/packages/ui/src/components/list.tsx
@@ -1,5 +1,6 @@
 import {
   Item,
+  ItemActions,
   ItemContent,
   ItemDescription,
   ItemGroup,
@@ -103,6 +104,14 @@ export function ListItemIcon({ className, ...props }: ItemMediaProps) {
  */
 export function ListItemContent({ className, ...props }: React.ComponentProps<"div">) {
   return <ItemContent className={cn("gap-1", className)} {...props} />;
+}
+
+/**
+ * Row-level controls stay separate from the primary link so list items remain
+ * valid, accessible compositions when they expose secondary actions.
+ */
+export function ListItemActions({ className, ...props }: React.ComponentProps<"div">) {
+  return <ItemActions className={className} {...props} />;
 }
 
 /**


### PR DESCRIPTION
Adds a subtle, confirmed removal flow to My Courses while preserving learner progress. Keeps CourseUser membership, course counts, and cache invalidation consistent, and exposes the same capability through the documented public API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a confirmed “Remove from My Courses” flow that removes library membership without clearing learner progress. Also adds a documented DELETE endpoint and keeps course counts and caches in sync.

- **New Features**
  - UI: Overflow menu with confirmation in My Courses; localized strings; removes the row after success.
  - API: DELETE /v1/me/courses/{courseId} for authenticated users; returns 204; documented in OpenAPI.
  - Core: `@zoonk/core/courses/remove-current-user` removes `courseUser`, decrements `userCount`, idempotent when not enrolled; revalidates course list, course, and user progress cache tags.
  - UI Kit: Added `ListItemActions` to support secondary row actions.
  - Tests: Added E2E and unit tests for UI, API, and OpenAPI contract.

<sup>Written for commit 89e509934554b00fc4655802262648b7b5ed4874. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

