### PR TITLE
chore(evals): update sonnet pricing

### DIFF
--- a/apps/evals/src/lib/models.ts
+++ b/apps/evals/src/lib/models.ts
@@ -24,7 +24,7 @@ export const EVAL_MODELS: ModelConfig[] = [
   { id: "anthropic/claude-fable-5", inputCost: 10, name: "claude-fable-5", outputCost: 50 },
   { id: "anthropic/claude-opus-5", inputCost: 5, name: "claude-opus-5", outputCost: 25 },
   { id: "anthropic/claude-opus-4.8", inputCost: 5, name: "claude-opus-4.8", outputCost: 25 },
-  { id: "anthropic/claude-sonnet-5", inputCost: 3, name: "claude-sonnet-5", outputCost: 15 },
+  { id: "anthropic/claude-sonnet-5", inputCost: 2, name: "claude-sonnet-5", outputCost: 10 },
   { id: "anthropic/claude-sonnet-4.6", inputCost: 3, name: "claude-sonnet-4.6", outputCost: 15 },
   { id: "anthropic/claude-haiku-4.5", inputCost: 1, name: "claude-haiku-4.5", outputCost: 5 },
   { id: "deepseek/deepseek-v4-pro", inputCost: 0.43, name: "deepseek-v4-pro", outputCost: 0.87 },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates eval pricing for `anthropic/claude-sonnet-5` to match current Anthropic rates, lowering calculated costs in the evals app.

- Old: input 3, output 15 → New: input 2, output 10.
- Affects only cost accounting; model behavior and selection are unchanged.
- Review: confirm dashboards and budget alerts reflect the new rates; no migrations required.
- Historical reports remain as-is unless recomputed.

<sup>Written for commit 91e525c4c3e80af73abc0526d097e930ab886377. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

