### PR TITLE
feat(evals): export pdf

### DIFF
--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/page.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/page.tsx
@@ -12,6 +12,7 @@ import {
   getOutputStatus,
   loadModelOutputs,
 } from "@/lib/output-loader";
+import { createReviewExportEntries } from "@/lib/review-export";
 import { RUNS_PER_TEST_CASE } from "@/tasks";
 import { BreadcrumbSeparator } from "@zoonk/ui/components/breadcrumb";
 import {
@@ -124,7 +125,7 @@ const getTaskModelContent = cache(async (taskId: string, rawModelId: string) => 
     ? combineOutputsWithTestCases({ modelOutputs, task })
     : null;
 
-  return { generatedOutputs, model, modelId, outputStatus, results, taskId };
+  return { generatedOutputs, model, modelId, outputStatus, results, taskId, taskName: task.name };
 });
 
 /**
@@ -142,7 +143,7 @@ async function getTaskModelContentFromParams(params: TaskModelRouteParams) {
  * result section so its fallback always has a matching resolved element.
  */
 async function TaskModelActions({ params }: TaskModelRouteProps) {
-  const { generatedOutputs, model, modelId, outputStatus, taskId } =
+  const { generatedOutputs, model, modelId, outputStatus, results, taskId, taskName } =
     await getTaskModelContentFromParams(params);
 
   return (
@@ -156,7 +157,12 @@ async function TaskModelActions({ params }: TaskModelRouteProps) {
       model={model}
       modelId={modelId}
       outputStatus={outputStatus}
+      reviewEntries={createReviewExportEntries({
+        outputs: generatedOutputs?.outputs ?? [],
+        results: results?.results ?? [],
+      })}
       taskId={taskId}
+      taskName={taskName}
     />
   );
 }

--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/review-pdf-export.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/review-pdf-export.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { type ReviewExportEntry } from "@/lib/review-export";
+import { Button } from "@zoonk/ui/components/button";
+import { Checkbox } from "@zoonk/ui/components/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@zoonk/ui/components/dialog";
+import { FileTextIcon, PrinterIcon } from "lucide-react";
+import { useState } from "react";
+import { printReviewOutputs } from "./review-print-document";
+
+/** Labels the fallback bucket naturally while keeping language codes compact. */
+function getLanguageLabel(language: string): string {
+  return language === "other" ? "Other" : language.toUpperCase();
+}
+
+/**
+ * Lets reviewers choose language slices while explaining that repeated runs are
+ * reduced to each test case's lowest-scoring output before the print view opens.
+ */
+export function ReviewPdfExport({
+  entries,
+  taskName,
+}: {
+  entries: ReviewExportEntry[];
+  taskName: string;
+}) {
+  const languages = [...new Set(entries.map((entry) => entry.language))].toSorted();
+  const [selectedLanguages, setSelectedLanguages] = useState(languages);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const selectedEntries = entries.filter((entry) => selectedLanguages.includes(entry.language));
+
+  /** Resets stale export errors whenever the language picker opens again. */
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+
+    if (nextOpen) {
+      setError(null);
+    }
+  }
+
+  /** Adds or removes one language without disturbing the review order of its outputs. */
+  function handleLanguageChange({ checked, language }: { checked: boolean; language: string }) {
+    setSelectedLanguages((currentLanguages) =>
+      checked
+        ? [...currentLanguages, language].toSorted()
+        : currentLanguages.filter((currentLanguage) => currentLanguage !== language),
+    );
+  }
+
+  /** Opens a print-only window containing only the chosen language entries. */
+  function printReview() {
+    setError(null);
+
+    try {
+      const opened = printReviewOutputs({ entries: selectedEntries, taskName });
+
+      if (!opened) {
+        setError("The print window was blocked. Allow pop-ups and try again.");
+        return;
+      }
+
+      setOpen(false);
+    } catch {
+      setError("The review could not be prepared. Try again.");
+    }
+  }
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogTrigger
+        render={<Button disabled={entries.length === 0} type="button" variant="outline" />}
+      >
+        <FileTextIcon />
+        Export review PDF
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Export review PDF</DialogTitle>
+          <DialogDescription>
+            Choose the output languages to include. For repeated runs, the PDF uses the
+            lowest-scoring output when scores are available. Otherwise, it includes one generated
+            output per test case. A print dialog will open, where you can save the review as a PDF.
+          </DialogDescription>
+        </DialogHeader>
+
+        <fieldset className="flex flex-col gap-1">
+          <legend className="sr-only">Output languages</legend>
+          {languages.map((language) => {
+            const outputCount = entries.filter((entry) => entry.language === language).length;
+
+            return (
+              <label
+                className="hover:bg-muted/60 flex min-h-11 cursor-pointer items-center gap-3 rounded-xl px-3 py-2 transition-colors"
+                key={language}
+              >
+                <Checkbox
+                  checked={selectedLanguages.includes(language)}
+                  onCheckedChange={(checked) => handleLanguageChange({ checked, language })}
+                />
+                <span className="font-medium">{getLanguageLabel(language)}</span>
+                <span className="text-muted-foreground ml-auto text-sm">
+                  {outputCount} {outputCount === 1 ? "output" : "outputs"}
+                </span>
+              </label>
+            );
+          })}
+        </fieldset>
+
+        <p aria-live="polite" className="text-muted-foreground text-sm">
+          {selectedEntries.length} {selectedEntries.length === 1 ? "output" : "outputs"} selected
+        </p>
+
+        {error && (
+          <p className="text-destructive text-sm" role="alert">
+            {error}
+          </p>
+        )}
+
+        <DialogFooter showCloseButton>
+          <Button disabled={selectedEntries.length === 0} onClick={printReview}>
+            <PrinterIcon />
+            Print or save PDF
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/review-print-document.ts
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/review-print-document.ts
@@ -1,0 +1,276 @@
+import { type ReviewExportEntry } from "@/lib/review-export";
+
+const PRINT_STYLES = `
+  @page {
+    margin: 16mm 18mm;
+    size: A4;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  html {
+    color: #18181b;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 11pt;
+    line-height: 1.55;
+  }
+
+  body {
+    margin: 0;
+  }
+
+  .output {
+    break-before: page;
+  }
+
+  .output:first-child {
+    break-before: auto;
+  }
+
+  .output-header {
+    border-bottom: 1px solid #e4e4e7;
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+  }
+
+  .output-count,
+  .output-meta {
+    color: #71717a;
+    font-size: 9pt;
+  }
+
+  .output-count {
+    letter-spacing: 0.08em;
+    margin: 0 0 8px;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    font-size: 20pt;
+    line-height: 1.2;
+    margin: 0;
+  }
+
+  .output-meta {
+    margin: 8px 0 0;
+  }
+
+  .output-content {
+    font: inherit;
+    margin: 0;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+  }
+`;
+
+type PrintTagName = "h1" | "header" | "main" | "p" | "pre" | "section";
+
+/** Converts code-shaped object keys into labels that read naturally on paper. */
+function formatLabel(label: string): string {
+  const words = label
+    .replaceAll(/(?<lower>[a-z0-9])(?<upper>[A-Z])/gu, "$<lower> $<upper>")
+    .replaceAll(/[_-]+/gu, " ")
+    .trim();
+
+  return words ? `${words.charAt(0).toUpperCase()}${words.slice(1)}` : "Value";
+}
+
+/** Preserves scalar content while replacing JavaScript-only null semantics. */
+function formatPrimitive(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+
+  if (typeof value === "number" || typeof value === "bigint") {
+    return value.toString();
+  }
+
+  return "None";
+}
+
+/** Narrows parsed JSON objects before their fields are formatted as plain text. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Places a generated title before its body while preserving every other field's output order. */
+function getReadableEntries(value: Record<string, unknown>): [string, unknown][] {
+  return Object.entries(value).toSorted(([firstKey], [secondKey]) => {
+    if (firstKey === "title") {
+      return -1;
+    }
+
+    return secondKey === "title" ? 1 : 0;
+  });
+}
+
+/** Parses structured model output once so the print view can omit JSON syntax. */
+function parseOutput(output: string): unknown {
+  try {
+    return JSON.parse(output) as unknown;
+  } catch {
+    return output;
+  }
+}
+
+/** Indents continuation lines so numbered array items remain easy to scan. */
+function indentText(text: string): string {
+  return text.replaceAll("\n", "\n   ");
+}
+
+/** Formats one named value as a label followed by its readable content. */
+function formatReadableField({ label, value }: { label: string; value: unknown }): string {
+  return `${formatLabel(label).toUpperCase()}\n${formatReadableValue(value)}`;
+}
+
+/** Gives one array item a visible reading order without reproducing JSON punctuation. */
+function formatReadableArrayItem({ index, value }: { index: number; value: unknown }): string {
+  return `${index + 1}. ${indentText(formatReadableValue(value))}`;
+}
+
+/** Recursively converts structured output into simple labels, paragraphs, and numbered text. */
+function formatReadableValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value
+      .map((arrayValue, index) => formatReadableArrayItem({ index, value: arrayValue }))
+      .join("\n\n");
+  }
+
+  if (isRecord(value)) {
+    return getReadableEntries(value)
+      .map(([label, nestedValue]) => formatReadableField({ label, value: nestedValue }))
+      .join("\n\n");
+  }
+
+  return formatPrimitive(value);
+}
+
+/** Creates text nodes through the DOM so generated content is never interpreted as HTML. */
+function createTextElement({
+  className,
+  printDocument,
+  tagName,
+  text,
+}: {
+  className?: string;
+  printDocument: Document;
+  tagName: PrintTagName;
+  text?: string;
+}): HTMLElement {
+  const element = printDocument.createElement(tagName);
+  element.className = className ?? "";
+
+  if (text !== undefined) {
+    element.textContent = text;
+  }
+
+  return element;
+}
+
+/** Starts one test case with concise context followed only by its generated output. */
+function createReviewOutput({
+  entry,
+  index,
+  printDocument,
+  taskName,
+  totalEntries,
+}: {
+  entry: ReviewExportEntry;
+  index: number;
+  printDocument: Document;
+  taskName: string;
+  totalEntries: number;
+}): HTMLElement {
+  const output = createTextElement({ className: "output", printDocument, tagName: "section" });
+
+  const header = createTextElement({
+    className: "output-header",
+    printDocument,
+    tagName: "header",
+  });
+
+  header.append(
+    createTextElement({
+      className: "output-count",
+      printDocument,
+      tagName: "p",
+      text: `Output ${index + 1} of ${totalEntries}`,
+    }),
+    createTextElement({ printDocument, tagName: "h1", text: taskName }),
+    createTextElement({
+      className: "output-meta",
+      printDocument,
+      tagName: "p",
+      text: `${entry.testCaseId} · ${entry.language.toUpperCase()}`,
+    }),
+  );
+
+  const content = createTextElement({
+    className: "output-content",
+    printDocument,
+    tagName: "pre",
+    text: formatReadableValue(parseOutput(entry.output)),
+  });
+
+  output.append(header, content);
+  return output;
+}
+
+/** Populates an isolated same-origin window with the selected anonymous review content. */
+function populatePrintDocument({
+  entries,
+  printDocument,
+  taskName,
+}: {
+  entries: ReviewExportEntry[];
+  printDocument: Document;
+  taskName: string;
+}) {
+  const charset = printDocument.createElement("meta");
+  charset.setAttribute("charset", "utf8");
+  const style = printDocument.createElement("style");
+  style.textContent = PRINT_STYLES;
+  const content = createTextElement({ printDocument, tagName: "main" });
+
+  content.append(
+    ...entries.map((entry, index) =>
+      createReviewOutput({ entry, index, printDocument, taskName, totalEntries: entries.length }),
+    ),
+  );
+
+  printDocument.head.replaceChildren(charset, style);
+  printDocument.title = `${taskName} outputs`;
+  printDocument.body.replaceChildren(content);
+}
+
+/** Opens the native print dialog, where the reviewer can print or save the output as a PDF. */
+export function printReviewOutputs({
+  entries,
+  taskName,
+}: {
+  entries: ReviewExportEntry[];
+  taskName: string;
+}): boolean {
+  const printWindow = window.open("", "_blank", "popup");
+
+  if (!printWindow) {
+    return false;
+  }
+
+  populatePrintDocument({ entries, printDocument: printWindow.document, taskName });
+  printWindow.opener = null;
+  printWindow.addEventListener("afterprint", () => printWindow.close(), { once: true });
+
+  printWindow.requestAnimationFrame(() => {
+    printWindow.focus();
+    printWindow.print();
+  });
+
+  return true;
+}

--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/task-model-actions-card.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/task-model-actions-card.tsx
@@ -1,6 +1,7 @@
 import { ModelStatusBadge, ModelStatusBadgeSkeleton } from "@/components/model-status-badge";
 import { type ModelConfig, getModelDisplayName } from "@/lib/models";
 import { type OutputProgress } from "@/lib/output-loader";
+import { type ReviewExportEntry } from "@/lib/review-export";
 import { ButtonSkeleton } from "@zoonk/ui/components/button";
 import {
   Card,
@@ -11,24 +12,29 @@ import {
 } from "@zoonk/ui/components/card";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
-import { DownloadIcon, PlayIcon, SparklesIcon, Trash2Icon } from "lucide-react";
+import { DownloadIcon, FileTextIcon, PlayIcon, SparklesIcon, Trash2Icon } from "lucide-react";
 import { generateOutputsAction, runEvalAction } from "./actions";
 import { DeleteModelDataDialog } from "./delete-model-data-dialog";
 import { type OutputExportEntry, OutputsExport } from "./outputs-export";
 import { ReasoningSelect } from "./reasoning-select";
+import { ReviewPdfExport } from "./review-pdf-export";
 
 export function TaskModelActionsCard({
   exportEntries,
   model,
   modelId,
   outputStatus,
+  reviewEntries,
   taskId,
+  taskName,
 }: {
   exportEntries: OutputExportEntry[];
   model: ModelConfig;
   modelId: string;
   outputStatus: OutputProgress;
+  reviewEntries: ReviewExportEntry[];
   taskId: string;
+  taskName: string;
 }) {
   const hasOutputs = outputStatus.status !== "missing";
 
@@ -72,6 +78,12 @@ export function TaskModelActionsCard({
           <DeleteModelDataDialog disabled={!hasOutputs} modelId={modelId} taskId={taskId} />
 
           <OutputsExport entries={exportEntries} />
+
+          <ReviewPdfExport
+            entries={reviewEntries}
+            key={`${taskId}-${modelId}`}
+            taskName={taskName}
+          />
         </div>
       </CardContent>
     </Card>
@@ -122,6 +134,10 @@ export function TaskModelActionsCardSkeleton() {
           <ButtonSkeleton variant="outline">
             <DownloadIcon />
             Export Outputs
+          </ButtonSkeleton>
+          <ButtonSkeleton variant="outline">
+            <FileTextIcon />
+            Export review PDF
           </ButtonSkeleton>
         </div>
       </CardContent>

--- a/apps/evals/src/app/tasks/[taskId]/[modelId]/test-case.tsx
+++ b/apps/evals/src/app/tasks/[taskId]/[modelId]/test-case.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { calculateScore, getScoreClassName } from "@/lib/score";
+import { getScoreClassName } from "@/lib/score";
+import { calculateScore } from "@/lib/score-calculation";
 import { type EvalResult, type ScoreStep, type TestCaseOutput } from "@/lib/types";
 import { AccordionContent, AccordionItem, AccordionTrigger } from "@zoonk/ui/components/accordion";
 import { Button } from "@zoonk/ui/components/button";

--- a/apps/evals/src/lib/leaderboard.ts
+++ b/apps/evals/src/lib/leaderboard.ts
@@ -1,5 +1,5 @@
 import { getModelById, getReasoningLabel } from "@/lib/models";
-import { calculateScore } from "@/lib/score";
+import { calculateScore } from "@/lib/score-calculation";
 import { getStatsFromResults } from "@/lib/stats";
 import { type TaskEvalResults } from "@/lib/types";
 

--- a/apps/evals/src/lib/output-loader.ts
+++ b/apps/evals/src/lib/output-loader.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { cache } from "react";
-import { getTestCaseRunProgress } from "./test-case-runs";
+import { getBaseTestCaseId, getTestCaseRunProgress } from "./test-case-runs";
 import {
   type ModelOutputs,
   type OutputEntry,
@@ -16,20 +16,6 @@ const OUTPUTS_DIR = path.join(EVAL_RESULTS_DIR, "outputs");
 function getOutputsFilePath(taskId: string, modelId: string): string {
   const modelPath = modelId.replaceAll("/", "-");
   return path.join(OUTPUTS_DIR, taskId, `${modelPath}.json`);
-}
-
-/**
- * Generated output ids include the run number so repeated runs do not overwrite
- * each other, but the task registry stores the base test case id.
- */
-function getBaseTestCaseId(testCaseId: string): string {
-  const lastDashIndex = testCaseId.lastIndexOf("-");
-
-  if (lastDashIndex === -1) {
-    return testCaseId;
-  }
-
-  return testCaseId.slice(0, lastDashIndex);
 }
 
 /**

--- a/apps/evals/src/lib/review-export.ts
+++ b/apps/evals/src/lib/review-export.ts
@@ -1,0 +1,119 @@
+import { calculateScore } from "./score-calculation";
+import { getBaseTestCaseId } from "./test-case-runs";
+import { type EvalResult, type TestCase, type TestCaseOutput } from "./types";
+
+const UNKNOWN_LANGUAGE = "other";
+
+export type ReviewExportEntry = { language: string; output: string; testCaseId: string };
+
+/**
+ * Normalizes language codes so equivalent values such as `pt_BR` and `pt-br`
+ * appear as one choice in the export dialog.
+ */
+function normalizeLanguage(language: string): string {
+  return language.trim().replaceAll("_", "-").toLowerCase();
+}
+
+/**
+ * Uses the task's explicit output language when available and falls back to the
+ * established language prefix used by older eval test case ids.
+ */
+function getOutputLanguage(testCase: TestCase): string {
+  const language = testCase.userInput.language;
+
+  if (typeof language === "string" && language.trim()) {
+    return normalizeLanguage(language);
+  }
+
+  const [testCasePrefix] = getBaseTestCaseId(testCase.id).split("-");
+
+  return testCasePrefix && /^[a-z]{2}$/iu.test(testCasePrefix)
+    ? normalizeLanguage(testCasePrefix)
+    : UNKNOWN_LANGUAGE;
+}
+
+/**
+ * Selects the weakest generated run for one test case so a manual reviewer sees
+ * the output most likely to reveal a model quality problem.
+ */
+function findLowestScoringResult({
+  results,
+  testCaseId,
+}: {
+  results: EvalResult[];
+  testCaseId: string;
+}): EvalResult | null {
+  const matchingResults = results.filter(
+    (result) => getBaseTestCaseId(result.testCase.id) === testCaseId,
+  );
+
+  if (matchingResults.length === 0) {
+    return null;
+  }
+
+  return matchingResults.reduce((lowestResult, result) =>
+    calculateScore(result.steps) < calculateScore(lowestResult.steps) ? result : lowestResult,
+  );
+}
+
+/**
+ * Uses the lowest scored run when evaluation exists, then falls back to the
+ * first generated run so outputs remain reviewable before scoring.
+ */
+function getReviewOutput({
+  outputs,
+  results,
+  testCaseId,
+}: {
+  outputs: TestCaseOutput[];
+  results: EvalResult[];
+  testCaseId: string;
+}): Pick<TestCaseOutput, "output" | "testCase"> | null {
+  const scoredOutput = findLowestScoringResult({ results, testCaseId });
+
+  if (scoredOutput) {
+    return scoredOutput;
+  }
+
+  return outputs.find((output) => getBaseTestCaseId(output.testCase.id) === testCaseId) ?? null;
+}
+
+/** Creates the single optional document row for one generated test case. */
+function createReviewEntry({
+  outputs,
+  results,
+  testCaseId,
+}: {
+  outputs: TestCaseOutput[];
+  results: EvalResult[];
+  testCaseId: string;
+}): ReviewExportEntry[] {
+  const reviewOutput = getReviewOutput({ outputs, results, testCaseId });
+
+  return reviewOutput
+    ? [
+        {
+          language: getOutputLanguage(reviewOutput.testCase),
+          output: reviewOutput.output,
+          testCaseId,
+        },
+      ]
+    : [];
+}
+
+/**
+ * Collapses generated runs into one output per test case without carrying prompt
+ * or input data into the manual-review document. Scores improve the selection,
+ * but they are not required to make generated content exportable.
+ */
+export function createReviewExportEntries({
+  outputs,
+  results,
+}: {
+  outputs: TestCaseOutput[];
+  results: EvalResult[];
+}): ReviewExportEntry[] {
+  const testCaseIds = [...new Set(outputs.map((output) => getBaseTestCaseId(output.testCase.id)))];
+
+  return testCaseIds.flatMap((testCaseId) => createReviewEntry({ outputs, results, testCaseId }));
+}

--- a/apps/evals/src/lib/score-calculation.ts
+++ b/apps/evals/src/lib/score-calculation.ts
@@ -1,0 +1,18 @@
+import { type ScoreStep } from "./types";
+
+const STEP_WEIGHTS = { majorErrors: 3, minorErrors: 2, potentialImprovements: 1 } as const;
+
+/**
+ * Calculates the shared weighted score without loading the judge runtime, so
+ * client displays and export selection use exactly the same ranking rule.
+ */
+export function calculateScore(steps: ScoreStep[]): number {
+  const weightedTotal = steps.reduce(
+    (total, step) => total + step.score * STEP_WEIGHTS[step.kind],
+    0,
+  );
+
+  const totalWeight = steps.reduce((total, step) => total + STEP_WEIGHTS[step.kind], 0);
+
+  return weightedTotal / totalWeight;
+}

--- a/apps/evals/src/lib/score.ts
+++ b/apps/evals/src/lib/score.ts
@@ -1,26 +1,12 @@
 import { cn } from "@zoonk/ui/lib/utils";
 import { Output, generateText } from "ai";
+import { calculateScore } from "./score-calculation";
 import systemPrompt from "./system-prompt.md";
 import { type ScoreStep, scoreSchema } from "./types";
 
 const BAD_SCORE = 8;
 const GOOD_SCORE = 9.2;
 const SCORE_STEP_KINDS = ["majorErrors", "minorErrors", "potentialImprovements"] as const;
-
-// Weight configuration for different step types
-const STEP_WEIGHTS = { majorErrors: 3, minorErrors: 2, potentialImprovements: 1 } as const;
-
-/**
- * Calculates a weighted average score from evaluation steps.
- * Major errors have 3x weight, minor errors 2x, and potential improvements 1x.
- */
-export function calculateScore(steps: ScoreStep[]): number {
-  const weightedTotal = steps.reduce((acc, step) => acc + step.score * STEP_WEIGHTS[step.kind], 0);
-
-  const totalWeight = steps.reduce((acc, step) => acc + STEP_WEIGHTS[step.kind], 0);
-
-  return weightedTotal / totalWeight;
-}
 
 /**
  * Builds deterministic score steps for extractor-style tasks where one exact

--- a/apps/evals/src/lib/test-case-runs.ts
+++ b/apps/evals/src/lib/test-case-runs.ts
@@ -3,6 +3,14 @@ import { type TestCase } from "./types";
 type TestCaseRunProgress = { completedRuns: number; totalRuns: number };
 
 /**
+ * Removes only the generated numeric run suffix so repeated outputs can be
+ * grouped without changing test case ids that already contain dashes or numbers.
+ */
+export function getBaseTestCaseId(testCaseRunId: string): string {
+  return testCaseRunId.replace(/-\d+$/u, "");
+}
+
+/**
  * Gives every generated run a stable id so generation, progress, and scoring
  * all refer to the same saved output entry.
  */


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a “Export review PDF” flow to task model pages so reviewers can print or save selected outputs as a PDF. It picks one output per test case (lowest-scoring when results exist), groups by language, and renders a clean, printable document.

- New Features
  - Review dialog with language filters, output counts, and popup-block error handling.
  - Print window with A4 pages, one output per page, and headers showing task name, test case, and language.
  - JSON outputs are parsed and rendered as readable labels, paragraphs, and numbered lists (no raw JSON).
  - Review entries collapse repeated runs via `getBaseTestCaseId`, normalize languages, and select the lowest score via `calculateScore` or the first run if unscored.

- Refactors
  - Extracted `calculateScore` to `score-calculation.ts` and updated imports.
  - Added `getBaseTestCaseId` to `test-case-runs.ts`; removed duplicate logic in `output-loader.ts`.
  - Threaded `taskName` and `results` to the actions card; added the new “Export review PDF” button and skeleton.

<sup>Written for commit b75f3312469dcfedee0a71f9be446171d1a79c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

