### PR TITLE
fix(api): preserve app locale during login

### DIFF
--- a/apps/admin/src/app/login/page.tsx
+++ b/apps/admin/src/app/login/page.tsx
@@ -1,10 +1,11 @@
 import { OneTimeTokenLoginRedirect } from "@zoonk/core/auth/ott/login";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
+import { DEFAULT_LOCALE } from "@zoonk/utils/locale";
 
 export default function LoginPage() {
   return (
     <>
-      <OneTimeTokenLoginRedirect callbackPath="/auth/callback" />
+      <OneTimeTokenLoginRedirect callbackPath="/auth/callback" locale={DEFAULT_LOCALE} />
       <FullPageLoading />
     </>
   );

--- a/apps/api/e2e/login.test.ts
+++ b/apps/api/e2e/login.test.ts
@@ -1,6 +1,16 @@
 import { expect, test } from "@zoonk/e2e/fixtures";
 
 test.describe("Login Page", () => {
+  test("uses the locale passed by the originating app throughout auth", async ({ page }) => {
+    await page.goto("/auth/login?locale=pt");
+
+    await expect(page.getByRole("heading", { name: "Entre ou crie uma conta" })).toBeVisible();
+
+    await page.goto("/auth/otp?email=learner@zoonk.test");
+
+    await expect(page.getByRole("heading", { name: "Confira seu email" })).toBeVisible();
+  });
+
   test("displays login form with email input and social buttons", async ({ page }) => {
     await page.goto("/auth/login");
 

--- a/apps/api/src/i18n/auth-locale.ts
+++ b/apps/api/src/i18n/auth-locale.ts
@@ -1,0 +1,18 @@
+import { type SupportedLocale, isValidLocale } from "@zoonk/utils/locale";
+import { type NextRequest } from "next/server";
+
+export const AUTH_LOCALE_HEADER = "x-zoonk-auth-locale";
+
+/**
+ * Accepts locale handoffs only on central-auth pages. API clients cannot use
+ * this query parameter to change the locale cookie or the request locale.
+ */
+export function getAuthLocale(request: NextRequest): SupportedLocale | null {
+  if (!request.nextUrl.pathname.startsWith("/auth/")) {
+    return null;
+  }
+
+  const locale = request.nextUrl.searchParams.get("locale");
+
+  return locale && isValidLocale(locale) ? locale : null;
+}

--- a/apps/api/src/i18n/request.ts
+++ b/apps/api/src/i18n/request.ts
@@ -1,6 +1,7 @@
-import { LOCALE_COOKIE, getLocaleFromHeaders } from "@zoonk/utils/locale";
+import { LOCALE_COOKIE, getLocaleFromRequest } from "@zoonk/utils/locale";
 import { getRequestConfig } from "next-intl/server";
 import { cookies, headers } from "next/headers";
+import { AUTH_LOCALE_HEADER } from "./auth-locale";
 
 export default getRequestConfig(async ({ locale: overrideLocale }) => {
   const store = await cookies();
@@ -8,8 +9,11 @@ export default getRequestConfig(async ({ locale: overrideLocale }) => {
 
   const cookieLocale = store.get(LOCALE_COOKIE)?.value;
 
-  const locale =
-    overrideLocale || cookieLocale || getLocaleFromHeaders(headerStore.get("accept-language"));
+  const locale = getLocaleFromRequest({
+    acceptLanguage: headerStore.get("accept-language"),
+    cookieLocale,
+    overrideLocale: overrideLocale ?? headerStore.get(AUTH_LOCALE_HEADER),
+  });
 
   const translations = await import(`../../messages/${locale}.po`);
 

--- a/apps/api/src/proxy.ts
+++ b/apps/api/src/proxy.ts
@@ -1,4 +1,6 @@
+import { AUTH_LOCALE_HEADER, getAuthLocale } from "@/i18n/auth-locale";
 import { errors } from "@/lib/api-errors";
+import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { isCorsAllowedOrigin } from "@zoonk/utils/origin";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -46,6 +48,30 @@ function requiresSameOrigin(request: NextRequest): boolean {
   );
 }
 
+/**
+ * Passes a validated auth locale to the current render and stores it on the
+ * API host so later OTP and provider callback pages keep the same language.
+ * Removing the incoming header ensures only this proxy can supply the value.
+ */
+function createPassThroughResponse(request: NextRequest): NextResponse {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.delete(AUTH_LOCALE_HEADER);
+
+  const locale = getAuthLocale(request);
+
+  if (locale) {
+    requestHeaders.set(AUTH_LOCALE_HEADER, locale);
+  }
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+
+  if (locale) {
+    response.cookies.set(LOCALE_COOKIE, locale, { path: "/", sameSite: "lax" });
+  }
+
+  return response;
+}
+
 export function proxy(request: NextRequest) {
   const origin = request.headers.get("origin");
 
@@ -56,7 +82,7 @@ export function proxy(request: NextRequest) {
   // Remaining requests without an origin are guests or explicit bearer clients.
   // We rate-limit requests in our Vercel config
   if (!origin) {
-    return NextResponse.next();
+    return createPassThroughResponse(request);
   }
 
   const isAllowed = isCorsAllowedOrigin(origin);
@@ -74,7 +100,7 @@ export function proxy(request: NextRequest) {
   }
 
   // Handle regular requests
-  const response = NextResponse.next();
+  const response = createPassThroughResponse(request);
   response.headers.set("Vary", "Origin");
 
   if (isAllowed) {
@@ -89,6 +115,6 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  // Apply shared CORS to every API route while Better Auth owns its origin validation.
-  matcher: "/v1/:path*",
+  // Apply shared CORS to API routes and locale handoff only to central-auth pages.
+  matcher: ["/auth/:path*", "/v1/:path*"],
 };

--- a/apps/main/e2e/auth-callback.test.ts
+++ b/apps/main/e2e/auth-callback.test.ts
@@ -78,6 +78,22 @@ function expectAuthErrorRedirect(response: APIResponse): void {
 }
 
 test.describe("Auth Callback", () => {
+  test("passes the current locale to central auth", async ({ page }) => {
+    const authUrls: string[] = [];
+
+    await page.route("**/auth/login**", async (route) => {
+      authUrls.push(route.request().url());
+      await route.fulfill({ body: "Auth app", contentType: "text/html", status: 200 });
+    });
+
+    await page.goto("/pt/login");
+    await expect.poll(() => authUrls.length).toBe(1);
+
+    const authUrl = getInterceptedAuthUrl(authUrls);
+
+    expect(new URL(authUrl).searchParams.get("locale")).toBe("pt");
+  });
+
   test("starts login when randomUUID is unavailable", async ({ context, page }) => {
     const baseURL = getBaseURL();
     const authUrls: string[] = [];

--- a/apps/main/src/app/[lang]/login/page.tsx
+++ b/apps/main/src/app/[lang]/login/page.tsx
@@ -1,6 +1,7 @@
 import { OneTimeTokenLoginRedirect } from "@zoonk/core/auth/ott/login";
 import { getSafeAppRelativePath } from "@zoonk/core/auth/ott/redirect";
 import { FullPageLoading } from "@zoonk/ui/components/loading";
+import { getSupportedLocaleFromLanguage } from "@zoonk/utils/locale";
 import { Suspense } from "react";
 
 type Props = PageProps<"/[lang]/login">;
@@ -24,22 +25,23 @@ function getCallbackPath(nextPath: string | null) {
  * Resolves the return target inside Suspense so the page can prerender its
  * loading shell without reading request-specific query parameters.
  */
-async function LoginRedirect({ searchParams }: Pick<Props, "searchParams">) {
-  const { next } = await searchParams;
+async function LoginRedirect({ params, searchParams }: Pick<Props, "params" | "searchParams">) {
+  const [{ lang }, { next }] = await Promise.all([params, searchParams]);
   const callbackPath = getCallbackPath(getSafeAppRelativePath(next));
+  const locale = getSupportedLocaleFromLanguage(lang);
 
   return (
     <>
-      <OneTimeTokenLoginRedirect callbackPath={callbackPath} />
+      <OneTimeTokenLoginRedirect callbackPath={callbackPath} locale={locale} />
       <FullPageLoading />
     </>
   );
 }
 
-export default function LoginPage({ searchParams }: Props) {
+export default function LoginPage({ params, searchParams }: Props) {
   return (
     <Suspense fallback={<FullPageLoading />}>
-      <LoginRedirect searchParams={searchParams} />
+      <LoginRedirect params={params} searchParams={searchParams} />
     </Suspense>
   );
 }

--- a/packages/core/src/auth/ott-login.tsx
+++ b/packages/core/src/auth/ott-login.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { setCookie } from "@zoonk/utils/cookies";
+import { type SupportedLocale } from "@zoonk/utils/locale";
 import { buildAuthLoginUrl } from "@zoonk/utils/origin";
 import { useEffect } from "react";
 import {
@@ -53,7 +54,13 @@ async function setLoginStateCookie(state: string): Promise<void> {
  * in the browser because `/login` is a normal page, while the state cookie must
  * be written before leaving the app origin.
  */
-async function startOneTimeTokenLogin(callbackPath: string): Promise<void> {
+async function startOneTimeTokenLogin({
+  callbackPath,
+  locale,
+}: {
+  callbackPath: string;
+  locale: SupportedLocale;
+}): Promise<void> {
   const state = createLoginState();
 
   const callbackUrl = addLoginStateToCallbackUrl({
@@ -62,7 +69,7 @@ async function startOneTimeTokenLogin(callbackPath: string): Promise<void> {
   });
 
   await setLoginStateCookie(state);
-  globalThis.location.assign(buildAuthLoginUrl({ callbackUrl }));
+  globalThis.location.assign(buildAuthLoginUrl({ callbackUrl, locale }));
 }
 
 /**
@@ -70,10 +77,16 @@ async function startOneTimeTokenLogin(callbackPath: string): Promise<void> {
  * effect synchronizes with browser APIs: it writes a cookie and performs a
  * document navigation outside the React app.
  */
-export function OneTimeTokenLoginRedirect({ callbackPath }: { callbackPath: string }) {
+export function OneTimeTokenLoginRedirect({
+  callbackPath,
+  locale,
+}: {
+  callbackPath: string;
+  locale: SupportedLocale;
+}) {
   useEffect(() => {
-    void startOneTimeTokenLogin(callbackPath);
-  }, [callbackPath]);
+    void startOneTimeTokenLogin({ callbackPath, locale });
+  }, [callbackPath, locale]);
 
   return null;
 }

--- a/packages/utils/src/locale.test.ts
+++ b/packages/utils/src/locale.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   getCountryFromAcceptLanguage,
-  getLocaleFromHeaders,
   getLocaleFromRequest,
   getSupportedLocaleFromLanguage,
   isValidLocale,
@@ -56,16 +55,6 @@ describe(getCountryFromAcceptLanguage, () => {
 
   it("extracts region from tags with script subtags", () => {
     expect(getCountryFromAcceptLanguage("zh-Hant-TW")).toBe("TW");
-  });
-});
-
-describe(getLocaleFromHeaders, () => {
-  it("matches French from regional browser preferences", () => {
-    expect(getLocaleFromHeaders("fr-FR,fr;q=0.9,en;q=0.8")).toBe("fr");
-  });
-
-  it("matches German from regional browser preferences", () => {
-    expect(getLocaleFromHeaders("de-DE,de;q=0.9,en;q=0.8")).toBe("de");
   });
 });
 

--- a/packages/utils/src/locale.ts
+++ b/packages/utils/src/locale.ts
@@ -78,7 +78,7 @@ function getManualLocale(value?: string | null): SupportedLocale | null {
 /**
  * Detect the best locale from an Accept-Language header.
  */
-export function getLocaleFromHeaders(acceptLanguage: string | null): SupportedLocale {
+function getLocaleFromHeaders(acceptLanguage: string | null): SupportedLocale {
   if (!acceptLanguage) {
     return DEFAULT_LOCALE;
   }

--- a/packages/utils/src/origin.ts
+++ b/packages/utils/src/origin.ts
@@ -1,4 +1,5 @@
 import { getEnvironment, isLocalhostSupported } from "./environment";
+import { type SupportedLocale } from "./locale";
 import { API_URL } from "./url";
 
 /**
@@ -42,11 +43,18 @@ export function getBaseUrl(): string {
 }
 
 /**
- * Builds the login URL for the centralized auth app.
- * @param callbackUrl - The URL to redirect to after successful authentication
+ * Builds the centralized auth URL with the originating app's locale so login
+ * does not fall back to a different API-host cookie or browser preference.
  */
-export function buildAuthLoginUrl({ callbackUrl }: { callbackUrl: string }): string {
+export function buildAuthLoginUrl({
+  callbackUrl,
+  locale,
+}: {
+  callbackUrl: string;
+  locale: SupportedLocale;
+}): string {
   const authUrl = new URL("/auth/login", API_URL);
+  authUrl.searchParams.set("locale", locale);
   authUrl.searchParams.set("redirectTo", callbackUrl);
 
   return authUrl.toString();


### PR DESCRIPTION
## Summary

- preserve the originating app locale during centralized login
- keep the selected locale across API auth pages
- add cross-app regression coverage