### PR TITLE
fix(core): prevent guest generation limit resets

### DIFF
--- a/packages/core/src/generation-quotas/claim-generation-quota.test.ts
+++ b/packages/core/src/generation-quotas/claim-generation-quota.test.ts
@@ -10,10 +10,33 @@ import { GENERATION_VISITOR_ID_HEADER, type GenerationQuotaPeriod } from "./cont
 vi.mock("next/headers", () => ({ headers: vi.fn() }));
 vi.mock("../users/get-session", () => ({ getSession: vi.fn() }));
 
+/** Creates a valid documentation-range address so repeated test runs never reuse a request quota. */
+function getUniqueNetworkAddress(): string {
+  const addressId = randomUUID().replaceAll("-", "");
+
+  return [
+    "2001",
+    "db8",
+    addressId.slice(0, 4),
+    addressId.slice(4, 8),
+    addressId.slice(8, 12),
+    addressId.slice(12, 16),
+    addressId.slice(16, 20),
+    addressId.slice(20, 24),
+  ].join(":");
+}
+
 /** Gives one test a distinct durable browser identity without sharing quota state with another test. */
 function useGuestViewer(): string {
   const visitorId = randomUUID();
-  vi.mocked(headers).mockResolvedValue(new Headers({ [GENERATION_VISITOR_ID_HEADER]: visitorId }));
+
+  vi.mocked(headers).mockResolvedValue(
+    new Headers({
+      [GENERATION_VISITOR_ID_HEADER]: visitorId,
+      "x-vercel-forwarded-for": getUniqueNetworkAddress(),
+    }),
+  );
+
   vi.mocked(getSession).mockResolvedValue(null);
   return visitorId;
 }
@@ -260,13 +283,13 @@ describe(claimGenerationQuotaIfNeeded, () => {
     },
   );
 
-  it("keeps anonymous visitors on one network in separate quota buckets", async () => {
-    const networkAddress = "203.0.113.10";
+  it("does not reset a guest quota when a private window creates a new visitor ID", async () => {
+    const networkAddress = getUniqueNetworkAddress();
 
     vi.mocked(headers).mockResolvedValue(
       new Headers({
         [GENERATION_VISITOR_ID_HEADER]: randomUUID(),
-        "x-forwarded-for": networkAddress,
+        "x-vercel-forwarded-for": networkAddress,
       }),
     );
 
@@ -281,13 +304,51 @@ describe(claimGenerationQuotaIfNeeded, () => {
     vi.mocked(headers).mockResolvedValue(
       new Headers({
         [GENERATION_VISITOR_ID_HEADER]: randomUUID(),
-        "x-forwarded-for": networkAddress,
+        "x-vercel-forwarded-for": networkAddress,
       }),
     );
 
     await expect(
       claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
-    ).resolves.toStrictEqual({ status: "ready" });
+    ).resolves.toStrictEqual({
+      limit: { period: "day", resource: "course", viewer: "guest" },
+      status: "limitReached",
+    });
+  });
+
+  it("does not reset a guest quota when the same browser changes networks", async () => {
+    const visitorId = randomUUID();
+    const firstNetworkAddress = getUniqueNetworkAddress();
+    const secondNetworkAddress = getUniqueNetworkAddress();
+
+    vi.mocked(headers).mockResolvedValue(
+      new Headers({
+        [GENERATION_VISITOR_ID_HEADER]: visitorId,
+        "x-vercel-forwarded-for": firstNetworkAddress,
+      }),
+    );
+
+    const firstNetworkResults = await Promise.all(
+      Array.from({ length: 3 }, () =>
+        claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+      ),
+    );
+
+    expect(firstNetworkResults.every((result) => result.status === "ready")).toBe(true);
+
+    vi.mocked(headers).mockResolvedValue(
+      new Headers({
+        [GENERATION_VISITOR_ID_HEADER]: visitorId,
+        "x-vercel-forwarded-for": secondNetworkAddress,
+      }),
+    );
+
+    await expect(
+      claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
+    ).resolves.toStrictEqual({
+      limit: { period: "day", resource: "course", viewer: "guest" },
+      status: "limitReached",
+    });
   });
 
   it("does not charge duplicate requests for the same target twice", async () => {

--- a/packages/core/src/generation-quotas/claim-generation-quota.ts
+++ b/packages/core/src/generation-quotas/claim-generation-quota.ts
@@ -10,6 +10,7 @@ import { getGenerationQuotaRules } from "./limits";
 import { getGenerationQuotaViewer } from "./viewer";
 
 type GenerationQuotaRule = ReturnType<typeof getGenerationQuotaRules>[number];
+type GenerationQuotaCounterTarget = { actorKey: string; rule: GenerationQuotaRule };
 type ReachedLimitSignal = { limit: GenerationQuotaLimit; type: symbol };
 
 const REACHED_LIMIT = Symbol("generation quota reached");
@@ -38,55 +39,88 @@ function isReachedLimitSignal(error: unknown): error is ReachedLimitSignal {
   );
 }
 
+/** Expands every identity and period into the counters one generation must claim together. */
+function getQuotaCounterTargets({
+  actorKeys,
+  rules,
+}: {
+  actorKeys: string[];
+  rules: GenerationQuotaRule[];
+}): GenerationQuotaCounterTarget[] {
+  return actorKeys.flatMap((actorKey) => rules.map((rule) => ({ actorKey, rule })));
+}
+
 /** Creates missing period buckets before conditional increments acquire their row locks. */
 async function ensureQuotaCounters({
-  actorKey,
+  counterTargets,
   resource,
-  rules,
   transaction,
 }: {
-  actorKey: string;
+  counterTargets: GenerationQuotaCounterTarget[];
   resource: GenerationQuotaResource;
-  rules: GenerationQuotaRule[];
   transaction: TransactionClient;
 }) {
   await transaction.generationQuotaCounter.createMany({
-    data: rules.map((rule) => ({
-      actorKey,
-      period: rule.period,
-      periodStart: rule.periodStart,
+    data: counterTargets.map((target) => ({
+      actorKey: target.actorKey,
+      period: target.rule.period,
+      periodStart: target.rule.periodStart,
       resource,
     })),
     skipDuplicates: true,
   });
 }
 
-/** Increments only counters still below their entitlement and returns each conditional update result. */
-async function incrementQuotaCounters({
-  actorKey,
+/** Conditionally increments one identity-period counter and keeps its rule beside the result. */
+async function incrementQuotaCounter({
+  counterTarget,
   resource,
-  rules,
   transaction,
 }: {
-  actorKey: string;
+  counterTarget: GenerationQuotaCounterTarget;
   resource: GenerationQuotaResource;
-  rules: GenerationQuotaRule[];
+  transaction: TransactionClient;
+}) {
+  const increment = await transaction.generationQuotaCounter.updateMany({
+    data: { count: { increment: 1 } },
+    where: {
+      actorKey: counterTarget.actorKey,
+      count: { lt: counterTarget.rule.limit },
+      period: counterTarget.rule.period,
+      periodStart: counterTarget.rule.periodStart,
+      resource,
+    },
+  });
+
+  return { increment, rule: counterTarget.rule };
+}
+
+/** Increments only counters still below their entitlement and returns each conditional update result. */
+async function incrementQuotaCounters({
+  counterTargets,
+  resource,
+  transaction,
+}: {
+  counterTargets: GenerationQuotaCounterTarget[];
+  resource: GenerationQuotaResource;
   transaction: TransactionClient;
 }) {
   return Promise.all(
-    rules.map((rule) =>
-      transaction.generationQuotaCounter.updateMany({
-        data: { count: { increment: 1 } },
-        where: {
-          actorKey,
-          count: { lt: rule.limit },
-          period: rule.period,
-          periodStart: rule.periodStart,
-          resource,
-        },
-      }),
+    counterTargets.map((counterTarget) =>
+      incrementQuotaCounter({ counterTarget, resource, transaction }),
     ),
   );
+}
+
+/** Keeps the durable claim row tied to one stable identity while all identities share its idempotency. */
+function getPrimaryActorKey(actorKeys: string[]): string {
+  const actorKey = actorKeys[0];
+
+  if (!actorKey) {
+    throw new Error("Generation quota requires at least one actor identity");
+  }
+
+  return actorKey;
 }
 
 /**
@@ -96,20 +130,22 @@ async function incrementQuotaCounters({
  * idempotent.
  */
 async function claimQuotaInTransaction({
-  actorKey,
+  actorKeys,
   resource,
   rules,
   targetId,
   transaction,
   viewer,
 }: {
-  actorKey: string;
+  actorKeys: string[];
   resource: GenerationQuotaResource;
   rules: GenerationQuotaRule[];
   targetId: string;
   transaction: TransactionClient;
   viewer: GenerationQuotaViewer;
 }): Promise<GenerationQuotaResult> {
+  const actorKey = getPrimaryActorKey(actorKeys);
+
   const claim = await transaction.generationQuotaClaim.createMany({
     data: [{ actorKey, resource, targetId }],
     skipDuplicates: true,
@@ -119,19 +155,14 @@ async function claimQuotaInTransaction({
     return { status: "ready" };
   }
 
-  await ensureQuotaCounters({ actorKey, resource, rules, transaction });
-  const increments = await incrementQuotaCounters({ actorKey, resource, rules, transaction });
-  const blockedRuleIndex = increments.findIndex((increment) => increment.count === 0);
+  const counterTargets = getQuotaCounterTargets({ actorKeys, rules });
+  await ensureQuotaCounters({ counterTargets, resource, transaction });
+  const increments = await incrementQuotaCounters({ counterTargets, resource, transaction });
+  const blockedIncrement = increments.find(({ increment }) => increment.count === 0);
 
-  if (blockedRuleIndex !== -1) {
-    const blockedRule = rules[blockedRuleIndex];
-
-    if (!blockedRule) {
-      throw new Error("Generation quota update did not match a configured rule");
-    }
-
+  if (blockedIncrement) {
     throw new Error("Generation quota reached", {
-      cause: getReachedLimitSignal({ period: blockedRule.period, resource, viewer }),
+      cause: getReachedLimitSignal({ period: blockedIncrement.rule.period, resource, viewer }),
     });
   }
 
@@ -151,12 +182,12 @@ async function claimGenerationQuota({
   resource: GenerationQuotaResource;
   targetId: string;
 }): Promise<GenerationQuotaResult> {
-  const { actorKey, viewer } = await getGenerationQuotaViewer();
+  const { actorKeys, viewer } = await getGenerationQuotaViewer();
   const rules = getGenerationQuotaRules({ now, resource, viewer });
 
   try {
     return await prisma.$transaction((transaction) =>
-      claimQuotaInTransaction({ actorKey, resource, rules, targetId, transaction, viewer }),
+      claimQuotaInTransaction({ actorKeys, resource, rules, targetId, transaction, viewer }),
     );
   } catch (error) {
     if (error instanceof Error && isReachedLimitSignal(error.cause)) {

--- a/packages/core/src/generation-quotas/viewer.ts
+++ b/packages/core/src/generation-quotas/viewer.ts
@@ -6,16 +6,17 @@ import { hasActiveSubscription } from "../auth/subscription";
 import { getSession } from "../users/get-session";
 import { GENERATION_VISITOR_ID_HEADER, type GenerationQuotaViewer } from "./contract";
 
-type GenerationQuotaViewerContext = { actorKey: string; viewer: GenerationQuotaViewer };
+type GenerationQuotaViewerContext = { actorKeys: string[]; viewer: GenerationQuotaViewer };
 
 /** Selects the original client address while keeping proxy header parsing out of the stored quota key. */
 function getClientAddress(requestHeaders: Headers): string {
   const forwardedAddress = requestHeaders.get("x-forwarded-for")?.split(",")[0]?.trim();
 
   return (
-    requestHeaders.get("cf-connecting-ip") ??
-    requestHeaders.get("x-real-ip") ??
+    requestHeaders.get("x-vercel-forwarded-for") ??
     forwardedAddress ??
+    requestHeaders.get("x-real-ip") ??
+    requestHeaders.get("cf-connecting-ip") ??
     "unknown"
   );
 }
@@ -35,15 +36,20 @@ function getRequestFingerprint(requestHeaders: Headers): string {
   return createHash("sha256").update(fingerprintParts.join("\n")).digest("hex");
 }
 
-/** Prefers the browser's durable random ID so unrelated learners on one shared network keep separate quotas. */
-function getGuestActorKey(requestHeaders: Headers): string {
+/**
+ * Enforces both a durable browser quota and a request-fingerprint quota. A
+ * private window can replace browser storage, but it still shares the second
+ * identity while the browser and connection signals remain the same.
+ */
+function getGuestActorKeys(requestHeaders: Headers): string[] {
   const visitorId = requestHeaders.get(GENERATION_VISITOR_ID_HEADER);
+  const requestActorKey = `request:${getRequestFingerprint(requestHeaders)}`;
 
   if (visitorId && isUuid(visitorId)) {
-    return `guest:${visitorId}`;
+    return [`guest:${visitorId}`, requestActorKey];
   }
 
-  return `request:${getRequestFingerprint(requestHeaders)}`;
+  return [requestActorKey];
 }
 
 /** Derives identity and entitlement from the request instead of trusting a caller-selected user or plan. */
@@ -51,10 +57,10 @@ export async function getGenerationQuotaViewer(): Promise<GenerationQuotaViewerC
   const [requestHeaders, session] = await Promise.all([headers(), getSession()]);
 
   if (!session) {
-    return { actorKey: getGuestActorKey(requestHeaders), viewer: "guest" };
+    return { actorKeys: getGuestActorKeys(requestHeaders), viewer: "guest" };
   }
 
   const viewer = (await hasActiveSubscription()) ? "subscriber" : "authenticated";
 
-  return { actorKey: `user:${session.user.id}`, viewer };
+  return { actorKeys: [`user:${session.user.id}`], viewer };
 }


### PR DESCRIPTION
Enforces anonymous generation quotas against both the durable browser identity and a hashed request fingerprint, preventing private windows from resetting the allowance while preserving browser-based limits across network changes.

Adds regression coverage for both identity paths.