### PR TITLE
feat(main): require login for ai generation

### DIFF
--- a/apps/api/e2e/course-prompts-and-generation-resources.test.ts
+++ b/apps/api/e2e/course-prompts-and-generation-resources.test.ts
@@ -4,7 +4,6 @@ import {
   COURSE_LANGUAGE_MAX_LENGTH,
   COURSE_PROMPT_MAX_LENGTH,
 } from "@zoonk/core/courses/prompt-contract";
-import { GENERATION_VISITOR_ID_HEADER } from "@zoonk/core/generation-quotas/contract";
 import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
@@ -13,6 +12,7 @@ import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
 import { normalizeString } from "@zoonk/utils/string";
+import { createAuthenticatedApiContext } from "./helpers/auth";
 
 test.describe("Course prompt and generation resources API", () => {
   let baseURL: string;
@@ -25,7 +25,94 @@ test.describe("Course prompt and generation resources API", () => {
     await prisma.$disconnect();
   });
 
-  test("resolves a cached coding prompt into a route-neutral generation target", async () => {
+  test("requires authentication before resolving a new course prompt", async () => {
+    const prompt = `Anonymous API course prompt ${randomUUID()}`;
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/course-prompts", {
+      data: { kind: "topic", language: "en", prompt },
+    });
+
+    expect(response.status()).toBe(401);
+
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    });
+
+    await expect(
+      prisma.coursePrompt.findUnique({
+        where: {
+          languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
+        },
+      }),
+    ).resolves.toBeNull();
+
+    await apiContext.dispose();
+  });
+
+  test("requires authentication before creating a language course prompt", async () => {
+    const language = `en-x-${randomUUID().slice(0, 5)}`;
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/course-prompts", {
+      data: { kind: "language", language, targetLanguage: "es" },
+    });
+
+    expect(response.status()).toBe(401);
+
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    });
+
+    await expect(
+      prisma.coursePrompt.findUnique({
+        where: {
+          languageNormalizedPrompt: {
+            language,
+            normalizedPrompt: normalizeString("Learn Spanish"),
+          },
+        },
+      }),
+    ).resolves.toBeNull();
+
+    await apiContext.dispose();
+  });
+
+  test("creates a language course prompt for an authenticated caller", async () => {
+    const language = `en-x-${randomUUID().slice(0, 5)}`;
+
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "language-course-prompt",
+    });
+
+    const response = await apiContext.post("/v1/course-prompts", {
+      data: { kind: "language", language, targetLanguage: "es" },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const responseBody = await response.json();
+
+    const coursePrompt = await prisma.coursePrompt.findUniqueOrThrow({
+      where: {
+        languageNormalizedPrompt: { language, normalizedPrompt: normalizeString("Learn Spanish") },
+      },
+    });
+
+    expect(responseBody).toStrictEqual({ coursePromptId: coursePrompt.id, kind: "generation" });
+
+    expect(coursePrompt).toMatchObject({
+      courseFormat: "language",
+      generationRunId: null,
+      generationStatus: "pending",
+      targetLanguage: "es",
+    });
+
+    await apiContext.dispose();
+  });
+
+  test("requires authentication before promoting a cached prompt to generation", async () => {
     const uniqueId = randomUUID();
     const prompt = `Learn focused API design ${uniqueId}`;
 
@@ -44,16 +131,15 @@ test.describe("Course prompt and generation resources API", () => {
       data: { kind: "topic", language: "en", prompt },
     });
 
-    expect(response.status()).toBe(200);
+    expect(response.status()).toBe(401);
 
-    await expect(response.json()).resolves.toStrictEqual({
-      coursePromptId: coursePrompt.id,
-      kind: "generation",
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
     });
 
     await expect(
       prisma.coursePrompt.findUniqueOrThrow({ where: { id: coursePrompt.id } }),
-    ).resolves.toMatchObject({ courseFormat: "coding", generationStatus: "pending" });
+    ).resolves.toMatchObject({ courseFormat: "coding", generationStatus: null });
 
     await apiContext.dispose();
   });
@@ -143,17 +229,21 @@ test.describe("Course prompt and generation resources API", () => {
   });
 
   test("returns a structured limit response instead of starting another generation", async () => {
-    const visitorId = randomUUID();
     const now = new Date();
 
     const periodStart = new Date(
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
     );
 
+    const { apiContext, user } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "course-generation-limit",
+    });
+
     await prisma.generationQuotaCounter.create({
       data: {
-        actorKey: `guest:${visitorId}`,
-        count: 3,
+        actorKey: `user:${user.id}`,
+        count: 5,
         period: "day",
         periodStart,
         resource: "course",
@@ -161,11 +251,6 @@ test.describe("Course prompt and generation resources API", () => {
     });
 
     const coursePrompt = await coursePromptFixture();
-
-    const apiContext = await request.newContext({
-      baseURL,
-      extraHTTPHeaders: { [GENERATION_VISITOR_ID_HEADER]: visitorId },
-    });
 
     const response = await apiContext.post("/v1/generations", {
       data: { target: { id: coursePrompt.id, type: "coursePrompt" } },
@@ -176,10 +261,27 @@ test.describe("Course prompt and generation resources API", () => {
     await expect(response.json()).resolves.toStrictEqual({
       error: {
         code: "GENERATION_LIMIT_REACHED",
-        details: { period: "day", resource: "course", viewer: "guest" },
+        details: { period: "day", resource: "course", viewer: "authenticated" },
         message: "Generation limit reached",
       },
     });
+
+    const [persistedCounter, persistedPrompt] = await Promise.all([
+      prisma.generationQuotaCounter.findUniqueOrThrow({
+        where: {
+          generationQuotaCounter: {
+            actorKey: `user:${user.id}`,
+            period: "day",
+            periodStart,
+            resource: "course",
+          },
+        },
+      }),
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: coursePrompt.id } }),
+    ]);
+
+    expect(persistedCounter.count).toBe(5);
+    expect(persistedPrompt).toMatchObject({ generationRunId: null, generationStatus: "pending" });
 
     await apiContext.dispose();
   });

--- a/apps/api/e2e/workflows-chapter-generation.test.ts
+++ b/apps/api/e2e/workflows-chapter-generation.test.ts
@@ -73,7 +73,7 @@ test.describe("Chapter Generation Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("allows first chapter generation without a session", async () => {
+  test("requires authentication before generating the first chapter", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const courseTitle = `E2E Chapter Public ${uniqueId}`;
 
@@ -109,16 +109,20 @@ test.describe("Chapter Generation Workflow API", () => {
       data: { target: { id: chapter.id, type: "chapter" } },
     });
 
-    expect(response.status()).toBe(202);
+    expect(response.status()).toBe(401);
 
-    const body = await response.json();
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    });
 
-    expect(body).toStrictEqual({ id: expect.any(String), status: expect.any(String) });
+    await expect(
+      prisma.chapter.findUniqueOrThrow({ where: { id: chapter.id } }),
+    ).resolves.toMatchObject({ generationRunId: null, generationStatus: "pending" });
 
     await apiContext.dispose();
   });
 
-  test("returns 402 when later chapter generation has no session", async () => {
+  test("requires authentication before checking later-chapter subscriptions", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const courseTitle = `E2E Chapter Paid ${uniqueId}`;
 
@@ -154,12 +158,15 @@ test.describe("Chapter Generation Workflow API", () => {
       data: { target: { id: chapter.id, type: "chapter" } },
     });
 
-    expect(response.status()).toBe(402);
+    expect(response.status()).toBe(401);
 
-    const body = await response.json();
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    });
 
-    expect(body.error).toBeDefined();
-    expect(body.error.code).toBe("PAYMENT_REQUIRED");
+    await expect(
+      prisma.chapter.findUniqueOrThrow({ where: { id: chapter.id } }),
+    ).resolves.toMatchObject({ generationRunId: null, generationStatus: "pending" });
 
     await apiContext.dispose();
   });

--- a/apps/api/e2e/workflows-course-generation.test.ts
+++ b/apps/api/e2e/workflows-course-generation.test.ts
@@ -31,7 +31,7 @@ test.describe("Course Generation Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("starts workflow without a session", async () => {
+  test("requires authentication without changing the course prompt", async () => {
     const uniqueId = randomUUID().slice(0, 8);
 
     const startRequest = await createCompletedCoursePrompt(`E2E Public Course ${uniqueId}`);
@@ -42,15 +42,15 @@ test.describe("Course Generation Workflow API", () => {
       data: { target: { id: startRequest.id, type: "coursePrompt" } },
     });
 
-    expect(response.status()).toBe(202);
+    expect(response.status()).toBe(401);
 
-    const body = await response.json();
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    });
 
-    expect(body).toStrictEqual({ id: expect.any(String), status: expect.any(String) });
-
-    expect(response.headers().location).toBe(
-      `/v1/generations/${encodeURIComponent(String(body.id))}`,
-    );
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: startRequest.id } }),
+    ).resolves.toMatchObject({ generationRunId: null, generationStatus: "completed" });
 
     await apiContext.dispose();
   });
@@ -66,7 +66,10 @@ test.describe("Course Generation Workflow API", () => {
       targetLanguage: "en",
     });
 
-    const apiContext = await request.newContext({ baseURL });
+    const { apiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "course-same-language",
+    });
 
     const response = await apiContext.post("/v1/generations", {
       data: { target: { id: startRequest.id, type: "coursePrompt" } },

--- a/apps/api/e2e/workflows-lesson-generation.test.ts
+++ b/apps/api/e2e/workflows-lesson-generation.test.ts
@@ -67,7 +67,7 @@ test.describe("Lesson Generation Workflow API", () => {
     await prisma.$disconnect();
   });
 
-  test("allows unauthenticated generation for every first-chapter lesson", async () => {
+  test("requires authentication before generating a first-chapter lesson", async () => {
     const uniqueId = randomUUID().slice(0, 8);
 
     const lesson = await createAiLessonForWorkflow({
@@ -83,16 +83,20 @@ test.describe("Lesson Generation Workflow API", () => {
       data: { target: { id: lesson.id, type: "lesson" } },
     });
 
-    expect(response.status()).toBe(202);
+    expect(response.status()).toBe(401);
 
-    const body = await response.json();
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    });
 
-    expect(body).toStrictEqual({ id: expect.any(String), status: expect.any(String) });
+    await expect(
+      prisma.lesson.findUniqueOrThrow({ where: { id: lesson.id } }),
+    ).resolves.toMatchObject({ generationRunId: null, generationStatus: "completed" });
 
     await apiContext.dispose();
   });
 
-  test("returns 402 when unauthenticated generation is outside the first chapter", async () => {
+  test("requires authentication before checking later-lesson subscriptions", async () => {
     const uniqueId = randomUUID().slice(0, 8);
 
     const lesson = await createAiLessonForWorkflow({ aiOrgId, chapterPosition: 1, uniqueId });
@@ -103,12 +107,15 @@ test.describe("Lesson Generation Workflow API", () => {
       data: { target: { id: lesson.id, type: "lesson" } },
     });
 
-    expect(response.status()).toBe(402);
+    expect(response.status()).toBe(401);
 
-    const body = await response.json();
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "UNAUTHORIZED", message: "Authentication required" },
+    });
 
-    expect(body.error).toBeDefined();
-    expect(body.error.code).toBe("PAYMENT_REQUIRED");
+    await expect(
+      prisma.lesson.findUniqueOrThrow({ where: { id: lesson.id } }),
+    ).resolves.toMatchObject({ generationRunId: null, generationStatus: "completed" });
 
     await apiContext.dispose();
   });

--- a/apps/api/src/app/v1/course-prompts/route.ts
+++ b/apps/api/src/app/v1/course-prompts/route.ts
@@ -47,6 +47,10 @@ async function createCoursePrompt(request: NextRequest) {
       prompt: parsed.data.prompt,
     });
 
+    if (result.kind === "unauthorized") {
+      return errors.unauthorized();
+    }
+
     if (result.kind === "invalid") {
       return errors.badRequest("Invalid course prompt");
     }
@@ -58,6 +62,10 @@ async function createCoursePrompt(request: NextRequest) {
     language: parsed.data.language,
     targetLanguage: parsed.data.targetLanguage,
   });
+
+  if (result.kind === "unauthorized") {
+    return errors.unauthorized();
+  }
 
   return NextResponse.json(
     result.kind === "course"

--- a/apps/api/src/app/v1/generations/route.ts
+++ b/apps/api/src/app/v1/generations/route.ts
@@ -35,6 +35,10 @@ function reachedGenerationLimit(result: Awaited<ReturnType<typeof claimGeneratio
 async function createCourseGeneration(coursePromptId: string) {
   const access = await getCourseGenerationAccess(coursePromptId);
 
+  if (access.status === "unauthorized") {
+    return errors.unauthorized();
+  }
+
   if (access.status === "notFound") {
     return errors.notFound();
   }
@@ -67,6 +71,10 @@ async function createCourseGeneration(coursePromptId: string) {
 async function createChapterGeneration(chapterId: string) {
   const access = await getChapterGenerationAccess(chapterId);
 
+  if (access.status === "unauthorized") {
+    return errors.unauthorized();
+  }
+
   if (access.status === "notFound") {
     return errors.notFound();
   }
@@ -94,6 +102,10 @@ async function createChapterGeneration(chapterId: string) {
 /** Starts a lesson workflow after its subscription gate and quota claim are accepted. */
 async function createLessonGeneration(lessonId: string) {
   const access = await getLessonGenerationAccess(lessonId);
+
+  if (access.status === "unauthorized") {
+    return errors.unauthorized();
+  }
 
   if (access.status === "notFound") {
     return errors.notFound();

--- a/apps/api/src/lib/openapi/document.test.ts
+++ b/apps/api/src/lib/openapi/document.test.ts
@@ -191,10 +191,13 @@ describe("OpenAPI document", () => {
   it("documents public and user-authenticated endpoint security", () => {
     const document = documentContractSchema.parse(openAPIDocument);
     const authenticated = [{ bearerAuth: [] }, { cookieAuth: [] }];
+    const optionalAuthentication = [{}, ...authenticated];
 
     expect(document.paths["/auth/health"]?.get?.security).toStrictEqual([]);
     expect(document.paths["/courses"]?.get?.security).toStrictEqual([]);
     expect(document.paths["/feedback"]?.post?.security).toStrictEqual([]);
+    expect(document.paths["/course-prompts"]?.post?.security).toStrictEqual(optionalAuthentication);
+    expect(document.paths["/generations"]?.post?.security).toStrictEqual(authenticated);
     expect(document.paths["/me"]?.get?.security).toStrictEqual(authenticated);
     expect(document.paths["/me"]?.patch?.security).toStrictEqual(authenticated);
   });
@@ -280,7 +283,7 @@ describe("OpenAPI document", () => {
     });
   });
 
-  it("documents optional authentication and public event streams", () => {
+  it("documents optional reads and public generation status", () => {
     const document = documentContractSchema.parse(openAPIDocument);
     const optionalAuthentication = [{}, { bearerAuth: [] }, { cookieAuth: [] }];
 
@@ -292,8 +295,6 @@ describe("OpenAPI document", () => {
       optionalAuthentication,
     );
 
-    expect(document.paths["/generations"]?.post?.security).toStrictEqual(optionalAuthentication);
-
     expect(document.paths["/generations/{generationId}"]?.get?.security).toStrictEqual([]);
     expect(document.paths["/generations/{generationId}/events"]?.get?.security).toStrictEqual([]);
   });
@@ -301,6 +302,7 @@ describe("OpenAPI document", () => {
   it("documents every response status returned by account and feedback routes", () => {
     const document = documentContractSchema.parse(openAPIDocument);
 
+    expect(document.paths["/course-prompts"]?.post?.responses).toHaveProperty("401");
     expect(document.paths["/course-prompts"]?.post?.responses).toHaveProperty("403");
     expect(document.paths["/feedback"]?.post?.responses).toHaveProperty("500");
     expect(document.paths["/auth/sign-in/apple-native"]?.post?.responses).toHaveProperty("500");
@@ -313,6 +315,7 @@ describe("OpenAPI document", () => {
   it("documents every response status returned by generation routes", () => {
     const document = documentContractSchema.parse(openAPIDocument);
 
+    expect(document.paths["/generations"]?.post?.responses).toHaveProperty("401");
     expect(document.paths["/generations"]?.post?.responses).toHaveProperty("402");
     expect(document.paths["/generations"]?.post?.responses).toHaveProperty("404");
     expect(document.paths["/generations"]?.post?.responses).toHaveProperty("403");

--- a/apps/api/src/lib/openapi/paths/course-prompts.ts
+++ b/apps/api/src/lib/openapi/paths/course-prompts.ts
@@ -4,12 +4,19 @@ import {
   resolveCoursePromptRequestSchema,
   resolveCoursePromptResponseSchema,
 } from "../schemas/course-prompts";
-import { forbiddenResponse, notFoundResponse, validationErrorResponse } from "../schemas/responses";
-import { PUBLIC_SECURITY } from "../security";
+import {
+  forbiddenResponse,
+  notFoundResponse,
+  unauthorizedResponse,
+  validationErrorResponse,
+} from "../schemas/responses";
+import { OPTIONAL_AUTHENTICATION_SECURITY, PUBLIC_SECURITY } from "../security";
 
 export const coursePromptPaths = {
   "/course-prompts": {
     post: {
+      description:
+        "Returns existing courses and side-effect-free cached classifications publicly. Authentication is required before a prompt can use AI or create a generation request.",
       operationId: "createCoursePrompt",
       requestBody: {
         content: { "application/json": { schema: resolveCoursePromptRequestSchema } },
@@ -21,9 +28,10 @@ export const coursePromptPaths = {
           description: "Course, generation, or classification outcome",
         },
         "400": validationErrorResponse,
+        "401": unauthorizedResponse,
         "403": forbiddenResponse,
       },
-      security: PUBLIC_SECURITY,
+      security: OPTIONAL_AUTHENTICATION_SECURITY,
       summary: "Resolve a course request",
       tags: ["Course prompts"],
     },

--- a/apps/api/src/lib/openapi/paths/generations.ts
+++ b/apps/api/src/lib/openapi/paths/generations.ts
@@ -6,6 +6,7 @@ import {
   notFoundResponse,
   paymentRequiredResponse,
   tooManyRequestsResponse,
+  unauthorizedResponse,
   validationErrorResponse,
 } from "../schemas/responses";
 import {
@@ -14,13 +15,13 @@ import {
   generationResourceSchema,
   workflowEventsQuerySchema,
 } from "../schemas/workflows";
-import { OPTIONAL_AUTHENTICATION_SECURITY, PUBLIC_SECURITY } from "../security";
+import { AUTHENTICATED_SECURITY, PUBLIC_SECURITY } from "../security";
 
 export const generationPaths = {
   "/generations": {
     post: {
       description:
-        "Starts course, chapter, or lesson generation. Daily and monthly limits depend on the caller's entitlement. Chapter and lesson targets also require an active subscription when the free first-chapter rule does not apply.",
+        "Starts authenticated course, chapter, or lesson generation. Daily and monthly limits depend on the caller's entitlement. Chapter and lesson targets also require an active subscription when the free first-chapter rule does not apply.",
       operationId: "createGeneration",
       requestBody: {
         content: { "application/json": { schema: createGenerationRequestSchema } },
@@ -35,12 +36,13 @@ export const generationPaths = {
           }),
         },
         "400": badRequestResponse,
+        "401": unauthorizedResponse,
         "402": paymentRequiredResponse,
         "403": forbiddenResponse,
         "404": notFoundResponse,
         "429": tooManyRequestsResponse,
       },
-      security: OPTIONAL_AUTHENTICATION_SECURITY,
+      security: AUTHENTICATED_SECURITY,
       summary: "Create a generation",
       tags: ["Workflows"],
     },

--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -10,7 +10,7 @@ import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 import {
   type GenerationTriggerResponse,
-  getGenerationLimitResponse,
+  getGenerationTriggerRequests,
   isGenerationEvents,
   isGenerationTrigger,
   routeGenerationApis,
@@ -20,7 +20,7 @@ import {
  * Test Architecture for Chapter Generation Page
  *
  * The generation page has 3 access states:
- * 1. First chapter - Shows generation UI without login
+ * 1. Unauthenticated - Shows the login gate
  * 2. Authenticated without subscription - Shows upgrade CTA
  * 3. Authenticated with subscription - Shows generation UI
  *
@@ -115,6 +115,31 @@ async function setupMockApis(page: Page, options: MockApiOptions = {}): Promise<
   await routeGenerationApis({ handler, page });
 }
 
+/** Confirms the server gate replaces every anonymous chapter-generation client. */
+async function expectChapterAuthenticationGate({
+  chapterId,
+  page,
+}: {
+  chapterId: string;
+  page: Page;
+}) {
+  await expect(page.getByRole("heading", { name: "Log in to create with AI" })).toBeVisible();
+
+  await expect(page.getByRole("link", { name: "Explore courses" })).toHaveAttribute(
+    "href",
+    "/courses",
+  );
+
+  await expect(page.getByRole("link", { name: "Log in" })).toHaveAttribute(
+    "href",
+    `/login?next=%2Fgenerate%2Fch%2F${chapterId}`,
+  );
+
+  await expect(getGenerationTriggerRequests({ page, targetType: "chapter" })).resolves.toHaveLength(
+    0,
+  );
+}
+
 /**
  * Creates a chapter with pending generation status for testing the generation workflow.
  */
@@ -169,32 +194,46 @@ async function createTestSubscription(userId: string) {
 }
 
 test.describe("Generate Chapter Page - Unauthenticated", () => {
-  test("explains when the daily chapter generation limit is reached", async ({ page }) => {
+  test("requires login before first-chapter generation", async ({ page }) => {
     const { chapter } = await createPendingChapter();
-
-    await setupMockApis(page, {
-      triggerResponse: getGenerationLimitResponse({
-        period: "day",
-        resource: "chapter",
-        viewer: "guest",
-      }),
-    });
 
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByRole("heading", { name: "Daily chapter limit reached" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Log in" })).toBeVisible();
+    await expectChapterAuthenticationGate({ chapterId: chapter.id, page });
   });
 
-  test("shows upgrade CTA for later chapters", async ({ page }) => {
+  test("requires login before checking a later chapter subscription", async ({ page }) => {
     const { chapter } = await createPendingChapter(1);
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByText(/^keep learning with plus$/iu)).toBeVisible();
+    await expectChapterAuthenticationGate({ chapterId: chapter.id, page });
+    await expect(page.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
+  });
 
-    const upgradeLink = page.getByRole("link", { name: /get zoonk plus/iu });
-    await expect(upgradeLink).toBeVisible();
-    await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
+  test("redirects a completed first chapter to its public page", async ({ page }) => {
+    const { chapter, course, organizationId } = await createPendingChapter();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    await Promise.all([
+      lessonFixture({
+        chapterId: chapter.id,
+        isPublished: true,
+        organizationId,
+        slug: `e2e-ready-public-lesson-${uniqueId}`,
+        title: `E2E Ready Public Lesson ${uniqueId}`,
+      }),
+      prisma.chapter.update({ data: { generationStatus: "completed" }, where: { id: chapter.id } }),
+    ]);
+
+    await page.goto(`/generate/ch/${chapter.id}`);
+
+    await page.waitForURL(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}`, {
+      timeout: 10_000,
+    });
+
+    await expect(
+      getGenerationTriggerRequests({ page, targetType: "chapter" }),
+    ).resolves.toHaveLength(0);
   });
 });
 
@@ -545,20 +584,6 @@ test.describe("Generate Chapter Page - With Subscription", () => {
 });
 
 test.describe("Generate Chapter Page - First Chapter Free", () => {
-  test("unauthenticated user sees generation UI for first chapter", async ({ page }) => {
-    const { chapter } = await createPendingChapter(0);
-
-    await setupMockApis(page, {
-      statusDelayMs: 2500,
-      streamMessages: [{ status: "started", step: "getChapter" }],
-    });
-
-    await page.goto(`/generate/ch/${chapter.id}`);
-
-    await expect(page.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
-    await expect(page.getByRole("heading", { name: chapter.title })).toBeVisible();
-  });
-
   test("authenticated user without subscription sees generation UI for first chapter", async ({
     authenticatedPage,
   }) => {
@@ -577,9 +602,7 @@ test.describe("Generate Chapter Page - First Chapter Free", () => {
 });
 
 test.describe("Generate Chapter Page - Running Later Chapter Requires Subscription", () => {
-  test("unauthenticated user sees upgrade CTA for non-first chapter when status is running", async ({
-    page,
-  }) => {
+  test("unauthenticated user sees the login gate when status is running", async ({ page }) => {
     const org = await getAiOrganization();
     const uniqueId = randomUUID().slice(0, 8);
 
@@ -606,13 +629,8 @@ test.describe("Generate Chapter Page - Running Later Chapter Requires Subscripti
 
     await page.goto(`/generate/ch/${chapter.id}`);
 
-    await expect(page.getByText(/^keep learning with plus$/iu)).toBeVisible();
-
-    await expect(
-      page.getByText(
-        "Plus gives you unlimited courses and lessons for whatever you want to learn.",
-      ),
-    ).toBeVisible();
+    await expectChapterAuthenticationGate({ chapterId: chapter.id, page });
+    await expect(page.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
   });
 });
 

--- a/apps/main/e2e/generate-course-redirect.test.ts
+++ b/apps/main/e2e/generate-course-redirect.test.ts
@@ -5,7 +5,12 @@ import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
-import { isGenerationEvents, isGenerationTrigger, routeGenerationApis } from "./generation-api";
+import {
+  getGenerationTriggerRequests,
+  isGenerationEvents,
+  isGenerationTrigger,
+  routeGenerationApis,
+} from "./generation-api";
 
 const TEST_RUN_ID = "test-run-id-redirect";
 
@@ -77,7 +82,7 @@ test.describe("Generate Course Redirect", () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  test("redirects unauthenticated users to generate/course/[id]", async ({ page }) => {
+  test("shows the login gate after resolving an unauthenticated prompt route", async ({ page }) => {
     const slug = `e2e-redirect-unauth-${randomUUID().slice(0, 8)}`;
     const org = await getAiOrganization();
     const title = "E2E Redirect Unauth Test";
@@ -99,15 +104,25 @@ test.describe("Generate Course Redirect", () => {
       prompt: `Generate ${title} ${slug}`,
     });
 
-    await routeGenerationApis({ handler: mockCourseGenerationApis, page });
-
     await page.goto(`/generate/c/${slug}`);
 
     await page.waitForURL(`/generate/course/${request.id}`, { timeout: 10_000 });
 
-    await expect(page.getByRole("heading", { name: `Creating the ${title} course` })).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(page.getByRole("heading", { name: "Log in to create with AI" })).toBeVisible();
+
+    await expect(page.getByRole("link", { name: "Explore courses" })).toHaveAttribute(
+      "href",
+      "/courses",
+    );
+
+    await expect(page.getByRole("link", { name: "Log in" })).toHaveAttribute(
+      "href",
+      `/login?next=%2Fgenerate%2Fcourse%2F${request.id}`,
+    );
+
+    await expect(
+      getGenerationTriggerRequests({ page, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(0);
   });
 
   test("shows 404 when course request does not exist", async ({ authenticatedPage }) => {

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { GENERATION_VISITOR_ID_HEADER } from "@zoonk/core/generation-quotas/contract";
 import {
   COURSE_COMPLETION_STEP,
   INTRODUCTION_LESSON_COMPLETION_STEP,
@@ -15,6 +14,7 @@ import { expect, test } from "./fixtures";
 import {
   type GenerationTriggerResponse,
   getGenerationLimitResponse,
+  getGenerationTriggerRequests,
   isGenerationEvents,
   isGenerationTrigger,
   routeGenerationApis,
@@ -217,71 +217,41 @@ function getIntroLessonCompletionTarget({
 }
 
 test.describe("Generate Course Page", () => {
-  test("starts course generation for unauthenticated users", async ({ page }) => {
+  test("asks unauthenticated users to log in without starting generation", async ({ page }) => {
     const coursePrompt = await coursePromptFixture({
       canonicalTitle: "E2E Unauth Course Generation",
       generationStatus: "pending",
       language: "en",
     });
 
-    await setupMockApis(page, {
-      statusDelayMs: 2500,
-      streamMessages: [{ status: "started", step: "getCoursePrompt" }],
-    });
-
-    const generationRequest = page.waitForRequest(
-      (pageRequest) =>
-        pageRequest.method() === "POST" &&
-        isGenerationTrigger({ request: pageRequest, targetType: "coursePrompt" }),
-    );
-
     await page.goto(`/generate/course/${coursePrompt.id}`);
 
-    const generationTriggerRequest = await generationRequest;
-    const requestHeaders = generationTriggerRequest.headers();
-
-    expect(requestHeaders[GENERATION_VISITOR_ID_HEADER.toLowerCase()]).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
-    );
-
-    await expect(
-      page.getByRole("heading", { name: "Creating the E2E Unauth Course Generation course" }),
-    ).toBeVisible({ timeout: 10_000 });
-  });
-
-  test("explains a daily guest limit and offers login without hiding existing learning", async ({
-    page,
-  }) => {
-    const request = await coursePromptFixture({
-      canonicalTitle: "E2E Limited Course Generation",
-      generationStatus: "pending",
-      language: "en",
-    });
-
-    await setupMockApis(page, {
-      triggerResponse: getGenerationLimitResponse({
-        period: "day",
-        resource: "course",
-        viewer: "guest",
-      }),
-    });
-
-    await page.goto(`/generate/course/${request.id}`);
-
-    await expect(page.getByRole("heading", { name: "Daily course limit reached" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Log in to create with AI" })).toBeVisible();
 
     await expect(
       page.getByText(
-        "You've reached today's limit for generating courses. You can keep learning from anything already generated.",
+        "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in.",
       ),
     ).toBeVisible();
+
+    const exploreCoursesLink = page.getByRole("link", { name: "Explore courses" });
+
+    await expect(exploreCoursesLink).toHaveAttribute("href", "/courses");
 
     const loginLink = page.getByRole("link", { name: "Log in" });
 
     await expect(loginLink).toHaveAttribute(
       "href",
-      `/login?next=%2Fgenerate%2Fcourse%2F${request.id}`,
+      `/login?next=%2Fgenerate%2Fcourse%2F${coursePrompt.id}`,
     );
+
+    await expect(
+      getGenerationTriggerRequests({ page, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(0);
+
+    await exploreCoursesLink.focus();
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(/\/courses$/u);
   });
 
   test("offers a subscription when an authenticated user reaches a monthly limit", async ({
@@ -341,14 +311,21 @@ test.describe("Generate Course Page", () => {
   });
 
   test.describe("Initial triggering state", () => {
-    test("hydrates localized progress values consistently", async ({ browser }) => {
+    test("hydrates localized progress values consistently", async ({
+      browser,
+      withProgressUser,
+    }) => {
       const request = await coursePromptFixture({
         canonicalTitle: "E2E Localized Progress",
         generationStatus: "pending",
         language: "de",
       });
 
-      const browserContext = await browser.newContext({ locale: "de-DE" });
+      const browserContext = await browser.newContext({
+        locale: "de-DE",
+        storageState: withProgressUser.storageState,
+      });
+
       const localizedPage = await browserContext.newPage();
       const hydrationErrors: Error[] = [];
 

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -11,7 +11,7 @@ import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
 import {
   type GenerationTriggerResponse,
-  getGenerationLimitResponse,
+  getGenerationTriggerRequests,
   isGenerationEvents,
   isGenerationTrigger,
   routeGenerationApis,
@@ -114,6 +114,31 @@ function createRouteHandler(options: MockApiOptions) {
 async function setupMockApis(page: Page, options: MockApiOptions = {}): Promise<void> {
   const handler = createRouteHandler(options);
   await routeGenerationApis({ handler, page });
+}
+
+/** Confirms the server gate replaces every anonymous lesson-generation client. */
+async function expectLessonAuthenticationGate({
+  lessonId,
+  page,
+}: {
+  lessonId: string;
+  page: Page;
+}) {
+  await expect(page.getByRole("heading", { name: "Log in to create with AI" })).toBeVisible();
+
+  await expect(page.getByRole("link", { name: "Explore courses" })).toHaveAttribute(
+    "href",
+    "/courses",
+  );
+
+  await expect(page.getByRole("link", { name: "Log in" })).toHaveAttribute(
+    "href",
+    `/login?next=%2Fgenerate%2Fl%2F${lessonId}`,
+  );
+
+  await expect(getGenerationTriggerRequests({ page, targetType: "lesson" })).resolves.toHaveLength(
+    0,
+  );
 }
 
 /**
@@ -300,38 +325,49 @@ async function createTestSubscription(userId: string) {
 }
 
 test.describe("Generate Lesson Page - Unauthenticated", () => {
-  test("explains when the daily lesson generation limit is reached", async ({ page }) => {
+  test("requires login before first-chapter lesson generation", async ({ page }) => {
     const { lesson } = await createPendingLesson();
-
-    await setupMockApis(page, {
-      triggerResponse: getGenerationLimitResponse({
-        period: "day",
-        resource: "lesson",
-        viewer: "guest",
-      }),
-    });
 
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByRole("heading", { name: "Daily lesson limit reached" })).toBeVisible();
-    await expect(page.getByRole("link", { name: "Log in" })).toBeVisible();
+    await expectLessonAuthenticationGate({ lessonId: lesson.id, page });
   });
 
-  test("shows upgrade CTA for later chapter lessons", async ({ page }) => {
+  test("requires login before checking a later lesson subscription", async ({ page }) => {
     const { lesson } = await createPendingLesson({ chapterPosition: 1 });
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByText(/^keep learning with plus$/iu)).toBeVisible();
+    await expectLessonAuthenticationGate({ lessonId: lesson.id, page });
+    await expect(page.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
+  });
+
+  test("redirects a completed first-chapter lesson to its public page", async ({ page }) => {
+    const { lesson } = await createPendingLesson();
+    const uniqueId = randomUUID().slice(0, 8);
+
+    await Promise.all([
+      stepFixture({
+        content: {
+          text: `E2E Ready Public Lesson ${uniqueId}`,
+          title: `E2E Ready Public Lesson ${uniqueId}`,
+          variant: "text",
+        },
+        isPublished: true,
+        kind: "static",
+        lessonId: lesson.id,
+      }),
+      prisma.lesson.update({ data: { generationStatus: "completed" }, where: { id: lesson.id } }),
+    ]);
+
+    await page.goto(`/generate/l/${lesson.id}`);
+
+    await page.waitForURL(new RegExp(`/b/${AI_ORG_SLUG}/c/.+/ch/.+/l/${lesson.slug}`, "u"), {
+      timeout: 10_000,
+    });
 
     await expect(
-      page.getByText(
-        "Plus gives you unlimited courses and lessons for whatever you want to learn.",
-      ),
-    ).toBeVisible();
-
-    const upgradeLink = page.getByRole("link", { name: /get zoonk plus/iu });
-    await expect(upgradeLink).toBeVisible();
-    await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
+      getGenerationTriggerRequests({ page, targetType: "lesson" }),
+    ).resolves.toHaveLength(0);
   });
 });
 
@@ -366,23 +402,6 @@ test.describe("Generate Lesson Page - No Subscription", () => {
 });
 
 test.describe("Generate Lesson Page - First Chapter Free", () => {
-  test("unauthenticated user sees generation UI for every first-chapter lesson", async ({
-    page,
-  }) => {
-    const { lesson } = await createPendingLesson({ chapterPosition: 0, lessonPosition: 99 });
-
-    await setupMockApis(page, {
-      statusDelayMs: 2500,
-      streamMessages: [{ status: "started", step: "getLesson" }],
-    });
-
-    await page.goto(`/generate/l/${lesson.id}`);
-
-    await expect(page.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
-
-    await expect(page.getByRole("heading", { name: lesson.title ?? "" })).toBeVisible();
-  });
-
   test("authenticated user without subscription sees generation UI for every first-chapter lesson", async ({
     authenticatedPage,
   }) => {
@@ -426,37 +445,39 @@ test.describe("Generate Lesson Page - Independent Lessons", () => {
   });
 
   test("redirects pending translation generation to source vocabulary generation", async ({
-    page,
+    authenticatedPage,
   }) => {
     const { companionLesson, sourceLesson } = await createPendingCompanionLesson({
       sourceKind: "vocabulary",
       targetKind: "translation",
     });
 
-    await setupMockApis(page, {
+    await setupMockApis(authenticatedPage, {
       statusDelayMs: 2500,
       streamMessages: [{ status: "started", step: "getLesson" }],
     });
 
-    await page.goto(`/generate/l/${companionLesson.id}`);
+    await authenticatedPage.goto(`/generate/l/${companionLesson.id}`);
 
-    await expect(page).toHaveURL(new RegExp(`/generate/l/${sourceLesson.id}$`, "u"));
+    await expect(authenticatedPage).toHaveURL(new RegExp(`/generate/l/${sourceLesson.id}$`, "u"));
   });
 
-  test("redirects pending listening generation to source reading generation", async ({ page }) => {
+  test("redirects pending listening generation to source reading generation", async ({
+    authenticatedPage,
+  }) => {
     const { companionLesson, sourceLesson } = await createPendingCompanionLesson({
       sourceKind: "reading",
       targetKind: "listening",
     });
 
-    await setupMockApis(page, {
+    await setupMockApis(authenticatedPage, {
       statusDelayMs: 2500,
       streamMessages: [{ status: "started", step: "getLesson" }],
     });
 
-    await page.goto(`/generate/l/${companionLesson.id}`);
+    await authenticatedPage.goto(`/generate/l/${companionLesson.id}`);
 
-    await expect(page).toHaveURL(new RegExp(`/generate/l/${sourceLesson.id}$`, "u"));
+    await expect(authenticatedPage).toHaveURL(new RegExp(`/generate/l/${sourceLesson.id}$`, "u"));
   });
 });
 
@@ -590,7 +611,7 @@ test.describe("Generate Lesson Page - With Subscription", () => {
 });
 
 test.describe("Generate Lesson Page - Running Later Lesson Requires Subscription", () => {
-  test("unauthenticated user sees upgrade CTA when status is running", async ({ page }) => {
+  test("unauthenticated user sees the login gate when status is running", async ({ page }) => {
     const org = await getAiOrganization();
     const uniqueId = randomUUID().slice(0, 8);
 
@@ -628,7 +649,8 @@ test.describe("Generate Lesson Page - Running Later Lesson Requires Subscription
 
     await page.goto(`/generate/l/${lesson.id}`);
 
-    await expect(page.getByText(/^keep learning with plus$/iu)).toBeVisible();
+    await expectLessonAuthenticationGate({ lessonId: lesson.id, page });
+    await expect(page.getByText(/^keep learning with plus$/iu)).toHaveCount(0);
   });
 });
 

--- a/apps/main/e2e/generation-api.ts
+++ b/apps/main/e2e/generation-api.ts
@@ -53,6 +53,18 @@ export function isGenerationEvents(url: string) {
   return /^\/v1\/generations\/[^/]+\/events$/u.test(new URL(url).pathname);
 }
 
+/** Returns the generation commands observed by the browser for one target type. */
+export async function getGenerationTriggerRequests({
+  page,
+  targetType,
+}: {
+  page: Page;
+  targetType: GenerationTargetType;
+}) {
+  const requests = await page.requests();
+  return requests.filter((request) => isGenerationTrigger({ request, targetType }));
+}
+
 /**
  * Intercepts the generation collection and its child resources with one
  * handler, matching the single public resource exposed by the API.

--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -9,7 +9,12 @@ import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
 import { expect, test } from "./fixtures";
-import { isGenerationEvents, isGenerationTrigger, routeGenerationApis } from "./generation-api";
+import {
+  getGenerationTriggerRequests,
+  isGenerationEvents,
+  isGenerationTrigger,
+  routeGenerationApis,
+} from "./generation-api";
 
 const TEST_RUN_ID = "test-run-id-learn-generate-link";
 
@@ -250,18 +255,40 @@ test.describe("Learn Form", () => {
     );
   });
 
-  test("submitting prompt starts topic course generation for unauthenticated users", async ({
+  test("submitting an uncached prompt requires login without starting generation", async ({
     page,
   }) => {
-    await mockCourseGenerationWorkflow(page);
-
-    const cached = await cacheTopicPrompt(`e2e guest topic ${randomUUID()}`);
+    const prompt = `e2e uncached guest topic ${randomUUID()}`;
+    const promptPath = `/start/learn/${encodeURIComponent(prompt)}`;
 
     await page.goto("/start/learn");
-    await page.getByRole("textbox").fill(cached.prompt);
+    await page.getByRole("textbox").fill(prompt);
     await page.keyboard.press("Enter");
 
-    await expect(page).toHaveURL(new RegExp(`/generate/course/${cached.request.id}$`, "u"));
+    await expect(page).toHaveURL(new RegExp(`${promptPath}$`, "u"));
+    await expect(page.getByRole("heading", { name: "Log in to create with AI" })).toBeVisible();
+
+    await expect(page.getByRole("link", { name: "Explore courses" })).toHaveAttribute(
+      "href",
+      "/courses",
+    );
+
+    await expect(page.getByRole("link", { name: "Log in" })).toHaveAttribute(
+      "href",
+      `/login?next=${encodeURIComponent(promptPath)}`,
+    );
+
+    await expect(
+      getGenerationTriggerRequests({ page, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(0);
+
+    await expect(
+      prisma.coursePrompt.findUnique({
+        where: {
+          languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
+        },
+      }),
+    ).resolves.toBeNull();
   });
 });
 
@@ -275,14 +302,18 @@ test.describe("Course Start Routing", () => {
     await expect(page.getByRole("textbox")).toBeVisible();
   });
 
-  test("redirects cached topic prompts to the generation page", async ({ page }) => {
-    await mockCourseGenerationWorkflow(page);
+  test("redirects cached topic prompts to the generation page for signed-in users", async ({
+    authenticatedPage,
+  }) => {
+    await mockCourseGenerationWorkflow(authenticatedPage);
 
     const cached = await cacheTopicPrompt(`e2e direct Python 3.12 topic ${randomUUID()}`);
 
-    await page.goto(`/start/learn/${encodeURIComponent(cached.prompt)}`);
+    await authenticatedPage.goto(`/start/learn/${encodeURIComponent(cached.prompt)}`);
 
-    await expect(page).toHaveURL(new RegExp(`/generate/course/${cached.request.id}$`, "u"));
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`/generate/course/${cached.request.id}$`, "u"),
+    );
   });
 
   test("redirects cached topic prompts to existing reusable courses", async ({ page }) => {

--- a/apps/main/e2e/start.test.ts
+++ b/apps/main/e2e/start.test.ts
@@ -7,7 +7,12 @@ import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { normalizeString } from "@zoonk/utils/string";
 import { mockFeedbackSubmission } from "./feedback";
 import { expect, test } from "./fixtures";
-import { isGenerationEvents, isGenerationTrigger, routeGenerationApis } from "./generation-api";
+import {
+  getGenerationTriggerRequests,
+  isGenerationEvents,
+  isGenerationTrigger,
+  routeGenerationApis,
+} from "./generation-api";
 
 const TEST_RUN_ID = "test-run-id-start-language";
 
@@ -96,32 +101,34 @@ test.describe("Start page", () => {
 });
 
 test.describe("Start language path", () => {
-  test("filters languages and creates a controlled language request", async ({ page }) => {
-    await mockCourseGenerationWorkflow(page);
-    await page.goto("/start/speak");
+  test("filters languages and creates a controlled language request", async ({
+    authenticatedPage,
+  }) => {
+    await mockCourseGenerationWorkflow(authenticatedPage);
+    await authenticatedPage.goto("/start/speak");
 
     await expect(
-      page.getByRole("heading", { name: /what language do you want to learn/iu }),
+      authenticatedPage.getByRole("heading", { name: /what language do you want to learn/iu }),
     ).toBeVisible();
 
-    await expect(page.getByRole("button", { name: "Português" })).not.toBeVisible();
-    await expect(page.getByRole("link", { name: /^english/iu })).not.toBeVisible();
+    await expect(authenticatedPage.getByRole("button", { name: "Português" })).not.toBeVisible();
+    await expect(authenticatedPage.getByRole("link", { name: /^english/iu })).not.toBeVisible();
 
-    await page.getByRole("searchbox", { name: /search languages/iu }).fill("Javanese");
+    await authenticatedPage.getByRole("searchbox", { name: /search languages/iu }).fill("Javanese");
 
-    await expect(page.getByRole("link", { name: /javanese/iu })).toBeVisible();
-    await expect(page.getByRole("link", { name: /^english/iu })).not.toBeVisible();
+    await expect(authenticatedPage.getByRole("link", { name: /javanese/iu })).toBeVisible();
+    await expect(authenticatedPage.getByRole("link", { name: /^english/iu })).not.toBeVisible();
 
-    const javaneseLink = page.getByRole("link", { name: /javanese/iu });
+    const javaneseLink = authenticatedPage.getByRole("link", { name: /javanese/iu });
 
     await expect(javaneseLink).toHaveAttribute("href", "/start/speak/jv");
     await expect(javaneseLink).toHaveAttribute("rel", "nofollow");
 
     await javaneseLink.click();
 
-    await expect(page).toHaveURL(/\/generate\/course\/[-a-f0-9]+$/u);
+    await expect(authenticatedPage).toHaveURL(/\/generate\/course\/[-a-f0-9]+$/u);
 
-    const requestId = page.url().split("/").at(-1);
+    const requestId = authenticatedPage.url().split("/").at(-1);
 
     if (!requestId) {
       throw new Error("Missing generated request id in URL");
@@ -130,6 +137,34 @@ test.describe("Start language path", () => {
     const request = await prisma.coursePrompt.findUnique({ where: { id: requestId } });
 
     expect(request?.targetLanguage).toBe("jv");
+  });
+
+  test("requires login before creating a missing language course", async ({ page }) => {
+    const normalizedPrompt = normalizeString("Learn Amharic");
+    const promptWhere = { languageNormalizedPrompt: { language: "en", normalizedPrompt } };
+    const promptBeforeVisit = await prisma.coursePrompt.findUnique({ where: promptWhere });
+
+    await page.goto("/start/speak/am");
+
+    await expect(page.getByRole("heading", { name: "Log in to create with AI" })).toBeVisible();
+
+    await expect(page.getByRole("link", { name: "Explore courses" })).toHaveAttribute(
+      "href",
+      "/courses",
+    );
+
+    await expect(page.getByRole("link", { name: "Log in" })).toHaveAttribute(
+      "href",
+      "/login?next=%2Fstart%2Fspeak%2Fam",
+    );
+
+    await expect(
+      getGenerationTriggerRequests({ page, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(0);
+
+    await expect(prisma.coursePrompt.findUnique({ where: promptWhere })).resolves.toStrictEqual(
+      promptBeforeVisit,
+    );
   });
 
   test("does not generate a course for the current app language", async ({ page }) => {

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -517,6 +517,7 @@ msgid "Online Courses using AI"
 msgstr "Online‑Kurse mit KI"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 msgctxt "s-Ncqj"
 msgid "Explore courses"
 msgstr "Kurse entdecken"
@@ -547,6 +548,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Melde dich an, um deine Kurse und Fortschritte an einem Ort zu verwalten."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
@@ -2684,6 +2686,16 @@ msgstr "Feedback"
 msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Sende Feedback, Fragen oder Vorschläge an uns. Fülle das Formular aus oder schreibe uns direkt an hello@zoonk.com."
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "kGkxlG"
+msgid "Log in to create with AI"
+msgstr "Melde dich an, um Inhalte mit KI zu erstellen"
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "Jjw_0c"
+msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
+msgstr "Du musst dich anmelden, um mit KI neue Kurse und Lektionen zu erstellen. Bestehende Kurse kannst du auch ohne Anmeldung erkunden."
 
 #: src/components/generation/generation-limit-cta.tsx
 #: src/components/subscription/upgrade-cta.tsx

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -517,6 +517,7 @@ msgid "Online Courses using AI"
 msgstr "Online Courses using AI"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 msgctxt "s-Ncqj"
 msgid "Explore courses"
 msgstr "Explore courses"
@@ -547,6 +548,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Keep your courses and progress in one place by logging in to your account."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
@@ -2684,6 +2686,16 @@ msgstr "Feedback"
 msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "kGkxlG"
+msgid "Log in to create with AI"
+msgstr "Log in to create with AI"
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "Jjw_0c"
+msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
+msgstr "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
 
 #: src/components/generation/generation-limit-cta.tsx
 #: src/components/subscription/upgrade-cta.tsx

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -517,6 +517,7 @@ msgid "Online Courses using AI"
 msgstr "Cursos en línea con IA"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 msgctxt "s-Ncqj"
 msgid "Explore courses"
 msgstr "Explorar cursos"
@@ -547,6 +548,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Inicia sesión en tu cuenta para tener tus cursos y tu progreso en un solo lugar."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
@@ -2684,6 +2686,16 @@ msgstr "Comentarios"
 msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envíanos comentarios, preguntas o sugerencias. Completa el formulario de abajo o escríbenos directamente a contacto@zoonk.com."
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "kGkxlG"
+msgid "Log in to create with AI"
+msgstr "Inicia sesión para crear con IA"
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "Jjw_0c"
+msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
+msgstr "Debes iniciar sesión para crear nuevos cursos y lecciones con IA. Puedes explorar los cursos existentes sin iniciar sesión."
 
 #: src/components/generation/generation-limit-cta.tsx
 #: src/components/subscription/upgrade-cta.tsx

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -517,6 +517,7 @@ msgid "Online Courses using AI"
 msgstr "Cours en ligne avec l'IA"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 msgctxt "s-Ncqj"
 msgid "Explore courses"
 msgstr "Explorer les cours"
@@ -547,6 +548,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Connecte-toi à ton compte pour retrouver tes cours et ta progression au même endroit."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
@@ -2684,6 +2686,16 @@ msgstr "Avis"
 msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envoie-nous tes avis, questions ou suggestions. Remplis le formulaire ci-dessous ou écris-nous directement à hello@zoonk.com."
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "kGkxlG"
+msgid "Log in to create with AI"
+msgstr "Connecte-toi pour créer avec l’IA"
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "Jjw_0c"
+msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
+msgstr "Tu dois te connecter pour créer de nouveaux cours et de nouvelles leçons avec l’IA. Tu peux explorer les cours existants sans te connecter."
 
 #: src/components/generation/generation-limit-cta.tsx
 #: src/components/subscription/upgrade-cta.tsx

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -517,6 +517,7 @@ msgid "Online Courses using AI"
 msgstr "Cursos online com IA"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 msgctxt "s-Ncqj"
 msgid "Explore courses"
 msgstr "Explorar cursos"
@@ -547,6 +548,7 @@ msgid "Keep your courses and progress in one place by logging in to your account
 msgstr "Entre na sua conta para manter seus cursos e progresso em um só lugar."
 
 #: src/app/[lang]/(catalog)/my/page.tsx
+#: src/components/generation/generation-authentication-cta.tsx
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "odXlk8"
 msgid "Log in"
@@ -2684,6 +2686,16 @@ msgstr "Feedback"
 msgctxt "eUzs3M"
 msgid "Send feedback, questions, or suggestions to us. Fill in the form below or email us directly at hello@zoonk.com."
 msgstr "Envie feedback, perguntas ou sugestões. Preencha o formulário abaixo ou fale com a gente direto pelo email contato@zoonk.com."
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "kGkxlG"
+msgid "Log in to create with AI"
+msgstr "Entre para criar com IA"
+
+#: src/components/generation/generation-authentication-cta.tsx
+msgctxt "Jjw_0c"
+msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
+msgstr "Você precisa entrar para criar novos cursos e aulas com IA. Você pode explorar os cursos existentes sem entrar."
 
 #: src/components/generation/generation-limit-cta.tsx
 #: src/components/subscription/upgrade-cta.tsx

--- a/apps/main/src/app/[lang]/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
@@ -1,3 +1,4 @@
+import { GenerationAuthenticationCTA } from "@/components/generation/generation-authentication-cta";
 import { resolveCoursePrompt } from "@/data/courses/course-prompt";
 import { Link, redirect } from "@/i18n/navigation";
 import { type UnsupportedCoursePrompt } from "@zoonk/core/courses/resolve-prompt";
@@ -117,6 +118,17 @@ export async function CourseStartResult({ prompt }: { prompt: string }) {
 
   if (result.kind === "generate") {
     return redirect({ href: `/generate/course/${result.prompt.id}`, locale });
+  }
+
+  if (result.kind === "unauthorized") {
+    const loginHref =
+      `/login?next=${encodeURIComponent(`/start/learn/${encodeURIComponent(prompt)}`)}` as const;
+
+    return (
+      <StartSurface>
+        <GenerationAuthenticationCTA loginHref={loginHref} />
+      </StartSurface>
+    );
   }
 
   if (result.kind === "unsafe") {

--- a/apps/main/src/app/[lang]/(catalog)/start/speak/[language]/page.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/start/speak/[language]/page.tsx
@@ -1,3 +1,4 @@
+import { GenerationAuthenticationCTA } from "@/components/generation/generation-authentication-cta";
 import { getAiCourseHref } from "@/data/courses/course-href";
 import { redirect } from "@/i18n/navigation";
 import { resolveLanguageCourse } from "@zoonk/core/courses/language";
@@ -37,6 +38,17 @@ async function StartSpeakLanguageRedirect({ params }: { params: StartSpeakLangua
 
   if (resolution.kind === "course") {
     return redirect({ href: getAiCourseHref(resolution.course), locale });
+  }
+
+  if (resolution.kind === "unauthorized") {
+    const loginHref =
+      `/login?next=${encodeURIComponent(`/start/speak/${targetLanguage}`)}` as const;
+
+    return (
+      <StartSurface>
+        <GenerationAuthenticationCTA loginHref={loginHref} />
+      </StartSurface>
+    );
   }
 
   return redirect({ href: `/generate/course/${resolution.coursePrompt.id}`, locale });

--- a/apps/main/src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
@@ -1,3 +1,4 @@
+import { GenerationAuthenticationCTA } from "@/components/generation/generation-authentication-cta";
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import { SubscriptionGate } from "@/components/subscription/subscription-gate";
 import { getInitialGenerationPageStatus } from "@/lib/workflow/get-initial-generation-page-status";
@@ -22,6 +23,18 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
 
   if (access.status === "notFound") {
     notFound();
+  }
+
+  if (access.status === "unauthorized") {
+    const loginHref = `/login?next=${encodeURIComponent(`/generate/ch/${id}`)}` as const;
+
+    return (
+      <Container variant="narrow">
+        <ContainerBody>
+          <GenerationAuthenticationCTA loginHref={loginHref} />
+        </ContainerBody>
+      </Container>
+    );
   }
 
   const { chapter } = access;

--- a/apps/main/src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
+++ b/apps/main/src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
@@ -1,6 +1,8 @@
+import { GenerationAuthenticationCTA } from "@/components/generation/generation-authentication-cta";
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import { redirect } from "@/i18n/navigation";
 import { getCoursePromptGeneration } from "@zoonk/core/courses/get-prompt-generation";
+import { getSession } from "@zoonk/core/users/session";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
 import { Empty, EmptyContent, EmptyHeader } from "@zoonk/ui/components/empty";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
@@ -15,7 +17,11 @@ export async function GenerateCoursePromptContent({
   params: Promise<{ id: string; lang: string }>;
 }) {
   const { id, lang: locale } = await params;
-  const generation = await getCoursePromptGeneration({ coursePromptId: id });
+
+  const [generation, session] = await Promise.all([
+    getCoursePromptGeneration({ coursePromptId: id }),
+    getSession(),
+  ]);
 
   if (generation.status === "notFound") {
     notFound();
@@ -30,6 +36,18 @@ export async function GenerateCoursePromptContent({
       href: `/b/${AI_ORG_SLUG}/c/${generation.target.courseSlug}/ch/${generation.target.chapterSlug}/l/${generation.target.lessonSlug}`,
       locale,
     });
+  }
+
+  if (!session) {
+    const loginHref = `/login?next=${encodeURIComponent(`/generate/course/${id}`)}` as const;
+
+    return (
+      <Container variant="narrow">
+        <ContainerBody>
+          <GenerationAuthenticationCTA loginHref={loginHref} />
+        </ContainerBody>
+      </Container>
+    );
   }
 
   const t = await getExtracted();

--- a/apps/main/src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
@@ -1,3 +1,4 @@
+import { GenerationAuthenticationCTA } from "@/components/generation/generation-authentication-cta";
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import { SubscriptionGate } from "@/components/subscription/subscription-gate";
 import { redirect } from "@/i18n/navigation";
@@ -28,6 +29,18 @@ export async function GenerateLessonContent({
 
   if (view.status === "notFound") {
     notFound();
+  }
+
+  if (view.status === "unauthorized") {
+    const loginHref = `/login?next=${encodeURIComponent(`/generate/l/${id}`)}` as const;
+
+    return (
+      <Container variant="narrow">
+        <ContainerBody>
+          <GenerationAuthenticationCTA loginHref={loginHref} />
+        </ContainerBody>
+      </Container>
+    );
   }
 
   if (view.status === "redirectToSource") {

--- a/apps/main/src/components/generation/generation-authentication-cta.tsx
+++ b/apps/main/src/components/generation/generation-authentication-cta.tsx
@@ -1,0 +1,49 @@
+import { GenerationShortcutLink } from "@/components/generation/generation-shortcut-link";
+import { type AppRoute } from "@/i18n/navigation";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@zoonk/ui/components/empty";
+import { LogInIcon } from "lucide-react";
+import { getExtracted } from "next-intl/server";
+
+/** Explains why AI creation is unavailable while keeping the public course catalog accessible. */
+export async function GenerationAuthenticationCTA<Href extends string>({
+  loginHref,
+}: {
+  loginHref: AppRoute<Href>;
+}) {
+  const t = await getExtracted();
+
+  return (
+    <Empty className="border-0">
+      <EmptyHeader align="start">
+        <EmptyMedia variant="icon">
+          <LogInIcon />
+        </EmptyMedia>
+
+        <EmptyTitle aria-level={1} role="heading">
+          {t("Log in to create with AI")}
+        </EmptyTitle>
+
+        <EmptyDescription>
+          {t(
+            "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in.",
+          )}
+        </EmptyDescription>
+      </EmptyHeader>
+
+      <EmptyContent align="stretch">
+        <GenerationShortcutLink href="/courses" prefetch variant="outline">
+          {t("Explore courses")}
+        </GenerationShortcutLink>
+
+        <GenerationShortcutLink href={loginHref}>{t("Log in")}</GenerationShortcutLink>
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/packages/core/src/courses/course-generation-access.test.ts
+++ b/packages/core/src/courses/course-generation-access.test.ts
@@ -24,21 +24,18 @@ describe(getCourseGenerationAccess, () => {
     });
   });
 
-  it("allows guest generation without inventing an acting user", async () => {
+  it("requires authentication before course generation", async () => {
     const prompt = await coursePromptFixture();
 
     await expect(getCourseGenerationAccess(prompt.id)).resolves.toStrictEqual({
-      coursePromptId: prompt.id,
-      courseSlug: null,
-      shouldClaimQuota: true,
-      status: "ready",
-      userId: null,
+      status: "unauthorized",
     });
   });
 
   it("returns the existing course slug without another generation lookup", async () => {
-    const course = await courseFixture();
+    const [course, user] = await Promise.all([courseFixture(), userFixture()]);
     const prompt = await coursePromptFixture({ courseId: course.id, generationStatus: "failed" });
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
 
     await expect(getCourseGenerationAccess(prompt.id)).resolves.toMatchObject({
       courseSlug: course.slug,
@@ -48,7 +45,12 @@ describe(getCourseGenerationAccess, () => {
   });
 
   it("does not claim quota when a course generation is already running", async () => {
-    const prompt = await coursePromptFixture({ generationStatus: "running" });
+    const [prompt, user] = await Promise.all([
+      coursePromptFixture({ generationStatus: "running" }),
+      userFixture(),
+    ]);
+
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
 
     await expect(getCourseGenerationAccess(prompt.id)).resolves.toMatchObject({
       shouldClaimQuota: false,
@@ -57,7 +59,12 @@ describe(getCourseGenerationAccess, () => {
   });
 
   it("distinguishes missing and invalid generation prompts", async () => {
-    const invalidPrompt = await coursePromptFixture({ intent: "question" });
+    const [invalidPrompt, user] = await Promise.all([
+      coursePromptFixture({ intent: "question" }),
+      userFixture(),
+    ]);
+
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
 
     const [missing, invalid] = await Promise.all([
       getCourseGenerationAccess(randomUUID()),

--- a/packages/core/src/courses/course-generation-access.ts
+++ b/packages/core/src/courses/course-generation-access.ts
@@ -8,7 +8,7 @@ function shouldClaimCourseGenerationQuota(generationStatus: string | null): bool
 }
 
 /**
- * Validates one persisted generation request and derives the optional learner
+ * Validates one persisted generation request and derives the learner
  * identity from the authenticated session before a delivery app starts the
  * workflow.
  *
@@ -21,6 +21,10 @@ export async function getCourseGenerationAccess(coursePromptId: string) {
     getCoursePromptById({ id: coursePromptId }),
     getSession(),
   ]);
+
+  if (!session) {
+    return { status: "unauthorized" as const };
+  }
 
   if (!coursePrompt) {
     return { status: "notFound" as const };
@@ -37,6 +41,6 @@ export async function getCourseGenerationAccess(coursePromptId: string) {
     courseSlug: coursePrompt.course?.slug ?? null,
     shouldClaimQuota: shouldClaimCourseGenerationQuota(coursePrompt.generationStatus),
     status: "ready" as const,
-    userId: session?.user.id ?? null,
+    userId: session.user.id,
   };
 }

--- a/packages/core/src/courses/language-course.test.ts
+++ b/packages/core/src/courses/language-course.test.ts
@@ -3,10 +3,14 @@ import { prisma } from "@zoonk/db";
 import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { aiOrganizationFixture, organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
 import { normalizeString } from "@zoonk/utils/string";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getSession } from "../users/get-session";
 import { listCompletedLanguageCourses, resolveLanguageCourse } from "./language-course";
 import { resolveCoursePrompt } from "./resolve-course-prompt";
+
+vi.mock("../users/get-session", () => ({ getSession: vi.fn() }));
 
 /**
  * Creates a source-language value that no seeded course should use, so each
@@ -209,10 +213,35 @@ describe(listCompletedLanguageCourses, () => {
 });
 
 describe(resolveLanguageCourse, () => {
+  beforeEach(async () => {
+    const user = await userFixture();
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
+  });
+
+  it("does not create a language course request without authentication", async () => {
+    const input = getLanguageCoursePromptInput();
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    await expect(resolveLanguageCourse(input)).resolves.toStrictEqual({ kind: "unauthorized" });
+
+    await expect(
+      prisma.coursePrompt.findUnique({
+        where: {
+          languageNormalizedPrompt: {
+            language: input.language,
+            normalizedPrompt: normalizeString("Learn Spanish"),
+          },
+        },
+      }),
+    ).resolves.toBeNull();
+  });
+
   it("returns the newest completed course without creating a generation prompt", async () => {
     const organization = await aiOrganizationFixture();
     const language = getUniqueSourceLanguage();
     const newerSlug = getCourseSlug("resolution-newer");
+
+    vi.mocked(getSession).mockResolvedValue(null);
 
     await Promise.all([
       courseFixture({

--- a/packages/core/src/courses/language-course.ts
+++ b/packages/core/src/courses/language-course.ts
@@ -9,6 +9,7 @@ import {
 import { normalizeString } from "@zoonk/utils/string";
 import { cacheTag } from "next/cache";
 import { LANGUAGE_COURSE_LIST_CACHE_TAG } from "../cache/tags";
+import { getSession } from "../users/get-session";
 
 type LanguageCourseInput = { language: string; targetLanguage: string };
 
@@ -19,7 +20,8 @@ type LanguageCoursePromptInput = LanguageCourseInput & { title: string };
 export type LanguageCourseTarget = { course: Course; targetLanguage: TTSSupportedLanguageCode };
 export type LanguageCourseResolution =
   | { course: Course; kind: "course" }
-  | { coursePrompt: CoursePrompt; kind: "generation" };
+  | { coursePrompt: CoursePrompt; kind: "generation" }
+  | { kind: "unauthorized" };
 
 /**
  * Rechecks course target languages after Prisma returns rows because the query
@@ -185,8 +187,10 @@ async function getOrCreateStoredLanguageCoursePrompt({
 /**
  * Resolves the complete reuse-or-generate decision for a language course in
  * core so every delivery app follows the same ordering and prompt rules. The
- * result deliberately contains domain resources rather than URLs or redirects,
- * leaving each app to map the outcome to its own navigation model.
+ * completed-course lookup remains public, but storing a new generation request
+ * requires a trusted session. The result deliberately contains domain
+ * resources rather than URLs or redirects, leaving each app to map the outcome
+ * to its own navigation model.
  */
 export async function resolveLanguageCourse({
   language,
@@ -196,10 +200,17 @@ export async function resolveLanguageCourse({
     throw new Error(`Unsupported TTS language: ${targetLanguage}`);
   }
 
-  const course = await getCompletedLanguageCourse({ language, targetLanguage });
+  const [course, session] = await Promise.all([
+    getCompletedLanguageCourse({ language, targetLanguage }),
+    getSession(),
+  ]);
 
   if (course) {
     return { course, kind: "course" };
+  }
+
+  if (!session) {
+    return { kind: "unauthorized" };
   }
 
   const title = getLanguageName({ targetLanguage, userLanguage: language });

--- a/packages/core/src/courses/resolve-course-prompt.test.ts
+++ b/packages/core/src/courses/resolve-course-prompt.test.ts
@@ -7,11 +7,15 @@ import { prisma } from "@zoonk/db";
 import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
 import { normalizeString } from "@zoonk/utils/string";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getSession } from "../users/get-session";
 import { COURSE_LANGUAGE_MAX_LENGTH, COURSE_PROMPT_MAX_LENGTH } from "./course-prompt-contract";
 import { getCourseSlugForTitle } from "./course-slug";
 import { type CoursePromptResolution, resolveCoursePrompt } from "./resolve-course-prompt";
+
+vi.mock("../users/get-session", () => ({ getSession: vi.fn() }));
 
 type GenerateCoursePromptResolution = Extract<CoursePromptResolution, { kind: "generate" }>;
 type CourseRedirectPromptResolution = Extract<CoursePromptResolution, { kind: "course" }>;
@@ -68,7 +72,7 @@ async function createCompletedAiCourse({ language, title }: { language: string; 
 /**
  * Mocks the model tasks with production-shaped return values so resolver tests
  * can prove the orchestration boundaries without making network calls. All
- * three model tasks run together for first-time prompts, even when the prompt
+ * four model tasks run together for first-time prompts, even when the prompt
  * ultimately redirects, waits for a future format, or blocks generation.
  */
 function mockPromptTasks({
@@ -100,6 +104,38 @@ function mockPromptTasks({
 }
 
 describe("course-prompt", () => {
+  beforeEach(async () => {
+    const user = await userFixture();
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
+  });
+
+  it("rejects unauthenticated prompts before calling models or persistence", async () => {
+    const prompt = `anonymous topic ${randomUUID()}`;
+    const courseFormatSpy = vi.spyOn(formatTask, "classifyCourseFormat");
+    const intentSpy = vi.spyOn(intentTask, "classifyCourseIntent");
+    const personalizationSpy = vi.spyOn(personalizationTask, "classifyCoursePersonalization");
+    const titleSpy = vi.spyOn(canonicalTitleTask, "generateCanonicalCourseTitle");
+
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    await expect(resolveCoursePrompt({ language: "en", prompt })).resolves.toStrictEqual({
+      kind: "unauthorized",
+    });
+
+    expect(intentSpy).not.toHaveBeenCalled();
+    expect(personalizationSpy).not.toHaveBeenCalled();
+    expect(courseFormatSpy).not.toHaveBeenCalled();
+    expect(titleSpy).not.toHaveBeenCalled();
+
+    await expect(
+      prisma.coursePrompt.findUnique({
+        where: {
+          languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
+        },
+      }),
+    ).resolves.toBeNull();
+  });
+
   it.each([
     { expectedReason: "prompt", language: "en", prompt: "a".repeat(COURSE_PROMPT_MAX_LENGTH + 1) },
     { expectedReason: "prompt", language: "en", prompt: "   " },
@@ -235,6 +271,28 @@ describe("course-prompt", () => {
     expect(titleSpy).not.toHaveBeenCalled();
   });
 
+  it("requires authentication before promoting a cached prompt to generation", async () => {
+    const prompt = `cached guest topic ${randomUUID()}`;
+
+    const cached = await coursePromptFixture({
+      canonicalTitle: `Cached Guest Course ${randomUUID()}`,
+      courseFormat: "coding",
+      generationStatus: null,
+      normalizedPrompt: normalizeString(prompt),
+      prompt,
+    });
+
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    await expect(resolveCoursePrompt({ language: "en", prompt })).resolves.toStrictEqual({
+      kind: "unauthorized",
+    });
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: cached.id } }),
+    ).resolves.toMatchObject({ generationStatus: null });
+  });
+
   it.each(["coding", "practical"] as const)(
     "enables generation for a cached %s prompt that was previously waitlisted",
     async (courseFormat) => {
@@ -304,7 +362,7 @@ describe("course-prompt", () => {
     expect(titleSpy).not.toHaveBeenCalled();
   });
 
-  it("redirects cached reusable prompts to an existing reusable course without model tasks", async () => {
+  it("redirects unauthenticated cached prompts to an existing course without model tasks", async () => {
     const prompt = `cached existing topic ${randomUUID()}`;
     const title = `Cached Existing Course ${randomUUID().slice(0, 8)}`;
     const course = await createCompletedAiCourse({ language: "en", title });
@@ -320,10 +378,13 @@ describe("course-prompt", () => {
     const courseFormatSpy = vi.spyOn(formatTask, "classifyCourseFormat");
     const titleSpy = vi.spyOn(canonicalTitleTask, "generateCanonicalCourseTitle");
 
+    vi.mocked(getSession).mockResolvedValue(null);
+
     const result = await resolveCoursePrompt({ language: "en", prompt });
 
     expectCourseResult(result);
     expect(result.course).toStrictEqual({ id: course.id, slug: course.slug });
+    expect(getSession).toHaveBeenCalledWith();
     expect(intentSpy).not.toHaveBeenCalled();
     expect(personalizationSpy).not.toHaveBeenCalled();
     expect(courseFormatSpy).not.toHaveBeenCalled();

--- a/packages/core/src/courses/resolve-course-prompt.ts
+++ b/packages/core/src/courses/resolve-course-prompt.ts
@@ -7,6 +7,7 @@ import { type CourseIntent, classifyCourseIntent } from "@zoonk/ai/tasks/courses
 import { classifyCoursePersonalization } from "@zoonk/ai/tasks/courses/personalization";
 import { type CoursePrompt, isPrismaUniqueConstraintError, prisma } from "@zoonk/db";
 import { normalizeString } from "@zoonk/utils/string";
+import { getSession } from "../users/get-session";
 import { getReusableCourseForCoursePrompt } from "./_utils/course-prompt-reusable-course";
 import { type CoursePromptWithCourse } from "./_utils/course-prompt-types";
 import { COURSE_LANGUAGE_MAX_LENGTH, COURSE_PROMPT_MAX_LENGTH } from "./course-prompt-contract";
@@ -30,6 +31,7 @@ export type CoursePromptResolution =
     }
   | { kind: "invalid"; reason: "language" | "prompt" }
   | { kind: "language" }
+  | { kind: "unauthorized" }
   | { kind: "unsafe" }
   | { kind: "unsupported"; prompt: UnsupportedCoursePrompt; title: string };
 
@@ -125,9 +127,13 @@ async function enableCoursePromptGeneration(prompt: CoursePrompt): Promise<void>
  * reused for cached and new prompts so first submissions and repeat visits
  * cannot drift while each delivery layer remains free to choose its own route.
  */
-async function getCoursePromptResolution(
-  prompt: CoursePromptWithCourse,
-): Promise<CoursePromptResolution> {
+async function getCoursePromptResolution({
+  canCreateGeneration,
+  prompt,
+}: {
+  canCreateGeneration: boolean;
+  prompt: CoursePromptWithCourse;
+}): Promise<CoursePromptResolution> {
   if (prompt.intent === "learn" && isRegularCourseFormat(prompt.courseFormat)) {
     const course = await getReusableCourseForCoursePrompt(prompt);
 
@@ -137,6 +143,10 @@ async function getCoursePromptResolution(
   }
 
   if (canGenerateCoursePrompt(prompt)) {
+    if (!canCreateGeneration) {
+      return { kind: "unauthorized" };
+    }
+
     await enableCoursePromptGeneration(prompt);
 
     return {
@@ -302,9 +312,11 @@ function getClassifiedCoursePromptInput({
 
 /**
  * Resolves a learner's free-text goal into the next domain capability.
- * First-time prompts run intent, personalization, format, and title tasks in one
- * model wave so every delivery layer can use the same persisted decision
- * without adding a waterfall.
+ * Cached existing-course and classification outcomes remain public because
+ * they cannot create generation work. New and cached generatable prompts
+ * require a trusted session before mutation or model work. First-time prompts
+ * run intent, personalization, format, and title tasks in one model wave so
+ * every delivery layer can use the same persisted decision without a waterfall.
  */
 export async function resolveCoursePrompt({
   language,
@@ -319,10 +331,20 @@ export async function resolveCoursePrompt({
     return { kind: "invalid", reason: inputError };
   }
 
-  const cachedPrompt = await findCachedCoursePrompt({ language, prompt });
+  const [cachedPrompt, session] = await Promise.all([
+    findCachedCoursePrompt({ language, prompt }),
+    getSession(),
+  ]);
 
   if (cachedPrompt) {
-    return getCoursePromptResolution(cachedPrompt);
+    return getCoursePromptResolution({
+      canCreateGeneration: Boolean(session),
+      prompt: cachedPrompt,
+    });
+  }
+
+  if (!session) {
+    return { kind: "unauthorized" };
   }
 
   // Start every independent task in one model wave to minimize routing latency.
@@ -351,5 +373,5 @@ export async function resolveCoursePrompt({
     }),
   });
 
-  return getCoursePromptResolution(coursePrompt);
+  return getCoursePromptResolution({ canCreateGeneration: true, prompt: coursePrompt });
 }

--- a/packages/core/src/workflows/chapter-generation-access.ts
+++ b/packages/core/src/workflows/chapter-generation-access.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { hasActiveSubscription } from "../auth/subscription";
 import { getChapterForGeneration } from "../chapters/get-chapter-for-generation";
+import { getSession } from "../users/get-session";
 
 /** A pending row with saved lessons is a status repair, while running and completed rows are resumptions. */
 function shouldClaimChapterGenerationQuota(
@@ -12,17 +13,10 @@ function shouldClaimChapterGenerationQuota(
   return canGenerate && chapter._count.lessons === 0;
 }
 
-/**
- * Applies the existing first-chapter subscription rule to an AI-owned chapter
- * before a delivery app starts its generation workflow.
- */
-export async function getChapterGenerationAccess(chapterId: string) {
-  const chapter = await getChapterForGeneration(chapterId);
-
-  if (!chapter) {
-    return { status: "notFound" as const };
-  }
-
+/** Applies paid access only after the public boundary has established a trusted learner. */
+async function getAuthenticatedChapterGenerationAccess(
+  chapter: NonNullable<Awaited<ReturnType<typeof getChapterForGeneration>>>,
+) {
   if (chapter.position !== 0 && !(await hasActiveSubscription())) {
     return { chapter, status: "subscriptionRequired" as const };
   }
@@ -35,9 +29,48 @@ export async function getChapterGenerationAccess(chapterId: string) {
 }
 
 /**
- * Resolves the chapter-generation view without caching it because generation
- * pages disable prefetching and API handlers do not repeat this read.
+ * Requires a trusted learner before applying the existing first-chapter
+ * subscription rule and allowing a delivery app to start generation.
+ */
+export async function getChapterGenerationAccess(chapterId: string) {
+  const [chapter, session] = await Promise.all([getChapterForGeneration(chapterId), getSession()]);
+
+  if (!session) {
+    return { status: "unauthorized" as const };
+  }
+
+  if (!chapter) {
+    return { status: "notFound" as const };
+  }
+
+  return getAuthenticatedChapterGenerationAccess(chapter);
+}
+
+/**
+ * Preserves public redirects for completed first chapters while requiring a
+ * trusted learner before the page can mount a client that starts or resumes
+ * generation. The read remains uncached because generation pages disable
+ * prefetching and API handlers do not repeat it.
  */
 export async function getChapterGenerationView(chapterId: string) {
-  return getChapterGenerationAccess(chapterId);
+  const [chapter, session] = await Promise.all([getChapterForGeneration(chapterId), getSession()]);
+
+  if (!chapter) {
+    return { status: "notFound" as const };
+  }
+
+  if (!session) {
+    const canRedirectToPublicChapter =
+      chapter.position === 0 &&
+      chapter.generationStatus === "completed" &&
+      chapter._count.lessons > 0;
+
+    if (!canRedirectToPublicChapter) {
+      return { status: "unauthorized" as const };
+    }
+
+    return { chapter, shouldClaimQuota: false, status: "ready" as const };
+  }
+
+  return getAuthenticatedChapterGenerationAccess(chapter);
 }

--- a/packages/core/src/workflows/generation-access.test.ts
+++ b/packages/core/src/workflows/generation-access.test.ts
@@ -6,7 +6,7 @@ import { aiOrganizationFixture, organizationFixture } from "@zoonk/testing/fixtu
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getSession } from "../users/get-session";
-import { getChapterGenerationAccess } from "./chapter-generation-access";
+import { getChapterGenerationAccess, getChapterGenerationView } from "./chapter-generation-access";
 import { getLessonGenerationAccess } from "./lesson-generation-access";
 
 vi.mock("../users/get-session", () => ({ getSession: vi.fn() }));
@@ -24,7 +24,7 @@ describe("generation access", () => {
 
   beforeEach(() => vi.mocked(getSession).mockResolvedValue(null));
 
-  it("allows guests to generate the free first chapter", async () => {
+  it("requires authentication before generating the first chapter", async () => {
     const chapter = await chapterFixture({
       courseId,
       generationStatus: "pending",
@@ -32,21 +32,40 @@ describe("generation access", () => {
       position: 0,
     });
 
-    const result = await getChapterGenerationAccess(chapter.id);
+    await expect(getChapterGenerationAccess(chapter.id)).resolves.toStrictEqual({
+      status: "unauthorized",
+    });
+  });
 
-    expect(result).toMatchObject({
+  it("requires authentication before checking later-chapter subscriptions", async () => {
+    const chapter = await chapterFixture({ courseId, organizationId, position: 1 });
+
+    await expect(getChapterGenerationAccess(chapter.id)).resolves.toStrictEqual({
+      status: "unauthorized",
+    });
+  });
+
+  it("lets guests continue from a completed first chapter to its public page", async () => {
+    const completedCourse = await courseFixture({ organizationId });
+
+    const chapter = await chapterFixture({
+      courseId: completedCourse.id,
+      generationStatus: "completed",
+      organizationId,
+      position: 0,
+    });
+
+    await lessonFixture({ chapterId: chapter.id, organizationId });
+
+    await expect(getChapterGenerationView(chapter.id)).resolves.toMatchObject({
       chapter: { id: chapter.id },
-      shouldClaimQuota: true,
       status: "ready",
     });
   });
 
-  it("requires a subscription for later chapters", async () => {
-    const chapter = await chapterFixture({ courseId, organizationId, position: 1 });
-
-    await expect(getChapterGenerationAccess(chapter.id)).resolves.toMatchObject({
-      chapter: { id: chapter.id },
-      status: "subscriptionRequired",
+  it("returns not found for missing chapter views before asking guests to log in", async () => {
+    await expect(getChapterGenerationView("999999999")).resolves.toStrictEqual({
+      status: "notFound",
     });
   });
 
@@ -79,7 +98,12 @@ describe("generation access", () => {
   });
 
   it("does not claim quota for chapter and lesson no-op repairs", async () => {
-    const repairCourse = await courseFixture({ organizationId });
+    const [repairCourse, user] = await Promise.all([
+      courseFixture({ organizationId }),
+      userFixture(),
+    ]);
+
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
 
     const chapter = await chapterFixture({
       courseId: repairCourse.id,
@@ -105,7 +129,12 @@ describe("generation access", () => {
   });
 
   it("requires a subscription for later lessons when the learner is not subscribed", async () => {
-    const chapter = await chapterFixture({ courseId, organizationId, position: 3 });
+    const [chapter, user] = await Promise.all([
+      chapterFixture({ courseId, organizationId, position: 3 }),
+      userFixture(),
+    ]);
+
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
 
     const lesson = await lessonFixture({
       chapterId: chapter.id,
@@ -141,7 +170,12 @@ describe("generation access", () => {
   });
 
   it("hides non-standalone and non-AI resources", async () => {
-    const chapter = await chapterFixture({ courseId, organizationId, position: 4 });
+    const [chapter, user] = await Promise.all([
+      chapterFixture({ courseId, organizationId, position: 4 }),
+      userFixture(),
+    ]);
+
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
 
     const companionLesson = await lessonFixture({
       chapterId: chapter.id,

--- a/packages/core/src/workflows/lesson-generation-access.ts
+++ b/packages/core/src/workflows/lesson-generation-access.ts
@@ -22,12 +22,16 @@ function shouldClaimLessonGenerationQuota(
 export async function getLessonGenerationAccess(lessonId: string) {
   const [lesson, session] = await Promise.all([getLessonForGeneration(lessonId), getSession()]);
 
+  if (!session) {
+    return { status: "unauthorized" as const };
+  }
+
   if (!lesson || !isStandaloneGeneratedLessonKind(lesson.kind)) {
     return { status: "notFound" as const };
   }
 
   const requirement = getLessonAccessRequirement({ lesson });
-  const isAdmin = session?.user.role === "admin";
+  const isAdmin = session.user.role === "admin";
 
   if (requirement === "subscription" && !isAdmin && !(await hasActiveSubscription())) {
     return { status: "subscriptionRequired" as const };

--- a/packages/core/src/workflows/lesson-generation-view.test.ts
+++ b/packages/core/src/workflows/lesson-generation-view.test.ts
@@ -19,9 +19,34 @@ describe(getLessonGenerationView, () => {
     organizationId = organization.id;
   });
 
-  beforeEach(() => vi.mocked(getSession).mockResolvedValue(null));
+  beforeEach(async () => {
+    const user = await userFixture();
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
+  });
 
-  it("returns the generated lesson and its completed-content readiness", async () => {
+  it("requires authentication before showing a pending generation", async () => {
+    const course = await courseFixture({
+      organizationId,
+      title: `Authentication generation view ${randomUUID()}`,
+    });
+
+    const chapter = await chapterFixture({ courseId: course.id, organizationId, position: 0 });
+
+    const lesson = await lessonFixture({
+      chapterId: chapter.id,
+      generationStatus: "pending",
+      kind: "explanation",
+      organizationId,
+    });
+
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    await expect(getLessonGenerationView(lesson.id)).resolves.toStrictEqual({
+      status: "unauthorized",
+    });
+  });
+
+  it("lets guests continue from a completed lesson to its public page", async () => {
     const course = await courseFixture({
       generationStatus: "completed",
       organizationId,
@@ -37,13 +62,15 @@ describe(getLessonGenerationView, () => {
       organizationId,
     });
 
+    vi.mocked(getSession).mockResolvedValue(null);
+
     await expect(getLessonGenerationView(lesson.id)).resolves.toMatchObject({
       isReadyForRedirect: true,
       lesson: { id: lesson.id, kind: "explanation" },
       status: "ready",
     });
 
-    expect(getSession).not.toHaveBeenCalled();
+    expect(getSession).toHaveBeenCalledWith();
   });
 
   it("routes an incomplete generated companion through its source lesson", async () => {
@@ -219,7 +246,7 @@ describe(getLessonGenerationView, () => {
     });
   });
 
-  it("hides lesson kinds without a generation workflow", async () => {
+  it("hides lesson kinds without a generation workflow before asking guests to log in", async () => {
     const course = await courseFixture({
       organizationId,
       title: `Unsupported generation view ${randomUUID()}`,
@@ -228,6 +255,8 @@ describe(getLessonGenerationView, () => {
     const chapter = await chapterFixture({ courseId: course.id, organizationId, position: 0 });
 
     const lesson = await lessonFixture({ chapterId: chapter.id, kind: "custom", organizationId });
+
+    vi.mocked(getSession).mockResolvedValue(null);
 
     await expect(getLessonGenerationView(lesson.id)).resolves.toStrictEqual({ status: "notFound" });
   });

--- a/packages/core/src/workflows/lesson-generation-view.test.ts
+++ b/packages/core/src/workflows/lesson-generation-view.test.ts
@@ -49,15 +49,22 @@ describe(getLessonGenerationView, () => {
   it("lets guests continue from a completed lesson to its public page", async () => {
     const course = await courseFixture({
       generationStatus: "completed",
+      isPublished: true,
       organizationId,
       title: `Generation view ${randomUUID()}`,
     });
 
-    const chapter = await chapterFixture({ courseId: course.id, organizationId, position: 0 });
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId,
+      position: 0,
+    });
 
     const lesson = await lessonFixture({
       chapterId: chapter.id,
       generationStatus: "completed",
+      isPublished: true,
       kind: "explanation",
       organizationId,
     });
@@ -72,6 +79,43 @@ describe(getLessonGenerationView, () => {
 
     expect(getSession).toHaveBeenCalledWith();
   });
+
+  it.each([
+    { chapterIsPublished: true, courseIsPublished: true, lessonIsPublished: false },
+    { chapterIsPublished: false, courseIsPublished: true, lessonIsPublished: true },
+    { chapterIsPublished: true, courseIsPublished: false, lessonIsPublished: true },
+  ])(
+    "requires authentication when a completed lesson is outside the public hierarchy",
+    async ({ chapterIsPublished, courseIsPublished, lessonIsPublished }) => {
+      const course = await courseFixture({
+        generationStatus: "completed",
+        isPublished: courseIsPublished,
+        organizationId,
+        title: `Private generation view ${randomUUID()}`,
+      });
+
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        isPublished: chapterIsPublished,
+        organizationId,
+        position: 0,
+      });
+
+      const lesson = await lessonFixture({
+        chapterId: chapter.id,
+        generationStatus: "completed",
+        isPublished: lessonIsPublished,
+        kind: "explanation",
+        organizationId,
+      });
+
+      vi.mocked(getSession).mockResolvedValue(null);
+
+      await expect(getLessonGenerationView(lesson.id)).resolves.toStrictEqual({
+        status: "unauthorized",
+      });
+    },
+  );
 
   it("routes an incomplete generated companion through its source lesson", async () => {
     const course = await courseFixture({

--- a/packages/core/src/workflows/lesson-generation-view.ts
+++ b/packages/core/src/workflows/lesson-generation-view.ts
@@ -56,8 +56,11 @@ export async function getLessonGenerationView(lessonId: string) {
 
   const requiresSubscription = getLessonAccessRequirement({ lesson }) === "subscription";
 
+  const isPubliclyVisible =
+    lesson.isPublished && lesson.chapter.isPublished && lesson.chapter.course.isPublished;
+
   if (!session) {
-    if (requiresSubscription || lesson.generationStatus !== "completed") {
+    if (requiresSubscription || lesson.generationStatus !== "completed" || !isPubliclyVisible) {
       return { status: "unauthorized" as const };
     }
 

--- a/packages/core/src/workflows/lesson-generation-view.ts
+++ b/packages/core/src/workflows/lesson-generation-view.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { hasActiveSubscription } from "../auth/subscription";
 import { getLessonAccessRequirement } from "../lessons/access";
 import {
+  type GeneratedLessonKind,
   isGeneratedCompanionLessonKind,
   isGeneratedLessonKind,
 } from "../lessons/generated-companion-kinds";
@@ -10,22 +11,60 @@ import {
   getSourceLessonForGeneratedCompanion,
 } from "../lessons/generated-companions";
 import { getLessonForGeneration } from "../lessons/get-lesson-for-generation";
+import { getSession } from "../users/get-session";
+
+/** Resolves whether persisted lesson content can safely redirect without starting AI work. */
+async function getReadyLessonGenerationView({
+  lesson,
+  lessonKind,
+}: {
+  lesson: NonNullable<Awaited<ReturnType<typeof getLessonForGeneration>>>;
+  lessonKind: GeneratedLessonKind;
+}) {
+  const companionLesson = await getGeneratedCompanionForSourceLesson({
+    chapterId: lesson.chapterId,
+    lessonId: lesson.id,
+  });
+
+  const companionNeedsRepair =
+    companionLesson?.generationStatus === "pending" ||
+    companionLesson?.generationStatus === "failed";
+
+  return {
+    isReadyForRedirect:
+      (lesson.generationStatus === "completed" || lesson._count.steps > 0) && !companionNeedsRepair,
+    lesson,
+    lessonKind,
+    status: "ready" as const,
+  };
+}
 
 /**
  * Resolves the route-neutral state needed to render a lesson generation page.
  * Delivery apps only translate the result into navigation and presentation;
- * subscription rules, companion ownership, and readiness remain consistent
- * across web, API, and future native clients. The read remains uncached because
- * generation pages disable prefetching and API handlers call it only once.
+ * authentication, subscription rules, companion ownership, and readiness
+ * remain consistent across web, API, and future native clients. The read
+ * remains uncached because generation pages disable prefetching and API
+ * handlers call it only once.
  */
 export async function getLessonGenerationView(lessonId: string) {
-  const lesson = await getLessonForGeneration(lessonId);
+  const [lesson, session] = await Promise.all([getLessonForGeneration(lessonId), getSession()]);
 
   if (!lesson || !isGeneratedLessonKind(lesson.kind)) {
     return { status: "notFound" as const };
   }
 
   const requiresSubscription = getLessonAccessRequirement({ lesson }) === "subscription";
+
+  if (!session) {
+    if (requiresSubscription || lesson.generationStatus !== "completed") {
+      return { status: "unauthorized" as const };
+    }
+
+    const readyView = await getReadyLessonGenerationView({ lesson, lessonKind: lesson.kind });
+
+    return readyView.isReadyForRedirect ? readyView : { status: "unauthorized" as const };
+  }
 
   if (requiresSubscription && !(await hasActiveSubscription())) {
     return { lesson, lessonKind: lesson.kind, status: "subscriptionRequired" as const };
@@ -49,20 +88,5 @@ export async function getLessonGenerationView(lessonId: string) {
     };
   }
 
-  const companionLesson = await getGeneratedCompanionForSourceLesson({
-    chapterId: lesson.chapterId,
-    lessonId: lesson.id,
-  });
-
-  const companionNeedsRepair =
-    companionLesson?.generationStatus === "pending" ||
-    companionLesson?.generationStatus === "failed";
-
-  return {
-    isReadyForRedirect:
-      (lesson.generationStatus === "completed" || lesson._count.steps > 0) && !companionNeedsRepair,
-    lesson,
-    lessonKind: lesson.kind,
-    status: "ready" as const,
-  };
+  return getReadyLessonGenerationView({ lesson, lessonKind: lesson.kind });
 }


### PR DESCRIPTION
Require authentication before creating AI-generated courses, chapters, or lessons. Add a login CTA that keeps the public course catalog available, and enforce the same boundary in Core and API while preserving completed-content redirects.