### PR TITLE
feat(api): track generation rate limits

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "catalog:",
+    "@vercel/analytics": "catalog:",
     "@zoonk/ai": "workspace:*",
     "@zoonk/auth": "workspace:*",
     "@zoonk/core": "workspace:*",

--- a/apps/api/src/app/v1/generations/route.ts
+++ b/apps/api/src/app/v1/generations/route.ts
@@ -1,13 +1,13 @@
 import { errors } from "@/lib/api-errors";
 import { withApiErrorBoundary } from "@/lib/api-handler";
 import { parseBody } from "@/lib/body-parser";
+import { claimGenerationQuotaIfNeeded } from "@/lib/generation-quota";
 import { toGenerationResource } from "@/lib/generation-resource";
 import { createGenerationRequestSchema } from "@/lib/openapi/schemas/workflows";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
 import { courseGenerationWorkflow } from "@/workflows/course-generation/course-generation-workflow";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
 import { getCourseGenerationAccess } from "@zoonk/core/courses/generation-access";
-import { claimGenerationQuotaIfNeeded } from "@zoonk/core/generation-quotas/claim";
 import { getChapterGenerationAccess } from "@zoonk/core/workflows/chapter-generation-access";
 import { getLessonGenerationAccess } from "@zoonk/core/workflows/lesson-generation-access";
 import { type NextRequest, NextResponse } from "next/server";
@@ -47,6 +47,7 @@ async function createCourseGeneration(coursePromptId: string) {
     await claimGenerationQuotaIfNeeded({
       resource: "course",
       shouldClaimQuota: access.shouldClaimQuota,
+      target: { coursePromptId, courseSlug: access.courseSlug },
       targetId: coursePromptId,
     }),
   );
@@ -78,6 +79,7 @@ async function createChapterGeneration(chapterId: string) {
     await claimGenerationQuotaIfNeeded({
       resource: "chapter",
       shouldClaimQuota: access.shouldClaimQuota,
+      target: { chapterSlug: access.chapter.slug, courseSlug: access.chapter.course.slug },
       targetId: chapterId,
     }),
   );
@@ -105,6 +107,11 @@ async function createLessonGeneration(lessonId: string) {
     await claimGenerationQuotaIfNeeded({
       resource: "lesson",
       shouldClaimQuota: access.shouldClaimQuota,
+      target: {
+        chapterSlug: access.lesson.chapter.slug,
+        courseSlug: access.lesson.chapter.course.slug,
+        lessonSlug: access.lesson.slug,
+      },
       targetId: lessonId,
     }),
   );

--- a/apps/api/src/app/v1/lessons/[lessonId]/preloads/route.ts
+++ b/apps/api/src/app/v1/lessons/[lessonId]/preloads/route.ts
@@ -1,10 +1,10 @@
 import { errors } from "@/lib/api-errors";
 import { withApiErrorBoundary } from "@/lib/api-handler";
+import { claimGenerationQuotaIfNeeded } from "@/lib/generation-quota";
 import { lessonPathParamsSchema } from "@/lib/openapi/schemas/paths";
 import { parsePathParams } from "@/lib/path-params";
 import { chapterGenerationWorkflow } from "@/workflows/chapter-generation/chapter-generation-workflow";
 import { lessonGenerationWorkflow } from "@/workflows/lesson-generation/lesson-generation-workflow";
-import { claimGenerationQuotaIfNeeded } from "@zoonk/core/generation-quotas/claim";
 import { getNextPreloadTargetResource } from "@zoonk/core/player/commands/get-next-lesson-preload-target";
 import { getChapterGenerationAccess } from "@zoonk/core/workflows/chapter-generation-access";
 import { getLessonGenerationAccess } from "@zoonk/core/workflows/lesson-generation-access";
@@ -28,6 +28,7 @@ async function startPreloadGeneration(target: PreloadTarget) {
     const quota = await claimGenerationQuotaIfNeeded({
       resource: "chapter",
       shouldClaimQuota: access.shouldClaimQuota,
+      target: { chapterSlug: access.chapter.slug, courseSlug: access.chapter.course.slug },
       targetId: target.chapterId,
     });
 
@@ -49,6 +50,11 @@ async function startPreloadGeneration(target: PreloadTarget) {
   const quota = await claimGenerationQuotaIfNeeded({
     resource: "lesson",
     shouldClaimQuota: access.shouldClaimQuota,
+    target: {
+      chapterSlug: access.lesson.chapter.slug,
+      courseSlug: access.lesson.chapter.course.slug,
+      lessonSlug: access.lesson.slug,
+    },
     targetId: target.lessonId,
   });
 

--- a/apps/api/src/lib/generation-quota.ts
+++ b/apps/api/src/lib/generation-quota.ts
@@ -1,0 +1,20 @@
+import {
+  type GenerationRateLimitTarget,
+  trackGenerationRateLimited,
+} from "@/lib/server-track-events";
+import { claimGenerationQuotaIfNeeded as claimCoreGenerationQuotaIfNeeded } from "@zoonk/core/generation-quotas/claim";
+
+type GenerationQuotaInput = Parameters<typeof claimCoreGenerationQuotaIfNeeded>[0] & {
+  target: GenerationRateLimitTarget;
+};
+
+/** Keeps quota accounting in Core while recording rejected API work with delivery-layer target metadata. */
+export async function claimGenerationQuotaIfNeeded({ target, ...input }: GenerationQuotaInput) {
+  const result = await claimCoreGenerationQuotaIfNeeded(input);
+
+  if (result.status === "limitReached") {
+    await trackGenerationRateLimited({ actor: result.actor, limit: result.limit, target });
+  }
+
+  return result;
+}

--- a/apps/api/src/lib/server-track-events.test.ts
+++ b/apps/api/src/lib/server-track-events.test.ts
@@ -1,0 +1,72 @@
+import { track as trackVercelEvent } from "@vercel/analytics/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createServerPostHogClient } from "./server-posthog";
+import { trackGenerationRateLimited } from "./server-track-events";
+
+vi.mock("@vercel/analytics/server", () => ({ track: vi.fn() }));
+vi.mock("./server-posthog", () => ({ createServerPostHogClient: vi.fn() }));
+
+const capture = vi.fn();
+const shutdown = vi.fn();
+
+describe(trackGenerationRateLimited, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(createServerPostHogClient).mockReturnValue({
+      [Symbol.asyncDispose]: shutdown,
+      capture,
+    });
+  });
+
+  it.each([
+    {
+      expectedTarget: { coursePromptId: "course-prompt-id" },
+      resource: "course" as const,
+      target: { coursePromptId: "course-prompt-id" },
+    },
+    {
+      expectedTarget: { courseSlug: "course-slug" },
+      resource: "course" as const,
+      target: { coursePromptId: "course-prompt-id", courseSlug: "course-slug" },
+    },
+    {
+      expectedTarget: { chapterSlug: "chapter-slug", courseSlug: "course-slug" },
+      resource: "chapter" as const,
+      target: { chapterSlug: "chapter-slug", courseSlug: "course-slug" },
+    },
+    {
+      expectedTarget: {
+        chapterSlug: "chapter-slug",
+        courseSlug: "course-slug",
+        lessonSlug: "lesson-slug",
+      },
+      resource: "lesson" as const,
+      target: { chapterSlug: "chapter-slug", courseSlug: "course-slug", lessonSlug: "lesson-slug" },
+    },
+  ])("tracks a rate-limited $resource generation", async ({ expectedTarget, resource, target }) => {
+    const properties = {
+      period: "day",
+      resource,
+      username: "learner",
+      viewer: "authenticated",
+      ...expectedTarget,
+    };
+
+    await trackGenerationRateLimited({
+      actor: { distinctId: "user-id", username: "learner" },
+      limit: { period: "day", resource, viewer: "authenticated" },
+      target,
+    });
+
+    expect(trackVercelEvent).toHaveBeenCalledExactlyOnceWith("Generation Rate Limited", properties);
+
+    expect(capture).toHaveBeenCalledExactlyOnceWith({
+      distinctId: "user-id",
+      event: "Generation Rate Limited",
+      properties,
+    });
+
+    expect(shutdown).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/lib/server-track-events.ts
+++ b/apps/api/src/lib/server-track-events.ts
@@ -1,9 +1,20 @@
 import "server-only";
 import { createServerPostHogClient } from "@/lib/server-posthog";
+import { track as trackVercelEvent } from "@vercel/analytics/server";
+import {
+  type GenerationQuotaActor,
+  type GenerationQuotaLimit,
+} from "@zoonk/core/generation-quotas/contract";
 import { safeAsync } from "@zoonk/utils/error";
 
 type AuthCompletionAction = "sign-in" | "sign-up";
-type ServerEventProperties = Record<string, boolean | number | string>;
+type ServerEventProperties = Record<string, boolean | null | number | string>;
+export type GenerationRateLimitTarget =
+  | { coursePromptId: string; courseSlug?: string | null }
+  | { chapterSlug: string; courseSlug: string }
+  | { chapterSlug: string; courseSlug: string; lessonSlug: string };
+
+const GENERATION_RATE_LIMITED_EVENT = "Generation Rate Limited";
 
 /**
  * Captures one API server event with a short-lived PostHog client so event
@@ -47,4 +58,54 @@ export async function trackAuthCompleted({
     distinctId: userId,
     event: action === "sign-up" ? "Sign Up Completed" : "Sign In Completed",
   });
+}
+
+/**
+ * Uses route slugs already loaded by the generation access boundary and falls
+ * back to the course-prompt ID before a generated course has a slug.
+ */
+function getGenerationTargetProperties(target: GenerationRateLimitTarget): ServerEventProperties {
+  if ("coursePromptId" in target) {
+    return target.courseSlug
+      ? { courseSlug: target.courseSlug }
+      : { coursePromptId: target.coursePromptId };
+  }
+
+  if ("lessonSlug" in target) {
+    return {
+      chapterSlug: target.chapterSlug,
+      courseSlug: target.courseSlug,
+      lessonSlug: target.lessonSlug,
+    };
+  }
+
+  return { chapterSlug: target.chapterSlug, courseSlug: target.courseSlug };
+}
+
+/** Records rejected generation work at the API boundary where its existing target metadata is available. */
+export async function trackGenerationRateLimited({
+  actor,
+  limit,
+  target,
+}: {
+  actor: GenerationQuotaActor;
+  limit: GenerationQuotaLimit;
+  target: GenerationRateLimitTarget;
+}) {
+  const properties = {
+    period: limit.period,
+    resource: limit.resource,
+    username: actor.username,
+    viewer: limit.viewer,
+    ...getGenerationTargetProperties(target),
+  };
+
+  await Promise.all([
+    safeAsync(() => trackVercelEvent(GENERATION_RATE_LIMITED_EVENT, properties)),
+    trackServerEvent({
+      distinctId: actor.distinctId,
+      event: GENERATION_RATE_LIMITED_EVENT,
+      properties,
+    }),
+  ]);
 }

--- a/packages/core/src/courses/course-generation-access.test.ts
+++ b/packages/core/src/courses/course-generation-access.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getSession } from "../users/get-session";
@@ -16,6 +17,7 @@ describe(getCourseGenerationAccess, () => {
 
     await expect(getCourseGenerationAccess(prompt.id)).resolves.toStrictEqual({
       coursePromptId: prompt.id,
+      courseSlug: null,
       shouldClaimQuota: true,
       status: "ready",
       userId: user.id,
@@ -27,9 +29,21 @@ describe(getCourseGenerationAccess, () => {
 
     await expect(getCourseGenerationAccess(prompt.id)).resolves.toStrictEqual({
       coursePromptId: prompt.id,
+      courseSlug: null,
       shouldClaimQuota: true,
       status: "ready",
       userId: null,
+    });
+  });
+
+  it("returns the existing course slug without another generation lookup", async () => {
+    const course = await courseFixture();
+    const prompt = await coursePromptFixture({ courseId: course.id, generationStatus: "failed" });
+
+    await expect(getCourseGenerationAccess(prompt.id)).resolves.toMatchObject({
+      courseSlug: course.slug,
+      shouldClaimQuota: true,
+      status: "ready",
     });
   });
 

--- a/packages/core/src/courses/course-generation-access.ts
+++ b/packages/core/src/courses/course-generation-access.ts
@@ -34,6 +34,7 @@ export async function getCourseGenerationAccess(coursePromptId: string) {
 
   return {
     coursePromptId: coursePrompt.id,
+    courseSlug: coursePrompt.course?.slug ?? null,
     shouldClaimQuota: shouldClaimCourseGenerationQuota(coursePrompt.generationStatus),
     status: "ready" as const,
     userId: session?.user.id ?? null,

--- a/packages/core/src/generation-quotas/claim-generation-quota.test.ts
+++ b/packages/core/src/generation-quotas/claim-generation-quota.test.ts
@@ -5,7 +5,12 @@ import { headers } from "next/headers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getSession } from "../users/get-session";
 import { claimGenerationQuotaIfNeeded } from "./claim-generation-quota";
-import { GENERATION_VISITOR_ID_HEADER, type GenerationQuotaPeriod } from "./contract";
+import {
+  GENERATION_VISITOR_ID_HEADER,
+  type GenerationQuotaPeriod,
+  type GenerationQuotaResource,
+  type GenerationQuotaViewer,
+} from "./contract";
 
 vi.mock("next/headers", () => ({ headers: vi.fn() }));
 vi.mock("../users/get-session", () => ({ getSession: vi.fn() }));
@@ -43,7 +48,13 @@ function useGuestViewer(): string {
 
 /** Uses the real subscription query while replacing only the request session boundary. */
 async function useAuthenticatedViewer({ subscriber }: { subscriber: boolean }) {
-  const user = await userFixture();
+  const fixture = await userFixture();
+
+  const user = await prisma.user.update({
+    data: { username: `rate-limit-${randomUUID()}` },
+    where: { id: fixture.id },
+  });
+
   vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
 
   if (subscriber) {
@@ -53,6 +64,19 @@ async function useAuthenticatedViewer({ subscriber }: { subscriber: boolean }) {
   }
 
   return user;
+}
+
+/** Keeps quota assertions focused on the rejected resource and entitlement. */
+function getReachedLimitResult({
+  period,
+  resource,
+  viewer,
+}: {
+  period: GenerationQuotaPeriod;
+  resource: GenerationQuotaResource;
+  viewer: GenerationQuotaViewer;
+}) {
+  return { limit: { period, resource, viewer }, status: "limitReached" };
 }
 
 /** Moves the counter created by a real claim near a boundary without issuing hundreds of requests. */
@@ -116,8 +140,8 @@ describe(claimGenerationQuotaIfNeeded, () => {
 
     expect(results.filter((result) => result.status === "ready")).toHaveLength(3);
 
-    expect(results.filter((result) => result.status === "limitReached")).toStrictEqual([
-      { limit: { period: "day", resource: "course", viewer: "guest" }, status: "limitReached" },
+    expect(results.filter((result) => result.status === "limitReached")).toMatchObject([
+      getReachedLimitResult({ period: "day", resource: "course", viewer: "guest" }),
     ]);
   });
 
@@ -138,10 +162,9 @@ describe(claimGenerationQuotaIfNeeded, () => {
 
     await expect(
       claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
-    ).resolves.toStrictEqual({
-      limit: { period: "month", resource: "course", viewer: "guest" },
-      status: "limitReached",
-    });
+    ).resolves.toMatchObject(
+      getReachedLimitResult({ period: "month", resource: "course", viewer: "guest" }),
+    );
   });
 
   it("limits authenticated learners to five courses per day", async () => {
@@ -156,10 +179,9 @@ describe(claimGenerationQuotaIfNeeded, () => {
 
     await expect(
       claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
-    ).resolves.toStrictEqual({
-      limit: { period: "day", resource: "course", viewer: "authenticated" },
-      status: "limitReached",
-    });
+    ).resolves.toMatchObject(
+      getReachedLimitResult({ period: "day", resource: "course", viewer: "authenticated" }),
+    );
   });
 
   it("limits subscribers to twenty courses per day", async () => {
@@ -180,10 +202,9 @@ describe(claimGenerationQuotaIfNeeded, () => {
 
     await expect(
       claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
-    ).resolves.toStrictEqual({
-      limit: { period: "day", resource: "course", viewer: "subscriber" },
-      status: "limitReached",
-    });
+    ).resolves.toMatchObject(
+      getReachedLimitResult({ period: "day", resource: "course", viewer: "subscriber" }),
+    );
   });
 
   it("limits chapter generation to fifty per day", async () => {
@@ -204,10 +225,9 @@ describe(claimGenerationQuotaIfNeeded, () => {
 
     await expect(
       claimGenerationQuota({ resource: "chapter", targetId: randomUUID() }),
-    ).resolves.toStrictEqual({
-      limit: { period: "day", resource: "chapter", viewer: "subscriber" },
-      status: "limitReached",
-    });
+    ).resolves.toMatchObject(
+      getReachedLimitResult({ period: "day", resource: "chapter", viewer: "subscriber" }),
+    );
   });
 
   it.each([
@@ -235,10 +255,7 @@ describe(claimGenerationQuotaIfNeeded, () => {
 
     await expect(
       claimGenerationQuota({ resource: "lesson", targetId: randomUUID() }),
-    ).resolves.toStrictEqual({
-      limit: { period: "day", resource: "lesson", viewer },
-      status: "limitReached",
-    });
+    ).resolves.toMatchObject(getReachedLimitResult({ period: "day", resource: "lesson", viewer }));
   });
 
   it.each([
@@ -276,10 +293,7 @@ describe(claimGenerationQuotaIfNeeded, () => {
 
       await expect(
         claimGenerationQuota({ resource, targetId: randomUUID() }),
-      ).resolves.toStrictEqual({
-        limit: { period: "month", resource, viewer },
-        status: "limitReached",
-      });
+      ).resolves.toMatchObject(getReachedLimitResult({ period: "month", resource, viewer }));
     },
   );
 
@@ -310,10 +324,9 @@ describe(claimGenerationQuotaIfNeeded, () => {
 
     await expect(
       claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
-    ).resolves.toStrictEqual({
-      limit: { period: "day", resource: "course", viewer: "guest" },
-      status: "limitReached",
-    });
+    ).resolves.toMatchObject(
+      getReachedLimitResult({ period: "day", resource: "course", viewer: "guest" }),
+    );
   });
 
   it("does not reset a guest quota when the same browser changes networks", async () => {
@@ -345,10 +358,9 @@ describe(claimGenerationQuotaIfNeeded, () => {
 
     await expect(
       claimGenerationQuota({ resource: "course", targetId: randomUUID() }),
-    ).resolves.toStrictEqual({
-      limit: { period: "day", resource: "course", viewer: "guest" },
-      status: "limitReached",
-    });
+    ).resolves.toMatchObject(
+      getReachedLimitResult({ period: "day", resource: "course", viewer: "guest" }),
+    );
   });
 
   it("does not charge duplicate requests for the same target twice", async () => {

--- a/packages/core/src/generation-quotas/claim-generation-quota.ts
+++ b/packages/core/src/generation-quotas/claim-generation-quota.ts
@@ -182,7 +182,7 @@ async function claimGenerationQuota({
   resource: GenerationQuotaResource;
   targetId: string;
 }): Promise<GenerationQuotaResult> {
-  const { actorKeys, viewer } = await getGenerationQuotaViewer();
+  const { actor, actorKeys, viewer } = await getGenerationQuotaViewer();
   const rules = getGenerationQuotaRules({ now, resource, viewer });
 
   try {
@@ -191,7 +191,7 @@ async function claimGenerationQuota({
     );
   } catch (error) {
     if (error instanceof Error && isReachedLimitSignal(error.cause)) {
-      return { limit: error.cause.limit, status: "limitReached" };
+      return { actor, limit: error.cause.limit, status: "limitReached" };
     }
 
     throw error;

--- a/packages/core/src/generation-quotas/contract.ts
+++ b/packages/core/src/generation-quotas/contract.ts
@@ -4,6 +4,8 @@ export type GenerationQuotaPeriod = "day" | "month";
 export type GenerationQuotaResource = "chapter" | "course" | "lesson";
 export type GenerationQuotaViewer = "authenticated" | "guest" | "subscriber";
 
+export type GenerationQuotaActor = { distinctId: string; username: string | null };
+
 export type GenerationQuotaLimit = {
   period: GenerationQuotaPeriod;
   resource: GenerationQuotaResource;
@@ -12,4 +14,4 @@ export type GenerationQuotaLimit = {
 
 export type GenerationQuotaResult =
   | { status: "ready" }
-  | { limit: GenerationQuotaLimit; status: "limitReached" };
+  | { actor: GenerationQuotaActor; limit: GenerationQuotaLimit; status: "limitReached" };

--- a/packages/core/src/generation-quotas/viewer.test.ts
+++ b/packages/core/src/generation-quotas/viewer.test.ts
@@ -1,0 +1,43 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { headers } from "next/headers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getSession } from "../users/get-session";
+import { GENERATION_VISITOR_ID_HEADER } from "./contract";
+import { getGenerationQuotaViewer } from "./viewer";
+
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
+vi.mock("../users/get-session", () => ({ getSession: vi.fn() }));
+
+describe(getGenerationQuotaViewer, () => {
+  beforeEach(() => {
+    vi.mocked(headers).mockResolvedValue(new Headers());
+    vi.mocked(getSession).mockResolvedValue(null);
+  });
+
+  it("uses the durable visitor identity and guest username for an anonymous viewer", async () => {
+    const visitorId = randomUUID();
+
+    vi.mocked(headers).mockResolvedValue(
+      new Headers({ [GENERATION_VISITOR_ID_HEADER]: visitorId }),
+    );
+
+    await expect(getGenerationQuotaViewer()).resolves.toMatchObject({
+      actor: { distinctId: `guest:${visitorId}`, username: "guest" },
+      viewer: "guest",
+    });
+  });
+
+  it("uses the existing session identity and username for an authenticated viewer", async () => {
+    const username = `rate-limit-${randomUUID()}`;
+    const fixture = await userFixture();
+    const user = await prisma.user.update({ data: { username }, where: { id: fixture.id } });
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
+
+    await expect(getGenerationQuotaViewer()).resolves.toMatchObject({
+      actor: { distinctId: user.id, username },
+      viewer: "authenticated",
+    });
+  });
+});

--- a/packages/core/src/generation-quotas/viewer.ts
+++ b/packages/core/src/generation-quotas/viewer.ts
@@ -4,9 +4,17 @@ import { isUuid } from "@zoonk/utils/uuid";
 import { headers } from "next/headers";
 import { hasActiveSubscription } from "../auth/subscription";
 import { getSession } from "../users/get-session";
-import { GENERATION_VISITOR_ID_HEADER, type GenerationQuotaViewer } from "./contract";
+import {
+  GENERATION_VISITOR_ID_HEADER,
+  type GenerationQuotaActor,
+  type GenerationQuotaViewer,
+} from "./contract";
 
-type GenerationQuotaViewerContext = { actorKeys: string[]; viewer: GenerationQuotaViewer };
+type GenerationQuotaViewerContext = {
+  actor: GenerationQuotaActor;
+  actorKeys: string[];
+  viewer: GenerationQuotaViewer;
+};
 
 /** Selects the original client address while keeping proxy header parsing out of the stored quota key. */
 function getClientAddress(requestHeaders: Headers): string {
@@ -52,15 +60,32 @@ function getGuestActorKeys(requestHeaders: Headers): string[] {
   return [requestActorKey];
 }
 
+/** Keeps anonymous analytics distinct without exposing the raw request fingerprint inputs. */
+function getGuestActor(actorKeys: string[]): GenerationQuotaActor {
+  const distinctId = actorKeys[0];
+
+  if (!distinctId) {
+    throw new Error("Generation quota requires at least one guest identity");
+  }
+
+  return { distinctId, username: "guest" };
+}
+
 /** Derives identity and entitlement from the request instead of trusting a caller-selected user or plan. */
 export async function getGenerationQuotaViewer(): Promise<GenerationQuotaViewerContext> {
   const [requestHeaders, session] = await Promise.all([headers(), getSession()]);
 
   if (!session) {
-    return { actorKeys: getGuestActorKeys(requestHeaders), viewer: "guest" };
+    const actorKeys = getGuestActorKeys(requestHeaders);
+
+    return { actor: getGuestActor(actorKeys), actorKeys, viewer: "guest" };
   }
 
   const viewer = (await hasActiveSubscription()) ? "subscriber" : "authenticated";
 
-  return { actorKeys: [`user:${session.user.id}`], viewer };
+  return {
+    actor: { distinctId: session.user.id, username: session.user.username ?? null },
+    actorKeys: [`user:${session.user.id}`],
+    viewer,
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       '@sentry/nextjs':
         specifier: 'catalog:'
         version: 10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.3.1(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.15.3(@swc/helpers@0.5.23))(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      '@vercel/analytics':
+        specifier: 'catalog:'
+        version: 2.0.1(next@16.3.1(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@zoonk/ai':
         specifier: workspace:*
         version: link:../../packages/ai
@@ -10358,6 +10361,11 @@ snapshots:
   '@vercel/analytics@2.0.1(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
       next: 16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+
+  '@vercel/analytics@2.0.1(next@16.3.1(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    optionalDependencies:
+      next: 16.3.1(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
   '@vercel/blob@2.8.0':


### PR DESCRIPTION
Tracks generation rate-limit events in PostHog and Vercel Analytics. Includes authenticated usernames or guest identity plus existing generation slugs or IDs across direct generation and preload quota paths.