### PR TITLE
fix(main): index chapters and improve catalog metadata

### DIFF
--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -295,6 +295,18 @@ test.describe("Chapter Detail Page", () => {
   test("shows chapter content with title, description, and image", async ({ page }) => {
     await page.goto(chapterUrl);
 
+    await expect(page).toHaveTitle(`${chapterTitle}: ${courseTitle} course | Zoonk`);
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => document.querySelector<HTMLMetaElement>("meta[name='description']")?.content ?? "",
+        ),
+      )
+      .toMatch(
+        new RegExp(`${chapterTitle}.*${courseTitle}.*Different types of learning ${uniqueId}`, "u"),
+      );
+
     await expect(
       page.getByRole("heading", { exact: true, level: 1, name: `1. ${chapterTitle}` }),
     ).toBeVisible();

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -948,7 +948,7 @@ test.describe("Lesson Player Page", () => {
 
     await page.goto(`/pt/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page).toHaveTitle(new RegExp(`Explicação sobre ${lessonTitle}`, "u"));
+    await expect(page).toHaveTitle(new RegExp(`${lessonTitle}.*:.*${course.title}`, "u"));
 
     await expect
       .poll(() =>
@@ -956,7 +956,9 @@ test.describe("Lesson Player Page", () => {
           () => document.querySelector<HTMLMetaElement>("meta[name='description']")?.content ?? "",
         ),
       )
-      .toBe(`E2E lesson description ${uniqueId}`);
+      .toMatch(
+        new RegExp(`${lessonTitle}.*${course.title}.*E2E lesson description ${uniqueId}`, "u"),
+      );
 
     await expectRobotsMeta({ page, value: "index, follow" });
   });
@@ -1029,7 +1031,7 @@ test.describe("Lesson Player Page", () => {
 
     await page.goto(`/pt/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
 
-    await expect(page).toHaveTitle(new RegExp(`Quiz sobre ${sourceTitle}`, "u"));
+    await expect(page).toHaveTitle(new RegExp(`${sourceTitle}.*:.*${course.title}`, "u"));
 
     await expect(page).not.toHaveTitle(/Quiz Quiz/u);
   });

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -398,6 +398,16 @@ msgctxt "xTTP0x"
 msgid "Not started"
 msgstr "Nicht begonnen"
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "QB2G_Y"
+msgid "Chapter about {chapter} in the {course} course. {description}"
+msgstr "Kapitel über {chapter} im Kurs {course}. {description}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "DcXGUl"
+msgid "{chapter}: {course} course"
+msgstr "{chapter}: Kurs {course}"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgctxt "iRubpl"
 msgid "Current chapter"
@@ -3011,6 +3021,16 @@ msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} expl
 msgstr "{chapter}: {kind, select, alphabet {Alphabet} custom {Eigene Lektion} explanation {Erklärung} grammar {Grammatik} listening {Hören} practice {Übung} quiz {Quiz} reading {Lesen} review {Wiederholung} translation {Übersetzung} tutorial {Tutorial} vocabulary {Wortschatz} other {Lektion}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "EuLBDj"
-msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
-msgstr "{kind, select, alphabet {Alphabet: {lesson}} custom {Eigene Lektion: {lesson}} explanation {Erklärung zu {lesson}} grammar {Grammatik: {lesson}} listening {Hörübung: {lesson}} practice {Übung zu {lesson}} quiz {Quiz zu {lesson}} reading {Leseübung: {lesson}} review {Wiederholung zu {lesson}} translation {Übersetzung von {lesson}} tutorial {Tutorial zu {lesson}} vocabulary {Wortschatz: {lesson}} other {{lesson}}} – {course}"
+msgctxt "teYphW"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}}: {course} course"
+msgstr "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Individuelle Lektion} explanation {{lesson} Erklärung} grammar {{lesson} Grammatik} listening {{lesson} Hören} practice {{lesson} Übung} quiz {{lesson} Quiz} reading {{lesson} Lesen} review {{lesson} Wiederholung} translation {{lesson} Übersetzung} tutorial {{lesson} Anleitung} vocabulary {{lesson} Wortschatz} other {{lesson}}}: Kurs {course}"
+
+#: src/lib/lessons.ts
+msgctxt "GeDl17"
+msgid "{lesson}: {course} course"
+msgstr "{lesson}: Kurs {course}"
+
+#: src/lib/lessons.ts
+msgctxt "aACHYf"
+msgid "Lesson about {lesson} in the {course} course. {description}"
+msgstr "Lektion über {lesson} im Kurs {course}. {description}"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -398,6 +398,16 @@ msgctxt "xTTP0x"
 msgid "Not started"
 msgstr "Not started"
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "QB2G_Y"
+msgid "Chapter about {chapter} in the {course} course. {description}"
+msgstr "Chapter about {chapter} in the {course} course. {description}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "DcXGUl"
+msgid "{chapter}: {course} course"
+msgstr "{chapter}: {course} course"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgctxt "iRubpl"
 msgid "Current chapter"
@@ -3011,6 +3021,16 @@ msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} expl
 msgstr "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} explanation {Explanation} grammar {Grammar} listening {Listening} practice {Practice} quiz {Quiz} reading {Reading} review {Review} translation {Translation} tutorial {Tutorial} vocabulary {Vocabulary} other {Lesson}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "EuLBDj"
-msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
-msgstr "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
+msgctxt "teYphW"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}}: {course} course"
+msgstr "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}}: {course} course"
+
+#: src/lib/lessons.ts
+msgctxt "GeDl17"
+msgid "{lesson}: {course} course"
+msgstr "{lesson}: {course} course"
+
+#: src/lib/lessons.ts
+msgctxt "aACHYf"
+msgid "Lesson about {lesson} in the {course} course. {description}"
+msgstr "Lesson about {lesson} in the {course} course. {description}"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -398,6 +398,16 @@ msgctxt "xTTP0x"
 msgid "Not started"
 msgstr "Sin empezar"
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "QB2G_Y"
+msgid "Chapter about {chapter} in the {course} course. {description}"
+msgstr "Capítulo sobre {chapter} del curso {course}. {description}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "DcXGUl"
+msgid "{chapter}: {course} course"
+msgstr "{chapter}: curso de {course}"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgctxt "iRubpl"
 msgid "Current chapter"
@@ -3011,6 +3021,16 @@ msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} expl
 msgstr "{chapter}: {kind, select, alphabet {Alfabeto} custom {Lección personalizada} explanation {Explicación} grammar {Gramática} listening {Escucha} practice {Práctica} quiz {Cuestionario} reading {Lectura} review {Repaso} translation {Traducción} tutorial {Tutorial} vocabulary {Vocabulario} other {Lección}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "EuLBDj"
-msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
-msgstr "{kind, select, alphabet {Alfabeto: {lesson}} custom {Lección personalizada: {lesson}} explanation {Explicación sobre {lesson}} grammar {Gramática: {lesson}} listening {Práctica de escucha: {lesson}} practice {Práctica de {lesson}} quiz {Quiz sobre {lesson}} reading {Práctica de lectura: {lesson}} review {Repaso de {lesson}} translation {Traducción de {lesson}} tutorial {Tutorial sobre {lesson}} vocabulary {Vocabulario: {lesson}} other {{lesson}}} - {course}"
+msgctxt "teYphW"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}}: {course} course"
+msgstr "{kind, select, alphabet {{lesson} Alfabeto} custom {{lesson} Lección personalizada} explanation {{lesson} Explicación} grammar {{lesson} Gramática} listening {{lesson} Escucha} practice {{lesson} Práctica} quiz {{lesson} Cuestionario} reading {{lesson} Lectura} review {{lesson} Repaso} translation {{lesson} Traducción} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulario} other {{lesson}}}: curso de {course}"
+
+#: src/lib/lessons.ts
+msgctxt "GeDl17"
+msgid "{lesson}: {course} course"
+msgstr "{lesson}: curso de {course}"
+
+#: src/lib/lessons.ts
+msgctxt "aACHYf"
+msgid "Lesson about {lesson} in the {course} course. {description}"
+msgstr "Lección sobre {lesson} del curso {course}. {description}"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -398,6 +398,16 @@ msgctxt "xTTP0x"
 msgid "Not started"
 msgstr "Pas commencé"
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "QB2G_Y"
+msgid "Chapter about {chapter} in the {course} course. {description}"
+msgstr "Chapitre sur {chapter} dans le cours {course}. {description}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "DcXGUl"
+msgid "{chapter}: {course} course"
+msgstr "{chapter} : cours {course}"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgctxt "iRubpl"
 msgid "Current chapter"
@@ -3011,6 +3021,16 @@ msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} expl
 msgstr "{chapter} : {kind, select, alphabet {Alphabet} custom {Leçon personnalisée} explanation {Explication} grammar {Grammaire} listening {Écoute} practice {Entraînement} quiz {Quiz} reading {Lecture} review {Révision} translation {Traduction} tutorial {Tutoriel} vocabulary {Vocabulaire} other {Leçon}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "EuLBDj"
-msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
-msgstr "{kind, select, alphabet {Alphabet : {lesson}} custom {Leçon personnalisée : {lesson}} explanation {Explication de {lesson}} grammar {Grammaire : {lesson}} listening {Exercice d’écoute : {lesson}} practice {Entraînement sur {lesson}} quiz {Quiz sur {lesson}} reading {Exercice de lecture : {lesson}} review {Révision de {lesson}} translation {Traduction de {lesson}} tutorial {Tutoriel sur {lesson}} vocabulary {Vocabulaire : {lesson}} other {{lesson}}} - {course}"
+msgctxt "teYphW"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}}: {course} course"
+msgstr "{kind, select, alphabet {{lesson} – Alphabet} custom {{lesson} – Leçon personnalisée} explanation {{lesson} – Explication} grammar {{lesson} – Grammaire} listening {{lesson} – Écoute} practice {{lesson} – Pratique} quiz {{lesson} – Quiz} reading {{lesson} – Lecture} review {{lesson} – Révision} translation {{lesson} – Traduction} tutorial {{lesson} – Tutoriel} vocabulary {{lesson} – Vocabulaire} other {{lesson}}} : cours {course}"
+
+#: src/lib/lessons.ts
+msgctxt "GeDl17"
+msgid "{lesson}: {course} course"
+msgstr "{lesson} : cours {course}"
+
+#: src/lib/lessons.ts
+msgctxt "aACHYf"
+msgid "Lesson about {lesson} in the {course} course. {description}"
+msgstr "Leçon sur {lesson} dans le cours {course}. {description}"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -398,6 +398,16 @@ msgctxt "xTTP0x"
 msgid "Not started"
 msgstr "Não começou"
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "QB2G_Y"
+msgid "Chapter about {chapter} in the {course} course. {description}"
+msgstr "Capítulo sobre {chapter} no curso de {course}. {description}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+msgctxt "DcXGUl"
+msgid "{chapter}: {course} course"
+msgstr "{chapter}: curso de {course}"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/chapter-list.tsx
 msgctxt "iRubpl"
 msgid "Current chapter"
@@ -3011,6 +3021,16 @@ msgid "{chapter}: {kind, select, alphabet {Alphabet} custom {Custom lesson} expl
 msgstr "{chapter}: {kind, select, alphabet {Alfabeto} custom {Aula personalizada} explanation {Explicação} grammar {Gramática} listening {Escuta} practice {Prática} quiz {Quiz} reading {Leitura} review {Revisão} translation {Tradução} tutorial {Tutorial} vocabulary {Vocabulário} other {Aula}} {position}"
 
 #: src/lib/lessons.ts
-msgctxt "EuLBDj"
-msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}"
-msgstr "{kind, select, alphabet {Alfabeto: {lesson}} custom {Aula personalizada: {lesson}} explanation {Explicação sobre {lesson}} grammar {Gramática: {lesson}} listening {Prática de escuta: {lesson}} practice {Prática de {lesson}} quiz {Quiz sobre {lesson}} reading {Prática de leitura: {lesson}} review {Revisão de {lesson}} translation {Tradução de {lesson}} tutorial {Tutorial sobre {lesson}} vocabulary {Vocabulário: {lesson}} other {{lesson}}} - {course}"
+msgctxt "teYphW"
+msgid "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}}: {course} course"
+msgstr "{kind, select, alphabet {{lesson} — Alfabeto} custom {{lesson} — Aula personalizada} explanation {{lesson} — Explicação} grammar {{lesson} — Gramática} listening {{lesson} — Escuta} practice {{lesson} — Prática} quiz {{lesson} — Quiz} reading {{lesson} — Leitura} review {{lesson} — Revisão} translation {{lesson} — Tradução} tutorial {{lesson} — Tutorial} vocabulary {{lesson} — Vocabulário} other {{lesson}}}: curso de {course}"
+
+#: src/lib/lessons.ts
+msgctxt "GeDl17"
+msgid "{lesson}: {course} course"
+msgstr "{lesson}: curso de {course}"
+
+#: src/lib/lessons.ts
+msgctxt "aACHYf"
+msgid "Lesson about {lesson} in the {course} course. {description}"
+msgstr "Aula sobre {lesson} no curso de {course}. {description}"

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -7,6 +7,7 @@ import { getLocalizedUrl } from "@/lib/metadata/localized-url";
 import { getChapter } from "@zoonk/core/chapters/get-by-slug";
 import { Grid } from "@zoonk/ui/components/grid";
 import { type Metadata } from "next";
+import { getExtracted } from "next-intl/server";
 import { Suspense } from "react";
 import { ChapterLessonGrid } from "./chapter-lesson-grid";
 import { ChapterSidebar } from "./chapter-sidebar";
@@ -22,6 +23,8 @@ export async function generateMetadata({
     return {};
   }
 
+  const t = await getExtracted({ locale: chapter.course.language });
+
   return {
     alternates: {
       canonical: getLocalizedUrl({
@@ -29,9 +32,16 @@ export async function generateMetadata({
         language: chapter.course.language,
       }),
     },
-    description: chapter.description,
-    robots: { follow: true, index: chapter.generationStatus === "completed" },
-    title: chapter.title,
+    description: t("Chapter about {chapter} in the {course} course. {description}", {
+      chapter: chapter.title,
+      course: chapter.course.title,
+      description: chapter.description,
+    }),
+    robots: { follow: true, index: true },
+    title: t("{chapter}: {course} course", {
+      chapter: chapter.title,
+      course: chapter.course.title,
+    }),
   };
 }
 

--- a/apps/main/src/data/sitemaps/chapters.test.ts
+++ b/apps/main/src/data/sitemaps/chapters.test.ts
@@ -7,7 +7,6 @@ import { countSitemapChapters, listSitemapChapters } from "./chapters";
 import { SITEMAP_BATCH_SIZE } from "./courses";
 
 const sitemapChapterWhere = getPublishedChapterWhere({
-  chapterWhere: { generationStatus: "completed" },
   courseWhere: { organization: { kind: "brand" } },
 });
 
@@ -37,28 +36,24 @@ describe(countSitemapChapters, () => {
     expect(count).toBeGreaterThan(0);
   });
 
-  it("only counts completed generated chapters", async () => {
+  it("counts published chapters regardless of generation status", async () => {
     const organization = await organizationFixture({ kind: "brand" });
     const course = await courseFixture({ isPublished: true, organizationId: organization.id });
 
-    const chapters = await Promise.all([
-      chapterFixture({
-        courseId: course.id,
-        generationStatus: "completed",
-        isPublished: true,
-        organizationId: organization.id,
-      }),
-      chapterFixture({
-        courseId: course.id,
-        generationStatus: "pending",
-        isPublished: true,
-        organizationId: organization.id,
-      }),
-    ]);
+    const chapters = await Promise.all(
+      (["pending", "running", "completed", "failed"] as const).map((generationStatus) =>
+        chapterFixture({
+          courseId: course.id,
+          generationStatus,
+          isPublished: true,
+          organizationId: organization.id,
+        }),
+      ),
+    );
 
     const chapterIds = chapters.map((chapter) => chapter.id);
 
-    await expect(countCreatedSitemapChapters(chapterIds)).resolves.toBe(1);
+    await expect(countCreatedSitemapChapters(chapterIds)).resolves.toBe(4);
   });
 });
 
@@ -90,6 +85,27 @@ describe(listSitemapChapters, () => {
       updatedAt: expect.any(Date),
     });
   });
+
+  it.each(["pending", "running", "failed"] as const)(
+    "includes published %s chapters",
+    async (generationStatus) => {
+      const organization = await organizationFixture({ kind: "brand" });
+      const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        generationStatus,
+        isPublished: true,
+        organizationId: organization.id,
+      });
+
+      const count = await countSitemapChapters();
+      const chapters = await listSitemapChapters(lastPage(count));
+      const found = chapters.find((item) => item.chapterSlug === chapter.slug);
+
+      expect(found).toBeDefined();
+    },
+  );
 
   it("excludes unpublished chapters", async () => {
     const org = await organizationFixture({ kind: "brand" });

--- a/apps/main/src/data/sitemaps/chapters.ts
+++ b/apps/main/src/data/sitemaps/chapters.ts
@@ -3,13 +3,10 @@ import { getPublishedChapterWhere, prisma } from "@zoonk/db";
 import { SITEMAP_BATCH_SIZE } from "./courses";
 
 /**
- * Search engines should only receive chapter URLs that have real public lesson
- * content behind them. Pending, running, and failed chapters are still useful
- * in the app because learners can start generation from those pages, but adding
- * them to the sitemap asks Google to index empty chapter creation pages.
+ * Every published brand chapter is a public catalog page worth discovering,
+ * including chapters whose lesson generation has not completed yet.
  */
 const sitemapChapterWhere = getPublishedChapterWhere({
-  chapterWhere: { generationStatus: "completed" },
   courseWhere: { organization: { kind: "brand" } },
 });
 

--- a/apps/main/src/data/sitemaps/lessons.test.ts
+++ b/apps/main/src/data/sitemaps/lessons.test.ts
@@ -112,7 +112,7 @@ describe(listSitemapLessons, () => {
       }),
     ]);
 
-    const [pendingLesson, reviewLesson, readingLesson, gatedLesson, untitledLesson] =
+    const [pendingLesson, runningLesson, reviewLesson, readingLesson, gatedLesson, untitledLesson] =
       await Promise.all([
         lessonFixture({
           chapterId: firstChapter.id,
@@ -123,12 +123,19 @@ describe(listSitemapLessons, () => {
         }),
         lessonFixture({
           chapterId: firstChapter.id,
+          generationStatus: "running",
+          isPublished: true,
+          organizationId: organization.id,
+          position: 1,
+        }),
+        lessonFixture({
+          chapterId: firstChapter.id,
           description: null,
           generationStatus: "completed",
           isPublished: true,
           kind: "review",
           organizationId: organization.id,
-          position: 1,
+          position: 2,
           title: null,
         }),
         lessonFixture({
@@ -137,7 +144,7 @@ describe(listSitemapLessons, () => {
           isPublished: true,
           kind: "reading",
           organizationId: organization.id,
-          position: 2,
+          position: 3,
           title: null,
         }),
         lessonFixture({
@@ -153,12 +160,12 @@ describe(listSitemapLessons, () => {
           generationStatus: "completed",
           isPublished: true,
           organizationId: organization.id,
-          position: 3,
+          position: 4,
           title: null,
         }),
       ]);
 
-    const includedLessons = [pendingLesson, reviewLesson, gatedLesson];
+    const includedLessons = [pendingLesson, runningLesson, reviewLesson, gatedLesson];
     const excludedLessons = [readingLesson, untitledLesson];
 
     const count = await countSitemapLessons();

--- a/apps/main/src/lib/lessons.ts
+++ b/apps/main/src/lib/lessons.ts
@@ -183,15 +183,22 @@ async function getSeoTitle({
     const t = await getExtracted();
 
     return t(
-      "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}} - {course}",
+      "{kind, select, alphabet {{lesson} Alphabet} custom {{lesson} Custom lesson} explanation {{lesson} Explanation} grammar {{lesson} Grammar} listening {{lesson} Listening} practice {{lesson} Practice} quiz {{lesson} Quiz} reading {{lesson} Reading} review {{lesson} Review} translation {{lesson} Translation} tutorial {{lesson} Tutorial} vocabulary {{lesson} Vocabulary} other {{lesson}}}: {course} course",
       { course: lesson.chapter.course.title, kind: lesson.kind, lesson: lessonTopic },
     );
   }
 
-  return getUntitledLessonSeoTitle({
+  const lessonTitle = await getUntitledLessonSeoTitle({
     chapterTitle: lesson.chapter.title,
     kind: lesson.kind,
     position: lesson.position,
+  });
+
+  const t = await getExtracted();
+
+  return t("{lesson}: {course} course", {
+    course: lesson.chapter.course.title,
+    lesson: lessonTitle,
   });
 }
 
@@ -237,11 +244,16 @@ export async function getLessonSeoMeta({
   sourceTitle: string | null;
 }): Promise<{ title: string; description: string }> {
   const lessonTopic = getLessonTopic({ lesson, sourceTitle });
+  const lessonTitle = lessonTopic ?? lesson.chapter.title;
   const title = await getSeoTitle({ lesson, sourceTitle });
 
-  const description = await getSeoLessonDescription({
-    lesson,
-    lessonTitle: lessonTopic ?? lesson.chapter.title,
+  const lessonDescription = await getSeoLessonDescription({ lesson, lessonTitle });
+  const t = await getExtracted();
+
+  const description = t("Lesson about {lesson} in the {course} course. {description}", {
+    course: lesson.chapter.course.title,
+    description: lessonDescription,
+    lesson: lessonTitle,
   });
 
   return { description, title };


### PR DESCRIPTION
Index every published brand chapter regardless of generation status and include those pages in the chapter sitemap.

Add localized course context to chapter and lesson metadata titles and descriptions, with matching SEO coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Index all published brand chapters in the sitemap and set chapter pages to be indexable. Add localized course context to chapter and lesson SEO titles and descriptions.

- **Bug Fixes**
  - Include all published brand chapters in the chapter sitemap, regardless of `generationStatus` (pending, running, failed, completed).
  - Chapter pages now use robots "index, follow".
  - Lessons sitemap includes published pending and running lessons; reading and untitled lessons remain excluded.

- **New Features**
  - Localized SEO: chapters use "{chapter}: {course} course" with descriptive summaries; lessons add ": {course} course" and "Lesson about {lesson} in the {course} course. {description}".
  - Added translations in `en.po`, `pt.po`, `es.po`, `fr.po`, `de.po`, and updated E2E tests to reflect the new SEO.

<sup>Written for commit 94165f4c093e51d3ae0cc5f5ae947f604826c109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

