### PR TITLE
fix(core): classify course prompts before auth gate

### DIFF
--- a/apps/api/e2e/course-prompts-and-generation-resources.test.ts
+++ b/apps/api/e2e/course-prompts-and-generation-resources.test.ts
@@ -25,31 +25,6 @@ test.describe("Course prompt and generation resources API", () => {
     await prisma.$disconnect();
   });
 
-  test("requires authentication before resolving a new course prompt", async () => {
-    const prompt = `Anonymous API course prompt ${randomUUID()}`;
-    const apiContext = await request.newContext({ baseURL });
-
-    const response = await apiContext.post("/v1/course-prompts", {
-      data: { kind: "topic", language: "en", prompt },
-    });
-
-    expect(response.status()).toBe(401);
-
-    await expect(response.json()).resolves.toMatchObject({
-      error: { code: "UNAUTHORIZED", message: "Authentication required" },
-    });
-
-    await expect(
-      prisma.coursePrompt.findUnique({
-        where: {
-          languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
-        },
-      }),
-    ).resolves.toBeNull();
-
-    await apiContext.dispose();
-  });
-
   test("requires authentication before creating a language course prompt", async () => {
     const language = `en-x-${randomUUID().slice(0, 5)}`;
     const apiContext = await request.newContext({ baseURL });

--- a/apps/api/e2e/course-prompts-and-generation-resources.test.ts
+++ b/apps/api/e2e/course-prompts-and-generation-resources.test.ts
@@ -87,7 +87,7 @@ test.describe("Course prompt and generation resources API", () => {
     await apiContext.dispose();
   });
 
-  test("requires authentication before promoting a cached prompt to generation", async () => {
+  test("requires authentication before promoting a classified prompt to generation", async () => {
     const uniqueId = randomUUID();
     const prompt = `Learn focused API design ${uniqueId}`;
 
@@ -100,21 +100,112 @@ test.describe("Course prompt and generation resources API", () => {
       prompt,
     });
 
-    const apiContext = await request.newContext({ baseURL });
+    const guestApiContext = await request.newContext({ baseURL });
 
-    const response = await apiContext.post("/v1/course-prompts", {
+    const guestResponse = await guestApiContext.post("/v1/course-prompts", {
       data: { kind: "topic", language: "en", prompt },
     });
 
-    expect(response.status()).toBe(401);
+    expect(guestResponse.status()).toBe(401);
 
-    await expect(response.json()).resolves.toMatchObject({
+    await expect(guestResponse.json()).resolves.toMatchObject({
       error: { code: "UNAUTHORIZED", message: "Authentication required" },
     });
 
     await expect(
       prisma.coursePrompt.findUniqueOrThrow({ where: { id: coursePrompt.id } }),
     ).resolves.toMatchObject({ courseFormat: "coding", generationStatus: null });
+
+    const { apiContext: authenticatedApiContext } = await createAuthenticatedApiContext({
+      baseURL,
+      prefix: "course-prompt-promotion",
+    });
+
+    const authenticatedResponse = await authenticatedApiContext.post("/v1/course-prompts", {
+      data: { kind: "topic", language: "en", prompt },
+    });
+
+    expect(authenticatedResponse.status()).toBe(200);
+
+    await expect(authenticatedResponse.json()).resolves.toStrictEqual({
+      coursePromptId: coursePrompt.id,
+      kind: "generation",
+    });
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: coursePrompt.id } }),
+    ).resolves.toMatchObject({ generationStatus: "pending" });
+
+    await Promise.all([guestApiContext.dispose(), authenticatedApiContext.dispose()]);
+  });
+
+  test("returns personalized classifications without requiring authentication", async () => {
+    const prompt = `Personalized API course ${randomUUID()}`;
+    const title = `Personalized API title ${randomUUID()}`;
+
+    const coursePrompt = await coursePromptFixture({
+      canonicalTitle: title,
+      courseFormat: "personalized",
+      generationStatus: null,
+      intent: "learn",
+      language: "en",
+      normalizedPrompt: normalizeString(prompt),
+      prompt,
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/course-prompts", {
+      data: { kind: "topic", language: "en", prompt },
+    });
+
+    expect(response.status()).toBe(200);
+
+    await expect(response.json()).resolves.toStrictEqual({
+      courseFormat: "personalized",
+      intent: "learn",
+      kind: "unsupported",
+      title,
+    });
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: coursePrompt.id } }),
+    ).resolves.toMatchObject({ generationStatus: null });
+
+    await apiContext.dispose();
+  });
+
+  test("returns existing courses for classified guest prompts", async () => {
+    const organization = await getAiOrganization();
+    const prompt = `Existing API course ${randomUUID()}`;
+
+    const course = await courseFixture({
+      generationStatus: "completed",
+      isPublished: true,
+      organizationId: organization.id,
+      title: `Existing API course ${randomUUID()}`,
+    });
+
+    const coursePrompt = await coursePromptFixture({
+      courseId: course.id,
+      generationStatus: "completed",
+      language: "en",
+      normalizedPrompt: normalizeString(prompt),
+      prompt,
+    });
+
+    const apiContext = await request.newContext({ baseURL });
+
+    const response = await apiContext.post("/v1/course-prompts", {
+      data: { kind: "topic", language: "en", prompt },
+    });
+
+    expect(response.status()).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ courseId: course.id, kind: "course" });
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: coursePrompt.id } }),
+    ).resolves.toMatchObject({ generationStatus: "completed" });
 
     await apiContext.dispose();
   });

--- a/apps/api/src/lib/openapi/paths/course-prompts.ts
+++ b/apps/api/src/lib/openapi/paths/course-prompts.ts
@@ -16,7 +16,7 @@ export const coursePromptPaths = {
   "/course-prompts": {
     post: {
       description:
-        "Returns existing courses and side-effect-free cached classifications publicly. Authentication is required before a prompt can use AI or create a generation request.",
+        "Classifies and stores topic prompts publicly, returning existing courses and unsupported outcomes without authentication. Authentication is required before a prompt can create a generation request.",
       operationId: "createCoursePrompt",
       requestBody: {
         content: { "application/json": { schema: resolveCoursePromptRequestSchema } },

--- a/apps/apple/Zoonk/openapi.json
+++ b/apps/apple/Zoonk/openapi.json
@@ -833,7 +833,7 @@
     },
     "/course-prompts": {
       "post": {
-        "description": "Returns existing courses and side-effect-free cached classifications publicly. Authentication is required before a prompt can use AI or create a generation request.",
+        "description": "Classifies and stores topic prompts publicly, returning existing courses and unsupported outcomes without authentication. Authentication is required before a prompt can create a generation request.",
         "operationId": "createCoursePrompt",
         "security": [
           {},

--- a/apps/main/e2e/learn.test.ts
+++ b/apps/main/e2e/learn.test.ts
@@ -57,7 +57,13 @@ async function handleCourseGenerationRoute(route: Route): Promise<void> {
  * Seeds one already-routed topic request so E2E can exercise the public page
  * without making an AI Gateway request, which is intentionally disabled in E2E.
  */
-async function cacheTopicPrompt(rawPrompt: string) {
+async function cacheTopicPrompt({
+  generationStatus = "pending",
+  rawPrompt,
+}: {
+  generationStatus?: "pending" | null;
+  rawPrompt: string;
+}) {
   const uniqueId = randomUUID().slice(0, 8);
   const language = "en";
   const title = `E2E Topic ${uniqueId}`;
@@ -67,7 +73,7 @@ async function cacheTopicPrompt(rawPrompt: string) {
     create: {
       canonicalTitle: title,
       courseFormat: "core",
-      generationStatus: "pending",
+      generationStatus,
       intent: "learn",
       language,
       normalizedPrompt,
@@ -76,7 +82,7 @@ async function cacheTopicPrompt(rawPrompt: string) {
     update: {
       canonicalTitle: title,
       courseFormat: "core",
-      generationStatus: "pending",
+      generationStatus,
       intent: "learn",
       prompt: rawPrompt,
       targetLanguage: null,
@@ -95,11 +101,11 @@ async function cacheWaitlistedPrompt({
   courseFormat = "question",
   rawPrompt,
 }: {
-  courseFormat?: "instrument" | "question";
+  courseFormat?: "instrument" | "personalized" | "question";
   rawPrompt: string;
 }) {
   const language = "en";
-  const intent = courseFormat === "instrument" ? "learn" : "question";
+  const intent = courseFormat === "question" ? "question" : "learn";
   const normalizedPrompt = normalizeString(rawPrompt);
 
   const request = await prisma.coursePrompt.upsert({
@@ -230,7 +236,7 @@ test.describe("Learn Form", () => {
       throw new Error("No subject link text found");
     }
 
-    const cached = await cacheTopicPrompt(subject);
+    const cached = await cacheTopicPrompt({ rawPrompt: subject });
 
     await suggestions.getByRole("link", { exact: true, name: subject }).click();
 
@@ -244,7 +250,7 @@ test.describe("Learn Form", () => {
   }) => {
     await mockCourseGenerationWorkflow(authenticatedPage);
 
-    const cached = await cacheTopicPrompt(`e2e signed-in topic ${randomUUID()}`);
+    const cached = await cacheTopicPrompt({ rawPrompt: `e2e signed-in topic ${randomUUID()}` });
 
     await authenticatedPage.goto("/start/learn");
     await authenticatedPage.getByRole("textbox").fill(cached.prompt);
@@ -255,10 +261,15 @@ test.describe("Learn Form", () => {
     );
   });
 
-  test("submitting an uncached prompt requires login without starting generation", async ({
+  test("requires login for classified guest prompts without starting generation", async ({
     page,
   }) => {
-    const prompt = `e2e uncached guest topic ${randomUUID()}`;
+    const cached = await cacheTopicPrompt({
+      generationStatus: null,
+      rawPrompt: `e2e classified guest topic ${randomUUID()}`,
+    });
+
+    const prompt = cached.prompt;
     const promptPath = `/start/learn/${encodeURIComponent(prompt)}`;
 
     await page.goto("/start/learn");
@@ -283,12 +294,8 @@ test.describe("Learn Form", () => {
     ).resolves.toHaveLength(0);
 
     await expect(
-      prisma.coursePrompt.findUnique({
-        where: {
-          languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
-        },
-      }),
-    ).resolves.toBeNull();
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: cached.request.id } }),
+    ).resolves.toMatchObject({ generationStatus: null });
   });
 });
 
@@ -302,27 +309,53 @@ test.describe("Course Start Routing", () => {
     await expect(page.getByRole("textbox")).toBeVisible();
   });
 
-  test("redirects cached topic prompts to the generation page for signed-in users", async ({
+  test("promotes classified topic prompts to generation for signed-in users", async ({
     authenticatedPage,
   }) => {
     await mockCourseGenerationWorkflow(authenticatedPage);
 
-    const cached = await cacheTopicPrompt(`e2e direct Python 3.12 topic ${randomUUID()}`);
+    const cached = await cacheTopicPrompt({
+      generationStatus: null,
+      rawPrompt: `e2e direct Python 3.12 topic ${randomUUID()}`,
+    });
 
     await authenticatedPage.goto(`/start/learn/${encodeURIComponent(cached.prompt)}`);
 
     await expect(authenticatedPage).toHaveURL(
       new RegExp(`/generate/course/${cached.request.id}$`, "u"),
     );
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: cached.request.id } }),
+    ).resolves.toMatchObject({ generationStatus: "pending" });
   });
 
-  test("redirects cached topic prompts to existing reusable courses", async ({ page }) => {
+  test("redirects classified guest prompts to existing reusable courses", async ({ page }) => {
     const cached = await cacheExistingCoursePrompt(`e2e existing topic ${randomUUID()}`);
 
     await page.goto(`/start/learn/${encodeURIComponent(cached.prompt)}`);
 
     await expect(page).toHaveURL(new RegExp(`/b/${AI_ORG_SLUG}/c/${cached.course.slug}$`, "u"));
     await expect(page.getByRole("heading", { level: 1, name: cached.course.title })).toBeVisible();
+  });
+
+  test("shows the waitlist for personalized guest prompts without requiring login", async ({
+    page,
+  }) => {
+    const cached = await cacheWaitlistedPrompt({
+      courseFormat: "personalized",
+      rawPrompt: `e2e personalized guest goal ${randomUUID()}`,
+    });
+
+    await page.goto(`/start/learn/${encodeURIComponent(cached.prompt)}`);
+
+    await expect(
+      page.getByRole("heading", { name: /this option isn't available yet/iu }),
+    ).toBeVisible();
+
+    await expect(page.getByRole("button", { name: /notify me/iu })).toBeVisible();
+    await expect(page.getByText(cached.prompt, { exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Log in to create with AI" })).toHaveCount(0);
   });
 
   test("shows the waitlist for cached instrument prompts", async ({ page }) => {

--- a/packages/core/src/courses/resolve-course-prompt.test.ts
+++ b/packages/core/src/courses/resolve-course-prompt.test.ts
@@ -109,12 +109,9 @@ describe("course-prompt", () => {
     vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
   });
 
-  it("rejects unauthenticated prompts before calling models or persistence", async () => {
+  it("stores unauthenticated generatable classifications and promotes them after login", async () => {
     const prompt = `anonymous topic ${randomUUID()}`;
-    const courseFormatSpy = vi.spyOn(formatTask, "classifyCourseFormat");
-    const intentSpy = vi.spyOn(intentTask, "classifyCourseIntent");
-    const personalizationSpy = vi.spyOn(personalizationTask, "classifyCoursePersonalization");
-    const titleSpy = vi.spyOn(canonicalTitleTask, "generateCanonicalCourseTitle");
+    const { courseFormatSpy, intentSpy, personalizationSpy, titleSpy } = mockPromptTasks({});
 
     vi.mocked(getSession).mockResolvedValue(null);
 
@@ -122,18 +119,90 @@ describe("course-prompt", () => {
       kind: "unauthorized",
     });
 
-    expect(intentSpy).not.toHaveBeenCalled();
-    expect(personalizationSpy).not.toHaveBeenCalled();
-    expect(courseFormatSpy).not.toHaveBeenCalled();
-    expect(titleSpy).not.toHaveBeenCalled();
+    expect(intentSpy).toHaveBeenCalledOnce();
+    expect(personalizationSpy).toHaveBeenCalledOnce();
+    expect(courseFormatSpy).toHaveBeenCalledOnce();
+    expect(titleSpy).toHaveBeenCalledOnce();
+
+    const storedPrompt = await prisma.coursePrompt.findUniqueOrThrow({
+      where: {
+        languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
+      },
+    });
+
+    expect(storedPrompt).toMatchObject({
+      canonicalTitle: "Canonical Test Course",
+      courseFormat: "core",
+      generationStatus: null,
+      intent: "learn",
+    });
+
+    const user = await userFixture();
+    vi.mocked(getSession, { partial: true }).mockResolvedValue({ user });
+
+    const authenticatedResult = await resolveCoursePrompt({ language: "en", prompt });
+
+    expectGenerateResult(authenticatedResult);
+    expect(authenticatedResult.prompt.id).toBe(storedPrompt.id);
 
     await expect(
-      prisma.coursePrompt.findUnique({
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: storedPrompt.id } }),
+    ).resolves.toMatchObject({ generationStatus: "pending" });
+  });
+
+  it("stores unauthenticated personalized prompts and returns them for the waitlist", async () => {
+    const prompt = `anonymous personalized topic ${randomUUID()}`;
+    const title = `Anonymous personalized ${randomUUID()}`;
+    mockPromptTasks({ requiresPersonalization: true, title });
+
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    await expect(resolveCoursePrompt({ language: "en", prompt })).resolves.toStrictEqual({
+      kind: "unsupported",
+      prompt: { courseFormat: "personalized", intent: "learn" },
+      title,
+    });
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({
         where: {
           languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
         },
       }),
-    ).resolves.toBeNull();
+    ).resolves.toMatchObject({
+      canonicalTitle: title,
+      courseFormat: "personalized",
+      generationStatus: null,
+      intent: "learn",
+    });
+  });
+
+  it("redirects unauthenticated classified prompts to an existing reusable course", async () => {
+    const prompt = `anonymous existing topic ${randomUUID()}`;
+    const title = `Anonymous Existing Biology ${randomUUID().slice(0, 8)}`;
+    const course = await createCompletedAiCourse({ language: "en", title });
+    mockPromptTasks({ title });
+
+    vi.mocked(getSession).mockResolvedValue(null);
+
+    await expect(resolveCoursePrompt({ language: "en", prompt })).resolves.toStrictEqual({
+      course: { id: course.id, slug: course.slug },
+      kind: "course",
+    });
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({
+        where: {
+          languageNormalizedPrompt: { language: "en", normalizedPrompt: normalizeString(prompt) },
+        },
+      }),
+    ).resolves.toMatchObject({
+      canonicalTitle: title,
+      courseFormat: "core",
+      courseId: course.id,
+      generationStatus: "completed",
+      intent: "learn",
+    });
   });
 
   it.each([

--- a/packages/core/src/courses/resolve-course-prompt.ts
+++ b/packages/core/src/courses/resolve-course-prompt.ts
@@ -285,9 +285,9 @@ async function upsertCoursePrompt({
 }
 
 /**
- * Builds the persisted prompt fields for a newly classified prompt. Keeping the
- * mapper separate makes the generation boundary explicit: shared regular
- * formats and concrete language prompts are sent to generation today.
+ * Builds the fields for a newly classified prompt, including the generation
+ * status an authenticated request should receive. Guest persistence clears
+ * that status separately so classification never starts generation by itself.
  */
 function getClassifiedCoursePromptInput({
   courseFormat,
@@ -311,12 +311,61 @@ function getClassifiedCoursePromptInput({
 }
 
 /**
+ * Stores guest classifications without marking them ready for generation. An
+ * authenticated revisit promotes the same row to pending at the generation
+ * boundary, preserving guest demand data without starting course work.
+ */
+function getPersistedCoursePromptInput({
+  canCreateGeneration,
+  prompt,
+}: {
+  canCreateGeneration: boolean;
+  prompt: CoursePromptInput;
+}): CoursePromptInput {
+  return { ...prompt, generationStatus: canCreateGeneration ? prompt.generationStatus : null };
+}
+
+/**
+ * Runs every independent classification task in one model wave. Persistence is
+ * handled separately so the same decision can be stored for every learner
+ * without coupling classification to generation access.
+ */
+async function classifyNewCoursePrompt({
+  language,
+  prompt,
+}: {
+  language: string;
+  prompt: string;
+}): Promise<CoursePromptInput> {
+  const [intent, personalization, formatClassification, canonicalTitle] = await Promise.all([
+    classifyCourseIntent({ prompt }),
+    classifyCoursePersonalization({ prompt }),
+    classifyCourseFormat({ prompt }),
+    generateCanonicalCourseTitle({ language, prompt }),
+  ]);
+
+  const courseFormat = getCourseFormatForPrompt({
+    courseFormat: formatClassification.data.courseFormat,
+    intent: intent.data.intent,
+    requiresPersonalization: personalization.data.requiresPersonalization,
+  });
+
+  return getClassifiedCoursePromptInput({
+    courseFormat,
+    intent: intent.data.intent,
+    prompt,
+    title: canonicalTitle.data.title,
+  });
+}
+
+/**
  * Resolves a learner's free-text goal into the next domain capability.
  * Cached existing-course and classification outcomes remain public because
- * they cannot create generation work. New and cached generatable prompts
- * require a trusted session before mutation or model work. First-time prompts
- * run intent, personalization, format, and title tasks in one model wave so
- * every delivery layer can use the same persisted decision without a waterfall.
+ * they cannot create generation work. First-time prompts run classification in
+ * memory for every learner so public redirects and waitlists remain available.
+ * Every valid classification is persisted for demand analysis, while new or
+ * cached prompts still require a trusted session before course generation can
+ * be marked pending or begin.
  */
 export async function resolveCoursePrompt({
   language,
@@ -343,35 +392,14 @@ export async function resolveCoursePrompt({
     });
   }
 
-  if (!session) {
-    return { kind: "unauthorized" };
-  }
-
-  // Start every independent task in one model wave to minimize routing latency.
-  // Some results are intentionally discarded after intent determines the route.
-  const [intent, personalization, formatClassification, canonicalTitle] = await Promise.all([
-    classifyCourseIntent({ prompt }),
-    classifyCoursePersonalization({ prompt }),
-    classifyCourseFormat({ prompt }),
-    generateCanonicalCourseTitle({ language, prompt }),
-  ]);
-
-  const courseFormat = getCourseFormatForPrompt({
-    courseFormat: formatClassification.data.courseFormat,
-    intent: intent.data.intent,
-    requiresPersonalization: personalization.data.requiresPersonalization,
-  });
+  const classifiedPrompt = await classifyNewCoursePrompt({ language, prompt });
+  const canCreateGeneration = Boolean(session);
 
   const coursePrompt = await upsertCoursePrompt({
     language,
     prompt,
-    request: getClassifiedCoursePromptInput({
-      courseFormat,
-      intent: intent.data.intent,
-      prompt,
-      title: canonicalTitle.data.title,
-    }),
+    request: getPersistedCoursePromptInput({ canCreateGeneration, prompt: classifiedPrompt }),
   });
 
-  return getCoursePromptResolution({ canCreateGeneration: true, prompt: coursePrompt });
+  return getCoursePromptResolution({ canCreateGeneration, prompt: coursePrompt });
 }


### PR DESCRIPTION
Classifies and stores guest course prompts before enforcing generation authentication. Keeps personalized waitlists and reusable-course redirects public, while promoting generatable prompts only after login. Updates the public API contract and regression coverage.