### PR TITLE
fix(player): separate chapter navigation and review

### DIFF
--- a/apps/main/e2e/completion.ts
+++ b/apps/main/e2e/completion.ts
@@ -48,7 +48,7 @@ export async function advanceToCompletionSummary({
 function getCompletionSummaryAction(completionScreen: Locator) {
   return completionScreen
     .getByRole("link", {
-      name: /^(?<summaryAction>exit|next|next chapter|review chapter|review course)$/iu,
+      name: /^(?<summaryAction>back to chapter|exit|next|next chapter|review course)$/iu,
     })
     .first();
 }

--- a/apps/main/e2e/completion.ts
+++ b/apps/main/e2e/completion.ts
@@ -48,7 +48,7 @@ export async function advanceToCompletionSummary({
 function getCompletionSummaryAction(completionScreen: Locator) {
   return completionScreen
     .getByRole("link", {
-      name: /^(?<summaryAction>back to chapter|exit|next|next chapter|review course)$/iu,
+      name: /^(?<summaryAction>back to chapter|back to course|exit|next|next chapter)$/iu,
     })
     .first();
 }

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -251,7 +251,7 @@ async function createChapterCompleteWithUngeneratedNextChapterScenario(prefix: s
 
 /**
  * One chapter, one lesson. Completing it → "Course Complete".
- * "Review Course" → course page. "Back to Chapter" → chapter page.
+ * "Back to course" uses Escape, while "Review" restarts the completed lesson.
  */
 async function createCourseCompleteScenario(prefix: string) {
   const org = await getAiOrganization();
@@ -286,7 +286,6 @@ async function createCourseCompleteScenario(prefix: string) {
   await createQuizLesson(lesson.id, uniqueId);
 
   return {
-    chapter,
     course,
     lessonUrl: `/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`,
     uniqueId,
@@ -443,7 +442,10 @@ test.describe("Lesson Completion UX", () => {
 
   // --- Course Complete ---
 
-  test("course complete: review course navigates to course page", async ({ baseURL, browser }) => {
+  test("course complete: Escape follows the back to course action", async ({
+    baseURL,
+    browser,
+  }) => {
     const email = await createUniqueUser(baseURL!);
     const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
     const { lessonUrl, course, uniqueId } = await createCourseCompleteScenario("crsrev");
@@ -457,29 +459,16 @@ test.describe("Lesson Completion UX", () => {
     await expect(completionScreen.getByText(course.title)).toBeVisible();
     await expect(completionScreen.getByText(`Final Lesson ${uniqueId}`)).not.toBeVisible();
     await expect(completionScreen.getByText("No chapters left in this course")).not.toBeVisible();
+    const backToCourseLink = completionScreen.getByRole("link", { name: /back to course/iu });
 
-    await completionScreen.getByRole("link", { name: /review course/iu }).click();
+    await expect(backToCourseLink).toBeVisible();
+    await expect(completionScreen.getByRole("link", { name: /back to chapter/iu })).toHaveCount(0);
+
+    await page.keyboard.press("Enter");
+    await expect(backToCourseLink).toBeVisible();
+
+    await page.keyboard.press("Escape");
     await expect(page.getByRole("heading", { level: 1, name: course.title })).toBeVisible();
-
-    await browserContext.close();
-  });
-
-  test("course complete: back to chapter navigates to current chapter page", async ({
-    baseURL,
-    browser,
-  }) => {
-    const email = await createUniqueUser(baseURL!);
-    const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
-    const { lessonUrl, chapter, uniqueId } = await createCourseCompleteScenario("crschrev");
-
-    await page.goto(lessonUrl);
-    await page.waitForLoadState("networkidle");
-    await completeQuizAndShowCompletionSummary({ page, uniqueId });
-
-    const completionScreen = page.getByRole("status");
-
-    await completionScreen.getByRole("link", { name: /back to chapter/iu }).click();
-    await expect(page.getByRole("heading", { level: 1, name: chapter.title })).toBeVisible();
 
     await browserContext.close();
   });

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -136,7 +136,8 @@ async function createLessonCompleteScenario(prefix: string) {
 
 /**
  * One lesson per chapter, two chapters. Completing chapter1's lesson → "Chapter Complete".
- * "Next Chapter" → chapter2 page. "Review Chapter" → chapter1 page.
+ * "Next Chapter" → chapter2 page. "Back to Chapter" → chapter1 page. "Review" restarts
+ * the lesson that completed chapter1.
  */
 async function createChapterCompleteScenario(prefix: string) {
   const org = await getAiOrganization();
@@ -249,8 +250,8 @@ async function createChapterCompleteWithUngeneratedNextChapterScenario(prefix: s
 }
 
 /**
- * One chapter, one lesson, one lesson. Completing it → "Course Complete".
- * "Review Course" → course page. "Review Chapter" → chapter page.
+ * One chapter, one lesson. Completing it → "Course Complete".
+ * "Review Course" → course page. "Back to Chapter" → chapter page.
  */
 async function createCourseCompleteScenario(prefix: string) {
   const org = await getAiOrganization();
@@ -369,7 +370,7 @@ test.describe("Lesson Completion UX", () => {
     await browserContext.close();
   });
 
-  test("chapter complete: review chapter navigates to current chapter page", async ({
+  test("chapter complete: back to chapter navigates to current chapter page", async ({
     baseURL,
     browser,
   }) => {
@@ -383,8 +384,29 @@ test.describe("Lesson Completion UX", () => {
 
     const completionScreen = page.getByRole("status");
 
-    await completionScreen.getByRole("link", { name: /review chapter/iu }).click();
+    await completionScreen.getByRole("link", { name: /back to chapter/iu }).click();
     await expect(page.getByRole("heading", { level: 1, name: chapter1.title })).toBeVisible();
+
+    await browserContext.close();
+  });
+
+  test("chapter complete: review restarts the completed lesson", async ({ baseURL, browser }) => {
+    const email = await createUniqueUser(baseURL!);
+    const { browserContext, page } = await createAuthenticatedPage(browser, baseURL!, email);
+    const { lessonUrl, uniqueId } = await createChapterCompleteScenario("chrestart");
+
+    await page.goto(lessonUrl);
+    await page.waitForLoadState("networkidle");
+    await completeQuizAndShowCompletionSummary({ page, uniqueId });
+
+    await page
+      .getByRole("status")
+      .getByRole("button", { name: /review/iu })
+      .click();
+
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`Question ${uniqueId}`, "u") }),
+    ).toBeVisible();
 
     await browserContext.close();
   });
@@ -442,7 +464,7 @@ test.describe("Lesson Completion UX", () => {
     await browserContext.close();
   });
 
-  test("course complete: review chapter navigates to current chapter page", async ({
+  test("course complete: back to chapter navigates to current chapter page", async ({
     baseURL,
     browser,
   }) => {
@@ -456,7 +478,7 @@ test.describe("Lesson Completion UX", () => {
 
     const completionScreen = page.getByRole("status");
 
-    await completionScreen.getByRole("link", { name: /review chapter/iu }).click();
+    await completionScreen.getByRole("link", { name: /back to chapter/iu }).click();
     await expect(page.getByRole("heading", { level: 1, name: chapter.title })).toBeVisible();
 
     await browserContext.close();

--- a/apps/main/e2e/review-step.test.ts
+++ b/apps/main/e2e/review-step.test.ts
@@ -356,7 +356,7 @@ test.describe("Review Step", () => {
       completionScreen.getByRole("heading", { name: /course complete/iu }),
     ).toBeVisible();
 
-    await expect(completionScreen.getByRole("link", { name: /review course/iu })).toBeVisible();
+    await expect(completionScreen.getByRole("link", { name: /back to course/iu })).toBeVisible();
 
     await expect(
       completionScreen.getByText(completionScoreText, { exact: true }),

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-client.tsx
@@ -185,7 +185,7 @@ export function LessonPlayerClient({
       milestone={model.milestone}
       navigation={model.navigation}
       onComplete={handleComplete}
-      onEscape={() => router.push(model.navigation.chapterHref)}
+      onEscape={(href) => router.push(href)}
       onNext={handleNext}
       onStepChange={handleStepChange}
       progressSnapshot={initialProgress?.progressSnapshot ?? null}

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
@@ -105,9 +105,9 @@ describe(buildLessonPlayerModel, () => {
     });
 
     expect(model.milestone).toStrictEqual({
+      chapterHref: "/b/brand/c/course/ch/chapter-1",
       kind: "chapter",
       nextHref: "/b/brand/c/course/ch/chapter-2",
-      reviewHref: "/b/brand/c/course/ch/chapter-1",
     });
 
     expect(model.onNextHref).toBe("/b/brand/c/course/ch/chapter-2/l/lesson-2");
@@ -123,9 +123,9 @@ describe(buildLessonPlayerModel, () => {
     });
 
     expect(model.milestone).toStrictEqual({
+      chapterHref: "/b/brand/c/course/ch/chapter-1",
+      courseHref: "/b/brand/c/course",
       kind: "course",
-      reviewHref: "/b/brand/c/course",
-      secondaryReviewHref: "/b/brand/c/course/ch/chapter-1",
     });
 
     expect(model.onNextHref).toBeNull();
@@ -142,9 +142,9 @@ describe(buildLessonPlayerModel, () => {
     });
 
     expect(model.milestone).toStrictEqual({
+      chapterHref: "/b/brand/c/course/ch/chapter-1",
       kind: "chapter",
       nextHref: "/b/brand/c/course/ch/chapter-2",
-      reviewHref: "/b/brand/c/course/ch/chapter-1",
     });
 
     expect(model.onNextHref).toBe("/b/brand/c/course/ch/chapter-2");

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
@@ -245,11 +245,11 @@ export function buildLessonPlayerModel({
 
   const milestone = (() => {
     if (nextChapterHref) {
-      return { kind: "chapter" as const, nextHref: nextChapterHref, reviewHref: chapterHref };
+      return { chapterHref, kind: "chapter" as const, nextHref: nextChapterHref };
     }
 
     if (!nextLesson) {
-      return { kind: "course" as const, reviewHref: courseHref, secondaryReviewHref: chapterHref };
+      return { chapterHref, courseHref, kind: "course" as const };
     }
 
     return null;

--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -174,9 +174,9 @@ msgid "Review"
 msgstr "Wiederholen"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "w0D7HC"
-msgid "Review Course"
-msgstr "Kurs wiederholen"
+msgctxt "qrEiLa"
+msgid "Back to course"
+msgstr "Zurück zum Kurs"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "_N8rYN"

--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -63,7 +63,6 @@ msgid "Try again"
 msgstr "Erneut versuchen"
 
 #: src/components/completion-actions.tsx
-#: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
 msgctxt "9-Ddtu"
 msgid "Next"
@@ -170,9 +169,9 @@ msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more le
 msgstr "Du bist auf halbem Weg zu {belt}, Level {level}. {count, plural, one {Noch eine Lektion, dann hast du es geschafft} other {Noch # Lektionen, dann hast du es geschafft}}."
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "DiIkZH"
-msgid "Next Chapter"
-msgstr "Nächstes Kapitel"
+msgctxt "R-J5ox"
+msgid "Review"
+msgstr "Wiederholen"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "w0D7HC"
@@ -180,9 +179,14 @@ msgid "Review Course"
 msgstr "Kurs wiederholen"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "wm_M34"
-msgid "Review Chapter"
-msgstr "Kapitel wiederholen"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
+msgstr "Zurück zum Kapitel"
+
+#: src/components/completion-milestone-actions.tsx
+msgctxt "DiIkZH"
+msgid "Next Chapter"
+msgstr "Nächstes Kapitel"
 
 #: src/components/completion-patterns-milestone.tsx
 msgctxt "e6_3Ke"

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -174,9 +174,9 @@ msgid "Review"
 msgstr "Review"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "w0D7HC"
-msgid "Review Course"
-msgstr "Review Course"
+msgctxt "qrEiLa"
+msgid "Back to course"
+msgstr "Back to course"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "_N8rYN"

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -63,7 +63,6 @@ msgid "Try again"
 msgstr "Try again"
 
 #: src/components/completion-actions.tsx
-#: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
 msgctxt "9-Ddtu"
 msgid "Next"
@@ -170,9 +169,9 @@ msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more le
 msgstr "You're halfway to {belt}, level {level}. {count, plural, one {One more lesson will get you there} other {# more lessons will get you there}}."
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "DiIkZH"
-msgid "Next Chapter"
-msgstr "Next Chapter"
+msgctxt "R-J5ox"
+msgid "Review"
+msgstr "Review"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "w0D7HC"
@@ -180,9 +179,14 @@ msgid "Review Course"
 msgstr "Review Course"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "wm_M34"
-msgid "Review Chapter"
-msgstr "Review Chapter"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
+msgstr "Back to chapter"
+
+#: src/components/completion-milestone-actions.tsx
+msgctxt "DiIkZH"
+msgid "Next Chapter"
+msgstr "Next Chapter"
 
 #: src/components/completion-patterns-milestone.tsx
 msgctxt "e6_3Ke"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -63,7 +63,6 @@ msgid "Try again"
 msgstr "Inténtalo de nuevo"
 
 #: src/components/completion-actions.tsx
-#: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
 msgctxt "9-Ddtu"
 msgid "Next"
@@ -170,9 +169,9 @@ msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more le
 msgstr "Ya recorriste la mitad del camino hacia {belt}, nivel {level}. {count, plural, one {Una lección más y llegarás} other {# lecciones más y llegarás}}."
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "DiIkZH"
-msgid "Next Chapter"
-msgstr "Capítulo siguiente"
+msgctxt "R-J5ox"
+msgid "Review"
+msgstr "Repasar"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "w0D7HC"
@@ -180,9 +179,14 @@ msgid "Review Course"
 msgstr "Repasar curso"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "wm_M34"
-msgid "Review Chapter"
-msgstr "Repasar capítulo"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
+msgstr "Volver al capítulo"
+
+#: src/components/completion-milestone-actions.tsx
+msgctxt "DiIkZH"
+msgid "Next Chapter"
+msgstr "Capítulo siguiente"
 
 #: src/components/completion-patterns-milestone.tsx
 msgctxt "e6_3Ke"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -174,9 +174,9 @@ msgid "Review"
 msgstr "Repasar"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "w0D7HC"
-msgid "Review Course"
-msgstr "Repasar curso"
+msgctxt "qrEiLa"
+msgid "Back to course"
+msgstr "Volver al curso"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "_N8rYN"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -63,7 +63,6 @@ msgid "Try again"
 msgstr "Réessayer"
 
 #: src/components/completion-actions.tsx
-#: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
 msgctxt "9-Ddtu"
 msgid "Next"
@@ -170,9 +169,9 @@ msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more le
 msgstr "Tu es à mi-chemin de {belt}, niveau {level}. {count, plural, one {Encore une leçon et tu y seras} other {Encore # leçons et tu y seras}}."
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "DiIkZH"
-msgid "Next Chapter"
-msgstr "Chapitre suivant"
+msgctxt "R-J5ox"
+msgid "Review"
+msgstr "Réviser"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "w0D7HC"
@@ -180,9 +179,14 @@ msgid "Review Course"
 msgstr "Réviser le cours"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "wm_M34"
-msgid "Review Chapter"
-msgstr "Réviser le chapitre"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
+msgstr "Retour au chapitre"
+
+#: src/components/completion-milestone-actions.tsx
+msgctxt "DiIkZH"
+msgid "Next Chapter"
+msgstr "Chapitre suivant"
 
 #: src/components/completion-patterns-milestone.tsx
 msgctxt "e6_3Ke"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -174,9 +174,9 @@ msgid "Review"
 msgstr "Réviser"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "w0D7HC"
-msgid "Review Course"
-msgstr "Réviser le cours"
+msgctxt "qrEiLa"
+msgid "Back to course"
+msgstr "Retour au cours"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "_N8rYN"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -63,7 +63,6 @@ msgid "Try again"
 msgstr "Tentar de novo"
 
 #: src/components/completion-actions.tsx
-#: src/components/completion-milestone-actions.tsx
 #: src/components/step-navigation-button-group.tsx
 msgctxt "9-Ddtu"
 msgid "Next"
@@ -170,9 +169,9 @@ msgid "You're halfway to {belt}, level {level}. {count, plural, one {One more le
 msgstr "Você está na metade do caminho para chegar à {belt}, nível {level}. {count, plural, one {Só falta mais uma aula} other {Só faltam mais # aulas}}."
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "DiIkZH"
-msgid "Next Chapter"
-msgstr "Próximo capítulo"
+msgctxt "R-J5ox"
+msgid "Review"
+msgstr "Revisar"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "w0D7HC"
@@ -180,9 +179,14 @@ msgid "Review Course"
 msgstr "Revisar curso"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "wm_M34"
-msgid "Review Chapter"
-msgstr "Revisar capítulo"
+msgctxt "_N8rYN"
+msgid "Back to chapter"
+msgstr "Voltar ao capítulo"
+
+#: src/components/completion-milestone-actions.tsx
+msgctxt "DiIkZH"
+msgid "Next Chapter"
+msgstr "Próximo capítulo"
 
 #: src/components/completion-patterns-milestone.tsx
 msgctxt "e6_3Ke"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -174,9 +174,9 @@ msgid "Review"
 msgstr "Revisar"
 
 #: src/components/completion-milestone-actions.tsx
-msgctxt "w0D7HC"
-msgid "Review Course"
-msgstr "Revisar curso"
+msgctxt "qrEiLa"
+msgid "Back to course"
+msgstr "Voltar ao curso"
 
 #: src/components/completion-milestone-actions.tsx
 msgctxt "_N8rYN"

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -523,12 +523,12 @@ describe("player browser integration: completion", () => {
       .not.toBeInTheDocument();
 
     await expect
-      .element(completionScreen.getByRole("link", { name: /review course/iu }))
+      .element(completionScreen.getByRole("link", { name: /back to course/iu }))
       .toBeInTheDocument();
 
     await expect
       .element(completionScreen.getByRole("link", { name: /back to chapter/iu }))
-      .toBeInTheDocument();
+      .not.toBeInTheDocument();
 
     await expect
       .element(completionScreen.getByRole("button", { name: /review/iu }))

--- a/packages/player/src/_browser-tests/player-completion.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-completion.browser.test.tsx
@@ -451,7 +451,7 @@ describe("player browser integration: completion", () => {
       .not.toBeInTheDocument();
   });
 
-  it("falls back to review-only chapter completion when there is no next chapter", async () => {
+  it("shows back and review actions when chapter completion has no next chapter", async () => {
     renderPlayer({
       chapterTitle: "Completed Chapter",
       lesson: buildCompletionQuizLesson(),
@@ -462,7 +462,7 @@ describe("player browser integration: completion", () => {
         totalLessonsInChapter: 4,
       },
       lessonTitle: "Completed Lesson",
-      milestone: { kind: "chapter", nextHref: null, reviewHref: "/review-chapter" },
+      milestone: { chapterHref: "/chapter", kind: "chapter", nextHref: null },
       viewer: buildAuthenticatedViewer(),
     });
 
@@ -484,7 +484,11 @@ describe("player browser integration: completion", () => {
       .not.toBeInTheDocument();
 
     await expect
-      .element(completionScreen.getByRole("link", { name: /review chapter/iu }))
+      .element(completionScreen.getByRole("link", { name: /back to chapter/iu }))
+      .toBeInTheDocument();
+
+    await expect
+      .element(completionScreen.getByRole("button", { name: /review/iu }))
       .toBeInTheDocument();
 
     await expect
@@ -492,16 +496,12 @@ describe("player browser integration: completion", () => {
       .not.toBeInTheDocument();
   });
 
-  it("renders course completion review actions", async () => {
+  it("renders course completion navigation and review actions", async () => {
     renderPlayer({
       courseTitle: "Completed Course",
       lesson: buildCompletionQuizLesson(),
       lessonTitle: "Final Lesson",
-      milestone: {
-        kind: "course",
-        reviewHref: "/review-course",
-        secondaryReviewHref: "/review-chapter",
-      },
+      milestone: { chapterHref: "/chapter", courseHref: "/course", kind: "course" },
       viewer: buildAuthenticatedViewer(),
     });
 
@@ -527,14 +527,18 @@ describe("player browser integration: completion", () => {
       .toBeInTheDocument();
 
     await expect
-      .element(completionScreen.getByRole("link", { name: /review chapter/iu }))
+      .element(completionScreen.getByRole("link", { name: /back to chapter/iu }))
+      .toBeInTheDocument();
+
+    await expect
+      .element(completionScreen.getByRole("button", { name: /review/iu }))
       .toBeInTheDocument();
   });
 
   it("shows structural milestones for guest completion", async () => {
     renderPlayer({
       lesson: buildCompletionQuizLesson(),
-      milestone: { kind: "chapter", nextHref: "/next-chapter", reviewHref: "/review-chapter" },
+      milestone: { chapterHref: "/chapter", kind: "chapter", nextHref: "/next-chapter" },
       navigation: buildNavigation({ loginHref: "/sign-in" }),
       viewer: { isAuthenticated: false, userName: null },
     });
@@ -551,7 +555,11 @@ describe("player browser integration: completion", () => {
     await expect.element(completionScreen.getByText(/chapter complete/iu)).toBeInTheDocument();
 
     await expect
-      .element(completionScreen.getByRole("link", { name: /review chapter/iu }))
+      .element(completionScreen.getByRole("link", { name: /back to chapter/iu }))
+      .toBeInTheDocument();
+
+    await expect
+      .element(completionScreen.getByRole("button", { name: /review/iu }))
       .toBeInTheDocument();
 
     await expect

--- a/packages/player/src/_browser-tests/player-static.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-static.browser.test.tsx
@@ -785,6 +785,10 @@ describe("player browser integration: static steps", () => {
     fireEvent.keyDown(globalThis.window, { key: "ArrowRight" });
     fireEvent.keyDown(globalThis.window, { key: "Enter" });
 
+    expect(onEscape).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(globalThis.window, { key: "Escape" });
+
     expect(onEscape).toHaveBeenCalledOnce();
   });
 });

--- a/packages/player/src/_test-utils/render-player.tsx
+++ b/packages/player/src/_test-utils/render-player.tsx
@@ -10,6 +10,7 @@ import {
   type PlayerLessonProgress,
   type PlayerMilestone,
   type PlayerNavigation,
+  type PlayerRoute,
   type PlayerViewer,
 } from "../player-context";
 import { PlayerProvider } from "../player-provider";
@@ -74,7 +75,7 @@ export function renderPlayer({
   milestone?: PlayerMilestone | null;
   navigation?: PlayerNavigation;
   onComplete?: (input: CompletionInput) => void;
-  onEscape?: () => void;
+  onEscape?: (href: PlayerRoute) => void;
   onNext?: () => void;
   progressSnapshot?: PlayerProgressSnapshot | null;
   totalBrainPower?: number;

--- a/packages/player/src/components/completion-action-link.tsx
+++ b/packages/player/src/components/completion-action-link.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { buttonVariants } from "@zoonk/ui/components/button";
+import { Button, buttonVariants } from "@zoonk/ui/components/button";
 import { ShortcutKbd } from "@zoonk/ui/components/kbd";
 import { cn } from "@zoonk/ui/lib/utils";
 import { type PlayerRoute } from "../player-context";
@@ -74,5 +74,33 @@ export function SecondaryActionLink({
       {children}
       <SecondaryKbd>{shortcut}</SecondaryKbd>
     </PlayerLink>
+  );
+}
+
+/**
+ * Gives completion callbacks the same secondary hierarchy and keyboard hint as
+ * completion links so navigation and in-player actions remain visually consistent.
+ */
+export function SecondaryActionButton({
+  children,
+  className,
+  onClick,
+  shortcut,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  onClick: () => void;
+  shortcut: string;
+}) {
+  return (
+    <Button
+      aria-keyshortcuts={getAriaKeyboardShortcut(shortcut)}
+      className={cn("w-full", className)}
+      onClick={onClick}
+      variant="outline"
+    >
+      {children}
+      <SecondaryKbd>{shortcut}</SecondaryKbd>
+    </Button>
   );
 }

--- a/packages/player/src/components/completion-actions.tsx
+++ b/packages/player/src/components/completion-actions.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { Button, buttonVariants } from "@zoonk/ui/components/button";
+import { buttonVariants } from "@zoonk/ui/components/button";
 import { cn } from "@zoonk/ui/lib/utils";
 import { useExtracted } from "next-intl";
 import { type PlayerRoute, usePlayerMilestone } from "../player-context";
 import { PlayerLink } from "../player-link";
-import { PrimaryActionLink, PrimaryKbd, SecondaryKbd } from "./completion-action-link";
+import {
+  PrimaryActionLink,
+  PrimaryKbd,
+  SecondaryActionButton,
+  SecondaryKbd,
+} from "./completion-action-link";
 import { MilestoneActions } from "./completion-milestone-actions";
 
 /**
@@ -55,15 +60,13 @@ function SecondaryActions({
   );
 
   const restartButton = (
-    <Button
-      aria-keyshortcuts="r"
-      className={cn(isInline ? "flex-1" : "w-full")}
+    <SecondaryActionButton
+      className={isInline ? "flex-1" : undefined}
       onClick={onRestart}
-      variant="outline"
+      shortcut="R"
     >
       {t("Try again")}
-      <SecondaryKbd>R</SecondaryKbd>
-    </Button>
+    </SecondaryActionButton>
   );
 
   if (isInline) {
@@ -103,7 +106,7 @@ export function CompletionActions({
   if (milestone) {
     return (
       <CompletionActionsLayout>
-        <MilestoneActions />
+        <MilestoneActions onRestart={onRestart} />
       </CompletionActionsLayout>
     );
   }

--- a/packages/player/src/components/completion-milestone-actions.tsx
+++ b/packages/player/src/components/completion-milestone-actions.tsx
@@ -2,29 +2,31 @@
 
 import { useExtracted } from "next-intl";
 import { usePlayerMilestone } from "../player-context";
-import { PrimaryActionLink, SecondaryActionLink } from "./completion-action-link";
+import {
+  PrimaryActionLink,
+  SecondaryActionButton,
+  SecondaryActionLink,
+} from "./completion-action-link";
 
-function NextButtonLabel() {
+/**
+ * Keeps lesson review inside the player. Going back to the chapter is a separate
+ * navigation action, while this callback resets the completed lesson from its first step.
+ */
+function ReviewButton({ onRestart }: { onRestart: () => void }) {
   const t = useExtracted();
-  const milestone = usePlayerMilestone();
 
-  return <span>{milestone?.kind === "chapter" ? t("Next Chapter") : t("Next")}</span>;
+  return (
+    <SecondaryActionButton onClick={onRestart} shortcut="R">
+      {t("Review")}
+    </SecondaryActionButton>
+  );
 }
 
-function ReviewLabel() {
-  const t = useExtracted();
-  const milestone = usePlayerMilestone();
-
-  if (!milestone) {
-    return null;
-  }
-
-  const milestoneLabel = milestone.kind === "course" ? t("Review Course") : t("Review Chapter");
-
-  return <span>{milestoneLabel}</span>;
-}
-
-function CourseCompleteActions() {
+/**
+ * Course completion keeps both curriculum destinations available, then offers
+ * lesson review without presenting the chapter link as though it starts a review.
+ */
+function CourseCompleteActions({ onRestart }: { onRestart: () => void }) {
   const t = useExtracted();
   const milestone = usePlayerMilestone();
 
@@ -34,18 +36,63 @@ function CourseCompleteActions() {
 
   return (
     <>
-      <PrimaryActionLink href={milestone.reviewHref} shortcut="Enter">
+      <PrimaryActionLink href={milestone.courseHref} shortcut="Enter">
         {t("Review Course")}
       </PrimaryActionLink>
 
-      <SecondaryActionLink href={milestone.secondaryReviewHref} shortcut="Esc">
-        {t("Review Chapter")}
+      <SecondaryActionLink href={milestone.chapterHref} shortcut="Esc">
+        {t("Back to chapter")}
       </SecondaryActionLink>
+
+      <ReviewButton onRestart={onRestart} />
     </>
   );
 }
 
-export function MilestoneActions() {
+/**
+ * Chapter completion prioritizes the learner's next chapter when one exists,
+ * while keeping chapter navigation and lesson review as distinct actions.
+ */
+function ChapterCompleteActions({ onRestart }: { onRestart: () => void }) {
+  const t = useExtracted();
+  const milestone = usePlayerMilestone();
+
+  if (!milestone || milestone.kind !== "chapter") {
+    return null;
+  }
+
+  if (milestone.nextHref) {
+    return (
+      <>
+        <PrimaryActionLink href={milestone.nextHref} shortcut="Enter">
+          {t("Next Chapter")}
+        </PrimaryActionLink>
+
+        <SecondaryActionLink href={milestone.chapterHref} shortcut="Esc">
+          {t("Back to chapter")}
+        </SecondaryActionLink>
+
+        <ReviewButton onRestart={onRestart} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <PrimaryActionLink href={milestone.chapterHref} shortcut="Esc">
+        {t("Back to chapter")}
+      </PrimaryActionLink>
+
+      <ReviewButton onRestart={onRestart} />
+    </>
+  );
+}
+
+/**
+ * Selects the structural completion actions while the caller supplies the same
+ * restart behavior used by ordinary lesson completion.
+ */
+export function MilestoneActions({ onRestart }: { onRestart: () => void }) {
   const milestone = usePlayerMilestone();
 
   if (!milestone) {
@@ -53,26 +100,8 @@ export function MilestoneActions() {
   }
 
   if (milestone.kind === "course") {
-    return <CourseCompleteActions />;
+    return <CourseCompleteActions onRestart={onRestart} />;
   }
 
-  if (milestone.nextHref) {
-    return (
-      <>
-        <PrimaryActionLink href={milestone.nextHref} shortcut="Enter">
-          <NextButtonLabel />
-        </PrimaryActionLink>
-
-        <SecondaryActionLink href={milestone.reviewHref} shortcut="Esc">
-          <ReviewLabel />
-        </SecondaryActionLink>
-      </>
-    );
-  }
-
-  return (
-    <PrimaryActionLink href={milestone.reviewHref} shortcut="Esc">
-      <ReviewLabel />
-    </PrimaryActionLink>
-  );
+  return <ChapterCompleteActions onRestart={onRestart} />;
 }

--- a/packages/player/src/components/completion-milestone-actions.tsx
+++ b/packages/player/src/components/completion-milestone-actions.tsx
@@ -23,8 +23,8 @@ function ReviewButton({ onRestart }: { onRestart: () => void }) {
 }
 
 /**
- * Course completion keeps both curriculum destinations available, then offers
- * lesson review without presenting the chapter link as though it starts a review.
+ * Course completion returns to the completed course with the same Escape
+ * shortcut used for chapter completion, while review stays inside the player.
  */
 function CourseCompleteActions({ onRestart }: { onRestart: () => void }) {
   const t = useExtracted();
@@ -36,13 +36,9 @@ function CourseCompleteActions({ onRestart }: { onRestart: () => void }) {
 
   return (
     <>
-      <PrimaryActionLink href={milestone.courseHref} shortcut="Enter">
-        {t("Review Course")}
+      <PrimaryActionLink href={milestone.courseHref} shortcut="Esc">
+        {t("Back to course")}
       </PrimaryActionLink>
-
-      <SecondaryActionLink href={milestone.chapterHref} shortcut="Esc">
-        {t("Back to chapter")}
-      </SecondaryActionLink>
 
       <ReviewButton onRestart={onRestart} />
     </>

--- a/packages/player/src/player-context.tsx
+++ b/packages/player/src/player-context.tsx
@@ -70,7 +70,6 @@ type PlayerLessonMetaInput = Omit<PlayerLessonMeta, "description"> & {
 
 type PlayerConfigContextValue = {
   lessonMeta: PlayerLessonMetaInput;
-  escape: () => void;
   linkComponent: PlayerLinkComponent;
   milestone: PlayerMilestone | null;
   navigation: PlayerNavigation;

--- a/packages/player/src/player-context.tsx
+++ b/packages/player/src/player-context.tsx
@@ -41,15 +41,11 @@ export type PlayerLessonProgress = {
   totalLessonsInChapter: number;
 };
 
-type ReviewMilestone = { kind: "chapter"; nextHref: PlayerRoute | null; reviewHref: PlayerRoute };
+type ChapterMilestone = { chapterHref: PlayerRoute; kind: "chapter"; nextHref: PlayerRoute | null };
 
-type CourseMilestone = {
-  kind: "course";
-  reviewHref: PlayerRoute;
-  secondaryReviewHref: PlayerRoute;
-};
+type CourseMilestone = { chapterHref: PlayerRoute; courseHref: PlayerRoute; kind: "course" };
 
-export type PlayerMilestone = ReviewMilestone | CourseMilestone;
+export type PlayerMilestone = ChapterMilestone | CourseMilestone;
 
 export type PlayerRuntimeContextValue = {
   actions: PlayerActions;

--- a/packages/player/src/player-provider.tsx
+++ b/packages/player/src/player-provider.tsx
@@ -14,6 +14,7 @@ import {
   type PlayerLinkComponent,
   type PlayerMilestone,
   type PlayerNavigation,
+  type PlayerRoute,
   PlayerRuntimeContext,
   type PlayerViewer,
 } from "./player-context";
@@ -58,7 +59,7 @@ export function PlayerProvider({
   milestone: PlayerMilestone | null;
   navigation: PlayerNavigation;
   onComplete: (input: CompletionInput) => void;
-  onEscape: () => void;
+  onEscape: (href: PlayerRoute) => void;
   onNext?: () => void;
   onStepChange?: (event: PlayerStepChangeEvent) => void;
   progressSnapshot?: PlayerProgressSnapshot | null;
@@ -93,11 +94,16 @@ export function PlayerProvider({
     onNext?.();
   }, [onNext]);
 
+  const escapeHref =
+    screen.scene === "completion" && milestone?.kind === "course"
+      ? milestone.courseHref
+      : navigation.chapterHref;
+
   usePlayerKeyboard({
     keyboard: screen.keyboard,
     onCheck: actions.check,
     onContinue: actions.continue,
-    onEscape,
+    onEscape: () => onEscape(escapeHref),
     onNavigateNext: actions.navigateNext,
     onNavigatePrev: actions.navigatePrev,
     onNext: onNext ? handleNext : null,
@@ -106,7 +112,6 @@ export function PlayerProvider({
 
   const configValue = useMemo(
     () => ({
-      escape: onEscape,
       lessonMeta: {
         chapterTitle,
         courseTitle,
@@ -136,7 +141,6 @@ export function PlayerProvider({
       linkComponent,
       milestone,
       navigation,
-      onEscape,
       viewer,
     ],
   );

--- a/packages/player/src/player-screen.test.ts
+++ b/packages/player/src/player-screen.test.ts
@@ -120,7 +120,7 @@ describe(getPlayerScreenModel, () => {
     expect(screen.kind).toBe("completed");
     expect(screen.scene).toBe("completion");
     expect(screen.bottomBar).toBeNull();
-    expect(screen.keyboard.enterAction).toBe("nextOrEscape");
+    expect(screen.keyboard.enterAction).toBe("next");
     expect(screen.keyboard.canRestart).toBe(true);
   });
 

--- a/packages/player/src/player-screen.ts
+++ b/packages/player/src/player-screen.ts
@@ -29,7 +29,7 @@ type PlayerBottomBarModel =
 
 export type PlayerKeyboardModel = {
   canRestart: boolean;
-  enterAction: "check" | "continue" | "navigateNext" | "nextOrEscape" | null;
+  enterAction: "check" | "continue" | "navigateNext" | "next" | null;
   leftAction: "navigatePrev" | null;
   rightAction: "navigateNext" | null;
 };
@@ -112,12 +112,7 @@ function getCompletedScreenModel({
 
   return {
     bottomBar: null,
-    keyboard: {
-      canRestart: true,
-      enterAction: "nextOrEscape",
-      leftAction: null,
-      rightAction: null,
-    },
+    keyboard: { canRestart: true, enterAction: "next", leftAction: null, rightAction: null },
     kind: "completed",
     scene: "completion",
     showChrome: false,
@@ -201,7 +196,7 @@ function getKeyboardModel({
   step: PlayerStepDescriptor;
 }): PlayerKeyboardModel {
   if (phase === "completed") {
-    return { canRestart: true, enterAction: "nextOrEscape", leftAction: null, rightAction: null };
+    return { canRestart: true, enterAction: "next", leftAction: null, rightAction: null };
   }
 
   const enterAction =

--- a/packages/player/src/use-player-keyboard.test.ts
+++ b/packages/player/src/use-player-keyboard.test.ts
@@ -73,16 +73,11 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onContinue).not.toHaveBeenCalled();
     });
 
-    it("calls onNext when completion Enter action prefers next", () => {
+    it("calls onNext when completion exposes a next action", () => {
       const onNext = vi.fn();
 
       const opts = buildOptions({
-        keyboard: {
-          canRestart: true,
-          enterAction: "nextOrEscape",
-          leftAction: null,
-          rightAction: null,
-        },
+        keyboard: { canRestart: true, enterAction: "next", leftAction: null, rightAction: null },
         onNext,
       });
 
@@ -94,14 +89,9 @@ describe(usePlayerKeyboard, () => {
       expect(opts.onEscape).not.toHaveBeenCalled();
     });
 
-    it("calls onEscape when completion Enter action has no next callback", () => {
+    it("does not fall back to Escape when completion has no next callback", () => {
       const opts = buildOptions({
-        keyboard: {
-          canRestart: true,
-          enterAction: "nextOrEscape",
-          leftAction: null,
-          rightAction: null,
-        },
+        keyboard: { canRestart: true, enterAction: "next", leftAction: null, rightAction: null },
         onNext: null,
       });
 
@@ -109,7 +99,7 @@ describe(usePlayerKeyboard, () => {
 
       fireKey("Enter");
 
-      expect(opts.onEscape).toHaveBeenCalledOnce();
+      expect(opts.onEscape).not.toHaveBeenCalled();
       expect(opts.onCheck).not.toHaveBeenCalled();
       expect(opts.onContinue).not.toHaveBeenCalled();
     });
@@ -183,12 +173,7 @@ describe(usePlayerKeyboard, () => {
   describe("R key", () => {
     it("calls onRestart when restart is enabled", () => {
       const opts = buildOptions({
-        keyboard: {
-          canRestart: true,
-          enterAction: "nextOrEscape",
-          leftAction: null,
-          rightAction: null,
-        },
+        keyboard: { canRestart: true, enterAction: "next", leftAction: null, rightAction: null },
       });
 
       renderHook(() => usePlayerKeyboard(opts));
@@ -209,12 +194,7 @@ describe(usePlayerKeyboard, () => {
 
     it("no-op when target is an input element", () => {
       const opts = buildOptions({
-        keyboard: {
-          canRestart: true,
-          enterAction: "nextOrEscape",
-          leftAction: null,
-          rightAction: null,
-        },
+        keyboard: { canRestart: true, enterAction: "next", leftAction: null, rightAction: null },
       });
 
       renderHook(() => usePlayerKeyboard(opts));

--- a/packages/player/src/use-player-keyboard.ts
+++ b/packages/player/src/use-player-keyboard.ts
@@ -23,7 +23,6 @@ function runKeyboardAction({
   action,
   onCheck,
   onContinue,
-  onEscape,
   onNavigateNext,
   onNavigatePrev,
   onNext,
@@ -34,7 +33,7 @@ function runKeyboardAction({
     | PlayerKeyboardModel["rightAction"];
 } & Pick<
   PlayerKeyboardParams,
-  "onCheck" | "onContinue" | "onEscape" | "onNavigateNext" | "onNavigatePrev" | "onNext"
+  "onCheck" | "onContinue" | "onNavigateNext" | "onNavigatePrev" | "onNext"
 >) {
   if (!action) {
     return false;
@@ -53,8 +52,12 @@ function runKeyboardAction({
     case "navigatePrev":
       onNavigatePrev();
       return;
-    case "nextOrEscape":
-      (onNext ?? onEscape)();
+    case "next":
+      if (!onNext) {
+        return false;
+      }
+
+      onNext();
       return;
     default:
       return false;
@@ -78,7 +81,6 @@ export function usePlayerKeyboard({
         action: keyboard.enterAction,
         onCheck,
         onContinue,
-        onEscape,
         onNavigateNext,
         onNavigatePrev,
         onNext,
@@ -105,7 +107,6 @@ export function usePlayerKeyboard({
         action: keyboard.rightAction,
         onCheck,
         onContinue,
-        onEscape,
         onNavigateNext,
         onNavigatePrev,
         onNext,
@@ -120,7 +121,6 @@ export function usePlayerKeyboard({
         action: keyboard.leftAction,
         onCheck,
         onContinue,
-        onEscape,
         onNavigateNext,
         onNavigatePrev,
         onNext,


### PR DESCRIPTION
## Summary

- rename completed-chapter navigation to Back to chapter
- add a Review action that restarts the completed lesson
- update milestone routes, translations, and completion coverage