### PR TITLE
fix(player): ignore rage clicks during lessons

### DIFF
--- a/packages/player/src/components/player-shell.tsx
+++ b/packages/player/src/components/player-shell.tsx
@@ -120,7 +120,7 @@ export function PlayerShell() {
   usePlayerHaptics({ current: { phase: state.phase, result: currentResult, step: currentStep } });
 
   return (
-    <main className="flex h-dvh flex-col overflow-hidden">
+    <main className="ph-no-rageclick flex h-dvh flex-col overflow-hidden">
       {screen.showChrome && <InPlayStickyHeader progressValue={progressValue} />}
 
       <PlayerAudioProvider


### PR DESCRIPTION
## Summary

- exclude the lesson player from PostHog rage-click detection
- preserve normal interaction analytics and session replay