### PR TITLE
chore(main): remove staleTimes

### DIFF
--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -23,7 +23,6 @@ const nextConfig: NextConfig = {
   experimental: {
     authInterrupts: true,
     exposeTestingApiInProductionBuild: isE2E,
-    staleTimes: { dynamic: 300 },
     turbopackRustReactCompiler: true,
     typedEnv: true,
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes the `experimental.staleTimes` config from the main app to rely on framework defaults. Previously, dynamic data used a 300s stale time; now Next.js defaults apply, which may slightly change cache freshness for dynamic routes.

- Change is limited to `apps/main/next.config.ts`; no runtime code touched.
- Review focus: confirm dynamic routes and ISR/fetch memoization behave as expected under default caching.
- No migration required; adjust route-level `revalidate` or cache headers if stricter freshness is needed.

<sup>Written for commit 55cd6f0b5c6329742d4f47124c8bdbed0ec20b69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

