### PR TITLE
fix(ai): revert using sol for lessons

### DIFF
--- a/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-explanation.ts
@@ -6,8 +6,9 @@ import { getPromptLanguageName } from "../../_utils/prompt-language";
 import { appendLessonRichTextPrompt } from "../_utils/append-lesson-rich-text-prompt";
 import baseSystemPrompt from "./lesson-explanation.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-sol"] as const;
+const defaultModel = "openai/gpt-5.5";
+const fallbackModels = ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-5"] as const;
+
 const systemPrompt = appendLessonRichTextPrompt(baseSystemPrompt);
 
 const anchorSchema = z.object({ text: z.string(), title: z.string().min(1) }).strict();

--- a/packages/ai/src/tasks/lessons/core/lesson-practice.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-practice.ts
@@ -9,8 +9,8 @@ import { type SourceLesson, formatSourceLessonForPrompt } from "../_utils/source
 import { normalizePracticeOptions, practiceOptionLimit } from "./_utils/normalize-practice-options";
 import baseSystemPrompt from "./lesson-practice.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-sol"] as const;
+const defaultModel = "openai/gpt-5.5";
+const fallbackModels = ["openai/gpt-5.6-sol", "anthropic/claude-sonnet-5"] as const;
 const systemPrompt = insertLessonFeedbackPrompt(appendLessonRichTextPrompt(baseSystemPrompt));
 
 const practiceOptionSchema = z.object({

--- a/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
+++ b/packages/ai/src/tasks/lessons/core/lesson-quiz.ts
@@ -7,11 +7,11 @@ import { insertLessonFeedbackPrompt } from "../_utils/append-lesson-feedback-pro
 import { type SourceLesson, formatSourceLessonForPrompt } from "../_utils/source-lessons";
 import baseSystemPrompt from "./lesson-quiz.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
+const defaultModel = "openai/gpt-5.5";
 
 const fallbackModels = [
+  "openai/gpt-5.6-sol",
   "anthropic/claude-opus-4.8",
-  "openai/gpt-5.5",
   "google/gemini-3.1-pro-preview",
 ] as const;
 

--- a/packages/ai/src/tasks/lessons/language/lesson-alphabet.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-alphabet.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-alphabet.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["google/gemini-3.5-flash"] as const;
+const defaultModel = "openai/gpt-5.5";
+const fallbackModels = ["openai/gpt-5.6-sol", "google/gemini-3.5-flash"] as const;
 
 const formSchema = z.object({ label: z.string(), symbol: z.string() }).strict();
 const introSchema = z.object({ text: z.string(), title: z.string() }).strict();

--- a/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-distractors.ts
@@ -6,8 +6,13 @@ import { z } from "zod";
 import { getPromptLanguageName } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-distractors.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["google/gemini-3.1-flash-lite", "anthropic/claude-sonnet-4.6"] as const;
+const defaultModel = "openai/gpt-5.5";
+
+const fallbackModels = [
+  "openai/gpt-5.6-sol",
+  "google/gemini-3.1-flash-lite",
+  "anthropic/claude-sonnet-4.6",
+] as const;
 
 const schema = z.object({ distractors: z.array(z.string().min(1)).min(1) });
 

--- a/packages/ai/src/tasks/lessons/language/lesson-grammar.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-grammar.ts
@@ -5,8 +5,13 @@ import { z } from "zod";
 import { getLanguagePromptContext } from "../../_utils/prompt-language";
 import systemPrompt from "./lesson-grammar.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["anthropic/claude-opus-4.8", "google/gemini-3.5-flash"] as const;
+const defaultModel = "openai/gpt-5.5";
+
+const fallbackModels = [
+  "openai/gpt-5.6-sol",
+  "anthropic/claude-opus-4.8",
+  "google/gemini-3.5-flash",
+] as const;
 
 const explanationSchema = z.object({ text: z.string(), title: z.string() });
 

--- a/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
+++ b/packages/ai/src/tasks/lessons/language/lesson-sentences.ts
@@ -6,8 +6,8 @@ import { getLanguagePromptContext } from "../../_utils/prompt-language";
 import { type SourceLesson, formatSourceLessonsForPrompt } from "../_utils/source-lessons";
 import systemPrompt from "./lesson-sentences.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["google/gemini-3.5-flash", "openai/gpt-5.5"] as const;
+const defaultModel = "openai/gpt-5.5";
+const fallbackModels = ["openai/gpt-5.6-sol", "google/gemini-3.5-flash"] as const;
 
 const sentenceSchema = z.object({
   explanation: z.string(),

--- a/packages/ai/src/tasks/steps/step-image-prompts.ts
+++ b/packages/ai/src/tasks/steps/step-image-prompts.ts
@@ -5,8 +5,13 @@ import { type Reasoning, buildProviderOptions } from "../../provider-options";
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import systemPrompt from "./step-image-prompts.prompt.md";
 
-const defaultModel = "openai/gpt-5.6-sol";
-const fallbackModels = ["anthropic/claude-opus-4.8", "google/gemini-3.1-pro-preview"] as const;
+const defaultModel = "openai/gpt-5.5";
+
+const fallbackModels = [
+  "openai/gpt-5.6-sol",
+  "anthropic/claude-opus-4.8",
+  "google/gemini-3.1-pro-preview",
+] as const;
 
 const imagePromptSchema = z.string().min(1);
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverted lessons and image prompt generation to use `openai/gpt-5.5` as the default model for better stability. `openai/gpt-5.6-sol` is now a fallback, with updated fallback orders across lessons.

- **Bug Fixes**
  - Set `openai/gpt-5.5` as default in lesson explanation, practice, quiz, alphabet, distractors, grammar, sentences, and step image prompts.
  - Moved `openai/gpt-5.6-sol` to fallbacks and expanded fallback lists (Claude/Gemini) to improve reliability.

<sup>Written for commit ba2879e249f676829ad63a30d17887144f578877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zoonk/zoonk/pull/1792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

