### PR TITLE
fix(player): preserve duplicate word bank selection

### DIFF
--- a/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-word-bank.browser.test.tsx
@@ -137,6 +137,38 @@ describe("player browser integration: word bank steps", () => {
     await expect.element(mundoOption).toBeEnabled();
   });
 
+  it("moves the tapped duplicate arrange-word option", async () => {
+    renderPlayer({
+      lesson: buildSerializedLesson({
+        kind: "reading",
+        steps: [
+          buildSerializedStep({
+            content: {},
+            kind: "reading",
+            sentence: buildSerializedSentence({ sentence: "he he", translation: "he he" }),
+            wordBankOptions: [
+              buildWordBankOption({ word: "he" }),
+              buildWordBankOption({ word: "he" }),
+            ],
+          }),
+        ],
+      }),
+      viewer: buildAuthenticatedViewer(),
+    });
+
+    const duplicateOptions = page
+      .getByRole("group", { name: /word bank/iu })
+      .getByRole("button", { exact: true, name: "he" });
+
+    const firstOption = duplicateOptions.nth(0);
+    const secondOption = duplicateOptions.nth(1);
+
+    await secondOption.click();
+
+    await expect.element(firstOption).toBeEnabled();
+    await expect.element(secondOption).toBeDisabled();
+  });
+
   it("keeps selected fill-blank options as disabled placeholders", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({

--- a/packages/player/src/components/arrange-words.tsx
+++ b/packages/player/src/components/arrange-words.tsx
@@ -13,11 +13,39 @@ import { ArrangeWordsAnswerArea, type PlacedWord } from "./arrange-words-answer-
 import { InteractiveStepLayout } from "./step-layouts";
 import { WordBankOptionButton } from "./word-bank-option-content";
 
-type WordBankTile = { isUsed: boolean; key: string; option: WordBankOption };
+type WordBankTile = { index: number; isUsed: boolean; key: string; option: WordBankOption };
+type PlacedWordWithBankIndex = PlacedWord & { wordBankIndex: number | null };
 
 /**
- * Duplicate words are valid, so a tile is considered used only when the learner
- * has already placed this exact occurrence of that word.
+ * Submitted answers preserve only their words, so a restored result cannot
+ * identify which duplicate bank tile originally supplied each word. Matching
+ * those untracked words by occurrence keeps the completed-answer view stable.
+ */
+function isUntrackedOccurrenceUsed({
+  index,
+  option,
+  placedWords,
+  words,
+}: {
+  index: number;
+  option: WordBankOption;
+  placedWords: PlacedWordWithBankIndex[];
+  words: WordBankOption[];
+}): boolean {
+  const usedCount = placedWords.filter(
+    (placed) => placed.wordBankIndex === null && placed.word === option.word,
+  ).length;
+
+  const occurrenceCount = words
+    .slice(0, index + 1)
+    .filter((item) => item.word === option.word).length;
+
+  return usedCount >= occurrenceCount;
+}
+
+/**
+ * Duplicate words are valid, so interactive selections use the original bank
+ * index to keep the tapped tile attached to the placed answer.
  */
 function getWordBankTile({
   index,
@@ -27,16 +55,14 @@ function getWordBankTile({
 }: {
   index: number;
   option: WordBankOption;
-  placedWords: PlacedWord[];
+  placedWords: PlacedWordWithBankIndex[];
   words: WordBankOption[];
 }): WordBankTile {
-  const usedCount = placedWords.filter((placed) => placed.word === option.word).length;
+  const isUsed =
+    placedWords.some((placed) => placed.wordBankIndex === index) ||
+    isUntrackedOccurrenceUsed({ index, option, placedWords, words });
 
-  const occurrenceCount = words
-    .slice(0, index + 1)
-    .filter((item) => item.word === option.word).length;
-
-  return { isUsed: usedCount >= occurrenceCount, key: `bank-${option.word}-${index}`, option };
+  return { index, isUsed, key: `bank-${option.word}-${index}`, option };
 }
 
 /**
@@ -47,7 +73,7 @@ function getWordBankTiles({
   placedWords,
   words,
 }: {
-  placedWords: PlacedWord[];
+  placedWords: PlacedWordWithBankIndex[];
   words: WordBankOption[];
 }): WordBankTile[] {
   return words.map((option, index) => getWordBankTile({ index, option, placedWords, words }));
@@ -60,8 +86,8 @@ function WordBank({
   words,
 }: {
   disabled: boolean;
-  onPlace: (option: WordBankOption) => void;
-  placedWords: PlacedWord[];
+  onPlace: (tile: WordBankTile) => void;
+  placedWords: PlacedWordWithBankIndex[];
   words: WordBankOption[];
 }) {
   const t = useExtracted();
@@ -81,7 +107,7 @@ function WordBank({
           disabled={disabled}
           isSelected={tile.isUsed}
           key={tile.key}
-          onToggle={() => onPlace(tile.option)}
+          onToggle={() => onPlace(tile)}
           option={tile.option}
         />
       ))}
@@ -113,7 +139,7 @@ export function ArrangeWordsInteraction({
   const idCounter = useRef(0);
   const { trigger } = useWebHaptics();
 
-  const [placedWords, setPlacedWords] = useState<PlacedWord[]>(() => {
+  const [placedWords, setPlacedWords] = useState<PlacedWordWithBankIndex[]>(() => {
     if (result?.answer?.kind === answerKind && "arrangedWords" in result.answer) {
       return result.answer.arrangedWords.map((word) => {
         const id = String(idCounter.current);
@@ -126,6 +152,7 @@ export function ArrangeWordsInteraction({
           romanization: null,
           translation: null,
           word,
+          wordBankIndex: null,
         };
       });
     }
@@ -138,7 +165,7 @@ export function ArrangeWordsInteraction({
   const maxAnswerLength = Math.max(...acceptedWordLengths, correctWords.length);
 
   const syncSelectedAnswer = useCallback(
-    (next: PlacedWord[]) => {
+    (next: PlacedWordWithBankIndex[]) => {
       const arrangedWords = next.map((placedWord) => placedWord.word);
 
       if (acceptedWordLengths.includes(next.length)) {
@@ -154,13 +181,19 @@ export function ArrangeWordsInteraction({
   );
 
   const handlePlace = useCallback(
-    (option: WordBankOption) => {
+    (tile: WordBankTile) => {
       if (result || placedWords.length >= maxAnswerLength) {
         return;
       }
 
-      void play(option.audioUrl);
-      const placed: PlacedWord = { ...option, id: String(idCounter.current) };
+      void play(tile.option.audioUrl);
+
+      const placed: PlacedWordWithBankIndex = {
+        ...tile.option,
+        id: String(idCounter.current),
+        wordBankIndex: tile.index,
+      };
+
       idCounter.current += 1;
       const next = [...placedWords, placed];
       setPlacedWords(next);


### PR DESCRIPTION
Keeps duplicate word-bank options tied to the exact tile the learner taps.

Adds browser coverage for selecting the second of two identical options.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate word-bank behavior in the player. Selecting a repeated option now moves the exact tile tapped and keeps that tile disabled.

- **Bug Fixes**
  - Track `wordBankIndex` on placed words to bind selections to their source tiles.
  - Update used-state logic to handle duplicates and restored answers without mixing occurrences.
  - Add browser test covering selecting the second of two identical options.

<sup>Written for commit 75368569a8cb594985c9cbbe374b4bcba8b50689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

