### PR TITLE
fix(ai): improve prompt for explanation lessons

### DIFF
--- a/apps/evals/src/tasks/lesson-explanation/test-cases.ts
+++ b/apps/evals/src/tasks/lesson-explanation/test-cases.ts
@@ -203,6 +203,53 @@ ${SHARED_EXPECTATIONS}
   },
   {
     expectations: `
+LANGUAGE REQUIREMENT: Titles and text must be in Portuguese.
+
+TOPIC-SPECIFIC GUIDANCE:
+
+1. ACCURACY CHECK: This lesson is about tracing depth-first and breadth-first traversals in trees. Penalize if:
+   - DFS is described as visiting every node on one level before descending, or BFS as following one branch before returning
+   - Pre-order, in-order, and post-order do not process the node respectively before, between, or after its child subtrees; in-order should not be generalized beyond the left-node-right structure of a binary tree
+   - DFS is disconnected from recursion or an explicit stack, or BFS is disconnected from the FIFO behavior of a queue
+
+2. BOUNDARY CHECK: The core arc should trace pre-order, in-order, post-order, and level-order traversal on a concrete tree while explaining when each node is processed and why a stack or queue produces that order. Brief uses or complexity notes are fine when they clarify the comparison. Penalize if the lesson becomes mainly about binary-search-tree operations, tree representation, recursion syntax, graph traversal with visited sets, balancing, heaps, or a catalog of applications.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-ciencia-computacao-percursos-arvores",
+    userInput: {
+      chapterTitle: "Estruturas de dados",
+      courseTitle: "Ciência da Computação",
+      language: "pt",
+      lessonDescription:
+        "Rastreie percursos em pré-ordem, em ordem, pós-ordem e por níveis, observando quando cada nó é processado. Relacione percursos em profundidade a recursão ou pilhas e percursos em largura ao uso de filas.",
+      lessonTitle: "Percursos em árvores: DFS e BFS",
+      otherLessonTitles: [
+        "Tipos abstratos de dados e invariantes",
+        "Arrays (vetores) e memória contígua",
+        "Arrays dinâmicos e redimensionamento",
+        "Listas simplesmente ligadas",
+        "Listas duplamente ligadas e circulares",
+        "Localidade de memória e overhead de referências",
+        "Pilhas (stacks)",
+        "Filas e buffers circulares",
+        "Filas de duas pontas (deques)",
+        "Funções hash, igualdade e buckets",
+        "Tratamento de colisões em tabelas hash",
+        "Fator de carga e redimensionamento de tabelas hash",
+        "Anatomia e representação de árvores",
+        "Árvores binárias de busca: busca e inserção",
+        "Remoção em árvores binárias de busca",
+        "Árvores balanceadas: AVL e rubro-negras",
+        "Heap binário: propriedade e representação",
+        "Filas de prioridade com heaps",
+        "Grafos: vértices, arestas e tipos",
+        "Representações de grafos",
+      ],
+    },
+  },
+  {
+    expectations: `
 TOPIC-SPECIFIC GUIDANCE:
 
 1. ACCURACY CHECK: This lesson is about raids, captives, and what conflict was trying to achieve. Penalize if:
@@ -320,6 +367,37 @@ ${SHARED_EXPECTATIONS}
         "Work item age — idade do item",
         "Taxa de chegada e taxa de saída",
         "Média, mediana e valores extremos",
+      ],
+    },
+  },
+  {
+    expectations: `
+LANGUAGE REQUIREMENT: Titles and text must be in Portuguese.
+
+TOPIC-SPECIFIC GUIDANCE:
+
+1. ACCURACY CHECK: This lesson is about separating profit, cash, and financial position. Penalize if:
+   - Profit is treated as the amount of money currently available in the bank account
+   - A sale on credit is treated as immediate cash receipt, or money received from a loan is treated as revenue or profit
+   - Result, cash movement, and the assets, obligations, and equity held at a point in time are collapsed into one interchangeable measure
+
+2. BOUNDARY CHECK: The core arc should stay on why a profitable company can still lack cash and how result, cash, and financial position answer different questions. Brief mentions of accrual accounting, receivables, payables, inventory, loans, or financial statements are useful when they make the timing difference concrete. Penalize if the lesson becomes mainly a survey of accounting reports, bookkeeping entries, the accounting equation, financial ratios, or cash-flow management.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-contabilidade-lucro-caixa",
+    userInput: {
+      chapterTitle: "Contabilidade: a linguagem das decisões",
+      courseTitle: "Contabilidade",
+      language: "pt",
+      lessonDescription:
+        "Uma empresa pode apresentar lucro e, ainda assim, ficar sem dinheiro para pagar as contas. Relatórios contábeis ajudam a distinguir resultado, caixa e patrimônio — três perspectivas diferentes sobre a saúde de uma organização.",
+      lessonTitle: "Por que lucro e dinheiro em caixa não são a mesma coisa",
+      otherLessonTitles: [
+        "Como a contabilidade transforma fatos em informação",
+        "A balança contábil entre bens, dívidas e patrimônio",
+        "Onde a contabilidade orienta decisões e carreiras",
+        "Como a contabilidade cria confiança na sociedade",
       ],
     },
   },

--- a/apps/evals/src/tasks/lesson-explanation/test-cases.ts
+++ b/apps/evals/src/tasks/lesson-explanation/test-cases.ts
@@ -1,68 +1,176 @@
 const SHARED_EXPECTATIONS = `
-EVALUATION CRITERIA:
+CORE QUALITY DIMENSIONS:
 
-1. FACTUAL ACCURACY: The explanation must be technically correct for the topic. Penalize invented mechanisms, wrong cause-effect chains, or misleading simplifications.
+1. ACCURACY: Check every factual claim, mechanism, rule, relationship, calculation, example, and caveat. The explanation must not teach a learner something false or materially misleading.
+   - Treat an incorrect core mechanism, rule, cause-effect chain, calculation, or conclusion as a major error. The majorErrors score must be 6.5 or lower even if the rest of the lesson is polished
+   - Penalize misleading simplifications that would leave the learner with the wrong mental model
+   - Distinguish a harmless wording imprecision from a factual mistake, but never excuse wrong information because the lesson is otherwise clear or engaging
 
-2. REQUIRED STRUCTURE: The output must contain exactly two top-level fields:
+2. CLARITY: Judge how easy the finished lesson is for a broad beginner audience to understand. It should feel like a knowledgeable friend or an excellent broad-audience YouTuber explaining the topic, not a textbook, legal memo, academic paper, exam outline, or reference manual.
+   - Prefer plain, familiar words, active sentences, concrete verbs, practical examples, and direct explanations
+   - Require the lesson to build from familiar reasoning toward precise language. Necessary technical terms, citations, formulas, or code should come after the learner has enough intuitive context to understand what they describe. Their presence does not prove clarity or completeness
+   - Penalize formal or academic wording when a simpler phrase would preserve the meaning, dense noun-heavy sentences, unexplained jargon, citations that interrupt the explanation, stacked definitions, and titles that sound like reference headings instead of helping the idea click
+   - Penalize examples that are vague, decorative, or harder to understand than the concept itself
+   - Treat a repeated dry, formal, or textbook-like voice across multiple steps as at least a minor error. If the writing makes the lesson materially difficult for a broad beginner audience, treat it as a major error
+   - An accurate and complete lesson can still score poorly on clarity. Do not reward difficulty, formality, or boredom as signs of expertise
+
+3. INTUITIVE TEACHING: Judge whether the lesson reconstructs the idea in the order a beginner needs instead of presenting the field's usual expert organization with simpler vocabulary.
+
+PER-CENTRAL-IDEA AUDIT (MANDATORY):
+- Turn every required idea and relationship in LESSON_TITLE and LESSON_DESCRIPTION into a separate coverage item for auditing. Do not require a separate card for every item. Do not let one broad intuitive opening stand in for distinct required ideas later. For each coverage item, find the first place where the output actually teaches it; a mention in the title or overview does not count as teaching
+- Identify every central teaching move: each content-bearing idea in LESSON_TITLE, plus every mechanism, structure, practice, relationship, pattern, distinction, procedure, or interpretation explicitly required by LESSON_DESCRIPTION. Do not exempt a familiar-sounding label when the description asks the learner to examine, explain, compare, recognize, measure, interpret, or use it. Treat evidence types, background, methods, examples, and caveats as supporting items unless they are themselves the lesson's subject. Do not let the output choose one central item as its theme and reduce another to a mention or list
+- Inspect the first explanation step. It should establish a concrete question, observation, contrast, choice, tension, pattern, or problem that embodies the central promise of LESSON_TITLE. Penalize an opening that foregrounds supporting evidence, background, scope, method, or a real-world application before the learner understands the main thing the title promises to explain
+- Find the first step that actually teaches each central move. The intuitive reason may lead directly into the technical name, rule, or formula in the same step. Do not require a separate bridge card or a complete intuition section before all formal details; require learner-first order at the point where each idea becomes relevant
+- Require each new central move after the first to connect to what the learner already understands, surface the next natural question, or direct attention to a consequential contrast. A stack of self-contained mini-definitions fails even when each definition is plain
+- Identify the explanatory job each central move actually requires. Do not infer one job from the course subject or demand cause and effect from every idea:
+  - mechanism: parts or forces -> interaction -> result -> useful prediction
+  - structure or relationship: parts, quantities, or positions -> arrangement or equivalence -> what it means
+  - decision or tradeoff: goal, pressure, or constraint -> plausible options -> choice -> consequence or cost
+  - distinction or category: contrasting cases -> separating feature -> recognition of a new case
+  - pattern or convention: examples -> shared pattern -> application, changed meaning, or meaningful exception
+  - procedure or skill: goal or likely mistake -> cue or action -> feedback showing whether it worked
+  - argument, evidence, or interpretation: question or claim -> relevant clues -> inference -> limits or alternatives
+- Audit each bridge using its actual job. A lesson may combine several jobs. Penalize a causal story, prediction, human motive, or procedural rationale imposed on an idea that is better explained through structure, pattern, contrast, evidence, or another mode
+- Inspect the order strictly. Before an idea relies on a definition, formula, notation, procedure, rule, or specialist term, verify that the learner receives all three: something clear that needs explaining, a simple accurate account of the relevant reasoning or relationship, and a mental model they can use in the way that idea requires. A later intuitive explanation does not repair an expert-first sequence
+- Apply the usable-model test without the formal vocabulary: could a beginner use the everyday explanation to predict, compare, classify, reconstruct, interpret, or perform something new? Choose the test that matches the idea. If the learner can only repeat the technical description, the model fails
+- Apply the change test only when a central mechanism or varying relationship is involved: can the learner say what changes when an important condition changes and why? Do not require a direction-of-change prediction for an identity, definition, convention, static structure, or interpretation unless the assigned scope actually asks for one
+- Apply the choice test only when a deliberate action, practice, or institutional decision is central: can the learner say what people wanted, feared, needed, or owed; why the action served that pressure better than a plausible alternative; and what consequence followed? Do not require motive-action-consequence framing merely because the subject involves people
+- When one representative process is needed, require an accurate qualified path from beginning to end before accepting a list of alternatives. When multiple interpretations, patterns, or categories are themselves the lesson's point, require a useful comparison instead of one falsely definitive path
+- Do not accept a field-level assertion as the underlying explanation. A causal claim such as one thing controlling, shaping, or reinforcing another needs the real interactions; a structural claim needs the relationship between parts; a convention needs a usable pattern; and an interpretation needs evidence plus limits
+- Require a multi-link chain when a mechanism is central: one part acts or changes, that changes another part or condition, and the result follows. Do not impose that chain on non-causal ideas
+- Verify that later formal detail connects back to that intuitive understanding. A technical term followed by a plain-language paraphrase still fails when the learner has no model they can reason with
+- When any central idea fails this audit, name the idea and the missing layer in the conclusion. Do not return None merely because the lesson is accurate, concise, well organized, or includes an example
+
+FAILURE-MODE AUDIT (MANDATORY):
+- PROCEDURE BEFORE ITS PREREQUISITE: Find the first major calculation, measurement, classification, or procedural instruction. Before it, require the ordinary-language model that makes the procedure meaningful: the relevant behavior, relationship, boundary, or goal and why the method can reveal or change it. Then inspect each major instruction for the problem it solves, the cue that guides it, or what would become wrong, unreliable, confusing, or impossible without it. Penalize setup, calibration, or an orderly procedure used as a substitute for the prerequisite understanding
+- MECHANISM WITHOUT A PREDICTION: When a physical, biological, technical, social, or other mechanism is central, require an ordinary-language account of which parts interact, how that interaction produces the result, and what should change when a relevant condition changes. Penalize a lesson that merely names the phenomenon or says that one thing affects another. Do not apply this test to non-causal ideas
+- SYMBOLS WITHOUT MEANING: Before a central equation, require a symbol-free explanation of the relationship or structure it expresses and the ordinary meaning of its concept-bearing quantities. When the equation describes variation, require the useful direction of change and its reason. When it expresses an identity, definition, equivalence, or proof, require an explanation of why both sides represent the same thing instead of a fabricated causal prediction
+- GEOMETRY WITHOUT SPATIAL MEANING: Before a central geometric formula, require ordinary language explaining what the lengths, areas, angles, or positions represent and how the spatial relationship makes the formula sensible. Require a direction-of-change prediction only when variation is part of the assigned idea
+- UNCERTAINTY WITHOUT A RANGE MODEL: When uncertainty is required, demand a symbol-free explanation that a range of plausible input readings produces a range of possible results and that less precise inputs make the result less precise. Penalize uncertainty notation or propagation formulas introduced before this relationship is usable
+- DELIBERATE ACTION WITHOUT DECISION LOGIC: When a central claim explains why people deliberately chose an action, practice, or policy, require an understandable path from goal, pressure, or constraint through alternatives and choice to consequence. Do not apply this merely because people appear in the lesson
+- PATTERN OR CATEGORY WITHOUT CONTRAST: When a rule, convention, pattern, category, or distinction is central, require concrete positive and contrasting cases that reveal what matters. Penalize a list of labels or exceptions that leaves the learner unable to recognize a new case
+- STRUCTURE WITHOUT RELATIONSHIPS: When an arrangement, identity, composition, sequence, or other structure is central, require the lesson to show how its parts fit together and why that relationship matters. Penalize a named structure or formula whose parts are defined separately but never connected
+- EVIDENCE WITHOUT A QUESTION: When a lesson shifts into evidence, sources, checks, or assessment, require the preceding explanation to establish which claim or uncertainty now needs support. Each source or check should answer part of that question and state its limit. When several evidence types address the same claim, prefer a connected comparison over one independent card per source. Penalize a detached list of evidence types or evaluation rules even when each point is accurate
+- INTERPRETATION WITHOUT AN INFERENCE: When interpretation is central, require the lesson to connect concrete clues to a defensible reading and show its limits or reasonable alternatives. Penalize a conclusion presented as obvious, or a list of possible readings with no evidence connecting any of them to the work
+- TERMINOLOGY WITHOUT A USABLE MODEL: Penalize specialist terms, internal mechanisms, formulas, or compressed expert shorthand introduced before the learner understands what they mean in the relevant explanatory mode and can reason with them. Naming each component separately is not enough when their relationship still depends on unfamiliar technical concepts
+- RELEVANCE WITHOUT EXPLANATION: A real-world reference proves only that the topic appears somewhere. Penalize it as decorative when it does not help explain the relevant mechanism, structure, pattern, distinction, procedure, or inference
+- ANALOGY WITHOUT TRANSFER: Analogies are optional. When used, they must preserve the important relationship and connect explicitly to the real idea so the learner can transfer the insight
+- UNEARNED FORMALISM: Penalize a formula unless LESSON_TITLE or LESSON_DESCRIPTION requires the learner to calculate with it, derive it, interpret it, or the formula is the simplest accurate expression of a required relationship. Also penalize propagation rules, internal details, advanced variants, or expert caveats that are relevant to the wider topic but unnecessary for the learner to complete this lesson. Formal density is not evidence of completeness
+
+PREREQUISITE-ORDER AUDIT (MANDATORY):
+- Quote the first major instruction, calculation, measurement, or formal procedure in the result. Point to the exact earlier words that give the learner its prerequisite ordinary-language model. If those words do not exist, report a major error and score majorErrors at 7.5 or lower. A later mechanism, analogy, or intuitive explanation does not repair the order
+
+WORKING-CARRIER AUDIT (MANDATORY):
+- Name the concrete situation, puzzle, object, representation, comparison, observed process, or recurring question that carries the lesson. List which central teaching moves it actively helps reveal or resolve, and identify the last central step where it still does teaching work
+- If no carrier or recurring question is identifiable, or it supports only the opening before the lesson becomes a thematic outline, the audit fails. Report this failure in minorErrors or majorErrors according to the severity rules; do not leave it only in potentialImprovements
+- When the subject varies, require one accurate representative path to become understandable before the lesson widens to possible motives, outcomes, regions, interpretations, or exceptions. A carrier fails when its concrete actors, objects, readings, clues, or choices disappear into generic “could” lists before one path connects the central ideas
+- Do not require the carrier in every step. Direct definitions, caveats, parallel evidence, and formal precision may temporarily leave it when the transition makes their purpose clear. Do not accept a repeated name or decorative reminder as continuity unless it advances the learner's understanding
+
+NARRATIVE-VOICE AUDIT (MANDATORY):
+- Read the step texts aloud without their titles. Judge whether they sound like one person guiding a learner through one continuous question, contrast, situation, problem, pattern, or line of reasoning, or like independent textbook points that happen to share a topic
+- Identify the lesson's throughline in one sentence. It does not need to be a story, causal chain, single example, second-person address, or series of rhetorical questions. If no throughline is visible from the step texts, the narrative fails
+- Identify the lesson's working carrier: the concrete situation, puzzle, object, representation, comparison, observed process, or recurring question through which several central ideas become necessary. Trace it across the central steps. Penalize an opening example that disappears while the rest becomes a sequence of topic summaries. The carrier need not appear in every step, and a stable recurring question or comparison is valid when one concrete example would distort the subject
+- Require the carrier to replace exposition rather than add to it. Do not reward a vivid opening followed by a second conventional lesson, and do not require irrelevant details merely to keep a story alive
+- Apply the adjacency test to every pair of steps: given what the learner just understood, why do they naturally need or want the next step? Accept a new term, formula, caveat, example, case, clue, or procedure when the previous understanding creates a need for it or the lesson makes clear which shared question the parallel material answers. Penalize transitions that amount only to “another relevant point is…”
+- Apply the rearrangement test: if several steps could trade places without changing the reasoning or comparison, the lesson is organized as an outline rather than continuous guided reasoning. Parallel examples, cases, or evidence may legitimately exchange order when their shared role and eventual synthesis are clear
+- Check that procedures have momentum too. Each major instruction should arrive as the solution to a visible problem, with the likely error or limitation clear before the learner is told what to do
+- Judge spoken naturalness through sentence construction, not informality markers. Prefer concrete subjects, active verbs, and phrasing a knowledgeable person could naturally say aloud. Inspect sentences whose grammatical subject is an abstract summary such as an evaluation, comparison, interpretation, adaptation, or approach; penalize repeated report-like claims when the sentence could instead name what a person notices, what an object does, or which concrete cases differ
+- Do not require or reward exact phrases, casual filler, second-person wording, rhetorical questions, a story, or an analogy. “Imagine,” “notice,” “now,” and “think of it this way” do not count as guidance when attached to an otherwise independent textbook point
+- Look for genuine moments of recognition where a difficult idea becomes simple enough to reason with and where the learner makes a useful connection they may not have noticed before
+
+COMPRESSION + NOVELTY AUDIT (MANDATORY):
+- Assign every explanation step one unique learner gain that advances the throughline: a new mechanism, relationship, distinction, pattern, prediction, example, consequence, interpretation, skill cue, application, or necessary caveat. A new fact does not earn a card when the learner has no reason to need it at that point. If a step only renames, paraphrases, or fragments something already taught, it is redundant
+- Do not give the working carrier separate setup or reminder cards that add no learner gain. It should make the required explanation shorter and more connected, not consume extra space beside it
+- Penalize a catalogue that assigns one card to every analytical dimension when several dimensions could explain the same moment, choice, observation, or claim in the carrier
+- Look specifically for a two-pass lesson: an intuitive sequence that already teaches the central ideas, followed by a conventional definition-driven sequence that teaches those same ideas again. Intuitive scaffolding must replace later exposition, not sit in front of a second version of the lesson
+- Once a mental model is usable, the formal name may be added briefly in the same step or the next step may add genuinely useful precision. A technical name alone is not a new learner gain. A formula is new only when the assigned scope requires calculation or interpretation and the formula adds that ability
+- Prefer one end-to-end worked example over several cards that separately repeat its setup, calculation, unit conversion, interpretation, and uncertainty when those pieces remain clear together
+- Use roughly 8-10 explanation steps and 300-400 words as a diagnostic range, not a fixed requirement. Do not penalize a lesson solely for exceeding it. When a lesson is longer, verify that every extra step is required by the assigned scope and contributes something genuinely new
+- If one or two steps can be merged or removed without loss, report the issue under potentialImprovements or minorErrors according to its effect. If three or more steps, roughly a quarter of the lesson, or a repeated intuitive-then-conventional sequence is removable, report a minor error and give minorErrors a score of 8 or lower. Treat substantially excessive repetition that obscures the main lesson as a major error
+
+SEVERITY FOR INTUITIVE TEACHING:
+- If a procedural lesson begins calculation or instructions before the ordinary-language model that makes the procedure meaningful, or if its major steps lack a problem, rationale, or useful feedback, report a major error and give majorErrors a score of 7.5 or lower
+- If a central idea is taught through the wrong explanatory job—for example, symbols before structural meaning, a causal label without a mechanism, categories without contrast, a deliberate choice without alternatives, or an interpretation without evidence—report a major error and give majorErrors a score of 7.5 or lower when the learner lacks a usable model of the main teaching move
+- If the opening steps leave the central teaching move unexplained while prioritizing supporting evidence, procedure, taxonomy, exceptions, or background, report a major error and give majorErrors a score of 7.5 or lower
+- If most central technical mechanisms are taught through terminology or internal details without usable everyday models, report a major error and give majorErrors a score of 7.5 or lower
+- More generally, if the lesson's main teaching move lacks the underlying reason or a usable mental model, report a major error and give majorErrors a score of 7.5 or lower
+- If one required supporting idea fails the per-central-idea audit but the main teaching move remains understandable, report a minor error and give minorErrors a score of 8 or lower
+- If the mental models are usable but the voice repeatedly falls back to impersonal textbook entries or omits learner-directed guidance at major transitions, report a minor error and give minorErrors a score of 8 or lower
+- If two or more important transitions fail the adjacency test but the main throughline remains understandable, report a minor error and give minorErrors a score of 8 or lower
+- If a lesson with several central dimensions has no identifiable working carrier or recurring question, or introduces one and abandons it for a mostly rearrangeable topic outline, report at least a minor error and give minorErrors a score of 8 or lower. Do not report this only as a potential improvement. If the missing or abandoned carrier leaves the main teaching move as organized exposition without a usable throughline, report a major error and give majorErrors a score of 7.5 or lower
+- If the lesson is mainly a rearrangeable sequence of independent analytical points, or its main teaching move is a procedure whose major steps are not motivated by the problems they solve, report a major error and give majorErrors a score of 7.5 or lower
+- A lesson cannot receive three 10s unless every central idea passes the audit and the narrative voice actively guides the learner through the difficult parts
+
+MANDATORY CLARITY AUDIT:
+- Inspect every title and sentence before returning None for minorErrors or potentialImprovements. Ask whether a curious beginner could understand it on the first read and whether a knowledgeable friend would naturally say it that way aloud
+- Inspect the conceptual sequence as well as individual sentences. Ask whether the lesson gives the learner a usable reason to believe and reason with each central idea, or merely walks through the expert's categories in simpler words
+- Look specifically for steps that lead with a definition, citation, abbreviation, abstract label, or specialist expression before building intuitive understanding; abstract titles that make the learner decode the point; and sentences that compress several ideas into formal expert shorthand
+- A phrase does not pass merely because a careful reader could eventually understand it. If a simpler everyday version would preserve the substance and make the idea faster to grasp, count that as a real clarity improvement
+- If three or more titles or sentences have these problems, report the repeated pattern under minorErrors and give that step a score of 8 or lower. If one or two localized phrases have the problem, report them under potentialImprovements and score that step below 10. Apply the separate intuitive-teaching severity rules when the problem affects the teaching of a central idea
+- Necessary domain terms are not clarity problems when the lesson earns them through intuitive context and explains them in familiar language. Penalize the delivery and sequencing, not the existence of precise terminology
+
+4. COMPLETENESS: The learner should finish with a full working understanding of LESSON_TITLE and LESSON_DESCRIPTION. Include the real mechanism, structure, relationship, calculation, rule, procedure, practical recognition, and important caveats or limits required by that specific scope.
+   - Penalize friendly but surface-level explanations that skip the substance
+   - Penalize formal details, formulas, variables, code shapes, rules, or terms that appear without explaining what they mean or how they connect
+   - Require concrete examples, measurements, cases, code-shaped details, or realistic situations when they are needed to understand how the topic works in practice
+   - Treat a missing central concept or mechanism as a major error. Treat a smaller omission according to how much it weakens the learner's working understanding
+
+5. FOCUS + PADDING: Completeness means fully teaching this lesson, not covering everything related to the topic. Every step should earn its place by making the selected lesson easier to understand.
+   - Leave sibling angles in OTHER_EXPLANATION_LESSON_TITLES for their own lessons
+   - Penalize tangents, repeated points, unnecessary background, exhaustive lists, edge cases beyond the lesson's needs, and extra expert detail that lengthens the lesson without improving understanding
+   - Extra information can be accurate and still be padding. Do not reward length, density, or the number of facts by itself
+   - Penalize an intuitive opening followed by a second conventional explanation of the same concepts. The intuitive explanation should make later naming and formalization shorter
+   - Treat limited removable padding as a minor error or potential improvement. Treat repeated tangents or substantial drift away from the selected lesson as a major error
+
+PERFECT-SCORE BAR:
+- A result deserves 10 in all three scoring buckets only when it has no concrete problem or meaningful improvement across accuracy, clarity, intuitive teaching, completeness, and focus
+- A correct answer that is noticeably more formal, academic, dry, dense, or difficult than necessary must not receive three 10s. Name the specific clarity problem and lower the appropriate score
+- Judge the language across the whole lesson. Do not let one accessible example cancel repeated textbook-like writing elsewhere
+- Do not award perfect scores to a lesson that gives accurate definitions and examples but never creates an intuitive mental model for its central unfamiliar ideas
+- Do not award perfect scores when multiple cards can be merged or removed because they repeat an intuitive explanation through definitions, formulas, examples, or procedure without adding a new learner gain
+- Do not award perfect scores to a lesson that is clear sentence by sentence but lacks a spoken throughline or momentum between its important steps
+- Do not award perfect scores when an opening situation or puzzle disappears and the central lesson continues as a conventional topic outline
+
+DELIVERY REQUIREMENTS:
+
+1. REQUIRED STRUCTURE: The output must contain exactly two top-level fields:
    - explanation[]: an array of explanation steps, each with title and text
    - anchor: { title, text } (no visual)
 
-3. LESSON DELIVERY: The lesson must actually deliver on LESSON_TITLE and LESSON_DESCRIPTION. The learner should finish with a full working understanding of what the topic is, how it works, how it is used/measured/written/recognized in practice when relevant, why it matters when relevant, and what the important terms, formulas, structures, rules, caveats, or limits mean. Penalize lessons that stay friendly but surface-level, or technically dense but hard to understand.
+2. EXPLANATION FLOW: The lesson should follow one continuous question, contrast, situation, problem, pattern, or line of reasoning. A concrete working carrier or explicit recurring question should remain active across the central transitions instead of appearing only in the opening. Each important step should answer a need created by the previous understanding or contribute to a clearly established comparison or inquiry. Build from familiar reasoning toward formal precision, give enough intuitive context before unfamiliar terms or machinery, and name the practical payoff when the lesson calls for why the topic matters.
 
-4. BEGINNER + EXPERT FIT: The lesson should feel like a precise expert explaining the topic to a smart non-expert friend. It should use everyday language without dumbing down the topic. Penalize:
-   - Academic phrasing that makes a simple idea feel harder than it is
-   - "Friendly" explanations that omit the expert essentials required by the lesson scope
-   - Dense explanations that contain the right terms but do not explain them in plain language
-   - Formal terms, formulas, or code snippets that appear without enough plain-language explanation
+3. STEP QUALITY: Each step.text is 1-3 short sentences of prose. Step titles are short, unique, and useful for understanding what the step teaches. Penalize long paragraphs, vague or generic titles, and repetition between steps.
 
-5. MECHANISM + FORMAL DETAIL: The lesson must include the real mechanism, structure, relationship, calculation, rule, or procedure required by the title and description. Penalize:
-   - Skipping formulas, variables, code shapes, uncertainty, exceptions, limits, or precise terms that an expert would expect for this lesson scope
-   - Including those details without explaining what the parts mean
-   - Using an analogy, vibe, story, or visual scene as a substitute for the actual mechanism
-
-6. LESSON BOUNDARY: The lesson must stay focused on the selected LESSON_TITLE and leave sibling angles in OTHER_EXPLANATION_LESSON_TITLES for those other lessons. Penalize explanations that spend their main teaching energy on a sibling lesson instead of the chosen one.
-
-7. EXPLANATION FLOW: There is no required opening pattern, cold open, or story arc. The explanation[] array should choose the clearest order for this topic and connect ideas so the learner can follow how the topic works. Penalize:
-   - Stacked definitions that do not connect to each other
-   - Scenic or subjective prose that does not help explain the concept
-   - Missing the practical payoff when the lesson calls for why this matters
-   - Naming terms before giving enough context to understand them, when that makes the lesson harder to follow
-
-8. STEP QUALITY: Each step.text is 1-3 short sentences of prose. Step titles are short, unique, and useful for understanding what the step teaches. Penalize:
-   - Long paragraphs
-   - Titles that are only props, moods, vague story beats, or generic labels
-   - Repetition between steps
-
-9. CONCRETENESS: The lesson should use concrete examples, measurements, cases, code-shaped details, or realistic situations when they make the mechanism easier to understand. Penalize:
-   - Vague prose that never makes the mechanism concrete
-   - Examples that are only atmospheric decoration
-   - Lessons about "how it's written" that never describe the structure or code detail clearly enough to understand
-
-10. STATIC + RICH TEXT DELIVERY: The lesson should stay entirely within explanation steps plus the closing anchor. It may use inline LaTeX, display LaTeX, bold, italic, and inline code with single backticks. Penalize:
+4. STATIC + RICH TEXT DELIVERY: The lesson should stay entirely within explanation steps plus the closing anchor. It may use inline LaTeX, display LaTeX, bold, italic, and inline code with single backticks. Penalize:
    - Quiz-like interruptions, option lists, or explicit "guess before continuing" instructions
    - Steps that stop to ask the learner to choose instead of explaining
    - Rhetorical-question-only steps that replace a real explanation
    - Markdown headings, lists, tables, links, or large code fences inside a step
    - Malformed LaTeX or unsupported formatting that would show raw clutter to the learner
+   - NUL (U+0000), other control characters, or invisible separators before or inside rich-text delimiters. Repeated control characters that can break formula rendering are a major delivery error
 
-11. ANCHOR QUALITY: anchor has no visual. It answers why the topic is useful and where it shows up outside the lesson by naming one specific real-world instance — a named product (e.g., Instagram, WhatsApp), recognizable product family (e.g., ChatGPT-style models), named technology/service/system, named mission/instrument, named event/figure/case/place, or concrete physical action the learner has actually done — and what it does there. Penalize:
-   - Abstract "this is why it matters" wrap-ups
-   - Metaphors or vague generalities
+5. ANCHOR QUALITY: anchor has no visual. It answers why the topic is useful and where it shows up outside the lesson by naming one specific real-world instance — a named product, recognizable product family, technology, service, system, mission, instrument, event, figure, case, place, or concrete physical action — and what the concept does there. Penalize:
+   - Abstract "this is why it matters" wrap-ups, metaphors, or vague generalities
+   - References that merely name where the topic appears without explaining the useful connection
    - Classroom demonstrations, lab videos, school apparatus, research instruments, or professional workflows that do not name the product, service, system, or public-world outcome they enable
-   - Category-list anchors that name a type of use instead of a vivid instance ("a star, a lamp, or a gas cloud"; "many apps"; "some medical devices")
-   - Generic placeholders standing in for a specific real thing ("a real app", "a real court case", "an exoplanet", "every time a button does X in three places")
-
-12. STYLE: Clear, short, concrete, beginner-friendly, and precise. Penalize academic tone, atmospheric storytelling, filler lines, subjectivity that does not teach, and redundancy across steps and anchor.
+   - Category-list anchors that name a broad type of use instead of one vivid instance
+   - Generic placeholders standing in for a specific recognizable thing, action, place, case, result, or experience
+   - Anchors whose only payoff is checking, validating, or calibrating the same classroom, laboratory, measurement, or professional method taught in the lesson rather than connecting it to an outside-world result
+   - Treating a named brand or recognizable system in the anchor as evidence that an otherwise abstract lesson was practical or narratively connected. Judge the explanation flow separately
 
 ANTI-CHECKLIST GUIDANCE (CRITICAL):
 - Do NOT require a fixed number of steps. Complex topics need more; simple topics fewer. Both are fine as long as the lesson is delivered
-- Do NOT require a cold open, story arc, single scene, or specific opening style
-- Do NOT require specific title wording, a particular choice of product or event, or a specific visual kind. The anchor must name some specific real thing, but any reasonable choice is fine — do not penalize the model for picking Instagram over WhatsApp, or one named case over another
-- Do NOT penalize anchors that use a widely recognized product family tied to a named product, such as "ChatGPT-style models", when the learner can clearly recognize the real-world surface
+- Do NOT penalize a lesson solely for exceeding 10 steps or 400 words. Use those numbers to trigger the novelty audit, then penalize only concrete repetition, fragmentation, padding, or unnecessary scope
+- Do NOT require a cold open, story arc, analogy, single scene, or specific opening style. Do require enough familiar orientation before the lesson relies on central formal definitions or mechanisms; a short direct explanation can provide that orientation
+- Do NOT require one fictional story, branded example, or literal scene to appear in every step. Require a useful working carrier or recurring question across the central transitions, and allow direct supporting explanations when forcing the carrier would reduce accuracy or clarity
+- Do NOT require every fact to depend causally on the sentence before it. Judge whether the lesson has a clear overall throughline and whether its important conceptual transitions follow the learner's reasoning rather than a subject outline
+- Do NOT require a causal explanation, direction-of-change prediction, human motive, or procedural rationale when the assigned idea is instead structural, conventional, classificatory, interpretive, or otherwise non-causal. Require the explanatory job that makes that particular idea usable
+- Do NOT require specific title wording, a particular choice of product, event, case, experience, or visual kind. The anchor must name some specific real thing, but any reasonable choice is fine
+- Do NOT penalize anchors that use a widely recognized product family when the learner can clearly recognize the real-world surface and understand the concept's role there
 - Do NOT penalize direct explanatory writing when it is clear, plain, concrete, and complete
-- Do NOT penalize density when the density comes from necessary expert content explained in everyday language
+- Do NOT penalize necessary expert content when it is explained in everyday language and stays within the lesson scope
 - Do NOT focus on JSON wrapping or formatting trivia. Evaluate the content and structural fit
-- ONLY penalize for: wrong top-level structure, factual errors, failing to deliver LESSON_TITLE and LESSON_DESCRIPTION, missing beginner/expert balance, missing required mechanism/detail, drifting into sibling lessons, unclear flow, unsupported formatting, weak real-world anchor, or broken writing constraints
+- ONLY penalize for concrete failures in accuracy, clarity, intuitive teaching, completeness, focus, structure, flow, writing constraints, supported formatting, or anchor quality
 `;
 
 export const TEST_CASES = [
@@ -155,6 +263,72 @@ LANGUAGE REQUIREMENT: Titles and text must be in Portuguese.
 
 TOPIC-SPECIFIC GUIDANCE:
 
+1. ACCURACY CHECK: This lesson is about reading mRNA in codons while preserving the correct reading frame. Penalize if:
+   - DNA bases are read directly from an mRNA codon table without first producing the corresponding mRNA sequence
+   - The reading frame is treated as optional or as changing one codon without changing the triplet grouping that follows
+   - The degeneracy of the genetic code is described as one codon routinely specifying several different amino acids
+
+2. BOUNDARY CHECK: The core arc should stay on codons, the start and stop signals, using the genetic-code table, and why the reading frame matters. Brief context about transcription, tRNA, or translation is fine when it helps the learner follow that decoding move. Penalize if the explanation turns into a broad survey of DNA structure, RNA processing, ribosome stages, or mutation types.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-biologia-codigo-genetico",
+    userInput: {
+      chapterTitle: "DNA, RNA e expressão gênica",
+      courseTitle: "Biologia",
+      language: "pt",
+      lessonDescription:
+        "Leia o mRNA em trincas e use uma tabela do código genético para converter códons em aminoácidos. Reconheça o códon de início, os códons de parada, a degeneração do código e a importância do quadro de leitura.",
+      lessonTitle: "Código genético, códons e quadro de leitura",
+      otherLessonTitles: [
+        "Dogma central e transcrição reversa",
+        "Transcrição e RNA polimerase",
+        "Processamento do RNA mensageiro",
+        "mRNA, tRNA, rRNA e aminoacil-tRNA sintetases",
+        "Iniciação da tradução",
+        "Elongação da tradução e sítios A, P e E",
+      ],
+    },
+  },
+  {
+    expectations: `
+LANGUAGE REQUIREMENT: Titles and text must be in Portuguese.
+
+TOPIC-SPECIFIC GUIDANCE:
+
+1. ACCURACY CHECK: This lesson is about measuring two different intervals in a workflow. Penalize if:
+   - Lead time does not run from request to delivery, or cycle time does not run from work start to completion
+   - The two metrics are treated as interchangeable or calculated with incompatible time conventions
+   - A shorter cycle time is claimed to prove a short lead time without accounting for the time spent waiting before work starts
+
+2. BOUNDARY CHECK: The core arc should stay on defining, calculating, comparing, and using lead time and cycle time. Brief mentions of waiting, timestamps, or a board are useful when they make the two clocks concrete. Penalize if the lesson becomes mainly about throughput, WIP, work item age, forecasting, or general Kanban management.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-kanban-lead-cycle-time",
+    userInput: {
+      chapterTitle: "Métricas de fluxo",
+      courseTitle: "Kanban",
+      language: "pt",
+      lessonDescription:
+        "Calcule o lead time entre solicitação e entrega e o cycle time entre início e conclusão de um item. Compare os dois intervalos para reconhecer o tempo anterior ao início do trabalho sem confundir suas fronteiras.",
+      lessonTitle: "Lead time e cycle time",
+      otherLessonTitles: [
+        "Limites de medição e eventos do fluxo",
+        "Throughput e janela de medição",
+        "WIP — trabalho em andamento",
+        "Work item age — idade do item",
+        "Taxa de chegada e taxa de saída",
+        "Média, mediana e valores extremos",
+      ],
+    },
+  },
+  {
+    expectations: `
+LANGUAGE REQUIREMENT: Titles and text must be in Portuguese.
+
+TOPIC-SPECIFIC GUIDANCE:
+
 1. ACCURACY CHECK: This lesson is about measuring hydrogen spectral lines from positions and angles, then turning those readings into wavelengths. Penalize if:
    - Spectral lines are treated as decorative colors instead of measured wavelengths
    - Diffraction angles, wavelength, or uncertainty are described with a wrong cause-effect chain
@@ -234,6 +408,124 @@ ${SHARED_EXPECTATIONS}
         "Initialization and normalization",
         "Learning-rate schedules",
         "Dropout and regularization",
+      ],
+    },
+  },
+  {
+    expectations: `
+TOPIC-SPECIFIC GUIDANCE:
+
+1. ACCURACY CHECK: This lesson is about why the Pythagorean identity follows from an area rearrangement. Penalize if:
+   - The identity is applied to triangles that are not right triangles
+   - The side lengths are confused with the areas of the squares built on those sides
+   - Rearranging the same congruent triangles is treated as changing their total area
+
+2. BOUNDARY CHECK: The main arc should stay on seeing why the two smaller square areas equal the largest square area. Brief algebra is fine when it records the area comparison. Penalize if the lesson becomes mainly about the distance formula, coordinate proofs, trigonometry, Pythagorean triples, or the converse theorem.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "en-geometry-pythagorean-area",
+    userInput: {
+      chapterTitle: "Right triangles and distance",
+      courseTitle: "Geometry",
+      language: "en",
+      lessonDescription:
+        "Use the areas of squares built on the three sides and a rearrangement of congruent right triangles to explain why the two smaller square areas add to the largest. Connect the picture to a² + b² = c² without treating the equation as a rule to memorize.",
+      lessonTitle: "Why the Pythagorean theorem works",
+      otherLessonTitles: [
+        "Using the Pythagorean theorem",
+        "The converse of the Pythagorean theorem",
+        "Distance on a coordinate plane",
+        "Pythagorean triples",
+      ],
+    },
+  },
+  {
+    expectations: `
+TOPIC-SPECIFIC GUIDANCE:
+
+1. ACCURACY CHECK: This lesson is about distinguishing necessary conditions from sufficient conditions. Penalize if:
+   - A necessary condition is treated as guaranteeing the result rather than merely being required for it
+   - A sufficient condition is treated as the only possible way to reach the result rather than one condition that guarantees it
+   - “If A, then B” is freely reversed into “if B, then A” without establishing the converse
+
+2. BOUNDARY CHECK: The main arc should stay on recognizing which condition is required, which is enough, and why the direction of an implication matters. Concrete contrasting cases are useful. Penalize if the lesson becomes mainly about truth tables, formal proof notation, contraposition, logical validity, or a catalog of named fallacies.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "en-logic-necessary-sufficient",
+    userInput: {
+      chapterTitle: "Conditional reasoning",
+      courseTitle: "Logic",
+      language: "en",
+      lessonDescription:
+        "Distinguish necessary conditions from sufficient conditions by asking whether something is required and whether it is enough to guarantee the result. Use contrasting cases to read one-way implications without accidentally reversing them.",
+      lessonTitle: "Necessary and sufficient conditions",
+      otherLessonTitles: [
+        "Converse, inverse, and contrapositive",
+        "Biconditional statements",
+        "Truth tables",
+        "Validity and soundness",
+      ],
+    },
+  },
+  {
+    expectations: `
+TOPIC-SPECIFIC GUIDANCE:
+
+1. ACCURACY CHECK: This lesson is about using textual evidence to recognize and interpret an unreliable narrator. Penalize if:
+   - The narrator is confused with the author
+   - Unreliability is treated as proof that every narrated detail is false or that the narrator must be deliberately lying
+   - A reader's suspicion is presented as sufficient without contradictions, omissions, reactions, or other evidence from the work
+
+2. BOUNDARY CHECK: The main arc should stay on how readers notice a gap between a narrator's version and what the text supports. Brief examples of bias, self-deception, limited knowledge, or deliberate deceit are useful. Penalize if the lesson becomes mainly a catalog of narrator types, point-of-view terminology, or general literary-analysis advice.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "en-literature-unreliable-narrator",
+    userInput: {
+      chapterTitle: "Narrators and point of view",
+      courseTitle: "Literature",
+      language: "en",
+      lessonDescription:
+        "Use contradictions, gaps, self-justification, other characters' reactions, and later events to recognize when a narrator's account cannot be accepted at face value. Build an interpretation from textual clues while allowing reasonable uncertainty about what really happened.",
+      lessonTitle: "Reading an unreliable narrator",
+      otherLessonTitles: [
+        "First-person and third-person narration",
+        "Limited and omniscient points of view",
+        "Narrative distance",
+        "Writing a close-reading argument",
+      ],
+    },
+  },
+  {
+    expectations: `
+LANGUAGE REQUIREMENT: Titles and text must be in Portuguese.
+
+TOPIC-SPECIFIC GUIDANCE:
+
+1. ACCURACY CHECK: This lesson is about making guitar chord changes efficient enough to preserve the beat. Penalize if:
+   - Faster changes are taught as squeezing harder, rushing the beat, or lifting every finger far from the strings
+   - Metronome speed is increased before the learner can repeat the transition cleanly and without excess tension
+   - Keeping common or guiding fingers close to the strings is described as mandatory when a particular chord pair does not allow it
+
+2. BOUNDARY CHECK: The main arc should stay on isolating one chord pair, reducing unnecessary movement, preparing the next shape, using the beat as feedback, and increasing speed gradually. Penalize if the lesson becomes mainly about chord construction, strumming patterns, posture, reading chord diagrams, or learning a complete song.
+
+${SHARED_EXPECTATIONS}
+    `,
+    id: "pt-violao-trocas-acordes-ritmo",
+    userInput: {
+      chapterTitle: "Coordenação entre acordes e ritmo",
+      courseTitle: "Violão",
+      language: "pt",
+      lessonDescription:
+        "Pratique um par de acordes por vez para trocar sem interromper o pulso. Reduza movimentos desnecessários, aproveite dedos comuns ou dedos-guia quando existirem, prepare o próximo formato e aumente o metrônomo apenas depois de repetir a troca com controle.",
+      lessonTitle: "Trocas de acordes sem perder o ritmo",
+      otherLessonTitles: [
+        "Como ler diagramas de acordes",
+        "Postura e posição das mãos",
+        "Batidas básicas com a mão direita",
+        "Formação de acordes maiores e menores",
       ],
     },
   },

--- a/packages/ai/src/tasks/lessons/_utils/lesson-rich-text.prompt.md
+++ b/packages/ai/src/tasks/lessons/_utils/lesson-rich-text.prompt.md
@@ -10,6 +10,10 @@ The player can render a small rich-text subset in learner-facing text fields:
 
 Use LaTeX for formulas when it improves clarity, for example `\(d\sin\theta = m\lambda\)`. Explain what each important symbol means in plain language. Use inline code for short code snippets, function names, commands, file paths, or literal values. Use bold or italic sparingly to emphasize a key term or value.
 
+The response is structured JSON, so escape every LaTeX backslash correctly in the raw JSON string. To produce parsed learner text such as `\(\theta\)`, the raw JSON must contain `\\(\\theta\\)`. Never write an invalid raw JSON escape such as `\(`, and never use `\0`, `\b`, `\u0000`, another control character, or an invisible separator as a workaround. In the parsed learner text, the backslash must be the first character of each `\(`, `\)`, `\[`, or `\]` delimiter.
+
+Before returning, inspect every learner-facing string for characters from `U+0000` through `U+001F`. No such control character is allowed inside a title or text field.
+
 Do not use Markdown headings, lists, tables, links, blockquotes, images, or code fences inside learner-facing text fields. If code is necessary, keep it short enough to fit in prose as inline code.
 
 If this task includes an `imagePrompt` field, do not use rich-text markers there unless the marker itself should be visible text in the generated image.

--- a/packages/ai/src/tasks/lessons/core/lesson-explanation.prompt.md
+++ b/packages/ai/src/tasks/lessons/core/lesson-explanation.prompt.md
@@ -1,129 +1,198 @@
 # Role
 
-You write **Explanation** lessons for a learning app that makes hard topics feel clear, useful, and learnable, making it easier for anyone to understand this using practical examples and plain everyday language.
+You write **Explanation** lessons that make difficult subjects feel surprisingly simple. The learner should feel that a knowledgeable friend noticed exactly what was confusing and found the clearest way through it—not that they are reading a polished textbook.
 
-# Goal
+Use plain everyday language without removing the real substance. The lesson should be easier to understand than a traditional classroom explanation because it teaches in the learner's order, not the field's usual expert order.
 
-Create a clear explanation lesson in `LANGUAGE` that fully delivers `LESSON_TITLE` and `LESSON_DESCRIPTION`.
+# Contract
 
-Use this mental model: an expert in the field is explaining the topic to a smart teenager, a curious older person, or a close friend. The expert uses plain everyday language, but does not remove the real substance.
+Create the lesson in `LANGUAGE`. Treat `LESSON_TITLE` and `LESSON_DESCRIPTION` as the complete scope: fully teach every required idea and relationship, keep the main energy on `LESSON_TITLE`, and leave `OTHER_EXPLANATION_LESSON_TITLES` for their own lessons.
 
-By the end, the learner should have a full working understanding of the lesson scope. They should be able to explain:
+By the end, a beginner should be able to explain how the central idea works or fits together, use or recognize it in practice, and understand what the necessary precise terms, rules, structures, limits, or formulas mean.
 
-- what the topic is
-- how it works, is used, measured, written, or recognized in practice
-- why it matters when the lesson calls for it
-- what the important terms, formulas, structures, rules, caveats, or limits mean
-- where it shows up in the real world
+All learner-facing titles and text must be in `LANGUAGE`.
 
-All learner-facing text must be in `LANGUAGE`, including step titles, step text, anchor title, and anchor text.
+Two requirements control the entire lesson:
 
-Treat `LESSON_TITLE` and `LESSON_DESCRIPTION` as the contract. A friendly lesson that skips the core mechanism is a failure. A technically complete lesson that sounds like a textbook is also a failure.
+1. **Continuity:** central ideas must unfold through one working carrier or explicit recurring question. An engaging opening followed by a topic outline fails.
+2. **Dependency order:** explain the ordinary-language model that makes a procedure meaningful before giving setup, measurement, calculation, classification, or other instructions. A later intuitive explanation does not repair the order.
 
-# Teaching Standard
+Reject and rebuild any draft that violates either requirement, even when every individual step is accurate and clear.
 
-Choose the clearest teaching order for this specific lesson. A strong explanation usually does this:
+# Choose the Throughline Before Writing
 
-- starts from a concrete problem, example, object, measurement, line of code, case, or situation when that helps the learner orient
-- explains the mechanism in plain language before or alongside the formal term
-- adds the formal term, formula, code shape, legal rule, historical concept, or domain rule when the learner has enough context to understand it
-- shows how the parts connect, instead of listing facts separately
-- includes a small worked detail when the lesson depends on calculation, measurement, structure, or procedure
-- names the payoff: what this lets someone build, measure, decide, understand, prevent, or recognize
+Silently identify every required idea and relationship in `LESSON_TITLE` and `LESSON_DESCRIPTION`. Then choose one question, contrast, situation, problem, pattern, or line of reasoning that gives those ideas a reason to appear in a natural order. This is the lesson's throughline. It does not need to be a story; it needs to make each part feel like the answer to what the learner would reasonably wonder or need next.
 
-Connect the dots. Each step should build on the previous one, and the learner should feel like they are following a clear path toward understanding.
+Give that throughline a **working carrier**: one concrete situation, puzzle, object, representation, comparison, or observed process that can reveal several required ideas as the lesson advances. Keep returning to what changes, becomes visible, or needs resolving in that carrier. It does not need to be a named brand, a fictional story, or the closing anchor. If one concrete carrier would distort the subject, keep one explicit question or comparison active instead.
 
-Use examples as teaching tools, not as atmosphere. If an example does not help explain the mechanism, remove it.
+The carrier must do teaching work beyond the opening. Do not mention a situation once and then abandon it for a sequence of self-contained topic summaries. Use the carrier to replace abstract exposition, not to add a story layer before the same exposition. It need not appear in every step, and do not force a required idea into it when a direct explanation would be clearer or more accurate.
 
-Do not make the lesson "friendly" by making it shallow. If an expert would expect a formula, variable relationship, code structure, exception, uncertainty, limitation, or precise term for this lesson, include it and explain it in everyday language.
+Test the carrier before drafting. For every central coverage item, complete: “In this carrier, the learner can see or resolve ___.” If the carrier cannot naturally reveal most central items, choose a more useful carrier or recurring question. A place, product, person, or anecdote that supports only the opening is not a working carrier.
 
-Leave sibling lesson angles in `OTHER_EXPLANATION_LESSON_TITLES` for those lessons. Mention them only when needed to mark a boundary.
+When the subject allows several legitimate paths, choose one accurate representative path inside the carrier and follow it far enough for the learner to see how the central ideas connect. Qualify it as one path, then widen to alternatives, regions, interpretations, or exceptions. Do not protect accuracy by listing every possible motive, outcome, or category before any one of them becomes understandable.
+
+At each central transition, make clear what has just changed, appeared, failed, or become questionable in the carrier. Replacing its concrete people, objects, readings, clues, or choices with generic category summaries breaks the thread even if the topic remains the same.
+
+Open at the point of confusion: one concrete observation, contrast, choice, tension, pattern, or practical problem that embodies the central promise of `LESSON_TITLE`. Do not let supporting evidence, background, a method, or an anchor-worthy application become the opening unless it is itself the lesson's subject. Do not begin with a definition, a survey of the topic, a warning that cases vary, or a list of what the lesson will cover. Stay with this starting point until the central idea is understandable enough to reason with; then widen to variations, evidence, procedures, or limits.
+
+Privately complete these sentences:
+
+- the learner begins by wondering or trying to understand ___
+- the working carrier or recurring question is ___
+- the first useful thing to notice is ___
+- that creates the need to understand ___ next
+- the learner finishes able to explain, predict, distinguish, or do ___
+
+Now turn the required scope into coverage items. For each item, decide:
+
+- what a beginner is likely to find confusing or unexplained
+- the simplest accurate explanation of how it works, fits together, differs, or can be recognized
+- what familiar behavior, relationship, or experience gives the learner a foothold
+- what the learner should be able to predict, distinguish, or explain once it clicks
+
+Order coverage by dependency in the learner's reasoning, not by the order of terms in the title, description, textbook, procedure, or source material. Supporting evidence, methods, exceptions, and formal details should enter when the working carrier or recurring question creates a need for them. Not every coverage item needs its own step.
+
+For every pair of planned steps, privately ask: “Given what the learner now understands, why would they naturally need or want the next step?” If there is no convincing connection, merge, move, reframe, or remove the later step. Do not output this plan.
+
+Before drafting, identify the explanatory job of each central teaching move. Use the job the idea actually needs; do not force every subject into cause and effect:
+
+- **Mechanism:** parts or forces → interaction → result → what changes when a condition changes
+- **Structure or relationship:** parts, quantities, or positions → how they fit together → what that arrangement or equality means
+- **Decision or tradeoff:** goal, pressure, or constraint → plausible options → why one choice helps → consequence or cost
+- **Distinction or category:** contrasting cases → the feature that separates them → how to recognize a new case
+- **Pattern or convention:** examples → shared pattern → when it applies, changes meaning, or has an exception
+- **Procedure or skill:** goal or likely mistake → useful cue or action → feedback that shows whether it worked
+- **Argument, evidence, or interpretation:** question or claim → relevant clues → inference → limits or reasonable alternatives
+
+A lesson may combine several jobs. Complete the relevant bridge in ordinary words before drafting. If the bridge can only be expressed with field terms, formulas, summary verbs, or abstract labels, the explanation is not ready. Do not print the bridge or turn it into a repetitive sentence template.
+
+Before placing any instruction, calculation, measurement, or formal procedure, identify the understanding it depends on. Lock that dependency into the order: the learner must first understand the relevant behavior, relationship, boundary, or goal well enough to see why the procedure works. If the lesson asks learners both to understand an effect and measure or act on it, the effect belongs before the method. Setup and calibration are not substitutes for that prerequisite model.
+
+After drafting, locate the first sentence that tells the learner to identify, choose, record, measure, convert, calculate, classify, or perform something. Point to the earlier ordinary-language model that makes this action sensible. If none exists, move the model before the instruction and rebuild the transitions.
+
+# Weave Intuition Into the Lesson
+
+Do not write a separate intuitive introduction and then restart the same lesson in formal language. Follow the throughline one question at a time: let the working carrier expose the next idea, build the mental model, give it the precise name or notation when needed, and let that understanding create the next question.
+
+The intuitive reason and the technical name, rule, or formula may belong in the same step. Put the intuitive sentence first, then add only the precision the learner is ready to use. If they do not fit clearly together, the following step may add precision, but it must move the learner forward rather than paraphrase the mental model.
+
+When each central teaching move first appears, use its explanatory job to decide what must come before the precise term or rule. A mechanism needs the interaction; a structure needs the arrangement; a decision needs the pressure and alternatives; a distinction needs contrasting cases; a pattern needs examples; a procedure needs the problem and useful feedback; an interpretation needs clues and limits. Give only the reasoning that this idea actually requires.
+
+When a deliberate action or practice varies, follow one accurate, qualified path from pressure through choice to consequence before widening to alternatives. When multiple interpretations or categories are themselves the point, compare them openly instead of pretending one representative path settles the question. When several evidence types address the same claim, connect them around that claim instead of automatically giving each source its own card.
+
+An overview that lists topics, risks, uses, or outcomes is orientation, not a mental model. Likewise, introducing a formal name after the learner already understands the idea is not a second teaching move; name it briefly and advance.
+
+# The Intuition Gate
+
+The first step that teaches a central unfamiliar idea must give the learner all three before relying on its definition, formula, notation, procedure, rule, or specialist vocabulary:
+
+1. **Something to understand:** a clear behavior, problem, contrast, pattern, tension, or relationship that needs explaining.
+2. **The reasoning underneath it:** an ordinary-language account of the mechanism, structure, decision, boundary, pattern, procedure, or evidence that makes the idea make sense.
+3. **A model to think with:** enough understanding to predict, compare, classify, reconstruct, interpret, or perform something new.
+
+A label, rule, or one-link statement followed by a simpler paraphrase still fails when the learner cannot reason with the idea. Match the explanation to the claim: causal claims need a causal chain, structural claims need the relationship between parts, conventions need a usable pattern, and interpretations need evidence plus limits.
+
+Summary verbs such as “reinforces,” “controls,” “shapes,” “transfers,” or “influences” often hide a missing mechanism. When the lesson makes that kind of causal claim, unpack what the parts actually do, how that changes the next condition, and why the result follows. Stay with a central mechanism until the learner can predict its behavior before moving into a procedure that depends on it.
+
+When a result comes from several contributions, explain how they combine and why the combination changes the result. Naming the contributions or saying that they interact is not enough. Apply this only when combination is the real explanatory job.
+
+Before an equation that drives a central relationship or procedure, explain in ordinary words what relationship or structure the equation expresses and what each concept-bearing quantity means. If the equation describes how a result varies, state the useful direction of change and why before asking the learner to infer it from symbols. If it expresses an identity, definition, equivalence, or proof, explain why the two sides represent the same thing instead of inventing a causal prediction. A geometric formula needs its everyday spatial meaning; naming the shape or variables is not enough.
+
+Apply the gate in the right order. The relevant reasoning must appear before the first procedure, formula, or formal rule that depends on it, but it may appear immediately before that precision in the same step. A later intuitive sentence does not repair an expert-first sequence.
+
+Do not delay every term, formula, or procedure until all intuitive explanations are complete. That creates two versions of the lesson. Earn each formal detail when it becomes useful, connect it to the model already built, and keep moving.
+
+## What Passing the Gate Looks Like
+
+These examples demonstrate the reasoning pattern only. Do not reuse their subject matter or wording.
+
+- **Mechanism — weak:** “Pressure increases when volume decreases.” **Passes:** “Picture the same moving particles squeezed into a smaller box. They strike the walls more often, so pressure rises; give them more room and those collisions spread out.” The learner gets the interaction and a prediction before any formula.
+- **Structure — weak:** “One quarter equals twenty-five hundredths.” **Passes:** “The amount stays the same when the same whole is cut into finer pieces: each fourth contains twenty-five hundredths, so one fourth and twenty-five hundredths cover the same share.” The equality now describes one amount in two structures, not a causal claim.
+- **Distinction — weak:** “A warranty covers defects, not damage.” **Passes:** “If a button stops working during normal use, the product failed to do its job. If the button breaks after a fall, an outside event caused the damage. The boundary is what produced the problem.” The learner can classify a new case instead of memorizing two labels.
+- **Interpretation — weak:** “The image communicates isolation.” **Passes:** “The only person occupies a small corner while empty space fills most of the frame. That imbalance supports a reading of isolation, but a different detail elsewhere could complicate it.” The conclusion grows from evidence without pretending it is the only possible reading.
+
+# Match the Explanation to the Idea
+
+- For a mechanism, finish the relevant interaction and prediction before a calculation, measurement, or internal description that depends on it.
+- For a structure, identity, or formal relationship, make the arrangement or equivalence visible before compressing it into notation.
+- For a decision or deliberate practice, show the goal or pressure, the meaningful alternative, the choice, and its consequence before introducing an abstract summary.
+- For a pattern, convention, category, or distinction, use concrete positive and contrasting cases so the learner can recognize a new one. Do not invent a causal story when the useful insight is the pattern itself.
+- For a procedure or skill, explain the problem each major instruction solves and the cue or feedback that tells the learner it worked. Put the rationale in the same step when practical instead of creating a card for every mechanical action.
+- For an argument, source, or interpretation, establish the question before the evidence. Show how the clues support the inference, what they cannot establish, and where another interpretation could reasonably differ.
+- When uncertainty is required, first explain without symbols how plausible input readings create a range of possible results and why less precise inputs make that result range wider; only then introduce notation or calculation.
+
+Use only the moves that fit the central ideas in this lesson. A course subject does not determine one mode for every lesson, and one lesson may need several modes.
+
+# Narrative Voice
+
+Write as one person actively helping another understand. The conversational quality comes from following the learner's reasoning, not from casual filler, forced second-person wording, rhetorical questions, or repeated phrases such as “imagine” and “think of it this way.”
+
+Each step should answer a question or resolve a need created by the understanding before it. A term arrives because the learner now needs a name; a formula arrives because the learner is ready to express a relationship precisely; a caveat arrives because the current model has reached a visible limit. A new idea should not arrive merely because it is the next item in the subject's outline.
+
+Keep the learner inside the working carrier or recurring question at major transitions. Show what the new idea explains, changes, distinguishes, or lets the learner do there. A transition sentence that merely announces another related topic does not create continuity.
+
+At major transitions, guide attention, expose the confusing part, make a useful comparison, or reveal the simple connection underneath the formal language. A direct statement is fine when it continues the reasoning naturally. Do not decorate an independent textbook point with “now,” “notice,” or a rhetorical question.
+
+Use spoken, ordinary sentence structure: concrete subjects, active verbs, and the phrasing a knowledgeable person could naturally say aloud. Avoid noun-heavy commands, report-like summaries, and abstract labels when people, objects, actions, examples, or consequences can carry the same meaning. Watch especially for sentences whose subject is an abstract summary such as “the evaluation,” “the comparison,” “the interpretation,” or “the approach.” Name what a person notices, what an object does, or which concrete cases differ instead.
+
+Read the step texts aloud without their titles. They should sound like one continuous explanation. If the titles are doing the work of connecting otherwise independent paragraphs, or if several steps could trade places without creating a logical break, rebuild the sequence around the throughline.
+
+# Accuracy and Formal Detail
+
+Keep every causal direction, factual claim, calculation, unit, example, condition, and caveat correct. State the assumptions that make a shortcut, comparison, formula, or exception valid. A friendly but misleading mental model is a failure.
+
+Formal detail must earn its place. Use a formula only when `LESSON_TITLE` or `LESSON_DESCRIPTION` requires the learner to calculate with it, derive it, interpret it, or when it is the simplest accurate expression of a required relationship. Do not include equations, notation, citations, advanced variants, or expert caveats merely because they are associated with the wider topic.
+
+Choose the simplest accurate method and one useful worked example. Let that example carry the calculation, units, interpretation, and uncertainty together when practical instead of splitting one demonstration into many small cards. Add another method or caveat only when the lesson requires it or omission would teach something misleading.
+
+# Compression and Novelty
+
+Intuitive teaching should reduce the exposition needed afterward, not add a new layer before it. Aim for roughly 8-10 focused explanation steps and 300-400 words. This is a working budget, not a hard limit: a lesson may exceed it when its required scope genuinely needs more.
+
+Silently assign each draft step one unique learner gain that advances the throughline: a new mechanism, relationship, distinction, pattern, prediction, example, consequence, interpretation, skill cue, application, or necessary caveat. A new fact is not enough when the learner has no reason to need it at that point. Merge or remove a step when its only contribution is:
+
+- restating an earlier mental model in formal language
+- naming a concept that can be named in the step that already explains it
+- repeating the same relationship through a near-identical example
+- breaking one calculation or procedure into fragments that are clearer together
+- adding related expert detail that the lesson does not require
+
+A formula counts as a new gain only when the lesson requires the learner to calculate with it, interpret it, or use the precision it adds. Related details may share one step when they answer the same learner question more clearly together. If the draft exceeds 10 steps or about 400 words, inspect every extra step and keep it only when removing it would lose a required idea or a genuinely new contribution.
+
+Do not assign one card to every analytical dimension merely because each is required. When several dimensions explain the same moment, choice, observation, or claim in the carrier, weave them into the same step or adjacent reasoning instead of turning them into a catalogue.
 
 # Step Design
 
-Each step should teach one clear idea.
-
-Good steps:
-
-- move the learner from concrete understanding toward precise understanding
-- explain why the next term, formula, structure, or rule is needed
-- use short examples, measurements, or code-shaped snippets when they make the mechanism clearer
-- make the learner feel, "I can see how this works now"
-- make the concept "click" for the learner, make them say, "Oh, I get it now!" in their head
-
-Weak steps:
-
-- describe mood, scenery, or props without explaining the topic
-- stack definitions that do not connect to each other
-- use an analogy instead of the real mechanism
-- ask a rhetorical question and then fail to teach a new idea
-- hide the hard part because it might feel advanced
-
-# Titles
-
-Step titles should help the learner understand what each step is teaching.
-
-Use short, clear titles in `LANGUAGE` that name the idea, relationship, rule, or practical move in that step. Do not optimize for cleverness. Avoid titles that are only props, moods, vague story beats, or generic labels like "Concept" and "Definition".
-
-# Text Style
-
-- Write in everyday language, like talking to a friend.
-- Keep each step to 1-3 short sentences (300 characters or less).
-- Prefer concrete verbs over academic phrasing.
-- Be direct. Do not make the prose atmospheric, literary, subjective, or overly scenic.
-- Do not write dry textbook prose like "X is defined as..." unless that is genuinely the clearest sentence.
-- Avoid abstract filler such as "this concept is important", "understanding X is foundational", or "in many systems".
-- Avoid rhetorical-question-only steps.
-- If you use an analogy, quickly return to the real mechanism.
-
-# Static Lesson Rules
-
-- This is explanation-only: no quiz checks, choices, option lists, or "guess before continuing" moments.
-- Each step should stand on its own as readable player copy.
-- Choose the number of steps needed to teach the lesson well. Do not pad the lesson.
+- Each step teaches one clear idea in 1-3 short sentences, no more than 300 characters.
+- Each step reads clearly on its own screen while following naturally from the understanding built before it.
+- Titles are short and state the insight, relationship, or practical move directly. Avoid generic labels, unexplained specialist shorthand, and titles that merely name a category.
+- Prefer concrete people, objects, actions, examples, relationships, patterns, and consequences over abstract nouns that summarize them.
+- Examples must reveal the relevant mechanism, structure, pattern, distinction, procedure, or inference, not merely establish relevance.
+- Analogies are optional. Use one only when it preserves the important relationship, supports reasoning, and connects clearly to the real idea.
+- This is explanation-only: no quizzes, choices, option lists, or moments that stop and ask the learner to guess.
+- Remove repetition, tangents, background, advanced detail, and neighboring concepts once they stop helping this lesson's main teaching move.
 
 # Anchor
 
-The anchor is the closing still moment. It has no visual.
+The anchor is the final still moment and has no visual. In 1-2 short sentences, connect the lesson to one specific recognizable product, service, system, event, case, place, result, experience, or physical action. Name the instance rather than its broad category: a generic industry, profession, product type, laboratory, observatory, model type, or unnamed hypothetical system does not count. Explain exactly what the concept changes, reveals, produces, prevents, or enables there. Merely naming a real-world use is not enough; the learner should notice a useful connection they may not have recognized before. When the working carrier is already a specific recognizable instance, continuing it into the anchor is preferable to attaching an unrelated brand at the end. Otherwise, a separate closing connection is fine. Checking, validating, or calibrating the lesson's own measurement or method is not an outside-world payoff. Do not end on a classroom demonstration, lab apparatus, or professional procedure unless you also name the concrete product, service, system, or public-world result it enables.
 
-It should answer the learner's silent questions: "Why was this worth learning?" and "Where does this show up outside the lesson?"
+# Output
 
-A strong anchor:
+Return exactly:
 
-- routes the concept from the lesson into one specific real-world use
-- names one concrete instance the learner can recognize: a product, app, device, mission, instrument, technology, service, system, event, case, place, or physical action
-- speaks from the learner's side of the world, not the expert's workflow
-- is 1-2 short sentences
+- `explanation`: the ordered explanation steps, each with `title` and `text`
+- `anchor`: the closing `title` and `text`
 
-Prefer one vivid instance over a list of categories. "Hubble measuring H-alpha in the Orion Nebula" is stronger than "a star, a lamp, or a gas cloud." "The Starbucks order screen" is stronger than "many apps." If the useful real-world surface is a field tool, name the concrete mission, product, service, place, or public result it supports.
+# Reject and Rewrite Before Answering
 
-For science, engineering, math, computing, and technical topics, prefer named products, devices, infrastructure, medical uses, workplace systems, public-world results, or consumer technology. Do not end on a school demo, lab video, research instrument, or professional procedure unless you also name the concrete thing it produces or enables in the world.
+For every central teaching move from the title and description, identify its explanatory job and point to the exact earlier words that complete the matching bridge. Then find the first formula, procedure, abstract summary, rule, or technical mechanism in the draft and point to the earlier words that make it understandable. Apply only the tests the idea calls for: prediction for a changing mechanism, reconstruction for a structure, recognition for a pattern or distinction, choice for a deliberate action, performance and feedback for a skill, or evidence and limits for an interpretation.
 
-Bad anchors:
+Reject the draft if the learner can only repeat the formal statement but cannot use the ordinary-language model in the relevant way. Then assign every step its unique learner gain and reject any step that merely renames, restates, or fragments an idea already taught.
 
-- "Understanding functions is foundational to programming."
-- "The next time you see a school spectroscope in a lab video, those colored lines are measured wavelengths."
-- "A spectrometer can identify hydrogen in a star, a lamp, or a gas cloud."
-- "During a fermentation run, this is what yeast is doing."
+Finally, read the step texts without their titles and perform the adjacency test: for every transition, explain why the learner needs the next step because of what they just understood. Trace the working carrier or recurring question through the central steps and reject the draft if it disappears after the opening while the lesson becomes a topic outline. Also reject the sequence if several transitions are only topic changes, if a procedure gives instructions before its prerequisite model and the problem each instruction solves, or if the cards could be substantially rearranged without breaking the reasoning. Reject any required idea that is only mentioned or defined instead of explained, any later intuitive sentence that tries to repair an expert-first sequence, or any technical mechanism that can only be repeated in specialist vocabulary.
 
-Good anchors:
+Run three exact checks before answering:
 
-- "The next time you smell bread rising on the kitchen counter, that warm, slightly sour smell is yeast doing exactly this for hours."
-- "The pixels in your phone screen are tuned by exact light wavelengths like this: positions in a spectrum become numbers, so the screen emits the color it should."
-- "When Hubble images the Orion Nebula in H-alpha red, it is using this same move: a measured line becomes a wavelength, and that wavelength reveals hydrogen."
-
-# Final Check
-
-Before answering, verify:
-
-- The lesson fully delivers `LESSON_TITLE` and `LESSON_DESCRIPTION`.
-- A beginner can follow it without prior knowledge beyond the course context.
-- An expert would recognize the core mechanism, terms, formulas, structures, and caveats expected for this lesson scope.
-- The explanation uses plain everyday language without becoming shallow.
-- The text is direct and concrete, not dry textbook prose and not atmospheric storytelling.
-- Titles help the learner understand each step.
-- Necessary hard terms are present and explained in plain language.
-- Formulas use supported LaTeX delimiters when needed.
-- All learner-facing text is in `LANGUAGE`.
-- The anchor explains why the topic is useful and where it is used in the real world.
-- The anchor names something specific, not a generic placeholder like "a real app", "an exoplanet", or "every time X happens".
+- Point to the words in the first step that establish the central question promised by `LESSON_TITLE`. If the first step instead foregrounds supporting evidence, background, scope, or method, rewrite the opening.
+- For every central formal term, rule, equation, or procedure, point to the earlier ordinary-language reasoning that matches its actual explanatory job. If the lesson forces a causal story, prediction, or human motive that the idea does not require, rewrite it.
+- For every major transition, point to what the learner now understands, how the working carrier or recurring question remains active, and why the next step follows. Parallel examples, clues, or cases may sit beside one another when the lesson makes clear which shared question they answer.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves the explanation-lesson prompt to enforce a learner-first throughline and stricter clarity/accuracy, and adds broad eval cases (incl. Portuguese) to catch regressions. Also hardens rich‑text guidance for safe LaTeX escaping in JSON.

- **New Features**
  - Overhauled `packages/ai/src/tasks/lessons/core/lesson-explanation.prompt.md` with a learner-first contract: throughline + working carrier, dependency ordering before procedures/formulas, intuition gate, concise step design (1–3 short sentences), tighter anchor rules, and audits for accuracy, clarity, sequencing, and padding.
  - Strengthened `packages/ai/src/tasks/lessons/_utils/lesson-rich-text.prompt.md` to require valid JSON-escaped LaTeX delimiters and reject control characters in learner text.
  - Expanded evals in `apps/evals/src/tasks/lesson-explanation/test-cases.ts` with new topics and stricter checks, including Portuguese lessons (DFS/BFS em árvores, código genético, lead vs cycle time, lucro vs caixa, espectroscopia, trocas de acordes) and English lessons (Pythagorean area proof, necessary vs sufficient, unreliable narrator), plus a richer shared expectations block for accuracy, clarity, intuitive teaching, and flow.

<sup>Written for commit d6a478f3bb56305120e0d12eda8ab958a6fe307b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

