### PR TITLE
feat(core): waitlist instrument course prompts

### DIFF
--- a/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
@@ -122,7 +122,7 @@ describe(getOrCreateCourse, () => {
 
     const request = await generatableCoursePromptFixture({
       canonicalTitle: title,
-      courseFormat: "instrument",
+      courseFormat: "practical",
       language,
     });
 
@@ -146,7 +146,7 @@ describe(getOrCreateCourse, () => {
     expect(courses).toHaveLength(1);
 
     expect(updatedRequest).toMatchObject({
-      courseFormat: "instrument",
+      courseFormat: "practical",
       courseId: existingCourse.id,
       generationRunId: winningWorkflowRunId,
       generationStatus: "running",

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -410,7 +410,7 @@ describe(courseGenerationWorkflow, () => {
       expect(course.userCount).toBe(1);
     });
 
-    it.each(["coding", "core", "instrument", "practical"] as const)(
+    it.each(["coding", "core", "practical"] as const)(
       "creates an intro chapter without triggering chapter generation for %s courses",
       async (courseFormat) => {
         vi.mocked(chapterGenerationWorkflow).mockClear();

--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -86,25 +86,32 @@ async function cacheTopicPrompt(rawPrompt: string) {
  * Seeds one unsupported request so E2E can verify the waitlist surface without
  * calling the AI router or relying on model output to choose that branch.
  */
-async function cacheWaitlistedPrompt(rawPrompt: string) {
+async function cacheWaitlistedPrompt({
+  courseFormat = "question",
+  rawPrompt,
+}: {
+  courseFormat?: "instrument" | "question";
+  rawPrompt: string;
+}) {
   const language = "en";
+  const intent = courseFormat === "instrument" ? "learn" : "question";
   const normalizedPrompt = normalizeString(rawPrompt);
 
   const request = await prisma.coursePrompt.upsert({
     create: {
       canonicalTitle: rawPrompt,
-      courseFormat: "question",
+      courseFormat,
       generationStatus: null,
-      intent: "question",
+      intent,
       language,
       normalizedPrompt,
       prompt: rawPrompt,
     },
     update: {
       canonicalTitle: rawPrompt,
-      courseFormat: "question",
+      courseFormat,
       generationStatus: null,
-      intent: "question",
+      intent,
       prompt: rawPrompt,
       targetLanguage: null,
     },
@@ -175,7 +182,7 @@ test.describe("Learn Form", () => {
   test("submits by button and shows its pending state while the prompt is routing", async ({
     page,
   }) => {
-    const cached = await cacheWaitlistedPrompt(`e2e pending topic ${randomUUID()}`);
+    const cached = await cacheWaitlistedPrompt({ rawPrompt: `e2e pending topic ${randomUUID()}` });
 
     await page.goto("/start/learn");
 
@@ -282,11 +289,27 @@ test.describe("Course Start Routing", () => {
     await expect(page.getByRole("heading", { level: 1, name: cached.course.title })).toBeVisible();
   });
 
+  test("shows the waitlist for cached instrument prompts", async ({ page }) => {
+    const cached = await cacheWaitlistedPrompt({
+      courseFormat: "instrument",
+      rawPrompt: `e2e instrument goal ${randomUUID()}`,
+    });
+
+    await page.goto(`/start/learn/${encodeURIComponent(cached.prompt)}`);
+
+    await expect(
+      page.getByRole("heading", { name: /this option isn't available yet/iu }),
+    ).toBeVisible();
+
+    await expect(page.getByRole("button", { name: /notify me/iu })).toBeVisible();
+    await expect(page.getByText(cached.prompt, { exact: true })).toBeVisible();
+  });
+
   test("prefills the waitlist email for signed-in users", async ({
     authenticatedPage,
     withProgressUser,
   }) => {
-    const cached = await cacheWaitlistedPrompt(`e2e waitlist goal ${randomUUID()}`);
+    const cached = await cacheWaitlistedPrompt({ rawPrompt: `e2e waitlist goal ${randomUUID()}` });
 
     await authenticatedPage.goto(`/start/learn/${encodeURIComponent(cached.prompt)}`);
 

--- a/packages/core/src/courses/course-prompt-generation.test.ts
+++ b/packages/core/src/courses/course-prompt-generation.test.ts
@@ -11,7 +11,7 @@ const generatableCorePrompt = {
 };
 
 describe(getCoursePromptGenerationError, () => {
-  it.each(["coding", "core", "instrument", "practical"] as const)(
+  it.each(["coding", "core", "practical"] as const)(
     "accepts a pending learn prompt with a canonical title and %s format",
     (courseFormat) => {
       expect(getCoursePromptGenerationError({ ...generatableCorePrompt, courseFormat })).toBeNull();
@@ -20,7 +20,11 @@ describe(getCoursePromptGenerationError, () => {
 
   it.each([
     ["missing canonical title", { ...generatableCorePrompt, canonicalTitle: null }],
-    ["unsupported format", { ...generatableCorePrompt, courseFormat: "question" as const }],
+    [
+      "unsupported instrument format",
+      { ...generatableCorePrompt, courseFormat: "instrument" as const },
+    ],
+    ["unsupported prompt format", { ...generatableCorePrompt, courseFormat: "question" as const }],
     ["missing generation status", { ...generatableCorePrompt, generationStatus: null }],
     ["unsupported intent", { ...generatableCorePrompt, intent: "question" as const }],
   ])("rejects a prompt with %s", (_reason, prompt) => {

--- a/packages/core/src/courses/course-prompt-generation.ts
+++ b/packages/core/src/courses/course-prompt-generation.ts
@@ -6,7 +6,6 @@ const UNSUPPORTED_COURSE_PROMPT_ERROR = "Course prompt is not generatable";
 const REGULAR_COURSE_FORMATS = [
   "coding",
   "core",
-  "instrument",
   "practical",
 ] as const satisfies readonly CourseFormat[];
 

--- a/packages/core/src/courses/resolve-course-prompt.test.ts
+++ b/packages/core/src/courses/resolve-course-prompt.test.ts
@@ -235,7 +235,7 @@ describe("course-prompt", () => {
     expect(titleSpy).not.toHaveBeenCalled();
   });
 
-  it.each(["coding", "instrument", "practical"] as const)(
+  it.each(["coding", "practical"] as const)(
     "enables generation for a cached %s prompt that was previously waitlisted",
     async (courseFormat) => {
       const prompt = `cached ${courseFormat} topic ${randomUUID()}`;
@@ -268,6 +268,41 @@ describe("course-prompt", () => {
       expect(titleSpy).not.toHaveBeenCalled();
     },
   );
+
+  it("keeps a cached instrument prompt on the waitlist without calling model tasks", async () => {
+    const prompt = `cached instrument topic ${randomUUID()}`;
+    const title = `Cached Instrument Course ${randomUUID()}`;
+
+    const cached = await coursePromptFixture({
+      canonicalTitle: title,
+      courseFormat: "instrument",
+      generationStatus: null,
+      normalizedPrompt: normalizeString(prompt),
+      prompt,
+    });
+
+    const intentSpy = vi.spyOn(intentTask, "classifyCourseIntent");
+    const personalizationSpy = vi.spyOn(personalizationTask, "classifyCoursePersonalization");
+    const courseFormatSpy = vi.spyOn(formatTask, "classifyCourseFormat");
+    const titleSpy = vi.spyOn(canonicalTitleTask, "generateCanonicalCourseTitle");
+
+    const result = await resolveCoursePrompt({ language: "en", prompt });
+
+    expect(result).toStrictEqual({
+      kind: "unsupported",
+      prompt: { courseFormat: "instrument", intent: "learn" },
+      title,
+    });
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: cached.id } }),
+    ).resolves.toMatchObject({ courseFormat: "instrument", generationStatus: null });
+
+    expect(intentSpy).not.toHaveBeenCalled();
+    expect(personalizationSpy).not.toHaveBeenCalled();
+    expect(courseFormatSpy).not.toHaveBeenCalled();
+    expect(titleSpy).not.toHaveBeenCalled();
+  });
 
   it("redirects cached reusable prompts to an existing reusable course without model tasks", async () => {
     const prompt = `cached existing topic ${randomUUID()}`;
@@ -445,11 +480,7 @@ describe("course-prompt", () => {
     expect(titleSpy).not.toHaveBeenCalled();
   });
 
-  it.each([
-    { courseFormat: "coding" },
-    { courseFormat: "instrument" },
-    { courseFormat: "practical" },
-  ] as const)(
+  it.each([{ courseFormat: "coding" }, { courseFormat: "practical" }] as const)(
     "creates a generatable prompt while preserving the $courseFormat format",
     async ({ courseFormat }) => {
       const prompt = `${courseFormat} prompt ${randomUUID()}`;
@@ -475,6 +506,33 @@ describe("course-prompt", () => {
       });
     },
   );
+
+  it("persists instrument prompts as waitlist requests", async () => {
+    const prompt = `instrument prompt ${randomUUID()}`;
+    const title = `Instrument course ${randomUUID()}`;
+    mockPromptTasks({ courseFormat: "instrument", title });
+
+    const result = await resolveCoursePrompt({ language: "en", prompt });
+
+    expect(result).toStrictEqual({
+      kind: "unsupported",
+      prompt: { courseFormat: "instrument", intent: "learn" },
+      title,
+    });
+
+    const storedPrompt = await prisma.coursePrompt.findUnique({
+      where: {
+        languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
+      },
+    });
+
+    expect(storedPrompt).toMatchObject({
+      canonicalTitle: title,
+      courseFormat: "instrument",
+      generationStatus: null,
+      intent: "learn",
+    });
+  });
 
   it("persists personalization-required learning prompts as personalized", async () => {
     const prompt = `personalized prompt ${randomUUID()}`;


### PR DESCRIPTION
Routes instrument course prompts to the existing waitlist instead of regular course generation. Adds Core coverage for new and cached prompts plus an end-to-end waitlist assertion.