### PR TITLE
chore(auth): upgrade better auth to 1.7.1

### DIFF
--- a/apps/api/e2e/me.test.ts
+++ b/apps/api/e2e/me.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { type APIResponse, request } from "@playwright/test";
 import { prisma } from "@zoonk/db";
 import { expect, test } from "@zoonk/e2e/fixtures";
+import { appleAccountFixture } from "@zoonk/testing/fixtures/accounts";
 import { courseFixture, courseUserFixture } from "@zoonk/testing/fixtures/courses";
 import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
 import { userFixture } from "@zoonk/testing/fixtures/users";
@@ -10,16 +11,6 @@ import { createAuthenticatedApiContext } from "./helpers/auth";
 import { getOTPForEmail } from "./helpers/db";
 
 const PASSWORD = "password123";
-
-/**
- * Links an Apple identity to the test user so the public account response can
- * prove that Apple provider state comes from durable account data.
- */
-function appleAccountFixture({ userId }: { userId: string }) {
-  return prisma.account.create({
-    data: { accountId: `e2e-apple-${randomUUID()}`, id: randomUUID(), providerId: "apple", userId },
-  });
-}
 
 /**
  * Verifies the public API error envelope so tests assert the client contract

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,12 +25,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@better-auth/prisma-adapter": "1.6.29",
-    "@better-auth/stripe": "1.6.29",
+    "@better-auth/prisma-adapter": "1.7.1",
+    "@better-auth/stripe": "1.7.1",
     "@zoonk/db": "workspace:*",
     "@zoonk/mailer": "workspace:*",
     "@zoonk/utils": "workspace:*",
-    "better-auth": "1.6.29",
+    "better-auth": "1.7.1",
     "jose": "6.2.9",
     "stripe": "22.5.0",
     "zod": "catalog:"

--- a/packages/auth/src/account-deletion.test.ts
+++ b/packages/auth/src/account-deletion.test.ts
@@ -6,6 +6,9 @@ import {
   deleteUserDependenciesBeforeAuthDelete,
 } from "./account-deletion";
 
+const APPLE_ISSUER = "https://appleid.apple.com";
+const APPLE_PROVIDER_ID = "apple";
+
 const mocks = vi.hoisted(() => ({
   cancelStripeSubscription: vi.fn(),
   revokeStoredAppleAuthorization: vi.fn(),
@@ -157,7 +160,8 @@ describe(deleteUserDependenciesBeforeAuthDelete, () => {
         data: {
           accountId: `apple-${randomUUID()}`,
           idToken: "stored-id-token",
-          providerId: "apple",
+          issuer: APPLE_ISSUER,
+          providerId: APPLE_PROVIDER_ID,
           refreshToken: "stored-refresh-token",
           userId: user.id,
         },

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -8,9 +8,9 @@ export const SESSION_EXPIRES_IN_DAYS = 30;
 export const COOKIE_CACHE_MINUTES = 60;
 export const IS_COOKIE_CACHE_ENABLED = process.env.AUTH_COOKIE_CACHE_ENABLED !== "false";
 
-export const AUTH_ADVANCED_OPTIONS = { database: { generateId: "uuid" } } satisfies NonNullable<
-  BetterAuthOptions["advanced"]
->;
+export const AUTH_ADVANCED_OPTIONS = {
+  database: { generateId: "uuid", joins: true },
+} satisfies NonNullable<BetterAuthOptions["advanced"]>;
 
 // We don't want to limit the number of memberships or organizations
 // So we use the maximum safe integer because Better Auth doesn't support infinity.

--- a/packages/auth/src/native-apple.test.ts
+++ b/packages/auth/src/native-apple.test.ts
@@ -3,6 +3,9 @@ import { prisma } from "@zoonk/db";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { reauthorizeAppleForAccountDeletion, signInWithNativeApple } from "./native-apple";
 
+const APPLE_ISSUER = "https://appleid.apple.com";
+const APPLE_PROVIDER_ID = "apple";
+
 const mocks = vi.hoisted(() => ({
   enforceSignInRateLimit: vi.fn(),
   exchangeAuthorizationCode: vi.fn(),
@@ -71,7 +74,9 @@ function createTestUser() {
  * native orchestration verifies ownership and stores provider credentials.
  */
 function createAppleAccount({ subject, userId }: { subject: string; userId: string }) {
-  return prisma.account.create({ data: { accountId: subject, providerId: "apple", userId } });
+  return prisma.account.create({
+    data: { accountId: subject, issuer: APPLE_ISSUER, providerId: APPLE_PROVIDER_ID, userId },
+  });
 }
 
 /**
@@ -99,7 +104,7 @@ async function createSessionResponse({ userId }: { userId: string }) {
  * accounts left by other integration tests cannot affect exact-owner lookup.
  */
 function verifySubject(subject: string) {
-  mocks.verifyIdentityToken.mockResolvedValue({ subject });
+  mocks.verifyIdentityToken.mockResolvedValue({ issuer: APPLE_ISSUER, subject });
 }
 
 describe(signInWithNativeApple, () => {
@@ -163,6 +168,44 @@ describe(signInWithNativeApple, () => {
       credentials,
       headers: nativeSignInRequest.headers,
     });
+  });
+
+  it("selects the verified Apple identity by issuer and subject", async () => {
+    const subject = `apple-${randomUUID()}`;
+    const [sessionUser, otherIssuerUser] = await Promise.all([createTestUser(), createTestUser()]);
+
+    const [account, otherIssuerAccount, sessionResponse] = await Promise.all([
+      createAppleAccount({ subject, userId: sessionUser.id }),
+      prisma.account.create({
+        data: {
+          accountId: subject,
+          issuer: "local:oauth:apple",
+          providerId: APPLE_PROVIDER_ID,
+          userId: otherIssuerUser.id,
+        },
+      }),
+      createSessionResponse({ userId: sessionUser.id }),
+    ]);
+
+    verifySubject(subject);
+
+    mocks.signInNativeAppleAccount.mockResolvedValue({
+      changes: { sessionToken: sessionResponse.token },
+      response: sessionResponse,
+      success: true,
+    });
+
+    await expect(signInWithNativeApple(nativeSignInRequest)).resolves.toStrictEqual(
+      sessionResponse,
+    );
+
+    const [persistedAccount, persistedOtherIssuerAccount] = await Promise.all([
+      prisma.account.findUniqueOrThrow({ where: { id: account.id } }),
+      prisma.account.findUniqueOrThrow({ where: { id: otherIssuerAccount.id } }),
+    ]);
+
+    expect(persistedAccount.refreshToken).toBe(authorization.refreshToken);
+    expect(persistedOtherIssuerAccount.refreshToken).toBeNull();
   });
 
   it("treats a malformed Better Auth success response as an internal failure", async () => {

--- a/packages/auth/src/native-apple.ts
+++ b/packages/auth/src/native-apple.ts
@@ -33,6 +33,7 @@ type AppleSessionCreator = (credentials: NativeAppleCredentials) => Promise<Nati
 type VerifiedAppleAuthorization = {
   authorization: AppleAuthorization;
   clientIdentifier: string;
+  issuer: string;
   subject: string;
 };
 
@@ -51,20 +52,11 @@ function getNativeClientIdentifier() {
 }
 
 /**
- * Finds exactly one Apple account for the verified provider subject. Treating
- * duplicates as invalid avoids choosing an arbitrary owner when legacy data is
- * inconsistent.
+ * Resolves the canonical Apple identity using the trusted issuer and verified
+ * provider subject required by Better Auth 1.7.
  */
-async function getExactAppleAccount(subject: string) {
-  const accounts = await prisma.account.findMany({
-    where: { accountId: subject, providerId: "apple" },
-  });
-
-  if (accounts.length !== 1) {
-    return null;
-  }
-
-  return accounts[0];
+async function getExactAppleAccount({ issuer, subject }: { issuer: string; subject: string }) {
+  return prisma.account.findUnique({ where: { issuer_accountId: { accountId: subject, issuer } } });
 }
 
 /**
@@ -196,16 +188,20 @@ async function exchangeVerifiedAuthorization(
       token: authorization.idToken,
     });
 
-    if (originalIdentity.subject !== exchangedIdentity.subject) {
+    if (
+      originalIdentity.issuer !== exchangedIdentity.issuer ||
+      originalIdentity.subject !== exchangedIdentity.subject
+    ) {
       throw new NativeAppleAccountError("Apple authorization identities do not match");
     }
 
-    return { authorization, clientIdentifier, subject: originalIdentity.subject };
+    return { ...originalIdentity, authorization, clientIdentifier };
   } catch (error) {
     return throwAfterAppleRevocation({
       authorization,
       clientIdentifier,
       error,
+      issuer: originalIdentity.issuer,
       subject: originalIdentity.subject,
     });
   }
@@ -246,14 +242,13 @@ async function createVerifiedSession({
     });
   }
 
-  const account = await getExactAppleAccount(verifiedAuthorization.subject).catch(
-    (error: unknown) =>
-      throwAfterSessionCleanup({
-        ...verifiedAuthorization,
-        changes,
-        error,
-        responseSessionToken: response.token,
-      }),
+  const account = await getExactAppleAccount(verifiedAuthorization).catch((error: unknown) =>
+    throwAfterSessionCleanup({
+      ...verifiedAuthorization,
+      changes,
+      error,
+      responseSessionToken: response.token,
+    }),
   );
 
   if (!account || account.userId !== response.user.id) {
@@ -280,8 +275,8 @@ async function requireExpectedAppleAccount({
   expectedUserId: string;
   verifiedAuthorization: VerifiedAppleAuthorization;
 }) {
-  const account = await getExactAppleAccount(verifiedAuthorization.subject).catch(
-    (error: unknown) => throwAfterAppleRevocation({ ...verifiedAuthorization, error }),
+  const account = await getExactAppleAccount(verifiedAuthorization).catch((error: unknown) =>
+    throwAfterAppleRevocation({ ...verifiedAuthorization, error }),
   );
 
   if (!account || account.userId !== expectedUserId) {

--- a/packages/auth/src/providers/apple-token.ts
+++ b/packages/auth/src/providers/apple-token.ts
@@ -1,9 +1,8 @@
 import { getApplePublicKey } from "better-auth/social-providers";
 import { decodeProtectedHeader, jwtVerify } from "jose";
-import { getAppleConfiguration } from "./apple";
+import { getAppleAccountIssuer, getAppleConfiguration } from "./apple";
 import { AppleAuthorizationError } from "./apple-rest";
 
-const APPLE_ISSUER = "https://appleid.apple.com";
 const HEX_RADIX = 16;
 const publicKeyPromises = new Map<string, ReturnType<typeof getApplePublicKey>>();
 
@@ -67,8 +66,8 @@ async function nonceMatches({ claim, nonce }: { claim: unknown; nonce: string })
 
 /**
  * Validates that an identity token was signed by Apple for this native app and
- * returns only its stable Apple subject. The subject is the value that must be
- * matched against Better Auth's existing Apple Account row.
+ * returns its trusted issuer and stable Apple subject. Together they form the
+ * Better Auth 1.7 identity that must match the existing Apple Account row.
  */
 export async function verifyNativeAppleIdentityToken({
   nonce,
@@ -78,8 +77,9 @@ export async function verifyNativeAppleIdentityToken({
   token: string;
 }) {
   const configuration = getAppleConfiguration();
+  const accountIssuer = getAppleAccountIssuer();
 
-  if (!configuration) {
+  if (!configuration || !accountIssuer) {
     throw new AppleAuthorizationError("configuration");
   }
 
@@ -96,18 +96,18 @@ export async function verifyNativeAppleIdentityToken({
       {
         algorithms: ["RS256"],
         audience: configuration.appBundleIdentifier,
-        issuer: APPLE_ISSUER,
+        issuer: accountIssuer,
         maxTokenAge: "1h",
       },
     );
 
     const validNonce = nonce ? await nonceMatches({ claim: payload.nonce, nonce }) : true;
 
-    if (!payload.sub || !validNonce) {
+    if (!payload.iss || !payload.sub || !validNonce) {
       throw new AppleAuthorizationError("invalidCredential");
     }
 
-    return { subject: payload.sub };
+    return { issuer: payload.iss, subject: payload.sub };
   } catch (error) {
     if (error instanceof AppleAuthorizationError) {
       throw error;

--- a/packages/auth/src/providers/apple.ts
+++ b/packages/auth/src/providers/apple.ts
@@ -1,4 +1,4 @@
-import { type AppleProfile } from "better-auth/social-providers";
+import { type AppleProfile, apple } from "better-auth/social-providers";
 import { SignJWT, importPKCS8 } from "jose";
 
 const cachedClientSecrets = new Map<string, { token: string; exp: number }>();
@@ -103,6 +103,16 @@ export const appleProvider = appleSigningConfiguration
       },
     }
   : {};
+
+const configuredAppleProvider = appleProvider.apple ? apple(appleProvider.apple) : null;
+
+/**
+ * Uses Better Auth's built-in provider metadata as the source of truth for the
+ * canonical issuer persisted with Apple accounts.
+ */
+export function getAppleAccountIssuer() {
+  return configuredAppleProvider?.accountIssuer;
+}
 
 /**
  * Gives the private native auth boundary an Apple provider that validates the

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -47,7 +47,6 @@ export const baseAuthConfig: Omit<BetterAuthOptions, "rateLimit"> = {
   },
   database: prismaAdapter(prisma, { provider: "postgresql" }),
   databaseHooks: { user: { create: { after: ensureUserProgressAfterAuthCreate } } },
-  experimental: { joins: true },
   session: {
     cookieCache: { enabled: IS_COOKIE_CACHE_ENABLED, maxAge: 60 * COOKIE_CACHE_MINUTES },
     expiresIn: 60 * 60 * 24 * SESSION_EXPIRES_IN_DAYS,

--- a/packages/core/src/users/delete-current-user.test.ts
+++ b/packages/core/src/users/delete-current-user.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { prisma } from "@zoonk/db";
+import { appleAccountFixture } from "@zoonk/testing/fixtures/accounts";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { deleteCurrentUser } from "./delete-current-user";
@@ -37,16 +38,6 @@ const appleCredentials = {
 };
 
 const emailCredentials = { email: "learner@example.com", otp: "123456" };
-
-/**
- * Adds the provider row that changes deletion reauthentication behavior while
- * leaving the account lookup itself on the real Prisma client.
- */
-function createAppleAccount(userId: string) {
-  return prisma.account.create({
-    data: { accountId: `apple-${randomUUID()}`, providerId: "apple", userId },
-  });
-}
 
 describe(deleteCurrentUser, () => {
   let currentUserId: string;
@@ -88,7 +79,7 @@ describe(deleteCurrentUser, () => {
   });
 
   it("keeps deletion available without fresh Apple credentials", async () => {
-    await createAppleAccount(currentUserId);
+    await appleAccountFixture({ userId: currentUserId });
 
     mocks.captureDeletionCleanup.mockImplementation(async (operation: () => Promise<unknown>) => ({
       appleAuthorizationRevoked: true,
@@ -102,7 +93,7 @@ describe(deleteCurrentUser, () => {
   });
 
   it("deletes with the fresh session returned after native Apple revocation", async () => {
-    await createAppleAccount(currentUserId);
+    await appleAccountFixture({ userId: currentUserId });
 
     mocks.captureDeletionCleanup.mockImplementation(async (operation: () => Promise<unknown>) => ({
       appleAuthorizationRevoked: true,
@@ -139,7 +130,7 @@ describe(deleteCurrentUser, () => {
   });
 
   it("reports stored Apple revocation failure after email reauthentication", async () => {
-    await createAppleAccount(currentUserId);
+    await appleAccountFixture({ userId: currentUserId });
 
     mocks.captureDeletionCleanup.mockImplementation(async (operation: () => Promise<unknown>) => ({
       appleAuthorizationRevoked: false,
@@ -152,7 +143,7 @@ describe(deleteCurrentUser, () => {
   });
 
   it("reports failure when either fresh or stored Apple revocation is unavailable", async () => {
-    await createAppleAccount(currentUserId);
+    await appleAccountFixture({ userId: currentUserId });
 
     mocks.captureDeletionCleanup.mockImplementation(async (operation: () => Promise<unknown>) => ({
       appleAuthorizationRevoked: false,
@@ -172,7 +163,7 @@ describe(deleteCurrentUser, () => {
     const temporarySessionToken = `${provider.toLowerCase()}-${randomUUID()}`;
 
     if (provider === "Apple") {
-      await createAppleAccount(currentUserId);
+      await appleAccountFixture({ userId: currentUserId });
 
       mocks.reauthorizeApple.mockResolvedValue({
         appleAuthorizationRevoked: true,

--- a/packages/core/src/users/get-current-user-has-apple-account.test.ts
+++ b/packages/core/src/users/get-current-user-has-apple-account.test.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "node:crypto";
-import { prisma } from "@zoonk/db";
+import { appleAccountFixture } from "@zoonk/testing/fixtures/accounts";
 import { userFixture } from "@zoonk/testing/fixtures/users";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockSession } from "../_test-utils/mock-session";
@@ -27,14 +26,7 @@ describe(getCurrentUserHasAppleAccount, () => {
     const user = await userFixture();
     mockSession(user.id);
 
-    await prisma.account.create({
-      data: {
-        accountId: `apple-${randomUUID()}`,
-        id: randomUUID(),
-        providerId: "apple",
-        userId: user.id,
-      },
-    });
+    await appleAccountFixture({ userId: user.id });
 
     await expect(getCurrentUserHasAppleAccount()).resolves.toBe(true);
   });

--- a/packages/db/src/prisma/migrations/20260818161626_better_auth_account_issuer/migration.sql
+++ b/packages/db/src/prisma/migrations/20260818161626_better_auth_account_issuer/migration.sql
@@ -1,0 +1,58 @@
+-- Better Auth 1.7 identifies external accounts by their trusted issuer and provider subject.
+-- Keep this nullable only while the existing provider rows are mapped below.
+BEGIN;
+
+ALTER TABLE "accounts" ADD COLUMN "issuer" TEXT;
+
+-- Unknown providers require a reviewed trusted-issuer mapping. Failing closed avoids assigning
+-- an identity based on mutable profile data or an unverified provider URL.
+DO $$
+DECLARE
+  unexpected_provider_ids TEXT;
+BEGIN
+  SELECT STRING_AGG("provider_id", ', ' ORDER BY "provider_id")
+  INTO unexpected_provider_ids
+  FROM (
+    SELECT DISTINCT "provider_id"
+    FROM "accounts"
+    WHERE "provider_id" NOT IN ('apple', 'credential', 'google')
+  ) AS unexpected_providers;
+
+  IF unexpected_provider_ids IS NOT NULL THEN
+    RAISE EXCEPTION 'Better Auth 1.7 issuer mapping is missing for provider_id values: %', unexpected_provider_ids;
+  END IF;
+END $$;
+
+-- Credential identity is the linked user's stable ID in 1.7; email is a mutable sign-in identifier.
+UPDATE "accounts"
+SET
+  "account_id" = "user_id"::TEXT,
+  "issuer" = 'local:credential'
+WHERE "provider_id" = 'credential';
+
+UPDATE "accounts"
+SET "issuer" = 'https://appleid.apple.com'
+WHERE "provider_id" = 'apple';
+
+UPDATE "accounts"
+SET "issuer" = 'https://accounts.google.com'
+WHERE "provider_id" = 'google';
+
+-- Never pick an arbitrary owner when the new canonical identity exposes legacy collisions.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "accounts"
+    GROUP BY "issuer", "account_id"
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Better Auth 1.7 account identity collisions must be resolved before migration';
+  END IF;
+END $$;
+
+ALTER TABLE "accounts" ALTER COLUMN "issuer" SET NOT NULL;
+
+CREATE UNIQUE INDEX "account_issuer_accountId_uidx" ON "accounts"("issuer", "account_id");
+
+COMMIT;

--- a/packages/db/src/prisma/models/accounts.prisma
+++ b/packages/db/src/prisma/models/accounts.prisma
@@ -56,6 +56,7 @@ model Session {
 
 model Account {
   id                    String    @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  issuer                String
   accountId             String    @map("account_id")
   providerId            String    @map("provider_id")
   userId                String    @map("user_id") @db.Uuid
@@ -70,6 +71,7 @@ model Account {
   createdAt             DateTime  @default(now()) @map("created_at")
   updatedAt             DateTime  @updatedAt @map("updated_at")
 
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@index([userId])
   @@map("accounts")
 }

--- a/packages/db/src/prisma/seed/accounts.ts
+++ b/packages/db/src/prisma/seed/accounts.ts
@@ -1,13 +1,16 @@
 import { type PrismaClient } from "../../generated/prisma/client";
 import { type SeedUsers } from "./users";
 
+const CREDENTIAL_ISSUER = "local:credential";
+const CREDENTIAL_PROVIDER_ID = "credential";
 const TEST_PASSWORD = "password123";
 
 export async function seedAccounts(prisma: PrismaClient, users: SeedUsers): Promise<void> {
   const accountData = Object.values(users).map((user) => ({
-    accountId: user.email,
+    accountId: user.id,
+    issuer: CREDENTIAL_ISSUER,
     password: TEST_PASSWORD,
-    providerId: "credential",
+    providerId: CREDENTIAL_PROVIDER_ID,
     userId: user.id,
   }));
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./fixtures/accounts": "./src/fixtures/accounts.ts",
     "./fixtures/auth": "./src/fixtures/auth.ts",
     "./fixtures/chapters": "./src/fixtures/chapters.ts",
     "./fixtures/course-prompts": "./src/fixtures/course-prompts.ts",

--- a/packages/testing/src/fixtures/accounts.ts
+++ b/packages/testing/src/fixtures/accounts.ts
@@ -1,0 +1,23 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+
+const APPLE_ISSUER = "https://appleid.apple.com";
+const APPLE_PROVIDER_ID = "apple";
+
+export function appleAccountFixture({
+  accountId = `apple-${randomUUID()}`,
+  userId,
+}: {
+  accountId?: string;
+  userId: string;
+}) {
+  return prisma.account.create({
+    data: {
+      accountId,
+      id: randomUUID(),
+      issuer: APPLE_ISSUER,
+      providerId: APPLE_PROVIDER_ID,
+      userId,
+    },
+  });
+}

--- a/packages/testing/src/fixtures/users.ts
+++ b/packages/testing/src/fixtures/users.ts
@@ -3,6 +3,9 @@ import { prisma } from "@zoonk/db";
 
 type UserAttrs = { email: string; name: string; role: "user" | "admin"; password: string };
 
+const CREDENTIAL_ISSUER = "local:credential";
+const CREDENTIAL_PROVIDER_ID = "credential";
+
 function userAttrs(attrs?: Partial<UserAttrs>): UserAttrs {
   return {
     email: attrs?.email || `testuser${randomUUID()}@example.test`,
@@ -23,19 +26,21 @@ function userAttrs(attrs?: Partial<UserAttrs>): UserAttrs {
  */
 export async function userFixture(attrs?: Partial<UserAttrs>) {
   const params = userAttrs(attrs);
+  const userId = randomUUID();
 
   const user = await prisma.user.create({
     data: {
       accounts: {
         create: {
-          accountId: params.email,
+          accountId: userId,
           id: randomUUID(),
+          issuer: CREDENTIAL_ISSUER,
           password: params.password,
-          providerId: "credential",
+          providerId: CREDENTIAL_PROVIDER_ID,
         },
       },
       email: params.email,
-      id: randomUUID(),
+      id: userId,
       name: params.name,
       role: params.role,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,11 +652,11 @@ importers:
   packages/auth:
     dependencies:
       '@better-auth/prisma-adapter':
-        specifier: 1.6.29
-        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
+        specifier: 1.7.1
+        version: 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
       '@better-auth/stripe':
-        specifier: 1.6.29
-        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(better-auth@1.6.29(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(better-call@1.4.0(zod@4.4.3))(stripe@22.5.0(@types/node@26.2.0))
+        specifier: 1.7.1
+        version: 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(better-auth@1.7.1(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(better-call@1.4.0(zod@4.4.3))(stripe@22.5.0(@types/node@26.2.0))
       '@zoonk/db':
         specifier: workspace:*
         version: link:../db
@@ -667,8 +667,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       better-auth:
-        specifier: 1.6.29
-        version: 1.6.29(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+        specifier: 1.7.1
+        version: 1.7.1(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       jose:
         specifier: 6.2.9
         version: 6.2.9
@@ -1255,8 +1255,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@better-auth/core@1.6.29':
-    resolution: {integrity: sha512-hkUxePo548G0Y247had36TcfsH7E+cofcTc2UivMAbjkdLPKn1ZUk6Pjkc/kvk9xTbWYCUDX6JA9emJc0Gnufg==}
+  '@better-auth/core@1.7.1':
+    resolution: {integrity: sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A==}
     peerDependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -1272,46 +1272,46 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@better-auth/drizzle-adapter@1.6.29':
-    resolution: {integrity: sha512-IdvrqHnnRNKqz6KOSII3rZNiTzv1pmVmx5xGRGZdVm8W3OYi98an5kIovao/b3GZh2nHGTzdeTfMSSZNCyGXBg==}
+  '@better-auth/drizzle-adapter@1.7.1':
+    resolution: {integrity: sha512-qlqNyg5V9bXHSP68/vtlsiZayhR4hgvEGiS/E3SIj8bCpWWFGmyQkxJbQCqpBmC7vT30wE/kNtJMHIgnV3rkiw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.29
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
-      drizzle-orm: ^0.45.2
+      drizzle-orm: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
 
-  '@better-auth/kysely-adapter@1.6.29':
-    resolution: {integrity: sha512-n87hHC/miSaUaKdnQygz+2wlj2KI2rsGazDPaKF0wbH8i87um9HPDWyz3VdbkqPN79e0qbVfMR9pY7GZQm/X8w==}
+  '@better-auth/kysely-adapter@1.7.1':
+    resolution: {integrity: sha512-yWCpE1cZpMUj37nD6JFDK+GDR8zS37L5WI73il3qbU9TXtWsxUQKc/5c3IHsHizWQsmcQI8uv2pAFKxsRDa+AQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.29
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       kysely: ^0.28.17 || ^0.29.0
     peerDependenciesMeta:
       kysely:
         optional: true
 
-  '@better-auth/memory-adapter@1.6.29':
-    resolution: {integrity: sha512-F1yLUbNTc/pikEaTlgWOgYlT2RDSi2dV1ysWxacRmQhYtLGYAun1JgU7TDdcEjts+wrLcm+JzRzt5F+ZgNfz9A==}
+  '@better-auth/memory-adapter@1.7.1':
+    resolution: {integrity: sha512-6NX1yv88DeqdoG7owYFqKwlrDGaIPhsC52JUGrUgeGVKyOq8a/6hHlHsqG1C2FwT23SHQiKVYCEAG9N6aH5OvQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.29
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.29':
-    resolution: {integrity: sha512-gyOpfBBCpe2wDnv9CY2T0jirC4oTqk3i5svWYBGkGTAFrKsfJA516NMOs001PiHsEDf/JttZapQv5dkoPD0x2w==}
+  '@better-auth/mongo-adapter@1.7.1':
+    resolution: {integrity: sha512-9ILTcNqhG37QK//qR4UhYLyKzNqq6w6zVTf5KX6xkiTjNcV7Oh1yS31lkIJEVTqRNcy9AoV6FZMW6Bbsm8IMDA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.29
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       mongodb: ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       mongodb:
         optional: true
 
-  '@better-auth/prisma-adapter@1.6.29':
-    resolution: {integrity: sha512-W5lr8AYXwa68qhS7PEpEsisF7ASs9rWJyczoZr8+vYypPBmGMq1Yf8bYJ9ig95zj1wdaQGim2ZSYs8hxZeaKVQ==}
+  '@better-auth/prisma-adapter@1.7.1':
+    resolution: {integrity: sha512-ZiUcafQ85InAofcUjyGgCPjKLfQjXr9SvDmMjuFUW8oEbreA6C6GaFAEA77VuV2doZUQlzvQQ4gCoTmS28W92A==}
     peerDependencies:
-      '@better-auth/core': ^1.6.29
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -1321,18 +1321,18 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/stripe@1.6.29':
-    resolution: {integrity: sha512-WXC2QoWWYUJ1wEco3eMtNrKCzTR80fg81k51mDdGyH2JO9jBN+qFWLCbthn6uYyoereQ/zSZG89ATrFAzIQAkQ==}
+  '@better-auth/stripe@1.7.1':
+    resolution: {integrity: sha512-BMntdoP6q6cWZuMBaWAPmvqc3TQXbXSNoGuNJMNxABvnYkTm/8gl6QzlwoBq5zTAkz0rmW4TiCY5xVTU6Fak/Q==}
     peerDependencies:
-      '@better-auth/core': ^1.6.29
-      better-auth: ^1.6.29
+      '@better-auth/core': ^1.7.1
+      better-auth: ^1.7.1
       better-call: 1.4.0
       stripe: ^18 || ^19 || ^20 || ^21 || ^22
 
-  '@better-auth/telemetry@1.6.29':
-    resolution: {integrity: sha512-zW1GRIBR/sn83siG+xK4ll/gzfTRxVh6rcpzzjYkR2W9/DkDMwEotl/Mz8OW0Gr2KpuhEkfwiVGH9zp/cyK4Pg==}
+  '@better-auth/telemetry@1.7.1':
+    resolution: {integrity: sha512-kLKjMfFlTbyt49DGeI9okHAsn0MtBZcMoQYKaEdgR0H3BHzqqyzePcQz/hxAmRgjB4p/6inise3zJwhX0sgXrQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.29
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -4583,8 +4583,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-auth@1.6.29:
-    resolution: {integrity: sha512-7i2kOry+Jb1mRUR14kCDVS23GCKUGWxayZRXULbNz/6nFLPT6XSuGJVrwo/d+Qfq/iubA0/4Acw2/eg/tPCCnA==}
+  better-auth@1.7.1:
+    resolution: {integrity: sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -4592,8 +4592,8 @@ packages:
       '@tanstack/react-start': ^1.0.0
       '@tanstack/solid-start': ^1.0.0
       better-sqlite3: ^12.0.0
-      drizzle-kit: '>=0.31.4'
-      drizzle-orm: ^0.45.2
+      drizzle-kit: '>=0.31.4 || >=1.0.0-beta.1'
+      drizzle-orm: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -8071,7 +8071,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)':
+  '@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -8085,48 +8085,48 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/kysely-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
+  '@better-auth/kysely-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.5
 
-  '@better-auth/memory-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))':
+  '@better-auth/prisma-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       '@prisma/client': 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2)
       prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
 
-  '@better-auth/stripe@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(better-auth@1.6.29(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(better-call@1.4.0(zod@4.4.3))(stripe@22.5.0(@types/node@26.2.0))':
+  '@better-auth/stripe@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(better-auth@1.7.1(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10))(better-call@1.4.0(zod@4.4.3))(stripe@22.5.0(@types/node@26.2.0))':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
-      better-auth: 1.6.29(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
+      better-auth: 1.7.1(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       better-call: 1.4.0(zod@4.4.3)
       defu: 6.1.7
       stripe: 22.5.0(@types/node@26.2.0)
       zod: 4.4.3
 
-  '@better-auth/telemetry@1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -11164,15 +11164,15 @@ snapshots:
 
   baseline-browser-mapping@2.11.14: {}
 
-  better-auth@1.6.29(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
+  better-auth@1.7.1(@opentelemetry/api@1.9.1)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(mysql2@3.15.3)(next@16.3.1(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.2.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
     dependencies:
-      '@better-auth/core': 1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
-      '@better-auth/memory-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
-      '@better-auth/telemetry': 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/drizzle-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
+      '@better-auth/memory-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))(typescript@7.0.2))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2))
+      '@better-auth/telemetry': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.3.0


### PR DESCRIPTION
- Upgrade Better Auth and its adapters to 1.7.1.
- Migrate account identities to issuer-scoped keys.
- Align native Apple lookups and test fixtures with the new schema.