### PR TITLE
fix(main): simplify subscription ctas

### DIFF
--- a/apps/main/e2e/generate-chapter.test.ts
+++ b/apps/main/e2e/generate-chapter.test.ts
@@ -244,7 +244,7 @@ test.describe("Generate Chapter Page - No Subscription", () => {
 
     await expect(authenticatedPage.getByText(/^keep learning with plus$/iu)).toBeVisible();
 
-    const upgradeLink = authenticatedPage.getByRole("link", { name: /get zoonk plus/iu });
+    const upgradeLink = authenticatedPage.getByRole("link", { name: /^subscribe$/iu });
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -277,7 +277,7 @@ test.describe("Generate Course Page", () => {
       authenticatedPage.getByRole("heading", { name: "Monthly course limit reached" }),
     ).toBeVisible();
 
-    await expect(authenticatedPage.getByRole("link", { name: "Get Zoonk Plus" })).toHaveAttribute(
+    await expect(authenticatedPage.getByRole("link", { name: "Subscribe" })).toHaveAttribute(
       "href",
       "/subscription",
     );

--- a/apps/main/e2e/generate-lesson.test.ts
+++ b/apps/main/e2e/generate-lesson.test.ts
@@ -378,7 +378,7 @@ test.describe("Generate Lesson Page - No Subscription", () => {
 
     await expect(authenticatedPage.getByText(/^keep learning with plus$/iu)).toBeVisible();
 
-    const upgradeLink = authenticatedPage.getByRole("link", { name: /get zoonk plus/iu });
+    const upgradeLink = authenticatedPage.getByRole("link", { name: /^subscribe$/iu });
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("href", /\/subscription/u);
   });

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -641,7 +641,7 @@ test.describe("Lesson Player Page", () => {
     await expect(authenticatedPage.getByText("This lesson is included with Plus.")).toBeVisible();
 
     const backLink = authenticatedPage.getByRole("link", { name: /back to chapter/iu });
-    const upgradeLink = authenticatedPage.getByRole("link", { name: /get zoonk plus/iu });
+    const upgradeLink = authenticatedPage.getByRole("link", { name: /^subscribe$/iu });
 
     await expect(backLink).toBeVisible();
     await expect(backLink.getByText(/^Esc$/u)).toBeVisible();
@@ -661,7 +661,7 @@ test.describe("Lesson Player Page", () => {
 
     await authenticatedPage.goto(lessonHref);
 
-    await expect(authenticatedPage.getByRole("link", { name: /get zoonk plus/iu })).toBeVisible();
+    await expect(authenticatedPage.getByRole("link", { name: /^subscribe$/iu })).toBeVisible();
 
     await pressShortcutAndWaitForUrl({
       expectedUrl: "/subscription",

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -117,10 +117,16 @@ async function captureStripeActionRequest({
  * Drive checkout through the single visible Plus action because the locale is
  * added by the client-side Better Auth call, not by the server-rendered page.
  */
-async function requestPlusCheckout({ page }: { page: Page }) {
+async function requestPlusCheckout({
+  page,
+  subscribeLabel,
+}: {
+  page: Page;
+  subscribeLabel: string;
+}) {
   const requestBody = captureStripeActionRequest({ page, path: "/api/auth/subscription/upgrade" });
 
-  await page.getByRole("button", { name: /^subscribe$/iu }).click();
+  await page.getByRole("button", { exact: true, name: subscribeLabel }).click();
 
   return requestBody;
 }
@@ -171,9 +177,9 @@ test.describe("Subscription Page - Stripe Locale", () => {
     await setLocale(authenticatedPage, "es");
     await authenticatedPage.goto("/subscription");
 
-    await expect(requestPlusCheckout({ page: authenticatedPage })).resolves.toMatchObject({
-      locale: "es",
-    });
+    await expect(
+      requestPlusCheckout({ page: authenticatedPage, subscribeLabel: "Suscríbete" }),
+    ).resolves.toMatchObject({ locale: "es" });
   });
 
   test("passes Portuguese locale as Brazilian Portuguese to Stripe checkout", async ({
@@ -182,34 +188,37 @@ test.describe("Subscription Page - Stripe Locale", () => {
     await setLocale(authenticatedPage, "pt");
     await authenticatedPage.goto("/subscription");
 
-    await expect(requestPlusCheckout({ page: authenticatedPage })).resolves.toMatchObject({
-      locale: "pt-BR",
-    });
+    await expect(
+      requestPlusCheckout({ page: authenticatedPage, subscribeLabel: "Assinar" }),
+    ).resolves.toMatchObject({ locale: "pt-BR" });
   });
 
   test("passes French locale to Stripe checkout", async ({ authenticatedPage }) => {
     await setLocale(authenticatedPage, "fr");
     await authenticatedPage.goto("/subscription");
 
-    await expect(requestPlusCheckout({ page: authenticatedPage })).resolves.toMatchObject({
-      locale: "fr",
-    });
+    await expect(
+      requestPlusCheckout({ page: authenticatedPage, subscribeLabel: "S’abonner" }),
+    ).resolves.toMatchObject({ locale: "fr" });
   });
 
   test("passes German locale to Stripe checkout", async ({ authenticatedPage }) => {
     await setLocale(authenticatedPage, "de");
     await authenticatedPage.goto("/subscription");
 
-    await expect(requestPlusCheckout({ page: authenticatedPage })).resolves.toMatchObject({
-      locale: "de",
-    });
+    await expect(
+      requestPlusCheckout({ page: authenticatedPage, subscribeLabel: "Abonnieren" }),
+    ).resolves.toMatchObject({ locale: "de" });
   });
 
   test("keeps English Stripe checkout locale unset", async ({ authenticatedPage }) => {
     await setLocale(authenticatedPage, "en");
     await authenticatedPage.goto("/subscription");
 
-    const requestBody = await requestPlusCheckout({ page: authenticatedPage });
+    const requestBody = await requestPlusCheckout({
+      page: authenticatedPage,
+      subscribeLabel: "Subscribe",
+    });
 
     expect(requestBody).not.toHaveProperty("locale");
   });

--- a/apps/main/e2e/subscription.test.ts
+++ b/apps/main/e2e/subscription.test.ts
@@ -120,7 +120,7 @@ async function captureStripeActionRequest({
 async function requestPlusCheckout({ page }: { page: Page }) {
   const requestBody = captureStripeActionRequest({ page, path: "/api/auth/subscription/upgrade" });
 
-  await page.getByRole("button", { name: /zoonk plus/iu }).click();
+  await page.getByRole("button", { name: /^subscribe$/iu }).click();
 
   return requestBody;
 }
@@ -138,7 +138,7 @@ test.describe("Subscription Page - Unauthenticated", () => {
       page.getByRole("heading", { name: /keep learning until you get there/iu }),
     ).toBeVisible();
 
-    const loginLink = page.getByRole("link", { name: /log in to unlock unlimited learning/iu });
+    const loginLink = page.getByRole("link", { name: /log in to subscribe/iu });
     await expect(loginLink).toHaveAttribute("href", "/login?next=%2Fsubscription");
     await expect(page.getByRole("button", { name: /monthly/iu })).toBeVisible();
     await expect(page.getByRole("button", { name: /yearly/iu })).toBeVisible();
@@ -154,9 +154,7 @@ test.describe("Subscription Page - No Subscription", () => {
       authenticatedPage.getByRole("heading", { level: 1, name: /learn anything/iu }),
     ).toBeVisible();
 
-    await expect(
-      authenticatedPage.getByRole("button", { name: /unlock unlimited learning/iu }),
-    ).toBeVisible();
+    await expect(authenticatedPage.getByRole("button", { name: /^subscribe$/iu })).toBeVisible();
 
     await expect(authenticatedPage.getByRole("button", { name: /monthly/iu })).toHaveAttribute(
       "aria-pressed",

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -1565,19 +1565,16 @@ msgid "Investing in your future is cheaper than"
 msgstr "In deine Zukunft zu investieren ist günstiger als"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "5MmaRi"
-msgid "Log in to unlock unlimited learning"
-msgstr "Melde dich an und lerne unbegrenzt"
+msgctxt "NYTy1D"
+msgid "Log in to subscribe"
+msgstr "Zum Abonnieren einloggen"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "tuK7B0"
-msgid "Unlock unlimited learning with Zoonk Plus"
-msgstr "Lerne unbegrenzt mit Zoonk Plus"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "nzee-0"
-msgid "Unlock unlimited learning"
-msgstr "Unbegrenzt lernen"
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "gczcC5"
+msgid "Subscribe"
+msgstr "Abonnieren"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "pTtXdP"
@@ -2696,12 +2693,6 @@ msgstr "Melde dich an, um Inhalte mit KI zu erstellen"
 msgctxt "Jjw_0c"
 msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
 msgstr "Du musst dich anmelden, um mit KI neue Kurse und Lektionen zu erstellen. Bestehende Kurse kannst du auch ohne Anmeldung erkunden."
-
-#: src/components/generation/generation-limit-cta.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Zoonk Plus holen"
 
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "GLlr0C"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1565,19 +1565,16 @@ msgid "Investing in your future is cheaper than"
 msgstr "Investing in your future is cheaper than"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "5MmaRi"
-msgid "Log in to unlock unlimited learning"
-msgstr "Log in to unlock unlimited learning"
+msgctxt "NYTy1D"
+msgid "Log in to subscribe"
+msgstr "Log in to subscribe"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "tuK7B0"
-msgid "Unlock unlimited learning with Zoonk Plus"
-msgstr "Unlock unlimited learning with Zoonk Plus"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "nzee-0"
-msgid "Unlock unlimited learning"
-msgstr "Unlock unlimited learning"
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "gczcC5"
+msgid "Subscribe"
+msgstr "Subscribe"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "pTtXdP"
@@ -2696,12 +2693,6 @@ msgstr "Log in to create with AI"
 msgctxt "Jjw_0c"
 msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
 msgstr "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
-
-#: src/components/generation/generation-limit-cta.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Get Zoonk Plus"
 
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "GLlr0C"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1565,19 +1565,16 @@ msgid "Investing in your future is cheaper than"
 msgstr "Invertir en tu futuro cuesta menos que"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "5MmaRi"
-msgid "Log in to unlock unlimited learning"
-msgstr "Inicia sesión para estudiar sin límites"
+msgctxt "NYTy1D"
+msgid "Log in to subscribe"
+msgstr "Inicia sesión para suscribirte"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "tuK7B0"
-msgid "Unlock unlimited learning with Zoonk Plus"
-msgstr "Desbloquea el estudio ilimitado con Zoonk Plus"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "nzee-0"
-msgid "Unlock unlimited learning"
-msgstr "Estudia sin límites"
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "gczcC5"
+msgid "Subscribe"
+msgstr "Suscríbete"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "pTtXdP"
@@ -2696,12 +2693,6 @@ msgstr "Inicia sesión para crear con IA"
 msgctxt "Jjw_0c"
 msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
 msgstr "Debes iniciar sesión para crear nuevos cursos y lecciones con IA. Puedes explorar los cursos existentes sin iniciar sesión."
-
-#: src/components/generation/generation-limit-cta.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Obtén Zoonk Plus"
 
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "GLlr0C"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -1565,19 +1565,16 @@ msgid "Investing in your future is cheaper than"
 msgstr "Investir dans ton avenir coûte moins cher que"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "5MmaRi"
-msgid "Log in to unlock unlimited learning"
-msgstr "Connecte-toi pour apprendre sans limites"
+msgctxt "NYTy1D"
+msgid "Log in to subscribe"
+msgstr "Connecte-toi pour t’abonner"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "tuK7B0"
-msgid "Unlock unlimited learning with Zoonk Plus"
-msgstr "Apprends sans limites avec Zoonk Plus"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "nzee-0"
-msgid "Unlock unlimited learning"
-msgstr "Apprends sans limites"
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "gczcC5"
+msgid "Subscribe"
+msgstr "S’abonner"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "pTtXdP"
@@ -2696,12 +2693,6 @@ msgstr "Connecte-toi pour créer avec l’IA"
 msgctxt "Jjw_0c"
 msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
 msgstr "Tu dois te connecter pour créer de nouveaux cours et de nouvelles leçons avec l’IA. Tu peux explorer les cours existants sans te connecter."
-
-#: src/components/generation/generation-limit-cta.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Passe à Zoonk Plus"
 
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "GLlr0C"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1565,19 +1565,16 @@ msgid "Investing in your future is cheaper than"
 msgstr "Investir no seu futuro custa menos que"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "5MmaRi"
-msgid "Log in to unlock unlimited learning"
-msgstr "Entre para estudar sem limites"
+msgctxt "NYTy1D"
+msgid "Log in to subscribe"
+msgstr "Entre para assinar"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "tuK7B0"
-msgid "Unlock unlimited learning with Zoonk Plus"
-msgstr "Libere estudos ilimitados com o Zoonk Plus"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "nzee-0"
-msgid "Unlock unlimited learning"
-msgstr "Estude sem limites"
+#: src/components/generation/generation-limit-cta.tsx
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "gczcC5"
+msgid "Subscribe"
+msgstr "Assinar"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "pTtXdP"
@@ -2696,12 +2693,6 @@ msgstr "Entre para criar com IA"
 msgctxt "Jjw_0c"
 msgid "You need to log in to create new courses and lessons with AI. You can explore existing courses without logging in."
 msgstr "Você precisa entrar para criar novos cursos e aulas com IA. Você pode explorar os cursos existentes sem entrar."
-
-#: src/components/generation/generation-limit-cta.tsx
-#: src/components/subscription/upgrade-cta.tsx
-msgctxt "LeTnGY"
-msgid "Get Zoonk Plus"
-msgstr "Assine o Zoonk Plus"
 
 #: src/components/generation/generation-limit-cta.tsx
 msgctxt "GLlr0C"

--- a/apps/main/src/app/[lang]/(settings)/subscription/plus-purchase.tsx
+++ b/apps/main/src/app/[lang]/(settings)/subscription/plus-purchase.tsx
@@ -231,11 +231,10 @@ function AvailablePlusPurchase({
             href="/login?next=%2Fsubscription"
             prefetch={false}
           >
-            {t("Log in to unlock unlimited learning")}
+            {t("Log in to subscribe")}
           </Link>
         ) : (
           <Button
-            aria-label={t("Unlock unlimited learning with Zoonk Plus")}
             aria-busy={isLoading}
             className="w-full"
             disabled={isLoading}
@@ -244,7 +243,7 @@ function AvailablePlusPurchase({
             type="button"
           >
             {isLoading && <Loader2Icon aria-hidden="true" className="animate-spin" />}
-            {t("Unlock unlimited learning")}
+            {t("Subscribe")}
           </Button>
         )}
 

--- a/apps/main/src/components/generation/generation-limit-cta.tsx
+++ b/apps/main/src/components/generation/generation-limit-cta.tsx
@@ -31,7 +31,7 @@ function GenerationLimitAction<Href extends string>({
   if (viewer === "authenticated") {
     return (
       <GenerationShortcutLink href="/subscription" prefetch>
-        {t("Get Zoonk Plus")}
+        {t("Subscribe")}
       </GenerationShortcutLink>
     );
   }

--- a/apps/main/src/components/subscription/upgrade-cta.tsx
+++ b/apps/main/src/components/subscription/upgrade-cta.tsx
@@ -51,7 +51,7 @@ export async function UpgradeCTA<Href extends string>({
         </GenerationShortcutLink>
 
         <GenerationShortcutLink href="/subscription" prefetch shortcut="Enter">
-          {t("Get Zoonk Plus")}
+          {t("Subscribe")}
         </GenerationShortcutLink>
       </EmptyContent>
     </Empty>


### PR DESCRIPTION
Simplifies subscription CTAs across gates, generation limits, and the subscription page. Updates the signed-out handoff, translations, and E2E assertions to match.