### PR TITLE
feat(mailbox): add local email inbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,11 @@ For detailed UX guidelines (interactions, animation, layout, accessibility), see
 - Do not store an unawaited promise solely to overlap async operations (for example, `const valuePromise = load(); ...; const value = await valuePromise`). Prefer a direct `await`. Only introduce explicit concurrency when it has a demonstrated benefit and can be expressed clearly with `Promise.all`
 - Run browser-launching test commands such as Playwright, Cypress, Puppeteer, Selenium, or repository E2E scripts with escalated sandbox permissions on the first attempt. Chromium-based browsers require Mach services that are blocked by the workspace sandbox, so do not first run these commands inside the sandbox; send the exact command to Auto-review for approval instead
 
+## Local Authentication
+
+- When a local page requires sign-in, choose an existing user from `packages/db/src/prisma/seed/users.ts`; it includes role-specific accounts such as `owner@zoonk.test`. Or if you need to test a new/random user, just use a random `@zoonk.test` email.
+- `pnpm dev` starts the local mailbox app. After requesting an OTP, open the newest message for that user's email and use its code. When parallel agents need isolated ports, start the full development command with a unique port, for example `MAILBOX_PORT=4317 pnpm dev`.
+
 ## Prisma Queries
 
 - **Don't use `select` by default.** Return the full model — most models have only small columns and `select` adds maintenance cost (manual types, updating selects when adding fields) with negligible performance benefit

--- a/apps/mailbox/README.md
+++ b/apps/mailbox/README.md
@@ -1,0 +1,5 @@
+# Local mailbox
+
+The mailbox starts with `pnpm dev` and opens at `http://127.0.0.1:3202`. Development emails are kept in memory for the lifetime of the Vite process. It has no build or deployment task and is never used when a mail provider key is configured.
+
+Set `MAILBOX_PORT` on the full development command when parallel work needs another port, for example `MAILBOX_PORT=4317 pnpm dev`. The mailbox app and development email transport use the same value.

--- a/apps/mailbox/index.html
+++ b/apps/mailbox/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light" />
+    <title>Local mailbox</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/mailbox/package.json
+++ b/apps/mailbox/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mailbox",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@zoonk/ui": "workspace:*",
+    "@zoonk/utils": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "6.0.4",
+    "@zoonk/mailer": "workspace:*",
+    "@zoonk/tsconfig": "workspace:*",
+    "typescript": "catalog:",
+    "vite": "8.1.5"
+  }
+}

--- a/apps/mailbox/postcss.config.mjs
+++ b/apps/mailbox/postcss.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "@zoonk/ui/postcss.config";

--- a/apps/mailbox/src/app.tsx
+++ b/apps/mailbox/src/app.tsx
@@ -1,0 +1,262 @@
+import { cn } from "@zoonk/ui/lib/utils";
+import { useState } from "react";
+import {
+  Mailbox,
+  MailboxActions,
+  MailboxBody,
+  MailboxButton,
+  MailboxEmpty,
+  MailboxHeader,
+  MailboxIdentity,
+  MailboxInbox,
+  MailboxList,
+  MailboxListItem,
+  MailboxMessageButton,
+  MailboxPreview,
+  MailboxStatus,
+  MailboxTitle,
+} from "./components/mailbox";
+import { type CapturedEmail } from "./email";
+import { clearEmailInbox, useEmailInbox } from "./email-store";
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit" });
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "medium",
+});
+
+const copy = {
+  clearInbox: "Clear inbox",
+  emailMessages: "Email messages",
+  emptyMark: "@",
+  inboxEmptyDescription: "Trigger an email in Main or API.",
+  inboxEmptyTitle: "No messages yet",
+  message: "Message",
+  noBody: "This email has no body.",
+  previewEmptyDescription: "Messages live in memory and disappear when this app stops.",
+  previewEmptyTitle: "Your development emails will appear here.",
+  received: "Received",
+  replyTo: "Reply to",
+  title: "Local mailbox",
+  to: "To",
+};
+
+/**
+ * Keeps the newest local email visible by default while preserving an older
+ * explicit selection as new messages arrive during a testing flow.
+ */
+export function App() {
+  const { emails, status } = useEmailInbox();
+  const [selectedEmailId, setSelectedEmailId] = useState<string | null>(null);
+  const selectedEmail = getSelectedEmail({ emails, selectedEmailId });
+
+  const handleClear = () => {
+    setSelectedEmailId(null);
+    void clearEmailInbox();
+  };
+
+  return (
+    <Mailbox>
+      <MailboxHeader>
+        <MailboxIdentity>
+          <MailboxTitle>{copy.title}</MailboxTitle>
+          <MailboxStatus data-status={status}>
+            <span aria-hidden="true" className={getStatusDotClassName(status)} />
+            {getStatusLabel(status)}
+          </MailboxStatus>
+        </MailboxIdentity>
+
+        <MailboxActions>
+          <span className="text-muted-foreground font-mono text-[11px]">
+            {getMessageCountLabel(emails.length)}
+          </span>
+          <MailboxButton disabled={emails.length === 0} onClick={handleClear}>
+            {copy.clearInbox}
+          </MailboxButton>
+        </MailboxActions>
+      </MailboxHeader>
+
+      <MailboxBody>
+        <MailboxInbox aria-label={copy.emailMessages}>
+          <EmailList
+            emails={emails}
+            onSelect={setSelectedEmailId}
+            selectedEmailId={selectedEmail?.id}
+          />
+        </MailboxInbox>
+
+        {selectedEmail ? (
+          <EmailPreview email={selectedEmail} />
+        ) : (
+          <MailboxEmpty className="grid min-h-full place-content-center px-10 py-16 text-center">
+            <span
+              className="border-border text-foreground mx-auto mb-5 grid size-12 place-items-center rounded-full border font-mono text-xl"
+              aria-hidden="true"
+            >
+              {copy.emptyMark}
+            </span>
+            <p className="text-foreground mb-1.5 text-sm font-semibold">{copy.previewEmptyTitle}</p>
+            <span className="text-[13px]">{copy.previewEmptyDescription}</span>
+          </MailboxEmpty>
+        )}
+      </MailboxBody>
+    </Mailbox>
+  );
+}
+
+/** Keeps list rendering shallow while preserving semantic, keyboard-accessible message rows. */
+function EmailList({
+  emails,
+  onSelect,
+  selectedEmailId,
+}: {
+  emails: CapturedEmail[];
+  onSelect: (emailId: string) => void;
+  selectedEmailId?: string;
+}) {
+  if (emails.length === 0) {
+    return (
+      <MailboxEmpty className="px-5.5 py-7">
+        <p className="text-foreground mb-1.5 text-sm font-semibold">{copy.inboxEmptyTitle}</p>
+        <span className="text-[13px]">{copy.inboxEmptyDescription}</span>
+      </MailboxEmpty>
+    );
+  }
+
+  return (
+    <MailboxList>
+      {emails.map((email) => (
+        <EmailListMessage
+          email={email}
+          isSelected={email.id === selectedEmailId}
+          key={email.id}
+          onSelect={onSelect}
+        />
+      ))}
+    </MailboxList>
+  );
+}
+
+/** Gives each message one selection action while keeping its visible metadata independently styled. */
+function EmailListMessage({
+  email,
+  isSelected,
+  onSelect,
+}: {
+  email: CapturedEmail;
+  isSelected: boolean;
+  onSelect: (emailId: string) => void;
+}) {
+  return (
+    <MailboxListItem>
+      <MailboxMessageButton aria-pressed={isSelected} onClick={() => onSelect(email.id)}>
+        <span className="overflow-hidden text-sm font-semibold tracking-[-0.01em] text-ellipsis whitespace-nowrap">
+          {email.subject}
+        </span>
+        <span className="text-muted-foreground overflow-hidden font-mono text-[10px] text-ellipsis whitespace-nowrap">
+          {`${copy.to} ${email.to}`}
+        </span>
+        <time
+          className="text-muted-foreground col-start-2 row-start-1 font-mono text-[10px]"
+          dateTime={email.receivedAt}
+        >
+          {timeFormatter.format(new Date(email.receivedAt))}
+        </time>
+      </MailboxMessageButton>
+    </MailboxListItem>
+  );
+}
+
+/** Renders one selected message without allowing its HTML to affect the mailbox UI. */
+function EmailPreview({ email }: { email: CapturedEmail }) {
+  return (
+    <MailboxPreview>
+      <header className="border-border border-b px-5 pt-7 pb-6 md:px-[clamp(1.5rem,5vw,4.5rem)] md:pt-10.5 md:pb-7">
+        <p className="text-muted-foreground mb-3 font-mono text-[10px] tracking-widest uppercase">
+          {copy.message}
+        </p>
+        <h2 className="max-w-225 text-3xl leading-[1.04] font-semibold tracking-[-0.045em] md:text-[clamp(1.75rem,4vw,3.125rem)]">
+          {email.subject}
+        </h2>
+        <dl className="text-muted-foreground mt-6 grid gap-3.5 font-mono text-[11px] md:mt-8 md:flex md:flex-wrap md:gap-x-8 md:gap-y-4">
+          <div className="grid gap-1">
+            <dt className="text-muted-foreground/70 tracking-[0.08em] uppercase">{copy.to}</dt>
+            <dd className="text-foreground m-0">{email.to}</dd>
+          </div>
+          {email.replyTo ? (
+            <div className="grid gap-1">
+              <dt className="text-muted-foreground/70 tracking-[0.08em] uppercase">
+                {copy.replyTo}
+              </dt>
+              <dd className="text-foreground m-0">{email.replyTo}</dd>
+            </div>
+          ) : null}
+          <div className="grid gap-1">
+            <dt className="text-muted-foreground/70 tracking-[0.08em] uppercase">
+              {copy.received}
+            </dt>
+            <dd className="text-foreground m-0">
+              {dateTimeFormatter.format(new Date(email.receivedAt))}
+            </dd>
+          </div>
+        </dl>
+      </header>
+
+      <div className="p-5 md:p-[clamp(1.5rem,5vw,4.5rem)]">
+        {email.htmlBody ? (
+          <iframe
+            className="border-border block min-h-95 w-full rounded-[3px] border bg-white md:min-h-105"
+            referrerPolicy="no-referrer"
+            sandbox=""
+            srcDoc={email.htmlBody}
+            title={`${email.subject} email body`}
+          />
+        ) : (
+          <pre className="border-border bg-background m-0 min-h-95 w-full overflow-auto rounded-[3px] border p-7 font-mono text-sm leading-[1.65] whitespace-pre-wrap md:min-h-105">
+            {email.textBody || copy.noBody}
+          </pre>
+        )}
+      </div>
+    </MailboxPreview>
+  );
+}
+
+/** Resolves selection as a pure derivation so new mail needs no synchronizing effect. */
+function getSelectedEmail({
+  emails,
+  selectedEmailId,
+}: {
+  emails: CapturedEmail[];
+  selectedEmailId: string | null;
+}): CapturedEmail | undefined {
+  return emails.find((email) => email.id === selectedEmailId) ?? emails[0];
+}
+
+/** Gives the live indicator a clear failure label when the Vite API is unavailable. */
+function getStatusLabel(status: "loading" | "ready" | "unavailable"): string {
+  if (status === "unavailable") {
+    return "Offline";
+  }
+
+  if (status === "loading") {
+    return "Connecting";
+  }
+
+  return "Live";
+}
+
+/** Maps the transport state to shared semantic colors without coupling status logic to markup. */
+function getStatusDotClassName(status: "loading" | "ready" | "unavailable"): string {
+  return cn(
+    "size-1.75 rounded-full",
+    status === "ready" && "bg-success ring-success/15 ring-3",
+    status === "loading" && "bg-warning",
+    status === "unavailable" && "bg-destructive",
+  );
+}
+
+/** Keeps the header count grammatical without adding localization machinery to a local tool. */
+function getMessageCountLabel(count: number): string {
+  return `${count} ${count === 1 ? "message" : "messages"}`;
+}

--- a/apps/mailbox/src/components/mailbox.tsx
+++ b/apps/mailbox/src/components/mailbox.tsx
@@ -1,0 +1,134 @@
+import { Button } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { type ComponentProps } from "react";
+
+/** Provides the full-height surface that anchors every mailbox region. */
+export function Mailbox({ className, ...props }: ComponentProps<"main">) {
+  return (
+    <main
+      className={cn(
+        "bg-muted/30 text-foreground grid min-h-svh grid-rows-[auto_minmax(0,1fr)] font-sans antialiased",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/** Keeps mailbox identity and global actions in one compact top bar. */
+export function MailboxHeader({ className, ...props }: ComponentProps<"header">) {
+  return (
+    <header
+      className={cn(
+        "border-border bg-background/90 z-10 flex min-h-18 flex-wrap items-center justify-between gap-3 border-b px-4 py-3 backdrop-blur-lg sm:flex-nowrap sm:px-6 sm:py-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/** Groups the title with live delivery status without coupling their content. */
+export function MailboxIdentity({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("flex items-center gap-3.5", className)} {...props} />;
+}
+
+/** Gives this development tool a single, immediately recognizable heading. */
+export function MailboxTitle({ children, className, ...props }: ComponentProps<"h1">) {
+  return (
+    <h1 className={cn("text-lg font-semibold tracking-[-0.025em]", className)} {...props}>
+      {children}
+    </h1>
+  );
+}
+
+/** Displays compact operational metadata in a developer-friendly monospace face. */
+export function MailboxStatus({ className, ...props }: ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "text-muted-foreground inline-flex items-center gap-2 font-mono text-[11px] tracking-[0.06em] uppercase",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/** Keeps global mailbox controls aligned separately from the inbox identity. */
+export function MailboxActions({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("flex items-center gap-2.5 sm:gap-4", className)} {...props} />;
+}
+
+/** Reuses the shared outline action so this app follows the same interaction states as every app. */
+export function MailboxButton({
+  className,
+  variant = "outline",
+  ...props
+}: ComponentProps<typeof Button>) {
+  return (
+    <Button
+      className={cn("rounded-lg text-[13px] motion-reduce:transition-none", className)}
+      type="button"
+      variant={variant}
+      {...props}
+    />
+  );
+}
+
+/** Creates the two-region inbox and message layout used by the local tool. */
+export function MailboxBody({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("min-h-0 md:grid md:grid-cols-[minmax(260px,330px)_minmax(0,1fr)]", className)}
+      {...props}
+    />
+  );
+}
+
+/** Marks the message list as navigation for assistive technology and small screens. */
+export function MailboxInbox({ className, ...props }: ComponentProps<"nav">) {
+  return (
+    <nav
+      className={cn(
+        "border-border bg-muted/30 max-h-[38svh] min-h-0 overflow-y-auto border-b md:max-h-none md:border-r md:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/** Resets list chrome so spacing and dividers carry the inbox hierarchy. */
+export function MailboxList({ className, ...props }: ComponentProps<"ol">) {
+  return <ol className={cn("m-0 list-none p-0", className)} {...props} />;
+}
+
+/** Makes each captured message one semantic list item. */
+export function MailboxListItem({ className, ...props }: ComponentProps<"li">) {
+  return <li className={cn("border-border border-b", className)} {...props} />;
+}
+
+/** Turns an entire message summary into one keyboard-accessible selection target. */
+export function MailboxMessageButton({ className, ...props }: ComponentProps<"button">) {
+  return (
+    <button
+      className={cn(
+        "focus-visible:ring-ring aria-pressed:bg-muted hover:bg-muted aria-pressed:before:bg-foreground relative grid w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-x-4 gap-y-2 border-0 bg-transparent py-4 pr-4 pl-5 text-left transition-colors outline-none before:absolute before:inset-y-3 before:left-0 before:w-0.5 before:bg-transparent focus-visible:ring-2 focus-visible:ring-inset motion-reduce:transition-none",
+        className,
+      )}
+      type="button"
+      {...props}
+    />
+  );
+}
+
+/** Holds the selected email's headers and safely isolated body preview. */
+export function MailboxPreview({ className, ...props }: ComponentProps<"article">) {
+  return <article className={cn("bg-background min-w-0 overflow-y-auto", className)} {...props} />;
+}
+
+/** Gives empty inbox states enough visual weight to explain the next action. */
+export function MailboxEmpty({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("text-muted-foreground", className)} {...props} />;
+}

--- a/apps/mailbox/src/email-payload.ts
+++ b/apps/mailbox/src/email-payload.ts
@@ -1,0 +1,21 @@
+import { isJsonObject, isOptionalString } from "@zoonk/utils/json";
+
+export type EmailPayload = {
+  to: string;
+  subject: string;
+  htmlBody?: string;
+  textBody?: string;
+  replyTo?: string;
+};
+
+/** Validates the message fields shared by captured inbox responses and local writes. */
+export function isEmailPayload(value: unknown): value is EmailPayload & Record<string, unknown> {
+  return (
+    isJsonObject(value) &&
+    typeof value.to === "string" &&
+    typeof value.subject === "string" &&
+    isOptionalString(value.htmlBody) &&
+    isOptionalString(value.textBody) &&
+    isOptionalString(value.replyTo)
+  );
+}

--- a/apps/mailbox/src/email-store.ts
+++ b/apps/mailbox/src/email-store.ts
@@ -1,0 +1,72 @@
+import { useSyncExternalStore } from "react";
+import { type EmailInboxResponse, isEmailInboxResponse } from "./email";
+
+type EmailStoreSnapshot = EmailInboxResponse & { status: "loading" | "ready" | "unavailable" };
+
+const EMAILS_PATH = "/api/emails";
+const POLLING_INTERVAL = 1000;
+const listeners = new Set<() => void>();
+let pollingTimer: ReturnType<typeof setInterval> | null = null;
+let snapshot: EmailStoreSnapshot = { emails: [], status: "loading" };
+
+/**
+ * Exposes the tiny external inbox store through React's native subscription
+ * API. The polling lifecycle belongs to the shared store rather than a view,
+ * which avoids effect-driven derived state and duplicate requests.
+ */
+export function useEmailInbox(): EmailStoreSnapshot {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/** Clears the server-owned inbox and refreshes the visible snapshot immediately. */
+export async function clearEmailInbox(): Promise<void> {
+  await fetch(EMAILS_PATH, { method: "DELETE" });
+  await refreshEmailInbox();
+}
+
+/** Starts one polling loop while the mailbox has an active React subscriber. */
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+
+  if (listeners.size === 1) {
+    void refreshEmailInbox();
+    pollingTimer = globalThis.setInterval(() => void refreshEmailInbox(), POLLING_INTERVAL);
+  }
+
+  return () => {
+    listeners.delete(listener);
+
+    if (listeners.size === 0 && pollingTimer !== null) {
+      globalThis.clearInterval(pollingTimer);
+      pollingTimer = null;
+    }
+  };
+}
+
+/** Returns the stable object React compares between inbox notifications. */
+function getSnapshot(): EmailStoreSnapshot {
+  return snapshot;
+}
+
+/** Loads the newest server state and preserves existing mail during brief connection failures. */
+async function refreshEmailInbox(): Promise<void> {
+  try {
+    const response = await fetch(EMAILS_PATH);
+
+    if (!response.ok) {
+      throw new Error(`Inbox request failed: ${response.statusText}`);
+    }
+
+    const data: unknown = await response.json();
+
+    if (!isEmailInboxResponse(data)) {
+      throw new Error("Inbox returned an invalid response.");
+    }
+
+    snapshot = { emails: data.emails, status: "ready" };
+  } catch {
+    snapshot = { emails: snapshot.emails, status: "unavailable" };
+  }
+
+  listeners.forEach((listener) => listener());
+}

--- a/apps/mailbox/src/email.ts
+++ b/apps/mailbox/src/email.ts
@@ -1,0 +1,21 @@
+import { isJsonObject } from "@zoonk/utils/json";
+import { type EmailPayload, isEmailPayload } from "./email-payload";
+
+export type CapturedEmail = EmailPayload & { id: string; receivedAt: string };
+
+export type EmailInboxResponse = { emails: CapturedEmail[] };
+
+/** Validates data read back from Vite before exposing it to React. */
+export function isEmailInboxResponse(value: unknown): value is EmailInboxResponse {
+  return isJsonObject(value) && Array.isArray(value.emails) && value.emails.every(isCapturedEmail);
+}
+
+/** Confirms server-owned fields are present in addition to the original message. */
+function isCapturedEmail(value: unknown): value is CapturedEmail {
+  return (
+    isJsonObject(value) &&
+    isEmailPayload(value) &&
+    typeof value.id === "string" &&
+    typeof value.receivedAt === "string"
+  );
+}

--- a/apps/mailbox/src/main.tsx
+++ b/apps/mailbox/src/main.tsx
@@ -1,0 +1,11 @@
+import { createRoot } from "react-dom/client";
+import "@zoonk/ui/globals.css";
+import { App } from "./app";
+
+const rootElement = document.querySelector("#root");
+
+if (!rootElement) {
+  throw new Error("The mailbox root element is missing.");
+}
+
+createRoot(rootElement).render(<App />);

--- a/apps/mailbox/src/server/email-inbox-plugin.ts
+++ b/apps/mailbox/src/server/email-inbox-plugin.ts
@@ -1,0 +1,114 @@
+import { type IncomingMessage, type ServerResponse } from "node:http";
+import { type Plugin } from "vite";
+import { type EmailPayload, isEmailPayload } from "../email-payload";
+import { type EmailInbox, createEmailInbox } from "./email-inbox";
+
+const EMAILS_PATH = "/api/emails";
+
+/**
+ * Adds the development-only inbox API directly to Vite. Keeping the API beside
+ * the UI means the feature has one process, one in-memory lifetime, and no
+ * runtime surface in any deployed application.
+ */
+export function createEmailInboxPlugin(): Plugin {
+  const inbox = createEmailInbox();
+
+  return {
+    configureServer(server) {
+      server.middlewares.use((request, response, next) => {
+        if (request.url !== EMAILS_PATH) {
+          next();
+          return;
+        }
+
+        void handleEmailRequest({ inbox, request, response }).catch(next);
+      });
+    },
+    name: "local-email-inbox",
+  };
+}
+
+/** Handles supported inbox operations after the synchronous Vite middleware has matched the path. */
+async function handleEmailRequest({
+  inbox,
+  request,
+  response,
+}: {
+  inbox: EmailInbox;
+  request: IncomingMessage;
+  response: ServerResponse;
+}): Promise<void> {
+  if (request.method === "GET") {
+    sendJson({ body: { emails: inbox.list() }, response, status: 200 });
+    return;
+  }
+
+  if (request.method === "POST") {
+    const email = await readEmailPayload(request);
+
+    if (!email) {
+      sendJson({ body: { error: "Invalid email payload" }, response, status: 400 });
+      return;
+    }
+
+    sendJson({ body: inbox.add(email), response, status: 201 });
+    return;
+  }
+
+  if (request.method === "DELETE") {
+    inbox.clear();
+    response.statusCode = 204;
+    response.end();
+    return;
+  }
+
+  sendJson({ body: { error: "Method not allowed" }, response, status: 405 });
+}
+
+/**
+ * Reads the request through the platform Web Stream bridge so message bodies
+ * can be parsed without maintaining a second mutable buffering abstraction.
+ * Invalid JSON is treated the same as an invalid shape at this local boundary.
+ */
+async function readEmailPayload(request: IncomingMessage): Promise<EmailPayload | null> {
+  try {
+    const body = await readRequestBody(request);
+    const value: unknown = JSON.parse(body);
+
+    return isEmailPayload(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Buffers one small local JSON request with explicit string chunks. Email size
+ * limits remain the provider's concern because this endpoint never leaves the
+ * developer's loopback interface.
+ */
+function readRequestBody(request: IncomingMessage): Promise<string> {
+  request.setEncoding("utf8");
+
+  return new Promise((resolve, reject) => {
+    const chunks: string[] = [];
+
+    request.on("data", (chunk: string) => chunks.push(chunk));
+    request.on("end", () => resolve(chunks.join("")));
+    request.on("error", reject);
+  });
+}
+
+/** Writes every endpoint response with one predictable JSON representation. */
+function sendJson({
+  body,
+  response,
+  status,
+}: {
+  body: unknown;
+  response: ServerResponse;
+  status: number;
+}): void {
+  response.statusCode = status;
+  response.setHeader("Content-Type", "application/json; charset=utf-8");
+  response.end(JSON.stringify(body));
+}

--- a/apps/mailbox/src/server/email-inbox.ts
+++ b/apps/mailbox/src/server/email-inbox.ts
@@ -1,0 +1,37 @@
+import { randomUUID } from "node:crypto";
+import { type CapturedEmail } from "../email";
+import { type EmailPayload } from "../email-payload";
+
+const MAX_EMAIL_COUNT = 100;
+
+export type EmailInbox = {
+  add: (email: EmailPayload) => CapturedEmail;
+  clear: () => void;
+  list: () => CapturedEmail[];
+};
+
+/**
+ * Keeps local messages for the lifetime of the Vite process so development
+ * email never requires a database, migration, cleanup job, or production
+ * service. The small limit prevents a long-running dev session from growing
+ * without bound.
+ */
+export function createEmailInbox(): EmailInbox {
+  let emails: CapturedEmail[] = [];
+
+  return {
+    add(email) {
+      const capturedEmail = { ...email, id: randomUUID(), receivedAt: new Date().toISOString() };
+
+      emails = [capturedEmail, ...emails].slice(0, MAX_EMAIL_COUNT);
+
+      return capturedEmail;
+    },
+    clear() {
+      emails = [];
+    },
+    list() {
+      return emails;
+    },
+  };
+}

--- a/apps/mailbox/src/vite-env.d.ts
+++ b/apps/mailbox/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/mailbox/tsconfig.json
+++ b/apps/mailbox/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": { "jsx": "react-jsx" },
+  "exclude": ["node_modules", "dist"],
+  "extends": "@zoonk/tsconfig/base.json",
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/mailbox/vite.config.ts
+++ b/apps/mailbox/vite.config.ts
@@ -1,0 +1,11 @@
+import react from "@vitejs/plugin-react";
+import { getLocalInboxConfig } from "@zoonk/mailer/local-inbox";
+import { defineConfig } from "vite";
+import { createEmailInboxPlugin } from "./src/server/email-inbox-plugin";
+
+const { port: localInboxPort } = getLocalInboxConfig();
+
+export default defineConfig({
+  plugins: [react(), createEmailInboxPlugin()],
+  server: { host: "127.0.0.1", port: localInboxPort, strictPort: true },
+});

--- a/knip.json
+++ b/knip.json
@@ -20,6 +20,7 @@
       "project": ["src/**/*.{ts,tsx}!", "e2e/**/*.ts", "!**/_test-utils/**!"]
     },
     "apps/blog": { "project": ["src/**/*.{ts,tsx,mdx}!"] },
+    "apps/mailbox": { "project": ["src/**/*.{ts,tsx,css}!", "!src/server/**!"] },
     "apps/main": {
       "entry": [".eloqnt/config.ts", "src/app/*/privacy/*.mdx", "src/app/*/terms/*.mdx"],
       "project": ["src/**/*.{ts,tsx,mdx,css}!", "e2e/**/*.ts", "!**/_test-utils/**!"]

--- a/packages/mailer/package.json
+++ b/packages/mailer/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/client.ts"
+    ".": "./src/client.ts",
+    "./local-inbox": "./src/local-inbox.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/mailer/src/client.test.ts
+++ b/packages/mailer/src/client.test.ts
@@ -21,12 +21,12 @@ describe("sendEmail", () => {
     vi.unstubAllEnvs();
   });
 
-  it("logs the email body when local development disables email sending", async () => {
+  it("captures the email in the local inbox when development disables email sending", async () => {
     vi.stubEnv("MAILER_API_KEY", "");
     vi.stubEnv("NODE_ENV", "development");
     vi.stubEnv("VERCEL_ENV", "");
 
-    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ ok: true }));
     const sendEmail = await getSendEmail();
 
     const { data, error } = await sendEmail({
@@ -38,13 +38,25 @@ describe("sendEmail", () => {
     expect(error).toBeNull();
     expect(data?.ok).toBe(true);
 
-    expect(info).toHaveBeenCalledWith(
-      expect.objectContaining({
-        subject: "Your OTP code",
-        textBody: otpBody,
-        to: "user@example.com",
-      }),
-    );
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:3202/api/emails", {
+      body: JSON.stringify({ htmlBody: otpBody, subject: "Your OTP code", to: "user@example.com" }),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    });
+  });
+
+  it("captures development email on the configured local inbox port", async () => {
+    vi.stubEnv("MAILBOX_PORT", "4317");
+    vi.stubEnv("MAILER_API_KEY", "");
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VERCEL_ENV", "");
+
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ ok: true }));
+    const sendEmail = await getSendEmail();
+
+    await sendEmail({ htmlBody: otpBody, subject: "Your OTP code", to: "user@example.com" });
+
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:4317/api/emails", expect.any(Object));
   });
 
   it("allows missing mailer config in e2e without logging the email body", async () => {

--- a/packages/mailer/src/client.ts
+++ b/packages/mailer/src/client.ts
@@ -1,8 +1,10 @@
 import { getEnvironment } from "@zoonk/utils/environment";
 import { type SafeReturn, toError } from "@zoonk/utils/error";
-import { logError, logInfo } from "@zoonk/utils/logger";
+import { logError } from "@zoonk/utils/logger";
+import { getLocalInboxConfig } from "./local-inbox";
 
 const apiUrl = "https://api.zeptomail.com/v1.1/email";
+const { url: localInboxUrl } = getLocalInboxConfig();
 
 type SendEmailParams = {
   to: string;
@@ -14,9 +16,9 @@ type SendEmailParams = {
 
 /**
  * Sends product emails through the configured provider while preserving the
- * local development workflow where missing credentials print OTP emails to the
- * terminal. Deployed environments must fail closed so a missing secret cannot
- * turn authentication codes into application logs.
+ * local development workflow where missing credentials capture messages in a
+ * browser inbox. Deployed environments must fail closed so a missing secret
+ * cannot turn authentication codes into application logs.
  */
 export async function sendEmail(params: SendEmailParams): Promise<SafeReturn<Response>> {
   const { to, subject, htmlBody, textBody, replyTo } = params;
@@ -61,10 +63,12 @@ export async function sendEmail(params: SendEmailParams): Promise<SafeReturn<Res
  * optional. Local development needs a disabled-mailer mode for OTP login, but
  * previews and production should expose the configuration problem immediately.
  */
-function handleMissingMailerApiKey(params: SendEmailParams): SafeReturn<Response> {
-  if (isMissingMailerApiKeyAllowed()) {
-    logDisabledEmail(params);
+async function handleMissingMailerApiKey(params: SendEmailParams): Promise<SafeReturn<Response>> {
+  if (getEnvironment() === "development") {
+    return captureDevelopmentEmail(params);
+  }
 
+  if (getEnvironment() === "e2e") {
     return { data: Response.json({ ok: true }), error: null };
   }
 
@@ -76,35 +80,32 @@ function handleMissingMailerApiKey(params: SendEmailParams): SafeReturn<Response
 }
 
 /**
- * Allows no-provider email only in environments that are not real mail
- * delivery surfaces. E2E reads OTPs from the database, while local development
- * prints them for manual login.
+ * Delivers a development message to the local-only Vite app instead of mixing
+ * HTML and sign-in codes into terminal output. The endpoint is bound to the
+ * loopback interface and exists only while the mailbox development server runs.
  */
-function isMissingMailerApiKeyAllowed(): boolean {
-  const environment = getEnvironment();
+async function captureDevelopmentEmail(params: SendEmailParams): Promise<SafeReturn<Response>> {
+  try {
+    const response = await fetch(localInboxUrl, {
+      body: JSON.stringify(params),
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+    });
 
-  return environment === "development" || environment === "e2e";
-}
+    if (!response.ok) {
+      const error = new Error(`Local email capture failed: ${response.statusText}`);
 
-/**
- * Logs disabled-mailer output without treating every non-provider environment
- * the same. Developers need the body locally to copy OTP codes, but E2E and any
- * future non-delivery mode should keep secret-bearing content out of logs.
- */
-function logDisabledEmail(params: SendEmailParams): void {
-  logInfo("Email sending is disabled.");
-  logInfo(getDisabledEmailLogPayload(params));
-}
+      logError(error.message);
 
-/**
- * Keeps the redaction rule explicit at the payload boundary so future mail
- * fields do not accidentally reintroduce OTP or message-body logging outside
- * local development.
- */
-function getDisabledEmailLogPayload({ subject, textBody, htmlBody, to }: SendEmailParams) {
-  if (getEnvironment() === "development") {
-    return { subject, textBody: textBody ?? htmlBody, to };
+      return { data: null, error };
+    }
+
+    return { data: response, error: null };
+  } catch (error) {
+    const normalizedError = toError(error);
+
+    logError(`Local email inbox is unavailable at ${localInboxUrl}. Run pnpm dev to start it.`);
+
+    return { data: null, error: normalizedError };
   }
-
-  return { subject, to };
 }

--- a/packages/mailer/src/local-inbox.ts
+++ b/packages/mailer/src/local-inbox.ts
@@ -1,0 +1,31 @@
+const DEFAULT_LOCAL_INBOX_PORT = 3202;
+const MAX_PORT = 65_535;
+
+/**
+ * Gives the mailbox server and development mail transport one shared config.
+ * Parallel agents can set MAILBOX_PORT without changing tracked files, while
+ * invalid values fail immediately instead of splitting delivery and preview
+ * across different ports.
+ */
+export function getLocalInboxConfig(): { port: number; url: string } {
+  const port = getLocalInboxPort();
+
+  return { port, url: `http://127.0.0.1:${port}/api/emails` };
+}
+
+/** Keeps environment parsing private because consumers need the complete shared mailbox config. */
+function getLocalInboxPort(): number {
+  const configuredPort = process.env.MAILBOX_PORT;
+
+  if (!configuredPort) {
+    return DEFAULT_LOCAL_INBOX_PORT;
+  }
+
+  const port = Number(configuredPort);
+
+  if (!Number.isInteger(port) || port < 1 || port > MAX_PORT) {
+    throw new Error(`MAILBOX_PORT must be an integer between 1 and ${MAX_PORT}.`);
+  }
+
+  return port;
+}

--- a/packages/utils/src/json.test.ts
+++ b/packages/utils/src/json.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { getNumber, stringifyUnknown } from "./json";
+import { getNumber, isOptionalString, stringifyUnknown } from "./json";
+
+describe(isOptionalString, () => {
+  it("accepts strings and omitted values", () => {
+    const value: { optional?: string } = {};
+
+    expect(isOptionalString("hello")).toBe(true);
+    expect(isOptionalString(value.optional)).toBe(true);
+  });
+
+  it("rejects other values", () => {
+    expect(isOptionalString(null)).toBe(false);
+    expect(isOptionalString(123)).toBe(false);
+  });
+});
 
 describe(getNumber, () => {
   it("reads a numeric property from an unknown object", () => {

--- a/packages/utils/src/json.ts
+++ b/packages/utils/src/json.ts
@@ -9,6 +9,14 @@ export function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Validates optional string fields at untrusted boundaries so each consumer
+ * does not need to recreate the same undefined-or-string check.
+ */
+export function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
 export function getString(body: unknown, key: string): string | null {
   if (!isJsonObject(body) || !(key in body)) {
     return null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,49 @@ importers:
         specifier: 'catalog:'
         version: 7.0.2
 
+  apps/mailbox:
+    dependencies:
+      '@zoonk/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@zoonk/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
+      react:
+        specifier: 'catalog:'
+        version: 19.2.8
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.8(react@19.2.8)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: 'catalog:'
+        version: 4.3.3
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 6.0.4
+        version: 6.0.4(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@zoonk/mailer':
+        specifier: workspace:*
+        version: link:../../packages/mailer
+      '@zoonk/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: 8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+
   apps/main:
     dependencies:
       '@next/third-parties':
@@ -10306,6 +10349,11 @@ snapshots:
       d3-time: 3.1.0
       d3-time-format: 4.1.0
       internmap: 2.0.3
+
+  '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,7 @@
       "GEMINI_API_KEY",
       "GOOGLE_*",
       "MAILER_API_KEY",
+      "MAILBOX_PORT",
       "OPENAI_API_KEY",
       "SENTRY_AUTH_TOKEN",
       "STRIPE_*",


### PR DESCRIPTION
Adds a local-only Vite mailbox for viewing development emails and OTP codes. Routes development mail through an in-memory inbox, supports per-agent port overrides, and documents the local authentication workflow.