### PR TITLE
fix(oxlint-plugin): check helpers inside class attributes

### DIFF
--- a/apps/mailbox/src/components/mailbox.tsx
+++ b/apps/mailbox/src/components/mailbox.tsx
@@ -36,7 +36,7 @@ export function MailboxIdentity({ className, ...props }: ComponentProps<"div">) 
 /** Gives this development tool a single, immediately recognizable heading. */
 export function MailboxTitle({ children, className, ...props }: ComponentProps<"h1">) {
   return (
-    <h1 className={cn("text-lg font-semibold tracking-[-0.025em]", className)} {...props}>
+    <h1 className={cn("text-lg font-semibold tracking-tight", className)} {...props}>
       {children}
     </h1>
   );

--- a/packages/oxlint-plugin/rules/tailwind-canonical-classes.js
+++ b/packages/oxlint-plugin/rules/tailwind-canonical-classes.js
@@ -233,16 +233,6 @@ function checkClassProperty({ context, property, sourceText }) {
   }
 }
 
-/**
- * A helper call inside `className={...}` is already covered by the surrounding
- * JSX attribute visitor, so skipping it here prevents duplicate diagnostics.
- */
-function isInsideClassAttribute({ context, node }) {
-  return context.sourceCode
-    .getAncestors(node)
-    .some((ancestor) => ancestor.type === "JSXAttribute" && isClassAttributeName(ancestor.name));
-}
-
 export default defineRule({
   create(context) {
     const sourceText = context.sourceCode.getText();
@@ -252,10 +242,6 @@ export default defineRule({
         const classFunctionName = getClassFunctionName(node.callee);
 
         if (!classFunctionName || !CLASS_FUNCTION_NAMES.has(classFunctionName)) {
-          return;
-        }
-
-        if (isInsideClassAttribute({ context, node })) {
           return;
         }
 

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -59,7 +59,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
   return (
     <th
       className={cn(
-        "text-foreground h-12 px-3 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        "text-foreground h-12 px-3 text-left align-middle font-medium whitespace-nowrap has-[[role=checkbox]]:pr-0",
         className,
       )}
       data-slot="table-head"
@@ -71,7 +71,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
 function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   return (
     <td
-      className={cn("p-3 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)}
+      className={cn("p-3 align-middle whitespace-nowrap has-[[role=checkbox]]:pr-0", className)}
       data-slot="table-cell"
       {...props}
     />


### PR DESCRIPTION
Ensures Tailwind canonical class linting checks supported helper calls inside class attributes and updates the newly detected mailbox and table classes.