### PR TITLE
chore(ci): limit apple workflow to apple changes

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -3,8 +3,10 @@ name: Apple App
 on:
   push:
     branches: [main]
+    paths: [apps/apple/**]
   pull_request:
     branches: [main]
+    paths: [apps/apple/**]
     types: [opened, synchronize, reopened]
 
 concurrency:


### PR DESCRIPTION
## Summary

- Run the Apple workflow only when files under `apps/apple` change