### PR TITLE
feat(main): track generation authentication gate

### DIFF
--- a/apps/main/src/app/[lang]/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/start/learn/[prompt]/course-prompt-result.tsx
@@ -126,7 +126,7 @@ export async function CourseStartResult({ prompt }: { prompt: string }) {
 
     return (
       <StartSurface>
-        <GenerationAuthenticationCTA loginHref={loginHref} />
+        <GenerationAuthenticationCTA loginHref={loginHref} target={{ resource: "course" }} />
       </StartSurface>
     );
   }

--- a/apps/main/src/app/[lang]/(catalog)/start/speak/[language]/page.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/start/speak/[language]/page.tsx
@@ -46,7 +46,10 @@ async function StartSpeakLanguageRedirect({ params }: { params: StartSpeakLangua
 
     return (
       <StartSurface>
-        <GenerationAuthenticationCTA loginHref={loginHref} />
+        <GenerationAuthenticationCTA
+          loginHref={loginHref}
+          target={{ resource: "course", targetLanguage }}
+        />
       </StartSurface>
     );
   }

--- a/apps/main/src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
@@ -31,7 +31,14 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
     return (
       <Container variant="narrow">
         <ContainerBody>
-          <GenerationAuthenticationCTA loginHref={loginHref} />
+          <GenerationAuthenticationCTA
+            loginHref={loginHref}
+            target={{
+              chapterSlug: access.chapterSlug,
+              courseSlug: access.courseSlug,
+              resource: "chapter",
+            }}
+          />
         </ContainerBody>
       </Container>
     );

--- a/apps/main/src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
+++ b/apps/main/src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
@@ -44,7 +44,10 @@ export async function GenerateCoursePromptContent({
     return (
       <Container variant="narrow">
         <ContainerBody>
-          <GenerationAuthenticationCTA loginHref={loginHref} />
+          <GenerationAuthenticationCTA
+            loginHref={loginHref}
+            target={{ courseSlug: generation.courseSlug, resource: "course" }}
+          />
         </ContainerBody>
       </Container>
     );

--- a/apps/main/src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
+++ b/apps/main/src/app/[lang]/generate/l/[id]/generate-lesson-content.tsx
@@ -37,7 +37,15 @@ export async function GenerateLessonContent({
     return (
       <Container variant="narrow">
         <ContainerBody>
-          <GenerationAuthenticationCTA loginHref={loginHref} />
+          <GenerationAuthenticationCTA
+            loginHref={loginHref}
+            target={{
+              chapterSlug: view.chapterSlug,
+              courseSlug: view.courseSlug,
+              lessonSlug: view.lessonSlug,
+              resource: "lesson",
+            }}
+          />
         </ContainerBody>
       </Container>
     );

--- a/apps/main/src/components/generation/generation-authentication-cta.tsx
+++ b/apps/main/src/components/generation/generation-authentication-cta.tsx
@@ -1,5 +1,6 @@
 import { GenerationShortcutLink } from "@/components/generation/generation-shortcut-link";
 import { type AppRoute } from "@/i18n/navigation";
+import { type GenerationAuthenticationGateTarget } from "@/lib/track-events";
 import {
   Empty,
   EmptyContent,
@@ -10,17 +11,22 @@ import {
 } from "@zoonk/ui/components/empty";
 import { LogInIcon } from "lucide-react";
 import { getExtracted } from "next-intl/server";
+import { GenerationAuthenticationGateTracker } from "./generation-authentication-gate-tracker";
 
 /** Explains why AI creation is unavailable while keeping the public course catalog accessible. */
 export async function GenerationAuthenticationCTA<Href extends string>({
   loginHref,
+  target,
 }: {
   loginHref: AppRoute<Href>;
+  target: GenerationAuthenticationGateTarget;
 }) {
   const t = await getExtracted();
 
   return (
     <Empty className="border-0">
+      <GenerationAuthenticationGateTracker {...target} />
+
       <EmptyHeader align="start">
         <EmptyMedia variant="icon">
           <LogInIcon />

--- a/apps/main/src/components/generation/generation-authentication-gate-tracker.tsx
+++ b/apps/main/src/components/generation/generation-authentication-gate-tracker.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import {
+  type GenerationAuthenticationGateTarget,
+  trackGenerationAuthenticationGateShown,
+} from "@/lib/track-events";
+import { useEffect } from "react";
+
+/** Records an impression only after the authentication gate reaches the browser. */
+export function GenerationAuthenticationGateTracker({
+  chapterSlug,
+  courseSlug,
+  lessonSlug,
+  resource,
+  targetLanguage,
+}: GenerationAuthenticationGateTarget) {
+  useEffect(() => {
+    trackGenerationAuthenticationGateShown({
+      ...(chapterSlug ? { chapterSlug } : {}),
+      ...(courseSlug ? { courseSlug } : {}),
+      ...(lessonSlug ? { lessonSlug } : {}),
+      resource,
+      ...(targetLanguage ? { targetLanguage } : {}),
+    });
+  }, [chapterSlug, courseSlug, lessonSlug, resource, targetLanguage]);
+
+  return null;
+}

--- a/apps/main/src/lib/track-events.ts
+++ b/apps/main/src/lib/track-events.ts
@@ -22,6 +22,14 @@ type ChapterCompletionEventInput = {
 
 type SubscriptionBillingPeriod = "monthly" | "yearly";
 
+export type GenerationAuthenticationGateTarget = {
+  chapterSlug?: string;
+  courseSlug?: string;
+  lessonSlug?: string;
+  resource: "chapter" | "course" | "lesson";
+  targetLanguage?: string;
+};
+
 export type FeedbackValue = "upvote" | "downvote";
 
 export type FeedbackTarget =
@@ -143,6 +151,14 @@ export function trackSubscriptionCheckoutStarted({
  */
 export function trackSubscriptionGateShown() {
   trackEvent({ name: "Subscription Gate Shown" });
+}
+
+/**
+ * Counts guests blocked from starting AI work and keeps durable generation
+ * targets filterable without treating a free-text prompt as a course slug.
+ */
+export function trackGenerationAuthenticationGateShown(target: GenerationAuthenticationGateTarget) {
+  trackEvent({ name: "Generation Authentication Gate Shown", properties: target });
 }
 
 /**

--- a/packages/core/src/workflows/chapter-generation-access.ts
+++ b/packages/core/src/workflows/chapter-generation-access.ts
@@ -66,7 +66,11 @@ export async function getChapterGenerationView(chapterId: string) {
       chapter._count.lessons > 0;
 
     if (!canRedirectToPublicChapter) {
-      return { status: "unauthorized" as const };
+      return {
+        chapterSlug: chapter.slug,
+        courseSlug: chapter.course.slug,
+        status: "unauthorized" as const,
+      };
     }
 
     return { chapter, shouldClaimQuota: false, status: "ready" as const };

--- a/packages/core/src/workflows/generation-access.test.ts
+++ b/packages/core/src/workflows/generation-access.test.ts
@@ -63,6 +63,23 @@ describe("generation access", () => {
     });
   });
 
+  it("returns chapter slugs when the generation view requires authentication", async () => {
+    const course = await courseFixture({ organizationId });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      generationStatus: "pending",
+      organizationId,
+      position: 0,
+    });
+
+    await expect(getChapterGenerationView(chapter.id)).resolves.toStrictEqual({
+      chapterSlug: chapter.slug,
+      courseSlug: course.slug,
+      status: "unauthorized",
+    });
+  });
+
   it("returns not found for missing chapter views before asking guests to log in", async () => {
     await expect(getChapterGenerationView("999999999")).resolves.toStrictEqual({
       status: "notFound",

--- a/packages/core/src/workflows/lesson-generation-view.test.ts
+++ b/packages/core/src/workflows/lesson-generation-view.test.ts
@@ -42,6 +42,9 @@ describe(getLessonGenerationView, () => {
     vi.mocked(getSession).mockResolvedValue(null);
 
     await expect(getLessonGenerationView(lesson.id)).resolves.toStrictEqual({
+      chapterSlug: chapter.slug,
+      courseSlug: course.slug,
+      lessonSlug: lesson.slug,
       status: "unauthorized",
     });
   });
@@ -112,6 +115,9 @@ describe(getLessonGenerationView, () => {
       vi.mocked(getSession).mockResolvedValue(null);
 
       await expect(getLessonGenerationView(lesson.id)).resolves.toStrictEqual({
+        chapterSlug: chapter.slug,
+        courseSlug: course.slug,
+        lessonSlug: lesson.slug,
         status: "unauthorized",
       });
     },

--- a/packages/core/src/workflows/lesson-generation-view.ts
+++ b/packages/core/src/workflows/lesson-generation-view.ts
@@ -13,6 +13,18 @@ import {
 import { getLessonForGeneration } from "../lessons/get-lesson-for-generation";
 import { getSession } from "../users/get-session";
 
+/** Keeps every login gate filterable without exposing the full unpublished lesson row. */
+function getUnauthorizedLessonGenerationView(
+  lesson: NonNullable<Awaited<ReturnType<typeof getLessonForGeneration>>>,
+) {
+  return {
+    chapterSlug: lesson.chapter.slug,
+    courseSlug: lesson.chapter.course.slug,
+    lessonSlug: lesson.slug,
+    status: "unauthorized" as const,
+  };
+}
+
 /** Resolves whether persisted lesson content can safely redirect without starting AI work. */
 async function getReadyLessonGenerationView({
   lesson,
@@ -61,12 +73,12 @@ export async function getLessonGenerationView(lessonId: string) {
 
   if (!session) {
     if (requiresSubscription || lesson.generationStatus !== "completed" || !isPubliclyVisible) {
-      return { status: "unauthorized" as const };
+      return getUnauthorizedLessonGenerationView(lesson);
     }
 
     const readyView = await getReadyLessonGenerationView({ lesson, lessonKind: lesson.kind });
 
-    return readyView.isReadyForRedirect ? readyView : { status: "unauthorized" as const };
+    return readyView.isReadyForRedirect ? readyView : getUnauthorizedLessonGenerationView(lesson);
   }
 
   if (requiresSubscription && !(await hasActiveSubscription())) {


### PR DESCRIPTION
## Summary

- track generation authentication gate impressions in Vercel Analytics and PostHog
- include the resource and available course, chapter, lesson, or language target context
- return slug-only metadata for gated chapter and lesson generation views