### PR TITLE
feat(api): add generation limits

### DIFF
--- a/apps/api/e2e/course-prompts-and-generation-resources.test.ts
+++ b/apps/api/e2e/course-prompts-and-generation-resources.test.ts
@@ -4,6 +4,7 @@ import {
   COURSE_LANGUAGE_MAX_LENGTH,
   COURSE_PROMPT_MAX_LENGTH,
 } from "@zoonk/core/courses/prompt-contract";
+import { GENERATION_VISITOR_ID_HEADER } from "@zoonk/core/generation-quotas/contract";
 import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
@@ -136,6 +137,48 @@ test.describe("Course prompt and generation resources API", () => {
       generationStatus: "running",
       status: "pending",
       title,
+    });
+
+    await apiContext.dispose();
+  });
+
+  test("returns a structured limit response instead of starting another generation", async () => {
+    const visitorId = randomUUID();
+    const now = new Date();
+
+    const periodStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+
+    await prisma.generationQuotaCounter.create({
+      data: {
+        actorKey: `guest:${visitorId}`,
+        count: 3,
+        period: "day",
+        periodStart,
+        resource: "course",
+      },
+    });
+
+    const coursePrompt = await coursePromptFixture();
+
+    const apiContext = await request.newContext({
+      baseURL,
+      extraHTTPHeaders: { [GENERATION_VISITOR_ID_HEADER]: visitorId },
+    });
+
+    const response = await apiContext.post("/v1/generations", {
+      data: { target: { id: coursePrompt.id, type: "coursePrompt" } },
+    });
+
+    expect(response.status()).toBe(429);
+
+    await expect(response.json()).resolves.toStrictEqual({
+      error: {
+        code: "GENERATION_LIMIT_REACHED",
+        details: { period: "day", resource: "course", viewer: "guest" },
+        message: "Generation limit reached",
+      },
     });
 
     await apiContext.dispose();

--- a/apps/api/e2e/lesson-resources.test.ts
+++ b/apps/api/e2e/lesson-resources.test.ts
@@ -347,6 +347,52 @@ test.describe("Lesson resources API", () => {
     await apiContext.dispose();
   });
 
+  test("skips derived generation when the learner has reached the lesson limit", async () => {
+    const { chapter, lesson, organization } = await createPublishedLesson({});
+
+    const nextLesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "pending",
+      isPublished: true,
+      kind: "explanation",
+      organizationId: organization.id,
+      position: 1,
+      title: `E2E Limited Preload ${randomUUID()}`,
+    });
+
+    const { apiContext, user } = await createBearerApiContext({
+      baseURL,
+      prefix: "lesson-preload-limit",
+    });
+
+    const now = new Date();
+
+    const periodStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+
+    await prisma.generationQuotaCounter.create({
+      data: {
+        actorKey: `user:${user.id}`,
+        count: 50,
+        period: "day",
+        periodStart,
+        resource: "lesson",
+      },
+    });
+
+    const response = await apiContext.post(`/v1/lessons/${lesson.id}/preloads`);
+
+    expect(response.status()).toBe(202);
+    await expect(response.json()).resolves.toStrictEqual({ generations: [] });
+
+    await expect(
+      prisma.lesson.findUniqueOrThrow({ where: { id: nextLesson.id } }),
+    ).resolves.toMatchObject({ generationRunId: null, generationStatus: "pending" });
+
+    await apiContext.dispose();
+  });
+
   test("requires authentication for learner mutations", async () => {
     const { lesson } = await createPublishedLesson({});
     const apiContext: APIRequestContext = await request.newContext({ baseURL });

--- a/apps/api/src/app/v1/generations/route.ts
+++ b/apps/api/src/app/v1/generations/route.ts
@@ -7,6 +7,7 @@ import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapte
 import { courseGenerationWorkflow } from "@/workflows/course-generation/course-generation-workflow";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
 import { getCourseGenerationAccess } from "@zoonk/core/courses/generation-access";
+import { claimGenerationQuotaIfNeeded } from "@zoonk/core/generation-quotas/claim";
 import { getChapterGenerationAccess } from "@zoonk/core/workflows/chapter-generation-access";
 import { getLessonGenerationAccess } from "@zoonk/core/workflows/lesson-generation-access";
 import { type NextRequest, NextResponse } from "next/server";
@@ -25,6 +26,96 @@ async function acceptedGeneration(run: Run<unknown>) {
   });
 }
 
+/** Returns the public quota response while keeping accepted workflow creation on the happy path. */
+function reachedGenerationLimit(result: Awaited<ReturnType<typeof claimGenerationQuotaIfNeeded>>) {
+  return result.status === "limitReached" ? errors.generationLimitReached(result.limit) : null;
+}
+
+/** Starts a course workflow after the course prompt and its quota claim are accepted. */
+async function createCourseGeneration(coursePromptId: string) {
+  const access = await getCourseGenerationAccess(coursePromptId);
+
+  if (access.status === "notFound") {
+    return errors.notFound();
+  }
+
+  if (access.status === "invalid") {
+    return errors.badRequest(access.error);
+  }
+
+  const quotaResponse = reachedGenerationLimit(
+    await claimGenerationQuotaIfNeeded({
+      resource: "course",
+      shouldClaimQuota: access.shouldClaimQuota,
+      targetId: coursePromptId,
+    }),
+  );
+
+  if (quotaResponse) {
+    return quotaResponse;
+  }
+
+  const run = await start(courseGenerationWorkflow, [
+    { coursePromptId: access.coursePromptId, userId: access.userId },
+  ]);
+
+  return acceptedGeneration(run);
+}
+
+/** Starts a chapter workflow after its subscription gate and quota claim are accepted. */
+async function createChapterGeneration(chapterId: string) {
+  const access = await getChapterGenerationAccess(chapterId);
+
+  if (access.status === "notFound") {
+    return errors.notFound();
+  }
+
+  if (access.status === "subscriptionRequired") {
+    return errors.paymentRequired();
+  }
+
+  const quotaResponse = reachedGenerationLimit(
+    await claimGenerationQuotaIfNeeded({
+      resource: "chapter",
+      shouldClaimQuota: access.shouldClaimQuota,
+      targetId: chapterId,
+    }),
+  );
+
+  if (quotaResponse) {
+    return quotaResponse;
+  }
+
+  return acceptedGeneration(await start(chapterGenerationWorkflow, [chapterId]));
+}
+
+/** Starts a lesson workflow after its subscription gate and quota claim are accepted. */
+async function createLessonGeneration(lessonId: string) {
+  const access = await getLessonGenerationAccess(lessonId);
+
+  if (access.status === "notFound") {
+    return errors.notFound();
+  }
+
+  if (access.status === "subscriptionRequired") {
+    return errors.paymentRequired();
+  }
+
+  const quotaResponse = reachedGenerationLimit(
+    await claimGenerationQuotaIfNeeded({
+      resource: "lesson",
+      shouldClaimQuota: access.shouldClaimQuota,
+      targetId: lessonId,
+    }),
+  );
+
+  if (quotaResponse) {
+    return quotaResponse;
+  }
+
+  return acceptedGeneration(await start(lessonGenerationWorkflow, [lessonId]));
+}
+
 /**
  * Starts the workflow selected by a validated generation target while keeping
  * every existing authorization and subscription decision in Core.
@@ -37,48 +128,14 @@ async function createGeneration(request: NextRequest) {
   }
 
   if (parsed.data.target.type === "coursePrompt") {
-    const access = await getCourseGenerationAccess(parsed.data.target.id);
-
-    if (access.status === "notFound") {
-      return errors.notFound();
-    }
-
-    if (access.status === "invalid") {
-      return errors.badRequest(access.error);
-    }
-
-    const run = await start(courseGenerationWorkflow, [
-      { coursePromptId: access.coursePromptId, userId: access.userId },
-    ]);
-
-    return acceptedGeneration(run);
+    return createCourseGeneration(parsed.data.target.id);
   }
 
   if (parsed.data.target.type === "chapter") {
-    const access = await getChapterGenerationAccess(parsed.data.target.id);
-
-    if (access.status === "notFound") {
-      return errors.notFound();
-    }
-
-    if (access.status === "subscriptionRequired") {
-      return errors.paymentRequired();
-    }
-
-    return acceptedGeneration(await start(chapterGenerationWorkflow, [parsed.data.target.id]));
+    return createChapterGeneration(parsed.data.target.id);
   }
 
-  const access = await getLessonGenerationAccess(parsed.data.target.id);
-
-  if (access.status === "notFound") {
-    return errors.notFound();
-  }
-
-  if (access.status === "subscriptionRequired") {
-    return errors.paymentRequired();
-  }
-
-  return acceptedGeneration(await start(lessonGenerationWorkflow, [parsed.data.target.id]));
+  return createLessonGeneration(parsed.data.target.id);
 }
 
 export const POST = withApiErrorBoundary(createGeneration);

--- a/apps/api/src/app/v1/lessons/[lessonId]/preloads/route.ts
+++ b/apps/api/src/app/v1/lessons/[lessonId]/preloads/route.ts
@@ -4,6 +4,7 @@ import { lessonPathParamsSchema } from "@/lib/openapi/schemas/paths";
 import { parsePathParams } from "@/lib/path-params";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
+import { claimGenerationQuotaIfNeeded } from "@zoonk/core/generation-quotas/claim";
 import { getNextPreloadTargetResource } from "@zoonk/core/player/commands/get-next-lesson-preload-target";
 import { getChapterGenerationAccess } from "@zoonk/core/workflows/chapter-generation-access";
 import { getLessonGenerationAccess } from "@zoonk/core/workflows/lesson-generation-access";
@@ -24,6 +25,16 @@ async function startPreloadGeneration(target: PreloadTarget) {
       return null;
     }
 
+    const quota = await claimGenerationQuotaIfNeeded({
+      resource: "chapter",
+      shouldClaimQuota: access.shouldClaimQuota,
+      targetId: target.chapterId,
+    });
+
+    if (quota.status === "limitReached") {
+      return null;
+    }
+
     const generation = await start(chapterGenerationWorkflow, [target.chapterId]);
 
     return { chapterId: target.chapterId, generationId: generation.runId, kind: target.kind };
@@ -32,6 +43,16 @@ async function startPreloadGeneration(target: PreloadTarget) {
   const access = await getLessonGenerationAccess(target.lessonId);
 
   if (access.status !== "ready") {
+    return null;
+  }
+
+  const quota = await claimGenerationQuotaIfNeeded({
+    resource: "lesson",
+    shouldClaimQuota: access.shouldClaimQuota,
+    targetId: target.lessonId,
+  });
+
+  if (quota.status === "limitReached") {
     return null;
   }
 

--- a/apps/api/src/lib/api-errors.ts
+++ b/apps/api/src/lib/api-errors.ts
@@ -1,3 +1,4 @@
+import { type GenerationQuotaLimit } from "@zoonk/core/generation-quotas/contract";
 import { NextResponse } from "next/server";
 import { type z } from "zod";
 
@@ -8,6 +9,7 @@ export const httpStatus = {
   internalError: 500,
   notFound: 404,
   paymentRequired: 402,
+  tooManyRequests: 429,
   unauthorized: 401,
   unprocessableEntity: 422,
 } as const;
@@ -21,6 +23,13 @@ export const errors = {
   conflict: (msg = "Resource already exists") =>
     errorResponse("CONFLICT", msg, httpStatus.conflict),
   forbidden: (msg = "Access denied") => errorResponse("FORBIDDEN", msg, httpStatus.forbidden),
+  generationLimitReached: (limit: GenerationQuotaLimit) =>
+    errorResponse(
+      "GENERATION_LIMIT_REACHED",
+      "Generation limit reached",
+      httpStatus.tooManyRequests,
+      limit,
+    ),
   internal: (msg = "Internal server error") =>
     errorResponse("INTERNAL_ERROR", msg, httpStatus.internalError),
   notFound: (msg = "Resource not found") => errorResponse("NOT_FOUND", msg, httpStatus.notFound),

--- a/apps/api/src/lib/openapi/paths/generations.ts
+++ b/apps/api/src/lib/openapi/paths/generations.ts
@@ -5,6 +5,7 @@ import {
   forbiddenResponse,
   notFoundResponse,
   paymentRequiredResponse,
+  tooManyRequestsResponse,
   validationErrorResponse,
 } from "../schemas/responses";
 import {
@@ -19,7 +20,7 @@ export const generationPaths = {
   "/generations": {
     post: {
       description:
-        "Starts course, chapter, or lesson generation. Chapter and lesson targets require an active subscription when the free first-chapter rule does not apply.",
+        "Starts course, chapter, or lesson generation. Daily and monthly limits depend on the caller's entitlement. Chapter and lesson targets also require an active subscription when the free first-chapter rule does not apply.",
       operationId: "createGeneration",
       requestBody: {
         content: { "application/json": { schema: createGenerationRequestSchema } },
@@ -37,6 +38,7 @@ export const generationPaths = {
         "402": paymentRequiredResponse,
         "403": forbiddenResponse,
         "404": notFoundResponse,
+        "429": tooManyRequestsResponse,
       },
       security: OPTIONAL_AUTHENTICATION_SECURITY,
       summary: "Create a generation",

--- a/apps/api/src/lib/openapi/schemas/responses.ts
+++ b/apps/api/src/lib/openapi/schemas/responses.ts
@@ -40,6 +40,11 @@ export const paymentRequiredResponse = {
   description: "Subscription required",
 } as const;
 
+export const tooManyRequestsResponse = {
+  content: { "application/json": { schema: errorSchema } },
+  description: "Generation limit reached",
+} as const;
+
 export const unprocessableEntityResponse = {
   content: { "application/json": { schema: errorSchema } },
   description: "The request is valid but cannot be applied to the resource",

--- a/apps/api/src/proxy.ts
+++ b/apps/api/src/proxy.ts
@@ -6,7 +6,7 @@ import { type NextRequest, NextResponse } from "next/server";
 
 const corsHeaders = {
   "Access-Control-Allow-Credentials": "true",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Generation-Visitor-Id",
   "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
   "Access-Control-Max-Age": "86400",
 };

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -8,7 +8,13 @@ import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
-import { isGenerationEvents, isGenerationTrigger, routeGenerationApis } from "./generation-api";
+import {
+  type GenerationTriggerResponse,
+  getGenerationLimitResponse,
+  isGenerationEvents,
+  isGenerationTrigger,
+  routeGenerationApis,
+} from "./generation-api";
 
 /**
  * Test Architecture for Chapter Generation Page
@@ -26,7 +32,7 @@ import { isGenerationEvents, isGenerationTrigger, routeGenerationApis } from "./
 const TEST_RUN_ID = "test-run-id-chapter-12345";
 
 type MockApiOptions = {
-  triggerResponse?: { id?: string; error?: string; status?: number };
+  triggerResponse?: GenerationTriggerResponse;
   streamMessages?: { reason?: string; step: string; status: string }[];
   streamError?: boolean;
   statusDelayMs?: number;
@@ -55,9 +61,9 @@ function createRouteHandler(options: MockApiOptions) {
 
     // Mock trigger API
     if (isGenerationTrigger({ request: route.request(), targetType: "chapter" })) {
-      if (triggerResponse.error) {
+      if (triggerResponse.error || (triggerResponse.status && triggerResponse.status >= 400)) {
         await route.fulfill({
-          body: JSON.stringify({ error: triggerResponse.error }),
+          body: JSON.stringify(triggerResponse.body ?? { error: triggerResponse.error }),
           contentType: "application/json",
           status: triggerResponse.status ?? 500,
         });
@@ -163,6 +169,23 @@ async function createTestSubscription(userId: string) {
 }
 
 test.describe("Generate Chapter Page - Unauthenticated", () => {
+  test("explains when the daily chapter generation limit is reached", async ({ page }) => {
+    const { chapter } = await createPendingChapter();
+
+    await setupMockApis(page, {
+      triggerResponse: getGenerationLimitResponse({
+        period: "day",
+        resource: "chapter",
+        viewer: "guest",
+      }),
+    });
+
+    await page.goto(`/generate/ch/${chapter.id}`);
+
+    await expect(page.getByRole("heading", { name: "Daily chapter limit reached" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Log in" })).toBeVisible();
+  });
+
   test("shows upgrade CTA for later chapters", async ({ page }) => {
     const { chapter } = await createPendingChapter(1);
     await page.goto(`/generate/ch/${chapter.id}`);

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { GENERATION_VISITOR_ID_HEADER } from "@zoonk/core/generation-quotas/contract";
 import {
   COURSE_COMPLETION_STEP,
   INTRODUCTION_LESSON_COMPLETION_STEP,
@@ -11,7 +12,13 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { ensureLocaleSuffix, toSlug } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
-import { isGenerationEvents, isGenerationTrigger, routeGenerationApis } from "./generation-api";
+import {
+  type GenerationTriggerResponse,
+  getGenerationLimitResponse,
+  isGenerationEvents,
+  isGenerationTrigger,
+  routeGenerationApis,
+} from "./generation-api";
 
 /**
  * Test Architecture for Course Generation Page
@@ -39,7 +46,7 @@ const TEST_RUN_ID = "test-run-id-12345";
 type MockApiOptions = {
   assertBearerAuth?: boolean;
   triggerResponseGate?: Promise<unknown>;
-  triggerResponse?: { id?: string; error?: string; status?: number };
+  triggerResponse?: GenerationTriggerResponse;
   streamMessages?: { entityId?: string; reason?: string; step: string; status: string }[];
   streamError?: boolean;
   statusDelayMs?: number;
@@ -89,9 +96,9 @@ function createRouteHandler(options: MockApiOptions) {
 
       await triggerResponseGate;
 
-      if (triggerResponse.error) {
+      if (triggerResponse.status && triggerResponse.status >= 400) {
         await route.fulfill({
-          body: JSON.stringify({ error: triggerResponse.error }),
+          body: JSON.stringify(triggerResponse.body ?? { error: triggerResponse.error }),
           contentType: "application/json",
           status: triggerResponse.status ?? 500,
         });
@@ -211,7 +218,7 @@ function getIntroLessonCompletionTarget({
 
 test.describe("Generate Course Page", () => {
   test("starts course generation for unauthenticated users", async ({ page }) => {
-    const request = await coursePromptFixture({
+    const coursePrompt = await coursePromptFixture({
       canonicalTitle: "E2E Unauth Course Generation",
       generationStatus: "pending",
       language: "en",
@@ -222,11 +229,115 @@ test.describe("Generate Course Page", () => {
       streamMessages: [{ status: "started", step: "getCoursePrompt" }],
     });
 
-    await page.goto(`/generate/course/${request.id}`);
+    const generationRequest = page.waitForRequest(
+      (pageRequest) =>
+        pageRequest.method() === "POST" &&
+        isGenerationTrigger({ request: pageRequest, targetType: "coursePrompt" }),
+    );
+
+    await page.goto(`/generate/course/${coursePrompt.id}`);
+
+    const generationTriggerRequest = await generationRequest;
+    const requestHeaders = generationTriggerRequest.headers();
+
+    expect(requestHeaders[GENERATION_VISITOR_ID_HEADER.toLowerCase()]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
 
     await expect(
       page.getByRole("heading", { name: "Creating the E2E Unauth Course Generation course" }),
     ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("explains a daily guest limit and offers login without hiding existing learning", async ({
+    page,
+  }) => {
+    const request = await coursePromptFixture({
+      canonicalTitle: "E2E Limited Course Generation",
+      generationStatus: "pending",
+      language: "en",
+    });
+
+    await setupMockApis(page, {
+      triggerResponse: getGenerationLimitResponse({
+        period: "day",
+        resource: "course",
+        viewer: "guest",
+      }),
+    });
+
+    await page.goto(`/generate/course/${request.id}`);
+
+    await expect(page.getByRole("heading", { name: "Daily course limit reached" })).toBeVisible();
+
+    await expect(
+      page.getByText(
+        "You've reached today's limit for generating courses. You can keep learning from anything already generated.",
+      ),
+    ).toBeVisible();
+
+    const loginLink = page.getByRole("link", { name: "Log in" });
+
+    await expect(loginLink).toHaveAttribute(
+      "href",
+      `/login?next=%2Fgenerate%2Fcourse%2F${request.id}`,
+    );
+  });
+
+  test("offers a subscription when an authenticated user reaches a monthly limit", async ({
+    authenticatedPage,
+  }) => {
+    const request = await coursePromptFixture({
+      canonicalTitle: "E2E Authenticated Course Limit",
+      generationStatus: "pending",
+      language: "en",
+    });
+
+    await setupMockApis(authenticatedPage, {
+      triggerResponse: getGenerationLimitResponse({
+        period: "month",
+        resource: "course",
+        viewer: "authenticated",
+      }),
+    });
+
+    await authenticatedPage.goto(`/generate/course/${request.id}`);
+
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Monthly course limit reached" }),
+    ).toBeVisible();
+
+    await expect(authenticatedPage.getByRole("link", { name: "Get Zoonk Plus" })).toHaveAttribute(
+      "href",
+      "/subscription",
+    );
+  });
+
+  test("offers support when a subscriber reaches a daily limit", async ({ authenticatedPage }) => {
+    const request = await coursePromptFixture({
+      canonicalTitle: "E2E Subscriber Course Limit",
+      generationStatus: "pending",
+      language: "en",
+    });
+
+    await setupMockApis(authenticatedPage, {
+      triggerResponse: getGenerationLimitResponse({
+        period: "day",
+        resource: "course",
+        viewer: "subscriber",
+      }),
+    });
+
+    await authenticatedPage.goto(`/generate/course/${request.id}`);
+
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Daily course limit reached" }),
+    ).toBeVisible();
+
+    await expect(authenticatedPage.getByRole("link", { name: "Contact support" })).toHaveAttribute(
+      "href",
+      "/support",
+    );
   });
 
   test.describe("Initial triggering state", () => {

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -9,7 +9,13 @@ import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
-import { isGenerationEvents, isGenerationTrigger, routeGenerationApis } from "./generation-api";
+import {
+  type GenerationTriggerResponse,
+  getGenerationLimitResponse,
+  isGenerationEvents,
+  isGenerationTrigger,
+  routeGenerationApis,
+} from "./generation-api";
 
 /**
  * Test Architecture for Lesson Generation Page
@@ -27,7 +33,7 @@ import { isGenerationEvents, isGenerationTrigger, routeGenerationApis } from "./
 const TEST_RUN_ID = "test-run-id-lesson-12345";
 
 type MockApiOptions = {
-  triggerResponse?: { id?: string; error?: string; status?: number };
+  triggerResponse?: GenerationTriggerResponse;
   streamMessages?: { reason?: string; step: string; status: string }[];
   streamError?: boolean;
   statusDelayMs?: number;
@@ -56,9 +62,9 @@ function createRouteHandler(options: MockApiOptions) {
 
     // Mock trigger API
     if (isGenerationTrigger({ request: route.request(), targetType: "lesson" })) {
-      if (triggerResponse.error) {
+      if (triggerResponse.error || (triggerResponse.status && triggerResponse.status >= 400)) {
         await route.fulfill({
-          body: JSON.stringify({ error: triggerResponse.error }),
+          body: JSON.stringify(triggerResponse.body ?? { error: triggerResponse.error }),
           contentType: "application/json",
           status: triggerResponse.status ?? 500,
         });
@@ -294,6 +300,23 @@ async function createTestSubscription(userId: string) {
 }
 
 test.describe("Generate Lesson Page - Unauthenticated", () => {
+  test("explains when the daily lesson generation limit is reached", async ({ page }) => {
+    const { lesson } = await createPendingLesson();
+
+    await setupMockApis(page, {
+      triggerResponse: getGenerationLimitResponse({
+        period: "day",
+        resource: "lesson",
+        viewer: "guest",
+      }),
+    });
+
+    await page.goto(`/generate/l/${lesson.id}`);
+
+    await expect(page.getByRole("heading", { name: "Daily lesson limit reached" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Log in" })).toBeVisible();
+  });
+
   test("shows upgrade CTA for later chapter lessons", async ({ page }) => {
     const { lesson } = await createPendingLesson({ chapterPosition: 1 });
     await page.goto(`/generate/l/${lesson.id}`);

--- a/apps/main/e2e/generation-api.ts
+++ b/apps/main/e2e/generation-api.ts
@@ -1,8 +1,30 @@
+import { type GenerationQuotaLimit } from "@zoonk/core/generation-quotas/contract";
 import { type Page, type Route } from "@zoonk/e2e/fixtures";
 import { isJsonObject } from "@zoonk/utils/json";
 
 type GenerationRouteHandler = (route: Route) => Promise<void>;
 type GenerationTargetType = "chapter" | "coursePrompt" | "lesson";
+
+export type GenerationTriggerResponse = {
+  body?: unknown;
+  error?: string;
+  id?: string;
+  status?: number;
+};
+
+/** Builds the public API error envelope that drives the reached-limit experience. */
+export function getGenerationLimitResponse(limit: GenerationQuotaLimit): GenerationTriggerResponse {
+  return {
+    body: {
+      error: {
+        code: "GENERATION_LIMIT_REACHED",
+        details: limit,
+        message: "Generation limit reached",
+      },
+    },
+    status: 429,
+  };
+}
 
 /**
  * Identifies a generation command for one target type. Inspecting the body is

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -342,6 +342,7 @@ msgstr "Kapitel erstellen"
 
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
+#: src/app/[lang]/generate/ch/[id]/generation-client.tsx
 msgctxt "qrEiLa"
 msgid "Back to course"
 msgstr "Zurück zum Kurs"
@@ -546,6 +547,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Melde dich an, um deine Kurse und Fortschritte an einem Ort zu verwalten."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
 msgstr "Anmelden"
@@ -1399,6 +1401,7 @@ msgid "This subscription is managed by Zoonk. Contact support if you need help c
 msgstr "Dieses Abonnement wird von Zoonk verwaltet. Kontaktiere den Support, wenn du Hilfe beim Ändern oder Kündigen brauchst."
 
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "5CI3KH"
 msgid "Contact support"
 msgstr "Support kontaktieren"
@@ -1689,6 +1692,7 @@ msgstr "Lektion erstellen"
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
 msgctxt "_N8rYN"
 msgid "Back to chapter"
 msgstr "Zurück zum Kapitel"
@@ -1806,6 +1810,7 @@ msgid "Finishing up..."
 msgstr "Abschließen..."
 
 #: src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "rPgekg"
 msgid "Back home"
 msgstr "Zurück zur Startseite"
@@ -2680,6 +2685,22 @@ msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Sende Feedback, Fragen oder Vorschläge an uns. Fülle das Formular aus oder schreibe uns direkt an hello@zoonk.com."
 
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Zoonk Plus holen"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "GLlr0C"
+msgid "{period, select, day {Daily} month {Monthly} other {Generation}} {resource, select, course {course} chapter {chapter} lesson {lesson} other {generation}} limit reached"
+msgstr "{resource, select, course {Kurse} chapter {Kapitel} lesson {Lektionen} other {Generierung}}: {period, select, day {Tageslimit erreicht} month {Monatslimit erreicht} other {Limit erreicht}}"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "xMbHsD"
+msgid "{period, select, day {You've reached today's limit} month {You've reached this month's limit} other {You've reached the limit}} for generating {resource, select, course {courses} chapter {chapters} lesson {lessons} other {content}}. You can keep learning from anything already generated."
+msgstr "{period, select, day {Du hast das heutige Limit} month {Du hast das Limit für diesen Monat} other {Du hast das Limit}} für das Erstellen von {resource, select, course {Kursen} chapter {Kapiteln} lesson {Lektionen} other {Inhalten}} erreicht. Du kannst mit allen bereits erstellten Inhalten weiterlernen."
+
 #: src/components/generation/workflow-generation-error.tsx
 msgctxt "ctqXbT"
 msgid "We lost the progress connection. Your content may still be generating."
@@ -2754,11 +2775,6 @@ msgstr "Mit Plus weiterlernen"
 msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Mit Plus erhältst du unbegrenzten Zugriff auf Kurse und Lektionen zu allem, was du lernen möchtest."
-
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Zoonk Plus holen"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -342,6 +342,7 @@ msgstr "Create chapter"
 
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
+#: src/app/[lang]/generate/ch/[id]/generation-client.tsx
 msgctxt "qrEiLa"
 msgid "Back to course"
 msgstr "Back to course"
@@ -546,6 +547,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Keep your courses and progress in one place by logging in to your account."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
 msgstr "Log in"
@@ -1399,6 +1401,7 @@ msgid "This subscription is managed by Zoonk. Contact support if you need help c
 msgstr "This subscription is managed by Zoonk. Contact support if you need help changing or canceling it."
 
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "5CI3KH"
 msgid "Contact support"
 msgstr "Contact support"
@@ -1689,6 +1692,7 @@ msgstr "Create lesson"
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
 msgctxt "_N8rYN"
 msgid "Back to chapter"
 msgstr "Back to chapter"
@@ -1806,6 +1810,7 @@ msgid "Finishing up..."
 msgstr "Finishing up..."
 
 #: src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "rPgekg"
 msgid "Back home"
 msgstr "Back home"
@@ -2680,6 +2685,22 @@ msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Get Zoonk Plus"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "GLlr0C"
+msgid "{period, select, day {Daily} month {Monthly} other {Generation}} {resource, select, course {course} chapter {chapter} lesson {lesson} other {generation}} limit reached"
+msgstr "{period, select, day {Daily} month {Monthly} other {Generation}} {resource, select, course {course} chapter {chapter} lesson {lesson} other {generation}} limit reached"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "xMbHsD"
+msgid "{period, select, day {You've reached today's limit} month {You've reached this month's limit} other {You've reached the limit}} for generating {resource, select, course {courses} chapter {chapters} lesson {lessons} other {content}}. You can keep learning from anything already generated."
+msgstr "{period, select, day {You've reached today's limit} month {You've reached this month's limit} other {You've reached the limit}} for generating {resource, select, course {courses} chapter {chapters} lesson {lessons} other {content}}. You can keep learning from anything already generated."
+
 #: src/components/generation/workflow-generation-error.tsx
 msgctxt "ctqXbT"
 msgid "We lost the progress connection. Your content may still be generating."
@@ -2754,11 +2775,6 @@ msgstr "Keep learning with Plus"
 msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Plus gives you unlimited courses and lessons for whatever you want to learn."
-
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Get Zoonk Plus"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -342,6 +342,7 @@ msgstr "Crear capítulo"
 
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
+#: src/app/[lang]/generate/ch/[id]/generation-client.tsx
 msgctxt "qrEiLa"
 msgid "Back to course"
 msgstr "Volver al curso"
@@ -546,6 +547,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Inicia sesión en tu cuenta para tener tus cursos y tu progreso en un solo lugar."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
 msgstr "Inicia sesión"
@@ -1399,6 +1401,7 @@ msgid "This subscription is managed by Zoonk. Contact support if you need help c
 msgstr "Esta suscripción la gestiona Zoonk. Contacta con soporte si necesitas ayuda para cambiarla o cancelarla."
 
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "5CI3KH"
 msgid "Contact support"
 msgstr "Contactar con soporte"
@@ -1689,6 +1692,7 @@ msgstr "Crear lección"
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
 msgctxt "_N8rYN"
 msgid "Back to chapter"
 msgstr "Volver al capítulo"
@@ -1806,6 +1810,7 @@ msgid "Finishing up..."
 msgstr "Terminando…"
 
 #: src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "rPgekg"
 msgid "Back home"
 msgstr "Volver al inicio"
@@ -2680,6 +2685,22 @@ msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envíanos comentarios, preguntas o sugerencias. Completa el formulario de abajo o escríbenos directamente a contacto@zoonk.com."
 
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Obtén Zoonk Plus"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "GLlr0C"
+msgid "{period, select, day {Daily} month {Monthly} other {Generation}} {resource, select, course {course} chapter {chapter} lesson {lesson} other {generation}} limit reached"
+msgstr "Se alcanzó el límite {period, select, day {diario} month {mensual} other {de generación}} de {resource, select, course {cursos} chapter {capítulos} lesson {lecciones} other {contenido}}"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "xMbHsD"
+msgid "{period, select, day {You've reached today's limit} month {You've reached this month's limit} other {You've reached the limit}} for generating {resource, select, course {courses} chapter {chapters} lesson {lessons} other {content}}. You can keep learning from anything already generated."
+msgstr "{period, select, day {Alcanzaste el límite de hoy} month {Alcanzaste el límite de este mes} other {Alcanzaste el límite}} para generar {resource, select, course {cursos} chapter {capítulos} lesson {lecciones} other {contenido}}. Puedes seguir estudiando con todo lo que ya se haya generado."
+
 #: src/components/generation/workflow-generation-error.tsx
 msgctxt "ctqXbT"
 msgid "We lost the progress connection. Your content may still be generating."
@@ -2754,11 +2775,6 @@ msgstr "Sigue estudiando con Plus"
 msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Plus te ofrece cursos y lecciones ilimitados sobre lo que quieras aprender."
-
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Obtén Zoonk Plus"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -342,6 +342,7 @@ msgstr "Créer le chapitre"
 
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
+#: src/app/[lang]/generate/ch/[id]/generation-client.tsx
 msgctxt "qrEiLa"
 msgid "Back to course"
 msgstr "Retour au cours"
@@ -546,6 +547,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Connecte-toi à ton compte pour retrouver tes cours et ta progression au même endroit."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
 msgstr "Se connecter"
@@ -1399,6 +1401,7 @@ msgid "This subscription is managed by Zoonk. Contact support if you need help c
 msgstr "Cet abonnement est géré par Zoonk. Contacte l’assistance si tu as besoin d’aide pour le modifier ou l’annuler."
 
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "5CI3KH"
 msgid "Contact support"
 msgstr "Contacter l’assistance"
@@ -1689,6 +1692,7 @@ msgstr "Créer la leçon"
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
 msgctxt "_N8rYN"
 msgid "Back to chapter"
 msgstr "Retour au chapitre"
@@ -1806,6 +1810,7 @@ msgid "Finishing up..."
 msgstr "Dernières finitions…"
 
 #: src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "rPgekg"
 msgid "Back home"
 msgstr "Retour à l’accueil"
@@ -2680,6 +2685,22 @@ msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envoie-nous tes avis, questions ou suggestions. Remplis le formulaire ci-dessous ou écris-nous directement à hello@zoonk.com."
 
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Passe à Zoonk Plus"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "GLlr0C"
+msgid "{period, select, day {Daily} month {Monthly} other {Generation}} {resource, select, course {course} chapter {chapter} lesson {lesson} other {generation}} limit reached"
+msgstr "{period, select, day {Limite quotidienne} month {Limite mensuelle} other {Limite}} {resource, select, course {de génération de cours} chapter {de génération de chapitres} lesson {de génération de leçons} other {de génération}} atteinte"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "xMbHsD"
+msgid "{period, select, day {You've reached today's limit} month {You've reached this month's limit} other {You've reached the limit}} for generating {resource, select, course {courses} chapter {chapters} lesson {lessons} other {content}}. You can keep learning from anything already generated."
+msgstr "{period, select, day {Tu as atteint la limite d’aujourd’hui} month {Tu as atteint la limite de ce mois-ci} other {Tu as atteint la limite}} pour générer {resource, select, course {des cours} chapter {des chapitres} lesson {des leçons} other {du contenu}}. Tu peux continuer à apprendre avec tout ce qui a déjà été généré."
+
 #: src/components/generation/workflow-generation-error.tsx
 msgctxt "ctqXbT"
 msgid "We lost the progress connection. Your content may still be generating."
@@ -2754,11 +2775,6 @@ msgstr "Continue d’apprendre avec Plus"
 msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Plus te donne accès à des cours et des leçons en illimité sur tout ce que tu veux apprendre."
-
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Passe à Zoonk Plus"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -342,6 +342,7 @@ msgstr "Criar capítulo"
 
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-not-generated.tsx
 #: src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
+#: src/app/[lang]/generate/ch/[id]/generation-client.tsx
 msgctxt "qrEiLa"
 msgid "Back to course"
 msgstr "Voltar para o curso"
@@ -546,6 +547,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Entre na sua conta para manter seus cursos e progresso em um só lugar."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
 msgstr "Entrar"
@@ -1399,6 +1401,7 @@ msgid "This subscription is managed by Zoonk. Contact support if you need help c
 msgstr "Esta assinatura é gerenciada pelo Zoonk. Fale com o suporte se precisar de ajuda para mudar ou cancelar."
 
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
+#: src/components/generation/generation-limit-cta.tsx
 msgctxt "5CI3KH"
 msgid "Contact support"
 msgstr "Falar com o suporte"
@@ -1689,6 +1692,7 @@ msgstr "Criar aula"
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-not-generated.tsx
 #: src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
 #: src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
+#: src/app/[lang]/generate/l/[id]/generation-client.tsx
 msgctxt "_N8rYN"
 msgid "Back to chapter"
 msgstr "Voltar ao capítulo"
@@ -1806,6 +1810,7 @@ msgid "Finishing up..."
 msgstr "Finalizando…"
 
 #: src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "rPgekg"
 msgid "Back home"
 msgstr "Voltar para o início"
@@ -2680,6 +2685,22 @@ msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envie feedback, perguntas ou sugestões. Preencha o formulário abaixo ou fale com a gente direto pelo email contato@zoonk.com."
 
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "LeTnGY"
+msgid "Get Zoonk Plus"
+msgstr "Assine o Zoonk Plus"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "GLlr0C"
+msgid "{period, select, day {Daily} month {Monthly} other {Generation}} {resource, select, course {course} chapter {chapter} lesson {lesson} other {generation}} limit reached"
+msgstr "{period, select, day {Limite diário de} month {Limite mensal de} other {Limite de}} {resource, select, course {cursos} chapter {capítulos} lesson {aulas} other {geração}} atingido"
+
+#: src/components/generation/generation-limit-cta.tsx
+msgctxt "xMbHsD"
+msgid "{period, select, day {You've reached today's limit} month {You've reached this month's limit} other {You've reached the limit}} for generating {resource, select, course {courses} chapter {chapters} lesson {lessons} other {content}}. You can keep learning from anything already generated."
+msgstr "{period, select, day {Você atingiu o limite de hoje} month {Você atingiu o limite deste mês} other {Você atingiu o limite}} para gerar {resource, select, course {cursos} chapter {capítulos} lesson {aulas} other {conteúdo}}. Você pode continuar estudando com qualquer conteúdo já gerado."
+
 #: src/components/generation/workflow-generation-error.tsx
 msgctxt "ctqXbT"
 msgid "We lost the progress connection. Your content may still be generating."
@@ -2754,11 +2775,6 @@ msgstr "Continue estudando com o Plus"
 msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Com o Plus, você tem cursos e aulas ilimitados sobre o que quiser aprender."
-
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Assine o Zoonk Plus"
 
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"

--- a/apps/main/src/app/[lang]/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/[lang]/generate/ch/[id]/generation-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { GenerationLimitCTA } from "@/components/generation/generation-limit-cta";
 import {
   GenerationProgressCompleted,
   GenerationTimeline,
@@ -42,6 +43,8 @@ export function GenerationClient({
   invalidateContent: () => Promise<void>;
 }) {
   const t = useExtracted();
+  const backHref = `/b/${AI_ORG_SLUG}/c/${courseSlug}` as const;
+  const loginHref = `/login?next=${encodeURIComponent(`/generate/ch/${chapterId}`)}` as const;
 
   const generation = useWorkflowGeneration<ChapterWorkflowStepName>({
     completionStep: CHAPTER_COMPLETION_STEP,
@@ -121,6 +124,17 @@ export function GenerationClient({
       <GenerationProgressCompleted subtitle={t("Taking you to your chapter...")}>
         {t("Your lessons are ready")}
       </GenerationProgressCompleted>
+    );
+  }
+
+  if (generation.status === "limitReached" && generation.limit) {
+    return (
+      <GenerationLimitCTA
+        backHref={backHref}
+        backLabel={t("Back to course")}
+        limit={generation.limit}
+        loginHref={loginHref}
+      />
     );
   }
 

--- a/apps/main/src/app/[lang]/generate/course/[id]/generation-client.tsx
+++ b/apps/main/src/app/[lang]/generate/course/[id]/generation-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { GenerationLimitCTA } from "@/components/generation/generation-limit-cta";
 import {
   GenerationProgressCompleted,
   GenerationTimeline,
@@ -113,6 +114,8 @@ export function GenerationClient({
     ? t("Taking you to your course...")
     : t("Taking you to your first lesson…");
 
+  const loginHref = `/login?next=${encodeURIComponent(`/generate/course/${requestId}`)}` as const;
+
   useCompletionRedirect({
     beforeRedirect: () => invalidateGeneratedCourse(redirectHref),
     status: generation.status,
@@ -157,6 +160,17 @@ export function GenerationClient({
       <GenerationProgressCompleted subtitle={completedSubtitle}>
         {completedTitle}
       </GenerationProgressCompleted>
+    );
+  }
+
+  if (generation.status === "limitReached" && generation.limit) {
+    return (
+      <GenerationLimitCTA
+        backHref="/"
+        backLabel={t("Back home")}
+        limit={generation.limit}
+        loginHref={loginHref}
+      />
     );
   }
 

--- a/apps/main/src/app/[lang]/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/[lang]/generate/l/[id]/generation-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { GenerationLimitCTA } from "@/components/generation/generation-limit-cta";
 import {
   GenerationProgressCompleted,
   GenerationTimeline,
@@ -47,6 +48,8 @@ export function GenerationClient({
   lessonTitle: string;
 }) {
   const t = useExtracted();
+  const backHref = `/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}` as const;
+  const loginHref = `/login?next=${encodeURIComponent(`/generate/l/${lessonId}`)}` as const;
 
   const generation = useWorkflowGeneration<LessonStepName>({
     completionStep: LESSON_COMPLETION_STEP,
@@ -127,6 +130,17 @@ export function GenerationClient({
       <GenerationProgressCompleted subtitle={t("Taking you to your lesson...")}>
         {t("Your lesson is ready")}
       </GenerationProgressCompleted>
+    );
+  }
+
+  if (generation.status === "limitReached" && generation.limit) {
+    return (
+      <GenerationLimitCTA
+        backHref={backHref}
+        backLabel={t("Back to chapter")}
+        limit={generation.limit}
+        loginHref={loginHref}
+      />
     );
   }
 

--- a/apps/main/src/components/generation/generation-limit-cta.tsx
+++ b/apps/main/src/components/generation/generation-limit-cta.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { GenerationShortcutLink } from "@/components/generation/generation-shortcut-link";
+import { type AppRoute } from "@/i18n/navigation";
+import { type GenerationQuotaLimit } from "@zoonk/core/generation-quotas/contract";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@zoonk/ui/components/empty";
+import { GaugeIcon } from "lucide-react";
+import { useExtracted } from "next-intl";
+
+/** Selects the next useful action from the entitlement that reached its generation limit. */
+function GenerationLimitAction<Href extends string>({
+  loginHref,
+  viewer,
+}: {
+  loginHref: AppRoute<Href>;
+  viewer: GenerationQuotaLimit["viewer"];
+}) {
+  const t = useExtracted();
+
+  if (viewer === "guest") {
+    return <GenerationShortcutLink href={loginHref}>{t("Log in")}</GenerationShortcutLink>;
+  }
+
+  if (viewer === "authenticated") {
+    return (
+      <GenerationShortcutLink href="/subscription" prefetch>
+        {t("Get Zoonk Plus")}
+      </GenerationShortcutLink>
+    );
+  }
+
+  return (
+    <GenerationShortcutLink href="/support" prefetch>
+      {t("Contact support")}
+    </GenerationShortcutLink>
+  );
+}
+
+/** Explains that only new generation is paused and offers the role-appropriate next step. */
+export function GenerationLimitCTA<BackHref extends string, LoginHref extends string>({
+  backHref,
+  backLabel,
+  limit,
+  loginHref,
+}: {
+  backHref: AppRoute<BackHref>;
+  backLabel: string;
+  limit: GenerationQuotaLimit;
+  loginHref: AppRoute<LoginHref>;
+}) {
+  const t = useExtracted();
+
+  return (
+    <Empty className="border-0">
+      <EmptyHeader align="start">
+        <EmptyMedia variant="icon">
+          <GaugeIcon />
+        </EmptyMedia>
+
+        <EmptyTitle aria-level={1} role="heading">
+          {t(
+            "{period, select, day {Daily} month {Monthly} other {Generation}} {resource, select, course {course} chapter {chapter} lesson {lesson} other {generation}} limit reached",
+            { period: limit.period, resource: limit.resource },
+          )}
+        </EmptyTitle>
+
+        <EmptyDescription>
+          {t(
+            "{period, select, day {You've reached today's limit} month {You've reached this month's limit} other {You've reached the limit}} for generating {resource, select, course {courses} chapter {chapters} lesson {lessons} other {content}}. You can keep learning from anything already generated.",
+            { period: limit.period, resource: limit.resource },
+          )}
+        </EmptyDescription>
+      </EmptyHeader>
+
+      <EmptyContent align="stretch">
+        <GenerationShortcutLink href={backHref} prefetch shortcut="Esc" variant="outline">
+          {backLabel}
+        </GenerationShortcutLink>
+
+        <GenerationLimitAction loginHref={loginHref} viewer={limit.viewer} />
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/apps/main/src/lib/workflow/_utils/generation-limit.test.ts
+++ b/apps/main/src/lib/workflow/_utils/generation-limit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getGenerationLimit } from "./generation-limit";
+
+describe(getGenerationLimit, () => {
+  it("parses the API generation limit contract", () => {
+    expect(
+      getGenerationLimit({
+        error: {
+          code: "GENERATION_LIMIT_REACHED",
+          details: { period: "month", resource: "lesson", viewer: "subscriber" },
+          message: "Generation limit reached",
+        },
+      }),
+    ).toStrictEqual({ period: "month", resource: "lesson", viewer: "subscriber" });
+  });
+
+  it("rejects unrelated and malformed API errors", () => {
+    expect(getGenerationLimit({ error: { code: "INTERNAL_ERROR" } })).toBeNull();
+
+    expect(
+      getGenerationLimit({
+        error: {
+          code: "GENERATION_LIMIT_REACHED",
+          details: { period: "year", resource: "lesson", viewer: "subscriber" },
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/main/src/lib/workflow/_utils/generation-limit.ts
+++ b/apps/main/src/lib/workflow/_utils/generation-limit.ts
@@ -1,0 +1,60 @@
+import {
+  type GenerationQuotaLimit,
+  type GenerationQuotaPeriod,
+  type GenerationQuotaResource,
+  type GenerationQuotaViewer,
+} from "@zoonk/core/generation-quotas/contract";
+import { getString, isJsonObject } from "@zoonk/utils/json";
+
+const GENERATION_QUOTA_PERIODS = new Set<string>(["day", "month"]);
+
+const GENERATION_QUOTA_RESOURCES = new Set<string>(["chapter", "course", "lesson"]);
+
+const GENERATION_QUOTA_VIEWERS = new Set<string>(["authenticated", "guest", "subscriber"]);
+
+/** Narrows the API value to one reset period understood by the quota UI. */
+function isGenerationQuotaPeriod(value: string | null): value is GenerationQuotaPeriod {
+  return value !== null && GENERATION_QUOTA_PERIODS.has(value);
+}
+
+/** Narrows the API value to one generated resource understood by the quota UI. */
+function isGenerationQuotaResource(value: string | null): value is GenerationQuotaResource {
+  return value !== null && GENERATION_QUOTA_RESOURCES.has(value);
+}
+
+/** Narrows the API value to one entitlement understood by the quota UI. */
+function isGenerationQuotaViewer(value: string | null): value is GenerationQuotaViewer {
+  return value !== null && GENERATION_QUOTA_VIEWERS.has(value);
+}
+
+/** Reads the standard API error envelope without trusting an arbitrary JSON object shape. */
+function getGenerationLimitDetails(body: unknown): unknown {
+  if (!isJsonObject(body) || !isJsonObject(body.error)) {
+    return null;
+  }
+
+  return getString(body.error, "code") === "GENERATION_LIMIT_REACHED" ? body.error.details : null;
+}
+
+/** Narrows a structured 429 response into the quota context needed by the reached-limit UI. */
+export function getGenerationLimit(body: unknown): GenerationQuotaLimit | null {
+  const details = getGenerationLimitDetails(body);
+
+  if (!isJsonObject(details)) {
+    return null;
+  }
+
+  const period = getString(details, "period");
+  const resource = getString(details, "resource");
+  const viewer = getString(details, "viewer");
+
+  if (
+    !isGenerationQuotaPeriod(period) ||
+    !isGenerationQuotaResource(resource) ||
+    !isGenerationQuotaViewer(viewer)
+  ) {
+    return null;
+  }
+
+  return { period, resource, viewer };
+}

--- a/apps/main/src/lib/workflow/generation-store.test.ts
+++ b/apps/main/src/lib/workflow/generation-store.test.ts
@@ -24,6 +24,7 @@ describe(isGenerationInProgress, () => {
     expect(isGenerationInProgress("streaming")).toBe(true);
     expect(isGenerationInProgress("completed")).toBe(false);
     expect(isGenerationInProgress("error")).toBe(false);
+    expect(isGenerationInProgress("limitReached")).toBe(false);
   });
 });
 
@@ -129,6 +130,20 @@ describe(generationReducer, () => {
 
       expect(state.status).toBe("error");
       expect(state.errorKind).toBe("generation");
+    });
+  });
+
+  describe("limitReached", () => {
+    it("keeps structured quota context for the reached-limit CTA", () => {
+      const limit = { period: "day", resource: "course", viewer: "guest" } as const;
+
+      const state = generationReducer(initialGenerationState({ status: "triggering" }), {
+        limit,
+        type: "limitReached",
+      });
+
+      expect(state.status).toBe("limitReached");
+      expect(state.limit).toStrictEqual(limit);
     });
   });
 

--- a/apps/main/src/lib/workflow/generation-store.ts
+++ b/apps/main/src/lib/workflow/generation-store.ts
@@ -1,6 +1,13 @@
+import { type GenerationQuotaLimit } from "@zoonk/core/generation-quotas/contract";
 import { type StepStreamMessage } from "@zoonk/core/workflows/steps";
 
-export type GenerationStatus = "idle" | "triggering" | "streaming" | "completed" | "error";
+export type GenerationStatus =
+  | "idle"
+  | "triggering"
+  | "streaming"
+  | "completed"
+  | "error"
+  | "limitReached";
 
 export type GenerationErrorKind = "connection" | "generation";
 
@@ -19,6 +26,7 @@ export type GenerationState<TStep extends string = string> = {
   currentStep: TStep | null;
   error: string | null;
   errorKind: GenerationErrorKind | null;
+  limit: GenerationQuotaLimit | null;
   completionEntityId: string | null;
   reconnectCount: number;
   runId: string | null;
@@ -29,6 +37,7 @@ export type GenerationState<TStep extends string = string> = {
 export type GenerationAction<TStep extends string = string> =
   | { type: "reconnect" }
   | { type: "reset" }
+  | { type: "limitReached"; limit: GenerationQuotaLimit }
   | { type: "setError"; error: string | null; errorKind?: GenerationErrorKind }
   | { type: "stepCompleted"; step: TStep }
   | { type: "stepStarted"; step: TStep }
@@ -45,6 +54,7 @@ export function initialGenerationState<TStep extends string = string>(
     currentStep: null,
     error: null,
     errorKind: null,
+    limit: null,
     reconnectCount: 0,
     runId: null,
     startedSteps: [] as TStep[],
@@ -62,6 +72,14 @@ export function generationReducer<TStep extends string>(
       return { ...state, reconnectCount: state.reconnectCount + 1 };
     case "reset":
       return initialGenerationState<TStep>();
+    case "limitReached":
+      return {
+        ...state,
+        error: null,
+        errorKind: null,
+        limit: action.limit,
+        status: "limitReached",
+      };
     case "setError":
       return {
         ...state,
@@ -86,7 +104,11 @@ export function generationReducer<TStep extends string>(
           : [...state.startedSteps, action.step],
       };
     case "streamEnded":
-      if (state.status === "completed" || state.status === "error") {
+      if (
+        state.status === "completed" ||
+        state.status === "error" ||
+        state.status === "limitReached"
+      ) {
         return state;
       }
 
@@ -101,7 +123,7 @@ export function generationReducer<TStep extends string>(
       return { ...state, completionEntityId: action.entityId ?? null, status: "completed" };
 
     case "triggerStart":
-      return { ...state, error: null, errorKind: null, status: "triggering" };
+      return { ...state, error: null, errorKind: null, limit: null, status: "triggering" };
     case "triggerSuccess":
       return { ...state, runId: action.runId, status: "streaming" };
     default: {

--- a/apps/main/src/lib/workflow/generation-visitor.ts
+++ b/apps/main/src/lib/workflow/generation-visitor.ts
@@ -1,0 +1,24 @@
+import { isUuid } from "@zoonk/utils/uuid";
+
+const GENERATION_VISITOR_STORAGE_KEY = "zoonk:generation-visitor:v1";
+
+/**
+ * Persists a random browser identity for guest generation quotas. Storage can
+ * be unavailable in privacy modes, so callers fall back to the API's hashed
+ * request fingerprint by omitting the visitor header in that case.
+ */
+export function getGenerationVisitorId(): string | null {
+  try {
+    const storedVisitorId = globalThis.localStorage.getItem(GENERATION_VISITOR_STORAGE_KEY);
+
+    if (storedVisitorId && isUuid(storedVisitorId)) {
+      return storedVisitorId;
+    }
+
+    const visitorId = globalThis.crypto.randomUUID();
+    globalThis.localStorage.setItem(GENERATION_VISITOR_STORAGE_KEY, visitorId);
+    return visitorId;
+  } catch {
+    return null;
+  }
+}

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -1,10 +1,13 @@
 "use client";
 
+import { GENERATION_VISITOR_ID_HEADER } from "@zoonk/core/generation-quotas/contract";
 import { type StepStreamMessage } from "@zoonk/core/workflows/steps";
+import { safeAsync } from "@zoonk/utils/error";
 import { getString } from "@zoonk/utils/json";
 import { API_URL } from "@zoonk/utils/url";
 import { useCallback, useEffect, useEffectEvent, useReducer, useRef } from "react";
 import { getGenerationEventsUrl } from "./_utils/generation-events-url";
+import { getGenerationLimit } from "./_utils/generation-limit";
 import { getWorkflowAuthHeaders } from "./auth-headers";
 import {
   type GenerationAction,
@@ -15,6 +18,7 @@ import {
   initialGenerationState,
 } from "./generation-store";
 import { type GenerationTarget } from "./generation-target";
+import { getGenerationVisitorId } from "./generation-visitor";
 import { useSSE } from "./use-sse";
 
 const MAX_STREAM_RECONNECTS = 5;
@@ -30,9 +34,15 @@ function getGenerationTriggerRequest({
   authHeaders: Awaited<ReturnType<typeof getWorkflowAuthHeaders>>;
   target: GenerationTarget;
 }): RequestInit {
+  const visitorId = getGenerationVisitorId();
+
   return {
     body: JSON.stringify({ target }),
-    headers: { ...authHeaders, "Content-Type": "application/json" },
+    headers: {
+      ...authHeaders,
+      ...(visitorId ? { [GENERATION_VISITOR_ID_HEADER]: visitorId } : {}),
+      "Content-Type": "application/json",
+    },
     method: "POST",
   };
 }
@@ -151,6 +161,14 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
       );
 
       if (!response.ok) {
+        const { data } = await safeAsync<unknown>(() => response.json());
+        const limit = getGenerationLimit(data);
+
+        if (limit) {
+          dispatch({ limit, type: "limitReached" });
+          return;
+        }
+
         throw new Error("Failed to start generation");
       }
 
@@ -196,6 +214,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
     currentStep: state.currentStep,
     error: state.error,
     errorKind: state.errorKind,
+    limit: state.limit,
     retry,
     startedSteps: state.startedSteps,
     status: state.status,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,8 @@
     "./content/thumbnail": "./src/content/content-thumbnail.ts",
     "./courses/search": "./src/courses/search-courses.ts",
     "./feedback/send": "./src/feedback/send-feedback-message.ts",
+    "./generation-quotas/claim": "./src/generation-quotas/claim-generation-quota.ts",
+    "./generation-quotas/contract": "./src/generation-quotas/contract.ts",
     "./images/optimize": "./src/images/optimize-image.ts",
     "./images/upload": "./src/images/upload-image.ts",
     "./lessons/access": "./src/lessons/access.ts",

--- a/packages/core/src/courses/course-generation-access.test.ts
+++ b/packages/core/src/courses/course-generation-access.test.ts
@@ -16,6 +16,7 @@ describe(getCourseGenerationAccess, () => {
 
     await expect(getCourseGenerationAccess(prompt.id)).resolves.toStrictEqual({
       coursePromptId: prompt.id,
+      shouldClaimQuota: true,
       status: "ready",
       userId: user.id,
     });
@@ -26,8 +27,18 @@ describe(getCourseGenerationAccess, () => {
 
     await expect(getCourseGenerationAccess(prompt.id)).resolves.toStrictEqual({
       coursePromptId: prompt.id,
+      shouldClaimQuota: true,
       status: "ready",
       userId: null,
+    });
+  });
+
+  it("does not claim quota when a course generation is already running", async () => {
+    const prompt = await coursePromptFixture({ generationStatus: "running" });
+
+    await expect(getCourseGenerationAccess(prompt.id)).resolves.toMatchObject({
+      shouldClaimQuota: false,
+      status: "ready",
     });
   });
 

--- a/packages/core/src/courses/course-generation-access.ts
+++ b/packages/core/src/courses/course-generation-access.ts
@@ -2,6 +2,11 @@ import { getSession } from "../users/get-session";
 import { getCoursePromptGenerationError } from "./course-prompt-generation";
 import { getCoursePromptById } from "./get-course-prompt";
 
+/** Charges only workflow states that can perform new AI work; active and completed runs are resumptions. */
+function shouldClaimCourseGenerationQuota(generationStatus: string | null): boolean {
+  return generationStatus === "pending" || generationStatus === "failed";
+}
+
 /**
  * Validates one persisted generation request and derives the optional learner
  * identity from the authenticated session before a delivery app starts the
@@ -29,6 +34,7 @@ export async function getCourseGenerationAccess(coursePromptId: string) {
 
   return {
     coursePromptId: coursePrompt.id,
+    shouldClaimQuota: shouldClaimCourseGenerationQuota(coursePrompt.generationStatus),
     status: "ready" as const,
     userId: session?.user.id ?? null,
   };

--- a/packages/core/src/generation-quotas/claim-generation-quota.test.ts
+++ b/packages/core/src/generation-quotas/claim-generation-quota.test.ts
@@ -1,0 +1,312 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { headers } from "next/headers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getSession } from "../users/get-session";
+import { claimGenerationQuotaIfNeeded } from "./claim-generation-quota";
+import { GENERATION_VISITOR_ID_HEADER, type GenerationQuotaPeriod } from "./contract";
+
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
+vi.mock("../users/get-session", () => ({ getSession: vi.fn() }));
+
+/** Gives one test a distinct durable browser identity without sharing quota state with another test. */
+function useGuestViewer(): string {
+  const visitorId = randomUUID();
+  vi.mocked(headers).mockResolvedValue(new Headers({ [GENERATION_VISITOR_ID_HEADER]: visitorId }));
+  vi.mocked(getSession).mockResolvedValue(null);
+  return visitorId;
+}
+
+/** Uses the real subscription query while replacing only the request session boundary. */
+async function useAuthenticatedViewer({ subscriber }: { subscriber: boolean }) {
+  const user = await userFixture();
+  vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
+
+  if (subscriber) {
+    await prisma.subscription.create({
+      data: { plan: "plus", provider: "zoonk", referenceId: user.id, status: "active" },
+    });
+  }
+
+  return user;
+}
+
+/** Moves the counter created by a real claim near a boundary without issuing hundreds of requests. */
+async function setClaimCounter({
+  count,
+  period,
+  resource,
+  targetId,
+}: {
+  count: number;
+  period: GenerationQuotaPeriod;
+  resource: "chapter" | "course" | "lesson";
+  targetId: string;
+}) {
+  const claim = await prisma.generationQuotaClaim.findUniqueOrThrow({
+    where: { generationQuotaClaim: { resource, targetId } },
+  });
+
+  await prisma.generationQuotaCounter.updateMany({
+    data: { count },
+    where: { actorKey: claim.actorKey, period, resource },
+  });
+}
+
+/** Exercises the production quota boundary while keeping each test call explicit about new AI work. */
+function claimGenerationQuota({
+  resource,
+  targetId,
+}: {
+  resource: "chapter" | "course" | "lesson";
+  targetId: string;
+}) {
+  return claimGenerationQuotaIfNeeded({ resource, shouldClaimQuota: true, targetId });
+}
+
+describe(claimGenerationQuotaIfNeeded, () => {
+  beforeEach(() => {
+    useGuestViewer();
+  });
+
+  it("does not charge a workflow resume that creates no new content", async () => {
+    const targetId = randomUUID();
+
+    await expect(
+      claimGenerationQuotaIfNeeded({ resource: "course", shouldClaimQuota: false, targetId }),
+    ).resolves.toStrictEqual({ status: "ready" });
+
+    await expect(
+      prisma.generationQuotaClaim.findUnique({
+        where: { generationQuotaClaim: { resource: "course", targetId } },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("limits guests to three course generations per day", async () => {
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+      ),
+    );
+
+    expect(results.filter((result) => result.status === "ready")).toHaveLength(3);
+
+    expect(results.filter((result) => result.status === "limitReached")).toStrictEqual([
+      { limit: { period: "day", resource: "course", viewer: "guest" }, status: "limitReached" },
+    ]);
+  });
+
+  it("limits guests to ten course generations per month", async () => {
+    const firstTargetId = randomUUID();
+    await claimGenerationQuota({ resource: "course", targetId: firstTargetId });
+
+    await setClaimCounter({
+      count: 9,
+      period: "month",
+      resource: "course",
+      targetId: firstTargetId,
+    });
+
+    await expect(
+      claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({ status: "ready" });
+
+    await expect(
+      claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({
+      limit: { period: "month", resource: "course", viewer: "guest" },
+      status: "limitReached",
+    });
+  });
+
+  it("limits authenticated learners to five courses per day", async () => {
+    await useAuthenticatedViewer({ subscriber: false });
+    const firstTargetId = randomUUID();
+    await claimGenerationQuota({ resource: "course", targetId: firstTargetId });
+    await setClaimCounter({ count: 4, period: "day", resource: "course", targetId: firstTargetId });
+
+    await expect(
+      claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({ status: "ready" });
+
+    await expect(
+      claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({
+      limit: { period: "day", resource: "course", viewer: "authenticated" },
+      status: "limitReached",
+    });
+  });
+
+  it("limits subscribers to twenty courses per day", async () => {
+    await useAuthenticatedViewer({ subscriber: true });
+    const firstTargetId = randomUUID();
+    await claimGenerationQuota({ resource: "course", targetId: firstTargetId });
+
+    await setClaimCounter({
+      count: 19,
+      period: "day",
+      resource: "course",
+      targetId: firstTargetId,
+    });
+
+    await expect(
+      claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({ status: "ready" });
+
+    await expect(
+      claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({
+      limit: { period: "day", resource: "course", viewer: "subscriber" },
+      status: "limitReached",
+    });
+  });
+
+  it("limits chapter generation to fifty per day", async () => {
+    await useAuthenticatedViewer({ subscriber: true });
+    const firstTargetId = randomUUID();
+    await claimGenerationQuota({ resource: "chapter", targetId: firstTargetId });
+
+    await setClaimCounter({
+      count: 49,
+      period: "day",
+      resource: "chapter",
+      targetId: firstTargetId,
+    });
+
+    await expect(
+      claimGenerationQuota({ resource: "chapter", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({ status: "ready" });
+
+    await expect(
+      claimGenerationQuota({ resource: "chapter", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({
+      limit: { period: "day", resource: "chapter", viewer: "subscriber" },
+      status: "limitReached",
+    });
+  });
+
+  it.each([
+    { daily: 20, subscriber: false, viewer: "guest" as const },
+    { daily: 50, subscriber: false, viewer: "authenticated" as const },
+    { daily: 400, subscriber: true, viewer: "subscriber" as const },
+  ])("applies the $viewer daily lesson limit", async ({ daily, subscriber, viewer }) => {
+    if (viewer !== "guest") {
+      await useAuthenticatedViewer({ subscriber });
+    }
+
+    const firstTargetId = randomUUID();
+    await claimGenerationQuota({ resource: "lesson", targetId: firstTargetId });
+
+    await setClaimCounter({
+      count: daily - 1,
+      period: "day",
+      resource: "lesson",
+      targetId: firstTargetId,
+    });
+
+    await expect(
+      claimGenerationQuota({ resource: "lesson", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({ status: "ready" });
+
+    await expect(
+      claimGenerationQuota({ resource: "lesson", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({
+      limit: { period: "day", resource: "lesson", viewer },
+      status: "limitReached",
+    });
+  });
+
+  it.each([
+    {
+      monthly: 10,
+      resource: "course" as const,
+      subscriber: false,
+      viewer: "authenticated" as const,
+    },
+    { monthly: 60, resource: "course" as const, subscriber: true, viewer: "subscriber" as const },
+    {
+      monthly: 300,
+      resource: "lesson" as const,
+      subscriber: false,
+      viewer: "authenticated" as const,
+    },
+    { monthly: 5000, resource: "lesson" as const, subscriber: true, viewer: "subscriber" as const },
+  ])(
+    "limits $viewer $resource generation to $monthly per month",
+    async ({ monthly, resource, subscriber, viewer }) => {
+      await useAuthenticatedViewer({ subscriber });
+      const firstTargetId = randomUUID();
+      await claimGenerationQuota({ resource, targetId: firstTargetId });
+
+      await setClaimCounter({
+        count: monthly - 1,
+        period: "month",
+        resource,
+        targetId: firstTargetId,
+      });
+
+      await expect(
+        claimGenerationQuota({ resource, targetId: randomUUID() }),
+      ).resolves.toStrictEqual({ status: "ready" });
+
+      await expect(
+        claimGenerationQuota({ resource, targetId: randomUUID() }),
+      ).resolves.toStrictEqual({
+        limit: { period: "month", resource, viewer },
+        status: "limitReached",
+      });
+    },
+  );
+
+  it("keeps anonymous visitors on one network in separate quota buckets", async () => {
+    const networkAddress = "203.0.113.10";
+
+    vi.mocked(headers).mockResolvedValue(
+      new Headers({
+        [GENERATION_VISITOR_ID_HEADER]: randomUUID(),
+        "x-forwarded-for": networkAddress,
+      }),
+    );
+
+    const firstVisitorResults = await Promise.all(
+      Array.from({ length: 3 }, () =>
+        claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+      ),
+    );
+
+    expect(firstVisitorResults.every((result) => result.status === "ready")).toBe(true);
+
+    vi.mocked(headers).mockResolvedValue(
+      new Headers({
+        [GENERATION_VISITOR_ID_HEADER]: randomUUID(),
+        "x-forwarded-for": networkAddress,
+      }),
+    );
+
+    await expect(
+      claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({ status: "ready" });
+  });
+
+  it("does not charge duplicate requests for the same target twice", async () => {
+    const targetId = randomUUID();
+
+    const [first, duplicate] = await Promise.all([
+      claimGenerationQuota({ resource: "course", targetId }),
+      claimGenerationQuota({ resource: "course", targetId }),
+    ]);
+
+    expect(first).toStrictEqual({ status: "ready" });
+    expect(duplicate).toStrictEqual({ status: "ready" });
+
+    const claim = await prisma.generationQuotaClaim.findUniqueOrThrow({
+      where: { generationQuotaClaim: { resource: "course", targetId } },
+    });
+
+    await expect(
+      prisma.generationQuotaCounter.findMany({ where: { actorKey: claim.actorKey, count: 1 } }),
+    ).resolves.toHaveLength(2);
+  });
+});

--- a/packages/core/src/generation-quotas/claim-generation-quota.ts
+++ b/packages/core/src/generation-quotas/claim-generation-quota.ts
@@ -1,0 +1,185 @@
+import "server-only";
+import { type TransactionClient, prisma } from "@zoonk/db";
+import {
+  type GenerationQuotaLimit,
+  type GenerationQuotaResource,
+  type GenerationQuotaResult,
+  type GenerationQuotaViewer,
+} from "./contract";
+import { getGenerationQuotaRules } from "./limits";
+import { getGenerationQuotaViewer } from "./viewer";
+
+type GenerationQuotaRule = ReturnType<typeof getGenerationQuotaRules>[number];
+type ReachedLimitSignal = { limit: GenerationQuotaLimit; type: symbol };
+
+const REACHED_LIMIT = Symbol("generation quota reached");
+
+/** Creates the transaction-local signal used to roll back every counter when any required period is full. */
+function getReachedLimitSignal({
+  period,
+  resource,
+  viewer,
+}: {
+  period: GenerationQuotaRule["period"];
+  resource: GenerationQuotaResource;
+  viewer: GenerationQuotaViewer;
+}): ReachedLimitSignal {
+  return { limit: { period, resource, viewer }, type: REACHED_LIMIT };
+}
+
+/** Distinguishes an expected quota rollback from database and infrastructure failures that must propagate. */
+function isReachedLimitSignal(error: unknown): error is ReachedLimitSignal {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "type" in error &&
+    error.type === REACHED_LIMIT &&
+    "limit" in error
+  );
+}
+
+/** Creates missing period buckets before conditional increments acquire their row locks. */
+async function ensureQuotaCounters({
+  actorKey,
+  resource,
+  rules,
+  transaction,
+}: {
+  actorKey: string;
+  resource: GenerationQuotaResource;
+  rules: GenerationQuotaRule[];
+  transaction: TransactionClient;
+}) {
+  await transaction.generationQuotaCounter.createMany({
+    data: rules.map((rule) => ({
+      actorKey,
+      period: rule.period,
+      periodStart: rule.periodStart,
+      resource,
+    })),
+    skipDuplicates: true,
+  });
+}
+
+/** Increments only counters still below their entitlement and returns each conditional update result. */
+async function incrementQuotaCounters({
+  actorKey,
+  resource,
+  rules,
+  transaction,
+}: {
+  actorKey: string;
+  resource: GenerationQuotaResource;
+  rules: GenerationQuotaRule[];
+  transaction: TransactionClient;
+}) {
+  return Promise.all(
+    rules.map((rule) =>
+      transaction.generationQuotaCounter.updateMany({
+        data: { count: { increment: 1 } },
+        where: {
+          actorKey,
+          count: { lt: rule.limit },
+          period: rule.period,
+          periodStart: rule.periodStart,
+          resource,
+        },
+      }),
+    ),
+  );
+}
+
+/**
+ * Claims the target once globally, then increments its daily and monthly
+ * counters in one transaction. A duplicate target returns ready without
+ * charging again, which keeps browser retries and duplicate workflow starts
+ * idempotent.
+ */
+async function claimQuotaInTransaction({
+  actorKey,
+  resource,
+  rules,
+  targetId,
+  transaction,
+  viewer,
+}: {
+  actorKey: string;
+  resource: GenerationQuotaResource;
+  rules: GenerationQuotaRule[];
+  targetId: string;
+  transaction: TransactionClient;
+  viewer: GenerationQuotaViewer;
+}): Promise<GenerationQuotaResult> {
+  const claim = await transaction.generationQuotaClaim.createMany({
+    data: [{ actorKey, resource, targetId }],
+    skipDuplicates: true,
+  });
+
+  if (claim.count === 0) {
+    return { status: "ready" };
+  }
+
+  await ensureQuotaCounters({ actorKey, resource, rules, transaction });
+  const increments = await incrementQuotaCounters({ actorKey, resource, rules, transaction });
+  const blockedRuleIndex = increments.findIndex((increment) => increment.count === 0);
+
+  if (blockedRuleIndex !== -1) {
+    const blockedRule = rules[blockedRuleIndex];
+
+    if (!blockedRule) {
+      throw new Error("Generation quota update did not match a configured rule");
+    }
+
+    throw new Error("Generation quota reached", {
+      cause: getReachedLimitSignal({ period: blockedRule.period, resource, viewer }),
+    });
+  }
+
+  return { status: "ready" };
+}
+
+/**
+ * Atomically claims one newly generated target for the current viewer. UTC
+ * calendar buckets make the reset behavior deterministic across API regions.
+ */
+async function claimGenerationQuota({
+  now = new Date(),
+  resource,
+  targetId,
+}: {
+  now?: Date;
+  resource: GenerationQuotaResource;
+  targetId: string;
+}): Promise<GenerationQuotaResult> {
+  const { actorKey, viewer } = await getGenerationQuotaViewer();
+  const rules = getGenerationQuotaRules({ now, resource, viewer });
+
+  try {
+    return await prisma.$transaction((transaction) =>
+      claimQuotaInTransaction({ actorKey, resource, rules, targetId, transaction, viewer }),
+    );
+  } catch (error) {
+    if (error instanceof Error && isReachedLimitSignal(error.cause)) {
+      return { limit: error.cause.limit, status: "limitReached" };
+    }
+
+    throw error;
+  }
+}
+
+/** Keeps status-only workflow resumes outside quota accounting at every transport boundary. */
+export async function claimGenerationQuotaIfNeeded({
+  resource,
+  shouldClaimQuota,
+  targetId,
+}: {
+  resource: GenerationQuotaResource;
+  shouldClaimQuota: boolean;
+  targetId: string;
+}): Promise<GenerationQuotaResult> {
+  if (!shouldClaimQuota) {
+    return { status: "ready" };
+  }
+
+  return claimGenerationQuota({ resource, targetId });
+}

--- a/packages/core/src/generation-quotas/contract.ts
+++ b/packages/core/src/generation-quotas/contract.ts
@@ -1,0 +1,15 @@
+export const GENERATION_VISITOR_ID_HEADER = "X-Generation-Visitor-Id";
+
+export type GenerationQuotaPeriod = "day" | "month";
+export type GenerationQuotaResource = "chapter" | "course" | "lesson";
+export type GenerationQuotaViewer = "authenticated" | "guest" | "subscriber";
+
+export type GenerationQuotaLimit = {
+  period: GenerationQuotaPeriod;
+  resource: GenerationQuotaResource;
+  viewer: GenerationQuotaViewer;
+};
+
+export type GenerationQuotaResult =
+  | { status: "ready" }
+  | { limit: GenerationQuotaLimit; status: "limitReached" };

--- a/packages/core/src/generation-quotas/limits.ts
+++ b/packages/core/src/generation-quotas/limits.ts
@@ -1,0 +1,74 @@
+import {
+  type GenerationQuotaPeriod,
+  type GenerationQuotaResource,
+  type GenerationQuotaViewer,
+} from "./contract";
+
+type PeriodLimits = Partial<Record<GenerationQuotaPeriod, number>>;
+type ResourceLimits = Record<GenerationQuotaResource, PeriodLimits>;
+type GenerationQuotaRule = { limit: number; period: GenerationQuotaPeriod; periodStart: Date };
+
+const GENERATION_LIMITS: Record<GenerationQuotaViewer, ResourceLimits> = {
+  authenticated: {
+    chapter: { day: 50 },
+    course: { day: 5, month: 10 },
+    lesson: { day: 50, month: 300 },
+  },
+  guest: { chapter: { day: 50 }, course: { day: 3, month: 10 }, lesson: { day: 20 } },
+  subscriber: {
+    chapter: { day: 50 },
+    course: { day: 20, month: 60 },
+    lesson: { day: 400, month: 5000 },
+  },
+};
+
+const QUOTA_PERIODS = ["day", "month"] as const;
+
+/** Uses UTC calendar boundaries so every API region increments the same daily and monthly buckets. */
+function getGenerationQuotaPeriodStart({
+  now,
+  period,
+}: {
+  now: Date;
+  period: GenerationQuotaPeriod;
+}): Date {
+  if (period === "day") {
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  }
+
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+}
+
+/** Omits unsupported periods instead of inventing a monthly limit for resources that only have a daily cap. */
+function getGenerationQuotaRule({
+  limits,
+  now,
+  period,
+}: {
+  limits: PeriodLimits;
+  now: Date;
+  period: GenerationQuotaPeriod;
+}): GenerationQuotaRule[] {
+  const limit = limits[period];
+
+  if (limit === undefined) {
+    return [];
+  }
+
+  return [{ limit, period, periodStart: getGenerationQuotaPeriodStart({ now, period }) }];
+}
+
+/** Resolves the exact counters one generation must increment for the viewer's current entitlement. */
+export function getGenerationQuotaRules({
+  now,
+  resource,
+  viewer,
+}: {
+  now: Date;
+  resource: GenerationQuotaResource;
+  viewer: GenerationQuotaViewer;
+}): GenerationQuotaRule[] {
+  const limits = GENERATION_LIMITS[viewer][resource];
+
+  return QUOTA_PERIODS.flatMap((period) => getGenerationQuotaRule({ limits, now, period }));
+}

--- a/packages/core/src/generation-quotas/viewer.ts
+++ b/packages/core/src/generation-quotas/viewer.ts
@@ -1,0 +1,60 @@
+import "server-only";
+import { createHash } from "node:crypto";
+import { isUuid } from "@zoonk/utils/uuid";
+import { headers } from "next/headers";
+import { hasActiveSubscription } from "../auth/subscription";
+import { getSession } from "../users/get-session";
+import { GENERATION_VISITOR_ID_HEADER, type GenerationQuotaViewer } from "./contract";
+
+type GenerationQuotaViewerContext = { actorKey: string; viewer: GenerationQuotaViewer };
+
+/** Selects the original client address while keeping proxy header parsing out of the stored quota key. */
+function getClientAddress(requestHeaders: Headers): string {
+  const forwardedAddress = requestHeaders.get("x-forwarded-for")?.split(",")[0]?.trim();
+
+  return (
+    requestHeaders.get("cf-connecting-ip") ??
+    requestHeaders.get("x-real-ip") ??
+    forwardedAddress ??
+    "unknown"
+  );
+}
+
+/**
+ * Provides a privacy-preserving fallback for API clients that do not persist a
+ * visitor ID. The database never receives a raw IP address or user-agent value.
+ */
+function getRequestFingerprint(requestHeaders: Headers): string {
+  const fingerprintParts = [
+    getClientAddress(requestHeaders),
+    requestHeaders.get("user-agent") ?? "unknown",
+    requestHeaders.get("accept-language") ?? "unknown",
+    requestHeaders.get("sec-ch-ua-platform") ?? "unknown",
+  ];
+
+  return createHash("sha256").update(fingerprintParts.join("\n")).digest("hex");
+}
+
+/** Prefers the browser's durable random ID so unrelated learners on one shared network keep separate quotas. */
+function getGuestActorKey(requestHeaders: Headers): string {
+  const visitorId = requestHeaders.get(GENERATION_VISITOR_ID_HEADER);
+
+  if (visitorId && isUuid(visitorId)) {
+    return `guest:${visitorId}`;
+  }
+
+  return `request:${getRequestFingerprint(requestHeaders)}`;
+}
+
+/** Derives identity and entitlement from the request instead of trusting a caller-selected user or plan. */
+export async function getGenerationQuotaViewer(): Promise<GenerationQuotaViewerContext> {
+  const [requestHeaders, session] = await Promise.all([headers(), getSession()]);
+
+  if (!session) {
+    return { actorKey: getGuestActorKey(requestHeaders), viewer: "guest" };
+  }
+
+  const viewer = (await hasActiveSubscription()) ? "subscriber" : "authenticated";
+
+  return { actorKey: `user:${session.user.id}`, viewer };
+}

--- a/packages/core/src/workflows/chapter-generation-access.ts
+++ b/packages/core/src/workflows/chapter-generation-access.ts
@@ -2,6 +2,16 @@ import "server-only";
 import { hasActiveSubscription } from "../auth/subscription";
 import { getChapterForGeneration } from "../chapters/get-chapter-for-generation";
 
+/** A pending row with saved lessons is a status repair, while running and completed rows are resumptions. */
+function shouldClaimChapterGenerationQuota(
+  chapter: NonNullable<Awaited<ReturnType<typeof getChapterForGeneration>>>,
+): boolean {
+  const canGenerate =
+    chapter.generationStatus === "pending" || chapter.generationStatus === "failed";
+
+  return canGenerate && chapter._count.lessons === 0;
+}
+
 /**
  * Applies the existing first-chapter subscription rule to an AI-owned chapter
  * before a delivery app starts its generation workflow.
@@ -17,7 +27,11 @@ export async function getChapterGenerationAccess(chapterId: string) {
     return { chapter, status: "subscriptionRequired" as const };
   }
 
-  return { chapter, status: "ready" as const };
+  return {
+    chapter,
+    shouldClaimQuota: shouldClaimChapterGenerationQuota(chapter),
+    status: "ready" as const,
+  };
 }
 
 /**

--- a/packages/core/src/workflows/generation-access.test.ts
+++ b/packages/core/src/workflows/generation-access.test.ts
@@ -25,11 +25,20 @@ describe("generation access", () => {
   beforeEach(() => vi.mocked(getSession).mockResolvedValue(null));
 
   it("allows guests to generate the free first chapter", async () => {
-    const chapter = await chapterFixture({ courseId, organizationId, position: 0 });
+    const chapter = await chapterFixture({
+      courseId,
+      generationStatus: "pending",
+      organizationId,
+      position: 0,
+    });
 
     const result = await getChapterGenerationAccess(chapter.id);
 
-    expect(result).toMatchObject({ chapter: { id: chapter.id }, status: "ready" });
+    expect(result).toMatchObject({
+      chapter: { id: chapter.id },
+      shouldClaimQuota: true,
+      status: "ready",
+    });
   });
 
   it("requires a subscription for later chapters", async () => {
@@ -49,6 +58,7 @@ describe("generation access", () => {
 
     const lesson = await lessonFixture({
       chapterId: chapter.id,
+      generationStatus: "pending",
       kind: "explanation",
       organizationId,
     });
@@ -61,7 +71,37 @@ describe("generation access", () => {
 
     const result = await getLessonGenerationAccess(lesson.id);
 
-    expect(result).toMatchObject({ lesson: { id: lesson.id }, status: "ready" });
+    expect(result).toMatchObject({
+      lesson: { id: lesson.id },
+      shouldClaimQuota: true,
+      status: "ready",
+    });
+  });
+
+  it("does not claim quota for chapter and lesson no-op repairs", async () => {
+    const repairCourse = await courseFixture({ organizationId });
+
+    const chapter = await chapterFixture({
+      courseId: repairCourse.id,
+      generationStatus: "pending",
+      organizationId,
+      position: 0,
+    });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "completed",
+      kind: "explanation",
+      organizationId,
+    });
+
+    const [chapterAccess, lessonAccess] = await Promise.all([
+      getChapterGenerationAccess(chapter.id),
+      getLessonGenerationAccess(lesson.id),
+    ]);
+
+    expect(chapterAccess).toMatchObject({ shouldClaimQuota: false, status: "ready" });
+    expect(lessonAccess).toMatchObject({ shouldClaimQuota: false, status: "ready" });
   });
 
   it("requires a subscription for later lessons when the learner is not subscribed", async () => {

--- a/packages/core/src/workflows/lesson-generation-access.ts
+++ b/packages/core/src/workflows/lesson-generation-access.ts
@@ -3,6 +3,17 @@ import { getLessonAccessRequirement } from "../lessons/access";
 import { isStandaloneGeneratedLessonKind } from "../lessons/generated-companion-kinds";
 import { getLessonForGeneration } from "../lessons/get-lesson-for-generation";
 
+/** A pending row with saved steps is repaired without AI work; failed rows regenerate their partial content. */
+function shouldClaimLessonGenerationQuota(
+  lesson: NonNullable<Awaited<ReturnType<typeof getLessonForGeneration>>>,
+): boolean {
+  if (lesson.generationStatus === "failed") {
+    return true;
+  }
+
+  return lesson.generationStatus === "pending" && lesson._count.steps === 0;
+}
+
 /**
  * Applies AI ownership, standalone-kind, and chapter subscription rules before
  * a delivery app starts lesson generation or preloading.
@@ -20,5 +31,9 @@ export async function getLessonGenerationAccess(lessonId: string) {
     return { status: "subscriptionRequired" as const };
   }
 
-  return { lesson, status: "ready" as const };
+  return {
+    lesson,
+    shouldClaimQuota: shouldClaimLessonGenerationQuota(lesson),
+    status: "ready" as const,
+  };
 }

--- a/packages/db/src/prisma/enums.prisma
+++ b/packages/db/src/prisma/enums.prisma
@@ -5,6 +5,17 @@ enum GenerationStatus {
   failed
 }
 
+enum GenerationQuotaPeriod {
+  day
+  month
+}
+
+enum GenerationQuotaResource {
+  course
+  chapter
+  lesson
+}
+
 enum LessonKind {
   alphabet
   custom

--- a/packages/db/src/prisma/migrations/20260813091213_add_generation_quotas/migration.sql
+++ b/packages/db/src/prisma/migrations/20260813091213_add_generation_quotas/migration.sql
@@ -1,0 +1,42 @@
+-- CreateEnum
+CREATE TYPE "GenerationQuotaPeriod" AS ENUM ('day', 'month');
+
+-- CreateEnum
+CREATE TYPE "GenerationQuotaResource" AS ENUM ('course', 'chapter', 'lesson');
+
+-- CreateTable
+CREATE TABLE "generation_quota_counters" (
+    "id" UUID NOT NULL DEFAULT uuidv7(),
+    "actor_key" VARCHAR(80) NOT NULL,
+    "resource" "GenerationQuotaResource" NOT NULL,
+    "period" "GenerationQuotaPeriod" NOT NULL,
+    "period_start" TIMESTAMP(3) NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "generation_quota_counters_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "generation_quota_claims" (
+    "id" UUID NOT NULL DEFAULT uuidv7(),
+    "actor_key" VARCHAR(80) NOT NULL,
+    "resource" "GenerationQuotaResource" NOT NULL,
+    "target_id" UUID NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "generation_quota_claims_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "generation_quota_counters_period_start_idx" ON "generation_quota_counters"("period_start");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "generation_quota_counters_actor_key_resource_period_period__key" ON "generation_quota_counters"("actor_key", "resource", "period", "period_start");
+
+-- CreateIndex
+CREATE INDEX "generation_quota_claims_actor_key_created_at_idx" ON "generation_quota_claims"("actor_key", "created_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "generation_quota_claims_resource_target_id_key" ON "generation_quota_claims"("resource", "target_id");

--- a/packages/db/src/prisma/models/generation-quotas.prisma
+++ b/packages/db/src/prisma/models/generation-quotas.prisma
@@ -1,0 +1,26 @@
+model GenerationQuotaCounter {
+  id          String                  @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  actorKey    String                  @map("actor_key") @db.VarChar(80)
+  resource    GenerationQuotaResource
+  period      GenerationQuotaPeriod
+  periodStart DateTime                @map("period_start")
+  count       Int                     @default(0)
+  createdAt   DateTime                @default(now()) @map("created_at")
+  updatedAt   DateTime                @default(now()) @updatedAt @map("updated_at")
+
+  @@unique([actorKey, resource, period, periodStart], name: "generationQuotaCounter")
+  @@index([periodStart])
+  @@map("generation_quota_counters")
+}
+
+model GenerationQuotaClaim {
+  id        String                  @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  actorKey  String                  @map("actor_key") @db.VarChar(80)
+  resource  GenerationQuotaResource
+  targetId  String                  @map("target_id") @db.Uuid
+  createdAt DateTime                @default(now()) @map("created_at")
+
+  @@unique([resource, targetId], name: "generationQuotaClaim")
+  @@index([actorKey, createdAt])
+  @@map("generation_quota_claims")
+}


### PR DESCRIPTION
## Summary

- enforce daily and monthly generation limits for courses, chapters, and lessons
- identify anonymous visitors without relying on IP alone and preserve access to generated content
- show entitlement-specific login, subscription, or support actions when limits are reached
- protect background preload generation and document structured 429 responses