### PR TITLE
feat(main): show monthly equivalent for yearly billing

### DIFF
--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -1509,14 +1509,9 @@ msgid "a planner you'll definitely use"
 msgstr "ein Planer, den du ganz bestimmt benutzen wirst"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "pro Monat"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "qxHg3H"
-msgid "per year"
-msgstr "pro Jahr"
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} jährlich abgerechnet"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
@@ -1548,6 +1543,11 @@ msgstr "Monatlich"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Jährlich"
+
+#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "pro Monat"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "Lxn0Fm"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1509,14 +1509,9 @@ msgid "a planner you'll definitely use"
 msgstr "a planner you'll definitely use"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "per month"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "qxHg3H"
-msgid "per year"
-msgstr "per year"
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} billed yearly"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
@@ -1548,6 +1543,11 @@ msgstr "Monthly"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Yearly"
+
+#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "per month"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "Lxn0Fm"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1509,14 +1509,9 @@ msgid "a planner you'll definitely use"
 msgstr "una agenda que esta vez sí vas a usar"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "al mes"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "qxHg3H"
-msgid "per year"
-msgstr "al año"
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} facturados al año"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
@@ -1548,6 +1543,11 @@ msgstr "Mensual"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Anual"
+
+#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "al mes"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "Lxn0Fm"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -1509,14 +1509,9 @@ msgid "a planner you'll definitely use"
 msgstr "un agenda que tu utiliseras, c'est sûr"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "par mois"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "qxHg3H"
-msgid "per year"
-msgstr "par an"
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} facturé par an"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
@@ -1548,6 +1543,11 @@ msgstr "Mensuel"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Annuel"
+
+#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "par mois"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "Lxn0Fm"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1509,14 +1509,9 @@ msgid "a planner you'll definitely use"
 msgstr "uma agenda que você com certeza vai usar"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "por mês"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "qxHg3H"
-msgid "per year"
-msgstr "por ano"
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} cobrados por ano"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
@@ -1548,6 +1543,11 @@ msgstr "Mensal"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Anual"
+
+#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "por mês"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "Lxn0Fm"

--- a/apps/main/src/app/[lang]/(settings)/subscription/_utils/billing-prices.test.ts
+++ b/apps/main/src/app/[lang]/(settings)/subscription/_utils/billing-prices.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from "vitest";
-import { getYearlySavings } from "./billing-savings";
+import { getMonthlyEquivalent, getYearlySavings } from "./billing-prices";
+
+describe(getMonthlyEquivalent, () => {
+  it("returns the yearly price divided across twelve months", () => {
+    const monthlyEquivalent = getMonthlyEquivalent({
+      yearlyPrice: { amount: 18_000, currency: "usd" },
+    });
+
+    expect(monthlyEquivalent).toStrictEqual({ amount: 1500, currency: "usd" });
+  });
+
+  it("rounds the equivalent to the nearest minor currency unit", () => {
+    const monthlyEquivalent = getMonthlyEquivalent({
+      yearlyPrice: { amount: 9999, currency: "usd" },
+    });
+
+    expect(monthlyEquivalent).toStrictEqual({ amount: 833, currency: "usd" });
+  });
+
+  it("returns null when the yearly price is missing", () => {
+    expect(getMonthlyEquivalent({ yearlyPrice: null })).toBeNull();
+  });
+});
 
 describe(getYearlySavings, () => {
   it("returns the proven yearly savings for Plus", () => {

--- a/apps/main/src/app/[lang]/(settings)/subscription/_utils/billing-prices.ts
+++ b/apps/main/src/app/[lang]/(settings)/subscription/_utils/billing-prices.ts
@@ -2,6 +2,27 @@ import { type PriceInfo } from "@zoonk/utils/currency";
 
 type PlanPrices = { monthlyPrice: PriceInfo | null; yearlyPrice: PriceInfo | null };
 
+const MONTHS_PER_YEAR = 12;
+
+/**
+ * Turns the yearly total into the closest monthly amount the currency can
+ * display. The exact yearly charge stays visible beside this comparison.
+ */
+export function getMonthlyEquivalent({
+  yearlyPrice,
+}: {
+  yearlyPrice: PriceInfo | null;
+}): PriceInfo | null {
+  if (!yearlyPrice) {
+    return null;
+  }
+
+  return {
+    amount: Math.round(yearlyPrice.amount / MONTHS_PER_YEAR),
+    currency: yearlyPrice.currency,
+  };
+}
+
 /**
  * The single Plus offer can make a yearly-savings claim only when Stripe proves
  * that its monthly and yearly prices use the same currency and the annual total
@@ -16,7 +37,7 @@ export function getYearlySavings({ monthlyPrice, yearlyPrice }: PlanPrices): Pri
     return null;
   }
 
-  const savedAmount = monthlyPrice.amount * 12 - yearlyPrice.amount;
+  const savedAmount = monthlyPrice.amount * MONTHS_PER_YEAR - yearlyPrice.amount;
 
   if (savedAmount <= 0) {
     return null;

--- a/apps/main/src/app/[lang]/(settings)/subscription/plus-purchase.tsx
+++ b/apps/main/src/app/[lang]/(settings)/subscription/plus-purchase.tsx
@@ -12,7 +12,7 @@ import { logError } from "@zoonk/utils/logger";
 import { Loader2Icon } from "lucide-react";
 import { useExtracted, useLocale } from "next-intl";
 import { useState } from "react";
-import { getYearlySavings } from "./_utils/billing-savings";
+import { getMonthlyEquivalent, getYearlySavings } from "./_utils/billing-prices";
 
 type BillingPeriod = "monthly" | "yearly";
 type RequestState = "error" | "idle" | "loading";
@@ -107,15 +107,16 @@ function AvailablePlusPurchase({
   const [requestState, setRequestState] = useState<RequestState>("idle");
   const t = useExtracted();
   const locale = useLocale();
-  const price = getSelectedPrice({ monthlyPrice, period, yearlyPrice });
+  const price = getDisplayedPrice({ monthlyPrice, period, yearlyPrice });
   const yearlySavings = getYearlySavings({ monthlyPrice, yearlyPrice });
   const valueComparisons = useValueComparisons();
   const isLoading = requestState === "loading";
-  const priceLabel = price ? formatPrice(price.amount, price.currency, locale) : null;
-  const periodLabel = period === "monthly" ? t("per month") : t("per year");
+  const priceLabel = formatOptionalPrice({ locale, price });
+  const yearlyPriceLabel = formatOptionalPrice({ locale, price: yearlyPrice });
+  const yearlySavingsAmount = formatOptionalPrice({ locale, price: yearlySavings });
 
-  const yearlySavingsAmount = yearlySavings
-    ? formatPrice(yearlySavings.amount, yearlySavings.currency, locale)
+  const yearlyBillingLabel = yearlyPriceLabel
+    ? t("{amount} billed yearly", { amount: yearlyPriceLabel })
     : null;
 
   const savingsLabel = yearlySavingsAmount
@@ -192,15 +193,15 @@ function AvailablePlusPurchase({
         {priceLabel ? (
           <p className="flex items-baseline gap-2">
             <span className="text-4xl font-semibold tracking-tight tabular-nums">{priceLabel}</span>
-            <span className="text-muted-foreground text-sm">{periodLabel}</span>
+            <span className="text-muted-foreground text-sm">{t("per month")}</span>
           </p>
         ) : (
           <p className="text-muted-foreground text-sm">{t("Price shown at checkout")}</p>
         )}
 
         <div className="min-h-5">
-          {period === "yearly" && savingsLabel && (
-            <p className="text-success text-sm font-medium">{savingsLabel}</p>
+          {period === "yearly" && yearlyBillingLabel && (
+            <p className="text-muted-foreground text-sm">{yearlyBillingLabel}</p>
           )}
         </div>
       </div>
@@ -344,10 +345,10 @@ function getStripeLocaleOverride(locale: string): StripeLocaleOverride | undefin
 }
 
 /**
- * Keeps the displayed amount and the checkout interval tied to the same
- * explicit billing choice.
+ * Keeps both billing options comparable at a glance. Yearly billing uses its
+ * monthly equivalent here while the exact charge remains visible below it.
  */
-function getSelectedPrice({
+function getDisplayedPrice({
   monthlyPrice,
   period,
   yearlyPrice,
@@ -356,5 +357,17 @@ function getSelectedPrice({
   period: BillingPeriod;
   yearlyPrice: PriceInfo | null;
 }) {
-  return period === "monthly" ? monthlyPrice : yearlyPrice;
+  if (period === "monthly") {
+    return monthlyPrice;
+  }
+
+  return getMonthlyEquivalent({ yearlyPrice });
+}
+
+/**
+ * Keeps optional Stripe prices out of the UI until a complete amount and
+ * currency are available to format together.
+ */
+function formatOptionalPrice({ locale, price }: { locale: string; price: PriceInfo | null }) {
+  return price ? formatPrice(price.amount, price.currency, locale) : null;
 }


### PR DESCRIPTION
Shows the monthly equivalent for yearly Plus billing while keeping the exact annual charge visible. Adds rounding coverage and localized billing copy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the monthly-equivalent price when users pick yearly Plus billing, while keeping the exact annual charge visible below. This makes monthly vs. yearly pricing easy to compare.

- **New Features**
  - Display the yearly plan’s monthly equivalent via `getMonthlyEquivalent` (rounded to the nearest minor unit).
  - Show "{amount} billed yearly" beneath the price when yearly is selected; keep "per month" next to the displayed amount.

- **Refactors**
  - Consolidated helpers into `billing-prices` and expanded tests for rounding and missing prices.
  - Updated localized copy in `en`, `es`, `fr`, `de`, and `pt`.

<sup>Written for commit 281f959afd5ef934af0546f0c3b733f7ba869cd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

