### PR TITLE
fix(main): prevent learn suggestion hydration errors

### DIFF
--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -170,13 +170,18 @@ async function cacheExistingCoursePrompt(rawPrompt: string) {
 }
 
 test.describe("Learn Form", () => {
-  test("shows form with auto-focused input", async ({ page }) => {
+  test("hydrates form with auto-focused input without errors", async ({ page }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (error) => pageErrors.push(error));
+
     await page.goto("/start/learn");
 
     await expect(page.getByRole("heading", { name: /what do you want to learn/iu })).toBeVisible();
 
     const input = page.getByRole("textbox");
     await expect(input).toBeFocused();
+    await page.waitForLoadState("networkidle");
+    expect(pageErrors).toEqual([]);
   });
 
   test("submits by button and shows its pending state while the prompt is routing", async ({

--- a/apps/main/src/app/[lang]/(catalog)/start/learn/learn-content.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/start/learn/learn-content.tsx
@@ -9,8 +9,8 @@ import { LEARN_TITLE_ID } from "./learn-title";
 const VISIBLE_SUGGESTIONS = 5;
 
 /**
- * Streams request-time suggestions without rendering a visible fallback set
- * that would reflow when the shuffled links replace it.
+ * Streams request-time suggestions into a navigation region that reserves its
+ * responsive row count without rendering a visible fallback set.
  */
 async function RandomSuggestionLinks({ suggestions }: { suggestions: string[] }) {
   await io();
@@ -81,7 +81,7 @@ export async function LearnContent() {
 
       <nav
         aria-label={t("Suggested subjects")}
-        className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2"
+        className="flex min-h-19 flex-wrap items-center justify-center gap-x-4 gap-y-2 min-[390px]:min-h-12 min-[672px]:min-h-5"
       >
         <Suspense fallback={null}>
           <RandomSuggestionLinks suggestions={allSuggestions} />

--- a/apps/main/src/app/[lang]/(catalog)/start/learn/learn-content.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/start/learn/learn-content.tsx
@@ -1,19 +1,32 @@
 import { Link } from "@/i18n/navigation";
 import { shuffle } from "@zoonk/utils/shuffle";
 import { getExtracted } from "next-intl/server";
+import { io } from "next/cache";
+import { Suspense } from "react";
 import { LearnForm } from "./learn-form";
 import { LEARN_TITLE_ID } from "./learn-title";
 
 const VISIBLE_SUGGESTIONS = 5;
 
 /**
- * Rotates suggestion copy on a shared schedule so the start page stays varied
- * without producing unstable values while Next.js builds its static shell.
+ * Streams request-time suggestions without rendering a visible fallback set
+ * that would reflow when the shuffled links replace it.
  */
-async function getShuffledItems({ items, limit }: { items: string[]; limit?: number }) {
-  "use cache";
+async function RandomSuggestionLinks({ suggestions }: { suggestions: string[] }) {
+  await io();
 
-  return shuffle(items).slice(0, limit);
+  return shuffle(suggestions)
+    .slice(0, VISIBLE_SUGGESTIONS)
+    .map((subject) => (
+      <Link
+        key={subject}
+        className="text-muted-foreground/70 hover:text-foreground text-sm transition-colors"
+        href={`/start/learn/${encodeURIComponent(subject)}`}
+        prefetch={false}
+      >
+        {subject}
+      </Link>
+    ));
 }
 
 /**
@@ -58,33 +71,21 @@ export async function LearnContent() {
     t("Harry Potter"),
   ];
 
-  const [suggestions, placeholders] = await Promise.all([
-    getShuffledItems({ items: allSuggestions, limit: VISIBLE_SUGGESTIONS }),
-    getShuffledItems({ items: placeholderOptions }),
-  ]);
-
   return (
     <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center gap-8 p-4 pb-28 md:gap-10">
       <h1 className="text-center text-4xl font-bold tracking-tight md:text-5xl" id={LEARN_TITLE_ID}>
         {t("What do you want to learn?")}
       </h1>
 
-      <LearnForm placeholders={placeholders} />
+      <LearnForm placeholders={placeholderOptions} />
 
       <nav
         aria-label={t("Suggested subjects")}
         className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2"
       >
-        {suggestions.map((subject) => (
-          <Link
-            key={subject}
-            className="text-muted-foreground/70 hover:text-foreground text-sm transition-colors"
-            href={`/start/learn/${encodeURIComponent(subject)}`}
-            prefetch={false}
-          >
-            {subject}
-          </Link>
-        ))}
+        <Suspense fallback={null}>
+          <RandomSuggestionLinks suggestions={allSuggestions} />
+        </Suspense>
       </nav>
     </main>
   );


### PR DESCRIPTION
## Summary

- keep learn suggestions shuffled per request behind a narrow dynamic boundary
- prevent hydration mismatches and visible fallback reflow
- add E2E coverage for browser hydration errors