### PR TITLE
fix(main): prevent progress headline overflow

### DIFF
--- a/apps/main/src/app/[lang]/(progress)/_components/progress-headline.tsx
+++ b/apps/main/src/app/[lang]/(progress)/_components/progress-headline.tsx
@@ -43,7 +43,7 @@ export function ProgressHeadlineValue({
 }: React.ComponentProps<"span">) {
   return (
     <span
-      className={cn("text-5xl font-bold tracking-tight tabular-nums", className)}
+      className={cn("text-5xl font-bold tracking-tight wrap-break-word tabular-nums", className)}
       data-slot="progress-headline-value"
       {...props}
     >


### PR DESCRIPTION
Prevents large localized progress headline values from causing horizontal page overflow by allowing emergency word breaks when a single count or label cannot fit.