### PR TITLE
fix(api): allow portless auth server actions

### DIFF
--- a/apps/api/src/proxy.test.ts
+++ b/apps/api/src/proxy.test.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import { proxy } from "./proxy";
+
+const INTERNAL_API_ORIGIN = "http://localhost:4284";
+const PORTLESS_API_ORIGIN = "http://fix-api-app-login-locale.api.zoonk.localhost:28474";
+
+describe(proxy, () => {
+  it("passes auth Server Actions through when Portless uses a different public origin", () => {
+    const request = new NextRequest(`${INTERNAL_API_ORIGIN}/auth/login?locale=en`, {
+      headers: { cookie: "ZOONK_LOCALE=en", origin: PORTLESS_API_ORIGIN },
+      method: "POST",
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("blocks cookie-authenticated API requests from a different origin", async () => {
+    const request = new NextRequest(`${INTERNAL_API_ORIGIN}/v1/courses`, {
+      headers: { cookie: "better-auth.session_token=test", origin: PORTLESS_API_ORIGIN },
+      method: "POST",
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(403);
+
+    await expect(response.json()).resolves.toStrictEqual({
+      error: { code: "FORBIDDEN", message: "Same-origin request required" },
+    });
+  });
+});

--- a/apps/api/src/proxy.ts
+++ b/apps/api/src/proxy.ts
@@ -11,8 +11,19 @@ const corsHeaders = {
   "Access-Control-Max-Age": "86400",
 };
 
+const AUTH_PATH = "/auth";
 const BETTER_AUTH_PATH = "/v1/auth";
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/**
+ * Keeps central-auth pages outside the API-specific origin guard. Next.js
+ * already protects Server Actions, while Portless presents a public browser
+ * origin that differs from the internal URL exposed through `request.nextUrl`.
+ */
+function isAuthPageRequest(request: NextRequest): boolean {
+  const pathname = request.nextUrl.pathname;
+  return pathname === AUTH_PATH || pathname.startsWith(`${AUTH_PATH}/`);
+}
 
 /**
  * Distinguishes token-authenticated native and CLI requests from browser
@@ -73,6 +84,10 @@ function createPassThroughResponse(request: NextRequest): NextResponse {
 }
 
 export function proxy(request: NextRequest) {
+  if (isAuthPageRequest(request)) {
+    return createPassThroughResponse(request);
+  }
+
   const origin = request.headers.get("origin");
 
   if (requiresSameOrigin(request) && origin !== request.nextUrl.origin) {


### PR DESCRIPTION
Keeps central auth pages outside the API-specific origin guard so Next.js Server Actions work behind Portless, while preserving API same-origin enforcement and adding regression coverage.