### PR TITLE
feat(main): add free chapter cta to subscription gate

### DIFF
--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -69,7 +69,50 @@ async function createTestLesson(options?: {
     );
   }
 
-  return { chapter, course, lesson, lessonTitle, uniqueId };
+  return { chapter, course, lesson, lessonTitle, organizationId: org.id, uniqueId };
+}
+
+/** Creates the access-policy free target so gate tests prove navigation reaches playable content. */
+async function freeFirstLessonFixture({
+  courseId,
+  organizationId,
+  uniqueId,
+}: {
+  courseId: string;
+  organizationId: string;
+  uniqueId: string;
+}) {
+  const chapter = await chapterFixture({
+    courseId,
+    isPublished: true,
+    organizationId,
+    position: 0,
+    slug: `e2e-free-chapter-${uniqueId}`,
+    title: `E2E Free Chapter ${uniqueId}`,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    generationStatus: "completed",
+    isPublished: true,
+    kind: "explanation",
+    organizationId,
+    position: 0,
+    slug: `e2e-free-lesson-${uniqueId}`,
+    title: `E2E Free Lesson ${uniqueId}`,
+  });
+
+  await stepFixture({
+    content: {
+      text: `Free lesson content ${uniqueId}`,
+      title: `Free lesson step ${uniqueId}`,
+      variant: "text",
+    },
+    isPublished: true,
+    lessonId: lesson.id,
+  });
+
+  return { chapter, lesson };
 }
 
 /**
@@ -618,17 +661,25 @@ test.describe("Lesson Player Page", () => {
     }
   });
 
-  test("authenticated users without subscription see upgrade CTA for later chapters", async ({
+  test("subscription gate offers the free first chapter for later lessons", async ({
     authenticatedPage,
   }) => {
-    const { chapter, course, lesson, lessonTitle, uniqueId } = await createTestLesson({
-      chapterPosition: 1,
-      generationStatus: "completed",
-      lessonPosition: 0,
+    const { chapter, course, lesson, lessonTitle, organizationId, uniqueId } =
+      await createTestLesson({
+        chapterPosition: 1,
+        generationStatus: "completed",
+        lessonPosition: 0,
+      });
+
+    const { chapter: freeChapter, lesson: freeLesson } = await freeFirstLessonFixture({
+      courseId: course.id,
+      organizationId,
+      uniqueId,
     });
 
     const lessonHref = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`;
     const chapterHref = `/b/ai/c/${course.slug}/ch/${chapter.slug}`;
+    const freeLessonHref = `/b/ai/c/${course.slug}/ch/${freeChapter.slug}/l/${freeLesson.slug}`;
 
     await authenticatedPage.goto(lessonHref);
 
@@ -641,6 +692,7 @@ test.describe("Lesson Player Page", () => {
     await expect(authenticatedPage.getByText("This lesson is included with Plus.")).toBeVisible();
 
     const backLink = authenticatedPage.getByRole("link", { name: /back to chapter/iu });
+    const freeChapterLink = authenticatedPage.getByRole("link", { name: /^try free chapter$/iu });
     const upgradeLink = authenticatedPage.getByRole("link", { name: /^subscribe$/iu });
 
     await expect(backLink).toBeVisible();
@@ -648,10 +700,22 @@ test.describe("Lesson Player Page", () => {
     await expect(backLink).toHaveAttribute("aria-keyshortcuts", "Escape");
     await expect(backLink).toHaveAttribute("href", chapterHref);
 
+    await expect(freeChapterLink).toBeVisible();
+    await expect(freeChapterLink).toHaveAttribute("href", freeLessonHref);
+
     await expect(upgradeLink).toBeVisible();
     await expect(upgradeLink.getByText(/^Enter$/u)).toBeVisible();
     await expect(upgradeLink).toHaveAttribute("aria-keyshortcuts", "Enter");
     await expect(upgradeLink).toHaveAttribute("href", "/subscription");
+
+    await freeChapterLink.click();
+
+    await expect(
+      authenticatedPage.getByRole("heading", { name: `Free lesson step ${uniqueId}` }),
+    ).toBeVisible();
+
+    await authenticatedPage.goto(lessonHref);
+    await expect(backLink).toBeVisible();
 
     await pressShortcutAndWaitForUrl({
       expectedUrl: chapterHref,

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -2779,6 +2779,11 @@ msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Mit Plus erhältst du unbegrenzten Zugriff auf Kurse und Lektionen zu allem, was du lernen möchtest."
 
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "Y9LULP"
+msgid "Try free chapter"
+msgstr "Kostenloses Kapitel testen"
+
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"
 msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -2779,6 +2779,11 @@ msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Plus gives you unlimited courses and lessons for whatever you want to learn."
 
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "Y9LULP"
+msgid "Try free chapter"
+msgstr "Try free chapter"
+
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"
 msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -2779,6 +2779,11 @@ msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Plus te ofrece cursos y lecciones ilimitados sobre lo que quieras aprender."
 
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "Y9LULP"
+msgid "Try free chapter"
+msgstr "Prueba un capítulo gratis"
+
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"
 msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -2779,6 +2779,11 @@ msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Plus te donne accès à des cours et des leçons en illimité sur tout ce que tu veux apprendre."
 
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "Y9LULP"
+msgid "Try free chapter"
+msgstr "Essayer un chapitre gratuitement"
+
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"
 msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -2779,6 +2779,11 @@ msgctxt "X4sblx"
 msgid "Plus gives you unlimited courses and lessons for whatever you want to learn."
 msgstr "Com o Plus, você tem cursos e aulas ilimitados sobre o que quiser aprender."
 
+#: src/components/subscription/upgrade-cta.tsx
+msgctxt "Y9LULP"
+msgid "Try free chapter"
+msgstr "Experimente um capítulo grátis"
+
 #: src/lib/belt-colors.ts
 msgctxt "znY9eW"
 msgid "{color, select, white {White Belt} yellow {Yellow Belt} orange {Orange Belt} green {Green Belt} blue {Blue Belt} purple {Purple Belt} brown {Brown Belt} red {Red Belt} gray {Gray Belt} black {Black Belt} other {Belt}}"

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -7,6 +7,7 @@ import { getLessonDisplayMeta, getLessonSeoMeta } from "@/lib/lessons";
 import { isLessonSeoIndexable } from "@/lib/lessons/seo";
 import { getLocalizedUrl } from "@/lib/metadata/localized-url";
 import { listCourseChapters } from "@zoonk/core/chapters/list-by-course";
+import { getFirstCourseLesson } from "@zoonk/core/courses/get-first-lesson";
 import { type CatalogLesson, getLesson as getCatalogLesson } from "@zoonk/core/lessons/get-by-slug";
 import { listChapterLessons } from "@zoonk/core/lessons/list-by-chapter";
 import { getNextLessonInCourse } from "@zoonk/core/lessons/next-in-course";
@@ -73,12 +74,22 @@ async function getSubscriptionRequiredContent({
   lesson: CatalogLesson;
 }) {
   const backHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}` as const;
+  const firstLesson = await getFirstCourseLesson({ courseId: lesson.chapter.course.id });
+
+  const freeLessonHref = firstLesson
+    ? (`/b/${brandSlug}/c/${courseSlug}/ch/${firstLesson.chapterSlug}/l/${firstLesson.lessonSlug}` as const)
+    : undefined;
+
   const t = await getExtracted();
 
   return (
     <Container className="min-h-dvh" variant="narrow">
       <ContainerBody className="justify-center sm:flex-1">
-        <UpgradeCTA backHref={backHref} backLabel={t("Back to chapter")}>
+        <UpgradeCTA
+          backHref={backHref}
+          backLabel={t("Back to chapter")}
+          freeLessonHref={freeLessonHref}
+        >
           <LessonPageSummary lesson={lesson} />
 
           <LessonSummaryStatus>{t("This lesson is included with Plus.")}</LessonSummaryStatus>

--- a/apps/main/src/components/generation/generation-shortcut-link.tsx
+++ b/apps/main/src/components/generation/generation-shortcut-link.tsx
@@ -6,7 +6,7 @@ import { ShortcutKbd, type ShortcutKbdTone } from "@zoonk/ui/components/kbd";
 import { useKeyboardCallback } from "@zoonk/ui/hooks/keyboard";
 import { cn } from "@zoonk/ui/lib/utils";
 
-type GenerationShortcutLinkVariant = "default" | "outline";
+type GenerationShortcutLinkVariant = "default" | "ghost" | "outline";
 type GenerationShortcut = "Enter" | "Esc" | "N";
 
 /**

--- a/apps/main/src/components/subscription/upgrade-cta.tsx
+++ b/apps/main/src/components/subscription/upgrade-cta.tsx
@@ -16,14 +16,16 @@ import { SubscriptionGateTracker } from "./subscription-gate-tracker";
  * Preserves one tracked subscription action while allowing a calling page to
  * provide durable context that is more useful than the generic Plus message.
  */
-export async function UpgradeCTA<Href extends string>({
+export async function UpgradeCTA<BackHref extends string, FreeLessonHref extends string = string>({
   backHref,
   backLabel,
   children,
+  freeLessonHref,
 }: {
-  backHref: AppRoute<Href>;
+  backHref: AppRoute<BackHref>;
   backLabel: string;
   children?: React.ReactNode;
+  freeLessonHref?: AppRoute<FreeLessonHref>;
 }) {
   const t = await getExtracted();
 
@@ -45,13 +47,25 @@ export async function UpgradeCTA<Href extends string>({
         </EmptyHeader>
       )}
 
-      <EmptyContent align="stretch">
-        <GenerationShortcutLink href={backHref} prefetch shortcut="Esc" variant="outline">
-          {backLabel}
-        </GenerationShortcutLink>
-
+      <EmptyContent align="stretch" className="gap-2">
         <GenerationShortcutLink href="/subscription" prefetch shortcut="Enter">
           {t("Subscribe")}
+        </GenerationShortcutLink>
+
+        {freeLessonHref && (
+          <GenerationShortcutLink href={freeLessonHref} prefetch variant="outline">
+            {t("Try free chapter")}
+          </GenerationShortcutLink>
+        )}
+
+        <GenerationShortcutLink
+          className="text-muted-foreground mt-1 w-fit max-w-full self-center px-2"
+          href={backHref}
+          prefetch
+          shortcut="Esc"
+          variant="ghost"
+        >
+          {backLabel}
         </GenerationShortcutLink>
       </EmptyContent>
     </Empty>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "./courses/generation-access": "./src/courses/course-generation-access.ts",
     "./courses/get-by-id": "./src/courses/get-course-by-id.ts",
     "./courses/get-by-slug": "./src/courses/get-course-by-slug.ts",
+    "./courses/get-first-lesson": "./src/courses/get-first-course-lesson.ts",
     "./courses/get-generation-status": "./src/courses/get-course-generation-status.ts",
     "./courses/get-prompt-generation": "./src/courses/get-course-prompt-generation.ts",
     "./courses/get-prompt-by-course": "./src/courses/get-course-prompt-by-course.ts",


### PR DESCRIPTION
Adds a direct Try free chapter action to gated lesson pages, resolving the course's first published lesson as the destination. Refines the gate hierarchy with a quieter back action and includes localized copy plus end-to-end coverage for the navigation flow.