### PR TITLE
chore(apple): cache ci builds

### DIFF
--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -32,13 +32,6 @@ jobs:
   build:
     runs-on: macos-26
     timeout-minutes: 30
-    env:
-      XCODEBUILD_ARGUMENTS: >-
-        -clonedSourcePackagesDirPath ${{ runner.temp }}/apple-source-packages
-        -onlyUsePackageVersionsFromResolvedFile
-        -skipPackageUpdates
-        COMPILATION_CACHE_ENABLE_CACHING=YES
-        COMPILER_INDEX_STORE_ENABLE=NO
     steps:
       - name: Check out code
         uses: actions/checkout@v7
@@ -60,4 +53,11 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-apple-compilation-xcode-26.6-
 
       - name: Build iPhone and iPad app
+        env:
+          XCODEBUILD_ARGUMENTS: >-
+            -clonedSourcePackagesDirPath ${{ runner.temp }}/apple-source-packages
+            -onlyUsePackageVersionsFromResolvedFile
+            -skipPackageUpdates
+            COMPILATION_CACHE_ENABLE_CACHING=YES
+            COMPILER_INDEX_STORE_ENABLE=NO
         run: make -C apps/apple build

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -36,21 +36,27 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
 
+      - name: Identify Xcode toolchain
+        id: xcode
+        run: |
+          set -o pipefail
+          xcodebuild -version | shasum -a 256 | awk '{ print "version=" $1 }' >> "$GITHUB_OUTPUT"
+
       - name: Cache Swift packages
         uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/apple-source-packages
-          key: ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-xcode-26.6-${{ hashFiles('apps/apple/**/Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-xcode-${{ steps.xcode.outputs.version }}-${{ hashFiles('apps/apple/**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-xcode-26.6-
+            ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-xcode-${{ steps.xcode.outputs.version }}-
 
       - name: Cache Xcode compilations
         uses: actions/cache@v6
         with:
           path: ~/Library/Developer/Xcode/DerivedData/CompilationCache.noindex
-          key: ${{ runner.os }}-${{ runner.arch }}-apple-compilation-xcode-26.6-${{ hashFiles('apps/apple/**/Package.resolved', 'apps/apple/**/*.pbxproj', 'apps/apple/Makefile') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-apple-compilation-xcode-${{ steps.xcode.outputs.version }}-${{ hashFiles('apps/apple/**/Package.resolved', 'apps/apple/**/*.pbxproj', 'apps/apple/Makefile') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-apple-compilation-xcode-26.6-
+            ${{ runner.os }}-${{ runner.arch }}-apple-compilation-xcode-${{ steps.xcode.outputs.version }}-
 
       - name: Build iPhone and iPad app
         env:

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -46,9 +46,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ${{ runner.temp }}/apple-source-packages
-          key: ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-xcode-${{ steps.xcode.outputs.version }}-${{ hashFiles('apps/apple/**/Package.resolved') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-${{ hashFiles('apps/apple/**/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-xcode-${{ steps.xcode.outputs.version }}-
+            ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-
 
       - name: Cache Xcode compilations
         uses: actions/cache@v6

--- a/.github/workflows/apple.yml
+++ b/.github/workflows/apple.yml
@@ -32,9 +32,32 @@ jobs:
   build:
     runs-on: macos-26
     timeout-minutes: 30
+    env:
+      XCODEBUILD_ARGUMENTS: >-
+        -clonedSourcePackagesDirPath ${{ runner.temp }}/apple-source-packages
+        -onlyUsePackageVersionsFromResolvedFile
+        -skipPackageUpdates
+        COMPILATION_CACHE_ENABLE_CACHING=YES
+        COMPILER_INDEX_STORE_ENABLE=NO
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+
+      - name: Cache Swift packages
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/apple-source-packages
+          key: ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-xcode-26.6-${{ hashFiles('apps/apple/**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-apple-swiftpm-xcode-26.6-
+
+      - name: Cache Xcode compilations
+        uses: actions/cache@v6
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/CompilationCache.noindex
+          key: ${{ runner.os }}-${{ runner.arch }}-apple-compilation-xcode-26.6-${{ hashFiles('apps/apple/**/Package.resolved', 'apps/apple/**/*.pbxproj', 'apps/apple/Makefile') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-apple-compilation-xcode-26.6-
 
       - name: Build iPhone and iPad app
         run: make -C apps/apple build

--- a/apps/apple/Makefile
+++ b/apps/apple/Makefile
@@ -4,7 +4,8 @@ SWIFT_SOURCES := Zoonk ZoonkTests ZoonkUITests
 CONFIGURATION ?= Release
 TEST_DESTINATION ?= platform=iOS Simulator,name=iPhone 17,OS=latest
 TEST_ARGUMENTS ?=
-XCODEBUILD := xcodebuild -quiet -skipPackagePluginValidation -project "$(PROJECT)"
+XCODEBUILD_ARGUMENTS ?=
+XCODEBUILD := xcodebuild -quiet -skipPackagePluginValidation $(XCODEBUILD_ARGUMENTS) -project "$(PROJECT)"
 BUILD_FLAGS := -configuration "$(CONFIGURATION)" CODE_SIGNING_ALLOWED=NO
 
 .PHONY: build build-ios test format format-check check


### PR DESCRIPTION
Caches locked Swift package sources and Xcode 26 compilation outputs between Apple CI runs.