### PR TITLE
fix(player): improve progress milestone copy

### DIFF
--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -75,9 +75,9 @@ msgid "New daily best"
 msgstr "Neuer Tagesrekord"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "0TbCx0"
-msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
-msgstr "Du hast heute {brainPower} BP verdient, mehr als an jedem anderen Tag. Weiter so—deine Mühe wird sich auszahlen."
+msgctxt "WhzRyH"
+msgid "You earned {brainPower} BP today, more than on any other day."
+msgstr "Heute hast du {brainPower} BP verdient – mehr als an jedem anderen Tag."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -120,9 +120,9 @@ msgid "{days} learning days"
 msgstr "{days} Lerntage"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "_M8z1y"
-msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
-msgstr "Lernen wird für dich zur Gewohnheit. Regelmäßiges Üben hilft dir, dir mehr von dem zu merken, was du lernst."
+msgctxt "nUxfIs"
+msgid "Every day you complete a lesson adds to this total. Every lesson adds to your Brain Power."
+msgstr "Jeder Tag, an dem du eine Lektion abschließt, zählt dazu. Jede Lektion erhöht deine Brain Power."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -140,9 +140,14 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# Stunde gelernt} other {# Stunden gelernt}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "YYZPzp"
-msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
-msgstr "Die ganze Zeit, die du mit Lernen verbringst, zahlt sich aus. Selbst kurze, regelmäßige Einheiten helfen dir, neue Ideen im Gedächtnis zu behalten."
+msgctxt "Y9ocVC"
+msgid "That's like reading about {pages} pages of a book."
+msgstr "Das ist etwa so, als würdest du {pages} Seiten in einem Buch lesen."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgctxt "PCoIee"
+msgid "That's like reading about {books, plural, one {one {pagesPerBook}-page book} other {# books of {pagesPerBook} pages each}}."
+msgstr "Das ist etwa so, als würdest du {books, plural, one {ein Buch mit {pagesPerBook} Seiten} other {# Bücher mit jeweils {pagesPerBook} Seiten}} lesen."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -150,9 +155,9 @@ msgid "Level achieved"
 msgstr "Level erreicht"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "WheDiX"
-msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
-msgstr "Deine Mühe zahlt sich aus—du hast {belt}, Level {level}, erreicht. Weiter so—jede Lektion steigert deine Brain Power."
+msgctxt "6gG1fx"
+msgid "You've reached {belt}, level {level}. Every lesson adds to your Brain Power."
+msgstr "Geschafft: {belt}, Level {level}. Mit jeder Lektion wächst deine Brain Power."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "VfEqvB"
@@ -185,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} ist dein bester Tag"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "bim3gG"
-msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
-msgstr "Du erreichst im Schnitt {percentage} {day, select, sunday {sonntags} monday {montags} tuesday {dienstags} wednesday {mittwochs} thursday {donnerstags} friday {freitags} saturday {samstags} other {an deinem besten Tag}}, mehr als an jedem anderen Tag. Überlege, was dann besonders gut funktioniert—vielleicht kannst du es die ganze Woche über nutzen."
+msgctxt "hJIIFP"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day."
+msgstr "Du erreichst im Schnitt {percentage} {day, select, sunday {am Sonntag} monday {am Montag} tuesday {am Dienstag} wednesday {am Mittwoch} thursday {am Donnerstag} friday {am Freitag} saturday {am Samstag} other {an deinem besten Tag}} – mehr als an jedem anderen Tag."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -75,9 +75,9 @@ msgid "New daily best"
 msgstr "New daily best"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "0TbCx0"
-msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
-msgstr "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
+msgctxt "WhzRyH"
+msgid "You earned {brainPower} BP today, more than on any other day."
+msgstr "You earned {brainPower} BP today, more than on any other day."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -120,9 +120,9 @@ msgid "{days} learning days"
 msgstr "{days} learning days"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "_M8z1y"
-msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
-msgstr "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
+msgctxt "nUxfIs"
+msgid "Every day you complete a lesson adds to this total. Every lesson adds to your Brain Power."
+msgstr "Every day you complete a lesson adds to this total. Every lesson adds to your Brain Power."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -140,9 +140,14 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "YYZPzp"
-msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
-msgstr "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
+msgctxt "Y9ocVC"
+msgid "That's like reading about {pages} pages of a book."
+msgstr "That's like reading about {pages} pages of a book."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgctxt "PCoIee"
+msgid "That's like reading about {books, plural, one {one {pagesPerBook}-page book} other {# books of {pagesPerBook} pages each}}."
+msgstr "That's like reading about {books, plural, one {one {pagesPerBook}-page book} other {# books of {pagesPerBook} pages each}}."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -150,9 +155,9 @@ msgid "Level achieved"
 msgstr "Level achieved"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "WheDiX"
-msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
-msgstr "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
+msgctxt "6gG1fx"
+msgid "You've reached {belt}, level {level}. Every lesson adds to your Brain Power."
+msgstr "You've reached {belt}, level {level}. Every lesson adds to your Brain Power."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "VfEqvB"
@@ -185,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} is your best day"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "bim3gG"
-msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
-msgstr "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
+msgctxt "hJIIFP"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day."
+msgstr "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -75,9 +75,9 @@ msgid "New daily best"
 msgstr "Nuevo récord diario"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "0TbCx0"
-msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
-msgstr "Hoy ganaste {brainPower} PM, más que cualquier otro día. Sigue así: este esfuerzo dará sus frutos."
+msgctxt "WhzRyH"
+msgid "You earned {brainPower} BP today, more than on any other day."
+msgstr "Hoy ganaste {brainPower} PM, más que cualquier otro día."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -120,9 +120,9 @@ msgid "{days} learning days"
 msgstr "{days} días de estudio"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "_M8z1y"
-msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
-msgstr "El estudio ya forma parte de tu rutina. Practicar con regularidad te ayuda a recordar mejor lo que aprendes."
+msgctxt "nUxfIs"
+msgid "Every day you complete a lesson adds to this total. Every lesson adds to your Brain Power."
+msgstr "Cada día que completas una lección se suma a este total. Cada lección aumenta tu Poder Mental."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -140,9 +140,14 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# hora de estudio} other {# horas de estudio}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "YYZPzp"
-msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
-msgstr "Todo el tiempo que dedicas al estudio suma. Incluso las sesiones cortas y frecuentes ayudan a que las ideas nuevas se queden contigo."
+msgctxt "Y9ocVC"
+msgid "That's like reading about {pages} pages of a book."
+msgstr "Es como leer unas {pages} páginas de un libro."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgctxt "PCoIee"
+msgid "That's like reading about {books, plural, one {one {pagesPerBook}-page book} other {# books of {pagesPerBook} pages each}}."
+msgstr "Es como leer {books, plural, one {aproximadamente un libro de {pagesPerBook} páginas} other {aproximadamente # libros de {pagesPerBook} páginas cada uno}}."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -150,9 +155,9 @@ msgid "Level achieved"
 msgstr "Nivel alcanzado"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "WheDiX"
-msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
-msgstr "Tu esfuerzo está dando frutos: alcanzaste {belt}, nivel {level}. Sigue así: cada lección aumenta tu Poder Mental."
+msgctxt "6gG1fx"
+msgid "You've reached {belt}, level {level}. Every lesson adds to your Brain Power."
+msgstr "Has alcanzado {belt}, nivel {level}. Cada lección aumenta tu Poder Mental."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "VfEqvB"
@@ -185,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} es tu mejor día"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "bim3gG"
-msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
-msgstr "Tu promedio es de {percentage} {day, select, sunday {los domingos} monday {los lunes} tuesday {los martes} wednesday {los miércoles} thursday {los jueves} friday {los viernes} saturday {los sábados} other {en tu mejor día}}, mejor que cualquier otro día. Piensa en qué funciona bien ese día: quizá puedas aplicarlo durante toda la semana."
+msgctxt "hJIIFP"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day."
+msgstr "Tu promedio es de {percentage} {day, select, sunday {los domingos} monday {los lunes} tuesday {los martes} wednesday {los miércoles} thursday {los jueves} friday {los viernes} saturday {los sábados} other {en tu mejor día}}, mejor que cualquier otro día."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -75,9 +75,9 @@ msgid "New daily best"
 msgstr "Nouveau record du jour"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "0TbCx0"
-msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
-msgstr "Tu as gagné {brainPower} PM aujourd’hui, plus que n’importe quel autre jour. Continue comme ça : tes efforts porteront leurs fruits."
+msgctxt "WhzRyH"
+msgid "You earned {brainPower} BP today, more than on any other day."
+msgstr "Tu as gagné {brainPower} PM aujourd’hui, plus que tous les autres jours."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -120,9 +120,9 @@ msgid "{days} learning days"
 msgstr "{days} jours d’apprentissage"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "_M8z1y"
-msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
-msgstr "Apprendre fait désormais partie de tes habitudes. T’entraîner régulièrement t’aide à mieux retenir ce que tu apprends."
+msgctxt "nUxfIs"
+msgid "Every day you complete a lesson adds to this total. Every lesson adds to your Brain Power."
+msgstr "Chaque jour où tu termines une leçon s’ajoute à ce total. Chaque leçon augmente ta Puissance Mentale."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -140,9 +140,14 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# heure d’apprentissage} other {# heures d’apprentissage}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "YYZPzp"
-msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
-msgstr "Tout ce temps passé à apprendre finit par compter. Même de courtes sessions régulières peuvent t’aider à retenir de nouvelles idées."
+msgctxt "Y9ocVC"
+msgid "That's like reading about {pages} pages of a book."
+msgstr "C’est comme lire environ {pages} pages d’un livre."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgctxt "PCoIee"
+msgid "That's like reading about {books, plural, one {one {pagesPerBook}-page book} other {# books of {pagesPerBook} pages each}}."
+msgstr "C’est comme lire environ {books, plural, one {un livre de {pagesPerBook} pages} other {# livres de {pagesPerBook} pages chacun}}."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -150,9 +155,9 @@ msgid "Level achieved"
 msgstr "Niveau atteint"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "WheDiX"
-msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
-msgstr "Tes efforts portent leurs fruits : tu as atteint {belt}, niveau {level}. Continue comme ça : chaque leçon augmente ta Puissance Mentale."
+msgctxt "6gG1fx"
+msgid "You've reached {belt}, level {level}. Every lesson adds to your Brain Power."
+msgstr "Tu as atteint la ceinture {belt}, niveau {level}. Chaque leçon augmente ta Puissance Mentale."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "VfEqvB"
@@ -185,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} est ton meilleur jour"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "bim3gG"
-msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
-msgstr "Tu obtiens en moyenne {percentage} {day, select, sunday {le dimanche} monday {le lundi} tuesday {le mardi} wednesday {le mercredi} thursday {le jeudi} friday {le vendredi} saturday {le samedi} other {lors de ton meilleur jour}}, plus que n’importe quel autre jour. Réfléchis à ce qui fonctionne bien ce jour-là : tu pourras peut-être t’en servir toute la semaine."
+msgctxt "hJIIFP"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day."
+msgstr "Ta moyenne est de {percentage} {day, select, sunday {le dimanche} monday {le lundi} tuesday {le mardi} wednesday {le mercredi} thursday {le jeudi} friday {le vendredi} saturday {le samedi} other {le jour où tu réussis le mieux}}, ce qui est mieux que tous les autres jours."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -75,9 +75,9 @@ msgid "New daily best"
 msgstr "Novo recorde diário"
 
 #: src/components/completion-brain-power-milestone.tsx
-msgctxt "0TbCx0"
-msgid "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off."
-msgstr "Você ganhou {brainPower} PM hoje, mais do que em qualquer outro dia. Continue assim — esse esforço vai valer a pena."
+msgctxt "WhzRyH"
+msgid "You earned {brainPower} BP today, more than on any other day."
+msgstr "Você ganhou {brainPower} PM hoje, mais do que em qualquer outro dia."
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "m2WzLQ"
@@ -120,9 +120,9 @@ msgid "{days} learning days"
 msgstr "{days} dias de estudo"
 
 #: src/components/completion-learning-days-milestone.tsx
-msgctxt "_M8z1y"
-msgid "You're making learning part of your routine. Regular practice helps you remember more of what you learn."
-msgstr "O estudo está virando parte da sua rotina. Praticar com frequência te ajuda a lembrar melhor o que aprendeu."
+msgctxt "nUxfIs"
+msgid "Every day you complete a lesson adds to this total. Every lesson adds to your Brain Power."
+msgstr "Cada dia em que você completa uma aula conta para esse total. Cada aula aumenta seu Poder Mental."
 
 #: src/components/completion-learning-time-milestone.tsx
 msgctxt "dZvEPp"
@@ -140,9 +140,14 @@ msgid "{hours, plural, one {# hour of learning} other {# hours of learning}}"
 msgstr "{hours, plural, one {# hora de estudo} other {# horas de estudo}}"
 
 #: src/components/completion-learning-time-milestone.tsx
-msgctxt "YYZPzp"
-msgid "All that time spent learning adds up. Even short, regular sessions can help new ideas stick."
-msgstr "Todo esse tempo de estudo faz diferença. Mesmo sessões curtas e frequentes ajudam a fixar novas ideias."
+msgctxt "Y9ocVC"
+msgid "That's like reading about {pages} pages of a book."
+msgstr "É como ler cerca de {pages} páginas de um livro."
+
+#: src/components/completion-learning-time-milestone.tsx
+msgctxt "PCoIee"
+msgid "That's like reading about {books, plural, one {one {pagesPerBook}-page book} other {# books of {pagesPerBook} pages each}}."
+msgstr "É como ler cerca de {books, plural, one {um livro de {pagesPerBook} páginas} other {# livros de {pagesPerBook} páginas cada}}."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "155cHi"
@@ -150,9 +155,9 @@ msgid "Level achieved"
 msgstr "Nível alcançado"
 
 #: src/components/completion-level-milestone.tsx
-msgctxt "WheDiX"
-msgid "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power."
-msgstr "Seu esforço está valendo a pena — você chegou à {belt}, nível {level}. Continue assim — cada aula aumenta seu Poder Mental."
+msgctxt "6gG1fx"
+msgid "You've reached {belt}, level {level}. Every lesson adds to your Brain Power."
+msgstr "Você chegou à {belt}, nível {level}. Cada aula aumenta seu Poder Mental."
 
 #: src/components/completion-level-milestone.tsx
 msgctxt "VfEqvB"
@@ -185,9 +190,9 @@ msgid "{day} is your best day"
 msgstr "{day} é seu melhor dia"
 
 #: src/components/completion-patterns-milestone.tsx
-msgctxt "bim3gG"
-msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week."
-msgstr "Sua média é de {percentage} {day, select, sunday {aos domingos} monday {às segundas-feiras} tuesday {às terças-feiras} wednesday {às quartas-feiras} thursday {às quintas-feiras} friday {às sextas-feiras} saturday {aos sábados} other {no seu melhor dia}}, melhor do que em qualquer outro dia. Pense no que dá certo nesse dia — talvez você possa usar isso durante toda a semana."
+msgctxt "hJIIFP"
+msgid "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day."
+msgstr "Você tem uma média de {percentage} {day, select, sunday {aos domingos} monday {às segundas-feiras} tuesday {às terças-feiras} wednesday {às quartas-feiras} thursday {às quintas-feiras} friday {às sextas-feiras} saturday {aos sábados} other {no seu melhor dia}}, melhor do que em qualquer outro dia."
 
 #: src/components/completion-progress-milestone-screen.tsx
 msgctxt "iSioEh"

--- a/packages/player/src/_utils/learning-time-reading-comparison.test.ts
+++ b/packages/player/src/_utils/learning-time-reading-comparison.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getLearningTimeReadingComparison } from "./learning-time-reading-comparison";
+
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+
+describe(getLearningTimeReadingComparison, () => {
+  it("uses pages for early learning-time milestones", () => {
+    expect(getLearningTimeReadingComparison(10 * SECONDS_PER_MINUTE)).toStrictEqual({
+      kind: "pages",
+      pages: 7,
+    });
+  });
+
+  it("turns nine learning hours into one 300-page book", () => {
+    expect(getLearningTimeReadingComparison(9 * SECONDS_PER_HOUR)).toStrictEqual({
+      books: 1,
+      kind: "books",
+      pagesPerBook: 300,
+    });
+  });
+
+  it("keeps larger comparisons easy to picture", () => {
+    expect(getLearningTimeReadingComparison(24 * SECONDS_PER_HOUR)).toStrictEqual({
+      books: 3,
+      kind: "books",
+      pagesPerBook: 300,
+    });
+  });
+});

--- a/packages/player/src/_utils/learning-time-reading-comparison.ts
+++ b/packages/player/src/_utils/learning-time-reading-comparison.ts
@@ -1,0 +1,28 @@
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+const READING_PAGES_PER_HOUR = 40;
+const REFERENCE_BOOK_PAGES = 300;
+const MINIMUM_BOOK_COMPARISON_HOURS = 9;
+
+export type LearningTimeReadingComparison =
+  | { kind: "pages"; pages: number }
+  | { books: number; kind: "books"; pagesPerBook: number };
+
+/**
+ * Makes accumulated learning time easier to picture with a simple book
+ * comparison. Early milestones stay in pages, while nine hours and beyond use
+ * a familiar 300-page book so large totals remain easy to understand.
+ */
+export function getLearningTimeReadingComparison(seconds: number): LearningTimeReadingComparison {
+  const hours = seconds / SECONDS_PER_HOUR;
+  const pages = Math.round(hours * READING_PAGES_PER_HOUR);
+
+  if (hours < MINIMUM_BOOK_COMPARISON_HOURS) {
+    return { kind: "pages", pages };
+  }
+
+  const books = Math.round(pages / REFERENCE_BOOK_PAGES);
+
+  return { books, kind: "books", pagesPerBook: REFERENCE_BOOK_PAGES };
+}

--- a/packages/player/src/components/completion-brain-power-milestone.tsx
+++ b/packages/player/src/components/completion-brain-power-milestone.tsx
@@ -28,10 +28,9 @@ export function BrainPowerMilestoneCopy({ milestone }: { milestone: BrainPowerMi
     <>
       <CompletionMilestoneTitle>{t("New daily best")}</CompletionMilestoneTitle>
       <PlayerSupportingText>
-        {t(
-          "You earned {brainPower} BP today, more than on any other day. Keep it up—this effort will pay off.",
-          { brainPower: formattedBrainPower },
-        )}
+        {t("You earned {brainPower} BP today, more than on any other day.", {
+          brainPower: formattedBrainPower,
+        })}
       </PlayerSupportingText>
     </>
   );

--- a/packages/player/src/components/completion-learning-days-milestone.tsx
+++ b/packages/player/src/components/completion-learning-days-milestone.tsx
@@ -39,7 +39,7 @@ export function LearningDaysMilestoneCopy({ milestone }: { milestone: LearningDa
       </CompletionMilestoneTitle>
       <PlayerSupportingText>
         {t(
-          "You're making learning part of your routine. Regular practice helps you remember more of what you learn.",
+          "Every day you complete a lesson adds to this total. Every lesson adds to your Brain Power.",
         )}
       </PlayerSupportingText>
     </>

--- a/packages/player/src/components/completion-learning-time-milestone.tsx
+++ b/packages/player/src/components/completion-learning-time-milestone.tsx
@@ -3,6 +3,7 @@
 import { formatWholeNumber } from "@zoonk/utils/number";
 import { ClockIcon } from "lucide-react";
 import { useExtracted, useFormatter } from "next-intl";
+import { getLearningTimeReadingComparison } from "../_utils/learning-time-reading-comparison";
 import { type PlayerCompletionMilestone } from "../completion-milestones";
 import { CompletionMilestoneMark, CompletionMilestoneTitle } from "./completion-milestone-shell";
 import { PlayerSupportingText } from "./player-supporting-text";
@@ -61,16 +62,31 @@ function LearningTimeMilestoneTitle({ seconds }: { seconds: number }) {
 }
 
 /**
- * Connects accumulated learning time to the value of regular practice without
- * repeating the duration already shown in the milestone title.
+ * Turns the abstract time total into a reading comparison that stays concrete
+ * from the first few pages through large numbers of full-length books.
  */
-function LearningTimeMilestoneDescription() {
+function LearningTimeMilestoneDescription({ seconds }: { seconds: number }) {
   const t = useExtracted();
+  const format = useFormatter();
+  const comparison = getLearningTimeReadingComparison(seconds);
+
+  if (comparison.kind === "pages") {
+    const formattedPages = formatWholeNumber({ format, value: comparison.pages });
+
+    return (
+      <PlayerSupportingText>
+        {t("That's like reading about {pages} pages of a book.", { pages: formattedPages })}
+      </PlayerSupportingText>
+    );
+  }
+
+  const formattedPagesPerBook = formatWholeNumber({ format, value: comparison.pagesPerBook });
 
   return (
     <PlayerSupportingText>
       {t(
-        "All that time spent learning adds up. Even short, regular sessions can help new ideas stick.",
+        "That's like reading about {books, plural, one {one {pagesPerBook}-page book} other {# books of {pagesPerBook} pages each}}.",
+        { books: comparison.books, pagesPerBook: formattedPagesPerBook },
       )}
     </PlayerSupportingText>
   );
@@ -84,7 +100,7 @@ export function LearningTimeMilestoneCopy({ milestone }: { milestone: LearningTi
   return (
     <>
       <LearningTimeMilestoneTitle seconds={milestone.seconds} />
-      <LearningTimeMilestoneDescription />
+      <LearningTimeMilestoneDescription seconds={milestone.seconds} />
     </>
   );
 }

--- a/packages/player/src/components/completion-level-milestone.tsx
+++ b/packages/player/src/components/completion-level-milestone.tsx
@@ -35,10 +35,10 @@ function AchievedLevelCopy({
     <>
       <CompletionMilestoneTitle>{t("Level achieved")}</CompletionMilestoneTitle>
       <PlayerSupportingText>
-        {t(
-          "Your effort is paying off—you've reached {belt}, level {level}. Keep it up—every lesson adds to your Brain Power.",
-          { belt: beltLabel, level: String(milestone.belt.level) },
-        )}
+        {t("You've reached {belt}, level {level}. Every lesson adds to your Brain Power.", {
+          belt: beltLabel,
+          level: String(milestone.belt.level),
+        })}
       </PlayerSupportingText>
     </>
   );

--- a/packages/player/src/components/completion-patterns-milestone.tsx
+++ b/packages/player/src/components/completion-patterns-milestone.tsx
@@ -73,7 +73,7 @@ export function PatternsMilestoneCopy({ milestone }: { milestone: PatternsMilest
       </CompletionMilestoneTitle>
       <PlayerSupportingText>
         {t(
-          "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day. Think about what works well then—you may be able to use it throughout the week.",
+          "You average {percentage} {day, select, sunday {on Sunday} monday {on Monday} tuesday {on Tuesday} wednesday {on Wednesday} thursday {on Thursday} friday {on Friday} saturday {on Saturday} other {on your best day}}, better than on any other day.",
           { day: weekdayKey, percentage: formattedScore },
         )}
       </PlayerSupportingText>


### PR DESCRIPTION
## Summary

- make learning-time milestones tangible with page and book comparisons
- tighten learning-day, best-day, daily Brain Power, and level descriptions
- update player translations and cover the comparison thresholds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make progress milestone copy clearer by turning learning time into a reading comparison and tightening messages across milestones. Adds a small utility with tests and updates translations.

- **New Features**
  - Added `getLearningTimeReadingComparison` (+ tests): converts seconds to pages; switches to 300‑page book units at 9+ hours.
  - Learning-time milestone now shows “about {pages} pages” or “{# books of {pagesPerBook} pages each}”.
  - Shortened copy for daily best Brain Power, learning days, level achieved, and best‑day patterns.
  - Updated `en`, `es`, `fr`, `de`, `pt` strings for the new comparison and phrasing.

<sup>Written for commit e2133038dce4596c5a18235505a013929cc52f29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

