### PR TITLE
Add eloqnt/cli to iOS app

### DIFF
--- a/apps/apple/.eloqnt/config.ts
+++ b/apps/apple/.eloqnt/config.ts
@@ -1,14 +1,6 @@
 import defineEloqntConfig from "@zoonk/i18n/define-eloqnt-config";
 
-/**
- * A String Catalog keeps every locale in one file, so `path` has no
- * `{locale}` placeholder and the inherited `locales: "infer"` reads them from
- * inside the catalogs. `{namespace}` matches each catalog by filename
- * (currently only `Navigation.xcstrings`), so new catalogs are picked up
- * without config changes. No `srcPath`: Xcode extracts strings from Swift
- * code into the catalogs, so there is no TypeScript source to scan.
- * @internal
- */
+/** @internal */
 export default defineEloqntConfig({
   messages: {
     format: { codec: "@eloqnt/format-apple-xcstrings", extension: ".xcstrings" },

--- a/apps/apple/.eloqnt/config.ts
+++ b/apps/apple/.eloqnt/config.ts
@@ -1,29 +1,18 @@
-import { defineConfig } from "@eloqnt/cli";
-import { codexCli } from "ai-sdk-provider-codex-cli";
-
-/**
- * Points Eloqnt at a Codex CLI installed outside this repo, matching
- * `@zoonk/i18n/define-eloqnt-config`.
- */
-function getCodexPath() {
-  return process.env.CODEX_PATH ?? "codex";
-}
+import defineEloqntConfig from "@zoonk/i18n/define-eloqnt-config";
 
 /**
  * A String Catalog keeps every locale in one file, so `path` has no
- * `{locale}` placeholder and `locales: "infer"` reads them from inside the
- * catalogs. `{namespace}` matches each catalog by filename (currently only
- * `Navigation.xcstrings`), so new catalogs are picked up without config
- * changes. No `srcPath`: Xcode extracts strings from Swift code into the
- * catalogs.
+ * `{locale}` placeholder and the inherited `locales: "infer"` reads them from
+ * inside the catalogs. `{namespace}` matches each catalog by filename
+ * (currently only `Navigation.xcstrings`), so new catalogs are picked up
+ * without config changes. No `srcPath`: Xcode extracts strings from Swift
+ * code into the catalogs, so there is no TypeScript source to scan.
  * @internal
  */
-export default defineConfig({
+export default defineEloqntConfig({
   messages: {
     format: { codec: "@eloqnt/format-apple-xcstrings", extension: ".xcstrings" },
-    locales: "infer",
     path: "./Shared/Resources/Localization/{namespace}",
-    sourceLocale: "en",
   },
-  model: codexCli("gpt-5.6-sol", { codexPath: getCodexPath() }),
+  srcPath: null,
 });

--- a/apps/apple/.eloqnt/config.ts
+++ b/apps/apple/.eloqnt/config.ts
@@ -10,16 +10,19 @@ function getCodexPath() {
 }
 
 /**
- * The Apple app keeps every locale in one String Catalog, so `path` points at
- * the catalog itself and `locales: "infer"` reads them from inside it. No
- * `srcPath`: Xcode extracts strings from Swift code into the catalog.
+ * A String Catalog keeps every locale in one file, so `path` has no
+ * `{locale}` placeholder and `locales: "infer"` reads them from inside the
+ * catalogs. `{namespace}` matches each catalog by filename (currently only
+ * `Navigation.xcstrings`), so new catalogs are picked up without config
+ * changes. No `srcPath`: Xcode extracts strings from Swift code into the
+ * catalogs.
  * @internal
  */
 export default defineConfig({
   messages: {
     format: { codec: "@eloqnt/format-apple-xcstrings", extension: ".xcstrings" },
     locales: "infer",
-    path: "./Shared/Resources/Localization/Navigation",
+    path: "./Shared/Resources/Localization/{namespace}",
     sourceLocale: "en",
   },
   model: codexCli("gpt-5.6-sol", { codexPath: getCodexPath() }),

--- a/apps/apple/.eloqnt/config.ts
+++ b/apps/apple/.eloqnt/config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "@eloqnt/cli";
+import { codexCli } from "ai-sdk-provider-codex-cli";
+
+/**
+ * Points Eloqnt at a Codex CLI installed outside this repo, matching
+ * `@zoonk/i18n/define-eloqnt-config`.
+ */
+function getCodexPath() {
+  return process.env.CODEX_PATH ?? "codex";
+}
+
+/**
+ * The Apple app keeps every locale in one String Catalog, so `path` points at
+ * the catalog itself and `locales: "infer"` reads them from inside it. No
+ * `srcPath`: Xcode extracts strings from Swift code into the catalog.
+ * @internal
+ */
+export default defineConfig({
+  messages: {
+    format: { codec: "@eloqnt/format-apple-xcstrings", extension: ".xcstrings" },
+    locales: "infer",
+    path: "./Shared/Resources/Localization/Navigation",
+    sourceLocale: "en",
+  },
+  model: codexCli("gpt-5.6-sol", { codexPath: getCodexPath() }),
+});

--- a/apps/apple/Shared/Resources/Localization/Navigation.xcstrings
+++ b/apps/apple/Shared/Resources/Localization/Navigation.xcstrings
@@ -4,91 +4,291 @@
     "Activity" : {
       "comment" : "Navigation title for the learner's activity history.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Aktivität" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Actividad" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Activité" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Atividade" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivität"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activité"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atividade"
+          }
+        }
       }
     },
     "Courses" : {
       "comment" : "Navigation title for the learner's courses.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Kurse" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Cursos" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Cours" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Cursos" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurse"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cursos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cursos"
+          }
+        }
       }
     },
     "Energy" : {
       "comment" : "Navigation title for the learner's Energy metric.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Energie" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Energía" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Énergie" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Energia" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energie"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Énergie"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energia"
+          }
+        }
       }
     },
     "Home" : {
       "comment" : "Navigation title for the app's primary home section.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Startseite" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Inicio" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Accueil" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Início" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Startseite"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accueil"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Início"
+          }
+        }
       }
     },
     "Level" : {
       "comment" : "Navigation title for the learner's current level.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Level" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Nivel" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Niveau" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Nível" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Level"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nível"
+          }
+        }
       }
     },
     "New course" : {
       "comment" : "Navigation title for the destination where the learner creates a course.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Neuer Kurs" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Curso nuevo" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Nouveau cours" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Novo curso" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neuer Kurs"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Curso nuevo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau cours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Novo curso"
+          }
+        }
       }
     },
     "Patterns" : {
       "comment" : "Navigation title for patterns in the learner's progress.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Muster" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Patrones" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Tendances" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Padrões" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muster"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Patrones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tendances"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Padrões"
+          }
+        }
       }
     },
     "Progress" : {
       "comment" : "Navigation title for the learner's progress overview.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Fortschritt" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Progreso" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Progression" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Progresso" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortschritt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progression"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progresso"
+          }
+        }
       }
     },
     "Score" : {
       "comment" : "Navigation title for the learner's score.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Punktestand" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Puntuación" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Score" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Pontuação" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Punktestand"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puntuación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Score"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pontuação"
+          }
+        }
       }
     },
     "Search" : {
       "comment" : "Navigation title for searching Zoonk.",
       "localizations" : {
-        "de" : { "stringUnit" : { "state" : "translated", "value" : "Suche" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Buscar" } },
-        "fr" : { "stringUnit" : { "state" : "translated", "value" : "Rechercher" } },
-        "pt" : { "stringUnit" : { "state" : "translated", "value" : "Pesquisar" } }
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suche"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pesquisar"
+          }
+        }
       }
     }
   },

--- a/apps/apple/package.json
+++ b/apps/apple/package.json
@@ -11,8 +11,8 @@
     "@eloqnt/cli": "catalog:",
     "@eloqnt/format-apple-xcstrings": "catalog:",
     "@types/node": "catalog:",
+    "@zoonk/i18n": "workspace:*",
     "@zoonk/tsconfig": "workspace:*",
-    "ai-sdk-provider-codex-cli": "2.1.2",
     "typescript": "catalog:"
   }
 }

--- a/apps/apple/package.json
+++ b/apps/apple/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "apple",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "i18n:lint": "eloqnt lint --strict",
+    "i18n": "eloqnt translate",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@eloqnt/cli": "catalog:",
+    "@eloqnt/format-apple-xcstrings": "catalog:",
+    "@types/node": "catalog:",
+    "@zoonk/tsconfig": "workspace:*",
+    "ai-sdk-provider-codex-cli": "2.1.2",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/apple/tsconfig.json
+++ b/apps/apple/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "exclude": ["node_modules"],
+  "extends": "@zoonk/tsconfig/base.json",
+  "include": [".eloqnt/**/*.ts"]
+}

--- a/knip.json
+++ b/knip.json
@@ -17,6 +17,10 @@
   "tags": ["-lintignore", "-internal", "-public"],
   "workspaces": {
     ".": { "project": ["scripts/dev/**/*.mts"] },
+    "apps/apple": {
+      "entry": [".eloqnt/config.ts"],
+      "ignoreDependencies": ["@eloqnt/format-apple-xcstrings"]
+    },
     "apps/api": {
       "entry": [".eloqnt/config.ts"],
       "project": ["src/**/*.{ts,tsx}!", "e2e/**/*.ts", "!**/_test-utils/**!"]

--- a/packages/i18n/src/define-eloqnt-config.ts
+++ b/packages/i18n/src/define-eloqnt-config.ts
@@ -2,8 +2,17 @@ import { defineConfig } from "@eloqnt/cli";
 import { codexCli } from "ai-sdk-provider-codex-cli";
 import { NEXT_INTL_PO_FORMAT } from "./next-intl/po-format";
 
-// Can be extended as necessary
-type EloqntProjectOptions = { srcPath?: string | string[] };
+type EloqntMessages = Parameters<typeof defineConfig>[0]["messages"];
+
+// Can be extended as necessary. `messages` overrides are shallow-merged into
+// the next-intl defaults so a consumer with a different message format (e.g.
+// the Apple app's String Catalogs) can replace `format` and `path` while
+// inheriting `locales` and `sourceLocale`. `srcPath: null` disables source
+// code analysis for consumers whose messages aren't used from TypeScript.
+type EloqntProjectOptions = {
+  messages?: Partial<EloqntMessages>;
+  srcPath?: string | string[] | null;
+};
 
 /**
  * Points Eloqnt at a Codex CLI installed outside this repo.
@@ -12,6 +21,16 @@ type EloqntProjectOptions = { srcPath?: string | string[] };
  */
 function getCodexPath() {
   return process.env.CODEX_PATH ?? "codex";
+}
+
+/**
+ * Distinguishes "not passed" (use the `./src` default) from an explicit
+ * `null` (no source code to scan, e.g. the Apple app where Xcode extracts
+ * strings from Swift). Eloqnt skips source analysis when `srcPath` is absent.
+ */
+function getSrcPath(srcPath: EloqntProjectOptions["srcPath"]) {
+  if (srcPath === null) return undefined;
+  return srcPath ?? "./src";
 }
 
 /**
@@ -25,8 +44,9 @@ export default function defineEloqntConfig(options: EloqntProjectOptions = {}) {
       locales: "infer",
       path: "./messages",
       sourceLocale: "en",
+      ...options.messages,
     },
     model: codexCli("gpt-5.6-sol", { codexPath: getCodexPath() }),
-    srcPath: options.srcPath ?? "./src",
+    srcPath: getSrcPath(options.srcPath),
   });
 }

--- a/packages/i18n/src/define-eloqnt-config.ts
+++ b/packages/i18n/src/define-eloqnt-config.ts
@@ -4,11 +4,6 @@ import { NEXT_INTL_PO_FORMAT } from "./next-intl/po-format";
 
 type EloqntMessages = Parameters<typeof defineConfig>[0]["messages"];
 
-// Can be extended as necessary. `messages` overrides are shallow-merged into
-// the next-intl defaults so a consumer with a different message format (e.g.
-// the Apple app's String Catalogs) can replace `format` and `path` while
-// inheriting `locales` and `sourceLocale`. `srcPath: null` disables source
-// code analysis for consumers whose messages aren't used from TypeScript.
 type EloqntProjectOptions = {
   messages?: Partial<EloqntMessages>;
   srcPath?: string | string[] | null;
@@ -23,11 +18,6 @@ function getCodexPath() {
   return process.env.CODEX_PATH ?? "codex";
 }
 
-/**
- * Distinguishes "not passed" (use the `./src` default) from an explicit
- * `null` (no source code to scan, e.g. the Apple app where Xcode extracts
- * strings from Swift). Eloqnt skips source analysis when `srcPath` is absent.
- */
 function getSrcPath(srcPath: EloqntProjectOptions["srcPath"]) {
   if (srcPath === null) return undefined;
   return srcPath ?? "./src";

--- a/packages/i18n/src/define-eloqnt-config.ts
+++ b/packages/i18n/src/define-eloqnt-config.ts
@@ -19,7 +19,10 @@ function getCodexPath() {
 }
 
 function getSrcPath(srcPath: EloqntProjectOptions["srcPath"]) {
-  if (srcPath === null) return undefined;
+  if (srcPath === null) {
+    return;
+  }
+
   return srcPath ?? "./src";
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,12 +324,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
+      '@zoonk/i18n':
+        specifier: workspace:*
+        version: link:../../packages/i18n
       '@zoonk/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
-      ai-sdk-provider-codex-cli:
-        specifier: 2.1.2
-        version: 2.1.2(zod@4.4.3)
       typescript:
         specifier: 'catalog:'
         version: 7.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,11 @@ catalogs:
       specifier: 3.2.2
       version: 3.2.2
     '@eloqnt/cli':
-      specifier: 0.6.5
-      version: 0.6.5
+      specifier: 0.6.6
+      version: 0.6.6
+    '@eloqnt/format-apple-xcstrings':
+      specifier: 0.0.1
+      version: 0.0.1
     '@mdx-js/loader':
       specifier: 3.1.1
       version: 3.1.1
@@ -132,7 +135,7 @@ importers:
     devDependencies:
       '@eloqnt/cli':
         specifier: 'catalog:'
-        version: 0.6.5(@swc/helpers@0.5.23)
+        version: 0.6.6(@swc/helpers@0.5.23)
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.62.1
@@ -309,6 +312,27 @@ importers:
       zod-openapi:
         specifier: 6.0.0
         version: 6.0.0(zod@4.4.3)
+
+  apps/apple:
+    devDependencies:
+      '@eloqnt/cli':
+        specifier: 'catalog:'
+        version: 0.6.6(@swc/helpers@0.5.23)
+      '@eloqnt/format-apple-xcstrings':
+        specifier: 'catalog:'
+        version: 0.0.1(@swc/helpers@0.5.23)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.3
+      '@zoonk/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      ai-sdk-provider-codex-cli:
+        specifier: 2.1.2
+        version: 2.1.2(zod@4.4.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
   apps/blog:
     dependencies:
@@ -791,7 +815,7 @@ importers:
     dependencies:
       '@eloqnt/cli':
         specifier: 'catalog:'
-        version: 0.6.5(@swc/helpers@0.5.23)
+        version: 0.6.6(@swc/helpers@0.5.23)
       ai-sdk-provider-codex-cli:
         specifier: 2.1.2
         version: 2.1.2(zod@4.4.3)
@@ -1431,12 +1455,15 @@ packages:
   '@electric-sql/pglite@0.4.3':
     resolution: {integrity: sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ==}
 
-  '@eloqnt/cli@0.6.5':
-    resolution: {integrity: sha512-AlcT+7W/+fXmj6frmL0RPtWYeeNmTTurk1talG4nTeqI/EzeHxufvR44OYKsC7M/Bt9u4iYMuesLWstpExpZ4g==}
+  '@eloqnt/cli@0.6.6':
+    resolution: {integrity: sha512-ODyCjA+NVg71QGpx3AeOfyCkyH8IbqcKGqbHhCVqJDk/lC27pWgTi8DchikxoLP7AJwtArdtrdEacbUJqU1bIg==}
     hasBin: true
 
-  '@eloqnt/sdk@0.6.4':
-    resolution: {integrity: sha512-A2UlgVntZHzqtt4eP49yJ/hRF9OeNyRL51xftDRySBPTQFGHfaGroly2Q+xqKdfJJrbHjLYgaOHmmxRmv9wTXg==}
+  '@eloqnt/format-apple-xcstrings@0.0.1':
+    resolution: {integrity: sha512-QD+TyC/zHhWWeetKN1ewCD5C7nyGF/SRMjad5ZYwzFYGUPFsilvGKJRTN1U0Hm4qiIbfDgICXzKEn+yYAGNR5Q==}
+
+  '@eloqnt/sdk@0.6.5':
+    resolution: {integrity: sha512-q8DPQngrkmEos0qn5H+bhX2DYvjp2lymBdRtm/mxPDpgmX09UfF28gj+aE3SDvjlHEDVErkV9FXeJjTo5CcEbQ==}
 
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
@@ -8105,17 +8132,24 @@ snapshots:
 
   '@electric-sql/pglite@0.4.3': {}
 
-  '@eloqnt/cli@0.6.5(@swc/helpers@0.5.23)':
+  '@eloqnt/cli@0.6.6(@swc/helpers@0.5.23)':
     dependencies:
       '@clack/prompts': 1.7.0
-      '@eloqnt/sdk': 0.6.4(@swc/helpers@0.5.23)
+      '@eloqnt/sdk': 0.6.5(@swc/helpers@0.5.23)
       citty: 0.1.6
       open: 11.0.0
       picocolors: 1.1.1
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@eloqnt/sdk@0.6.4(@swc/helpers@0.5.23)':
+  '@eloqnt/format-apple-xcstrings@0.0.1(@swc/helpers@0.5.23)':
+    dependencies:
+      '@eloqnt/sdk': 0.6.5(@swc/helpers@0.5.23)
+      '@formatjs/icu-messageformat-parser': 3.5.16
+    transitivePeerDependencies:
+      - '@swc/helpers'
+
+  '@eloqnt/sdk@0.6.5(@swc/helpers@0.5.23)':
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.16
       '@swc/core': 1.15.47(@swc/helpers@0.5.23)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: 0.6.6
       version: 0.6.6
     '@eloqnt/format-apple-xcstrings':
-      specifier: 0.0.1
-      version: 0.0.1
+      specifier: 0.0.2
+      version: 0.0.2
     '@mdx-js/loader':
       specifier: 3.1.1
       version: 3.1.1
@@ -320,7 +320,7 @@ importers:
         version: 0.6.6(@swc/helpers@0.5.23)
       '@eloqnt/format-apple-xcstrings':
         specifier: 'catalog:'
-        version: 0.0.1(@swc/helpers@0.5.23)
+        version: 0.0.2(@swc/helpers@0.5.23)
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -1459,8 +1459,8 @@ packages:
     resolution: {integrity: sha512-ODyCjA+NVg71QGpx3AeOfyCkyH8IbqcKGqbHhCVqJDk/lC27pWgTi8DchikxoLP7AJwtArdtrdEacbUJqU1bIg==}
     hasBin: true
 
-  '@eloqnt/format-apple-xcstrings@0.0.1':
-    resolution: {integrity: sha512-QD+TyC/zHhWWeetKN1ewCD5C7nyGF/SRMjad5ZYwzFYGUPFsilvGKJRTN1U0Hm4qiIbfDgICXzKEn+yYAGNR5Q==}
+  '@eloqnt/format-apple-xcstrings@0.0.2':
+    resolution: {integrity: sha512-5aXfwaKrmP45jETXhMDFgW9uxdavjGtDAEW4Pi4dDVUuzqB5A6ZX+BxnKIRm3V7/RQY1rMyMPvMpfOiU/IXEmw==}
 
   '@eloqnt/sdk@0.6.5':
     resolution: {integrity: sha512-q8DPQngrkmEos0qn5H+bhX2DYvjp2lymBdRtm/mxPDpgmX09UfF28gj+aE3SDvjlHEDVErkV9FXeJjTo5CcEbQ==}
@@ -8142,7 +8142,7 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@eloqnt/format-apple-xcstrings@0.0.1(@swc/helpers@0.5.23)':
+  '@eloqnt/format-apple-xcstrings@0.0.2(@swc/helpers@0.5.23)':
     dependencies:
       '@eloqnt/sdk': 0.6.5(@swc/helpers@0.5.23)
       '@formatjs/icu-messageformat-parser': 3.5.16

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,8 @@ catalog:
   "@dnd-kit/core": 6.3.1
   "@dnd-kit/sortable": 10.0.0
   "@dnd-kit/utilities": 3.2.2
-  "@eloqnt/cli": 0.6.5
+  "@eloqnt/cli": 0.6.6
+  "@eloqnt/format-apple-xcstrings": 0.0.1
   "@mdx-js/loader": 3.1.1
   "@mdx-js/react": 3.1.1
   "@next/mdx": 16.3.1-canary.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   "@dnd-kit/sortable": 10.0.0
   "@dnd-kit/utilities": 3.2.2
   "@eloqnt/cli": 0.6.6
-  "@eloqnt/format-apple-xcstrings": 0.0.1
+  "@eloqnt/format-apple-xcstrings": 0.0.2
   "@mdx-js/loader": 3.1.1
   "@mdx-js/react": 3.1.1
   "@next/mdx": 16.3.1-canary.8


### PR DESCRIPTION
Hey @ceolinwill,

here's a follow-up to our conversation from last week. eloqnt/cli now supports Apple's `.xcstrings` through a published codec (see https://studio.eloqnt.dev/docs/formats/apple-xcstrings).

This sets up some wiring, you might want to double check if this matches your standards.

One aspect I'm unsure about: In the xcstrings file, eloqnt/cli will cause a whitespace change—e.g. after calling `eloqnt translate`. But apparently this matches what Xcode does. I tested with Xcode v26.6, hit save on the catalog and I get the same diff.

Did you use any particular tool for a more compact display of the `localizations`?