### PR TITLE
feat(main): show yearly subscription price comparison

### DIFF
--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -1377,6 +1377,26 @@ msgctxt "X0ha1a"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} jährlich abgerechnet"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "g_N8_Z"
+msgid "From <original>{originalAmount}</original> to <discounted>{discountedAmount}</discounted> per year"
+msgstr "Von <original>{originalAmount}</original> auf <discounted>{discountedAmount}</discounted> pro Jahr"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "pro Monat"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Lxn0Fm"
+msgid "Price shown at checkout"
+msgstr "Preis wird beim Bezahlen angezeigt"
+
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
 msgctxt "3iCRcP"
 msgid "Manage in App Store"
@@ -1514,11 +1534,6 @@ msgid "a planner you'll definitely use"
 msgstr "ein Planer, den du ganz bestimmt benutzen wirst"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "1qALXt"
-msgid "{amount} billed yearly"
-msgstr "{amount} jährlich abgerechnet"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
 msgid "Save {amount} every year"
 msgstr "Spare jedes Jahr {amount}"
@@ -1548,16 +1563,6 @@ msgstr "Monatlich"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Jährlich"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "pro Monat"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Lxn0Fm"
-msgid "Price shown at checkout"
-msgstr "Preis wird beim Bezahlen angezeigt"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "DWdUaF"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -1377,6 +1377,26 @@ msgctxt "X0ha1a"
 msgid "Save changes"
 msgstr "Save changes"
 
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} billed yearly"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "g_N8_Z"
+msgid "From <original>{originalAmount}</original> to <discounted>{discountedAmount}</discounted> per year"
+msgstr "From <original>{originalAmount}</original> to <discounted>{discountedAmount}</discounted> per year"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "per month"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Lxn0Fm"
+msgid "Price shown at checkout"
+msgstr "Price shown at checkout"
+
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
 msgctxt "3iCRcP"
 msgid "Manage in App Store"
@@ -1514,11 +1534,6 @@ msgid "a planner you'll definitely use"
 msgstr "a planner you'll definitely use"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "1qALXt"
-msgid "{amount} billed yearly"
-msgstr "{amount} billed yearly"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
 msgid "Save {amount} every year"
 msgstr "Save {amount} every year"
@@ -1548,16 +1563,6 @@ msgstr "Monthly"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Yearly"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "per month"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Lxn0Fm"
-msgid "Price shown at checkout"
-msgstr "Price shown at checkout"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "DWdUaF"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1377,6 +1377,26 @@ msgctxt "X0ha1a"
 msgid "Save changes"
 msgstr "Guardar cambios"
 
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} facturados al año"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "g_N8_Z"
+msgid "From <original>{originalAmount}</original> to <discounted>{discountedAmount}</discounted> per year"
+msgstr "De <original>{originalAmount}</original> a <discounted>{discountedAmount}</discounted> al año"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "al mes"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Lxn0Fm"
+msgid "Price shown at checkout"
+msgstr "El precio se muestra al pagar"
+
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
 msgctxt "3iCRcP"
 msgid "Manage in App Store"
@@ -1514,11 +1534,6 @@ msgid "a planner you'll definitely use"
 msgstr "una agenda que esta vez sí vas a usar"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "1qALXt"
-msgid "{amount} billed yearly"
-msgstr "{amount} facturados al año"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
 msgid "Save {amount} every year"
 msgstr "Ahorra {amount} al año"
@@ -1548,16 +1563,6 @@ msgstr "Mensual"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Anual"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "al mes"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Lxn0Fm"
-msgid "Price shown at checkout"
-msgstr "El precio se muestra al pagar"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "DWdUaF"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -1377,6 +1377,26 @@ msgctxt "X0ha1a"
 msgid "Save changes"
 msgstr "Enregistrer les changements"
 
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} facturé par an"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "g_N8_Z"
+msgid "From <original>{originalAmount}</original> to <discounted>{discountedAmount}</discounted> per year"
+msgstr "De <original>{originalAmount}</original> à <discounted>{discountedAmount}</discounted> par an"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "par mois"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Lxn0Fm"
+msgid "Price shown at checkout"
+msgstr "Prix affiché au moment du paiement"
+
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
 msgctxt "3iCRcP"
 msgid "Manage in App Store"
@@ -1514,11 +1534,6 @@ msgid "a planner you'll definitely use"
 msgstr "un agenda que tu utiliseras, c'est sûr"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "1qALXt"
-msgid "{amount} billed yearly"
-msgstr "{amount} facturé par an"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
 msgid "Save {amount} every year"
 msgstr "Économise {amount} chaque année"
@@ -1548,16 +1563,6 @@ msgstr "Mensuel"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Annuel"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "par mois"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Lxn0Fm"
-msgid "Price shown at checkout"
-msgstr "Prix affiché au moment du paiement"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "DWdUaF"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1377,6 +1377,26 @@ msgctxt "X0ha1a"
 msgid "Save changes"
 msgstr "Salvar alterações"
 
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "1qALXt"
+msgid "{amount} billed yearly"
+msgstr "{amount} cobrados por ano"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "g_N8_Z"
+msgid "From <original>{originalAmount}</original> to <discounted>{discountedAmount}</discounted> per year"
+msgstr "De <original>{originalAmount}</original> por <discounted>{discountedAmount}</discounted> por ano"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Rw82_V"
+msgid "per month"
+msgstr "por mês"
+
+#: src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+msgctxt "Lxn0Fm"
+msgid "Price shown at checkout"
+msgstr "Preço mostrado ao finalizar a compra"
+
 #: src/app/[lang]/(settings)/subscription/managed-subscription.tsx
 msgctxt "3iCRcP"
 msgid "Manage in App Store"
@@ -1514,11 +1534,6 @@ msgid "a planner you'll definitely use"
 msgstr "uma agenda que você com certeza vai usar"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "1qALXt"
-msgid "{amount} billed yearly"
-msgstr "{amount} cobrados por ano"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "h9kFux"
 msgid "Save {amount} every year"
 msgstr "Economize {amount} por ano"
@@ -1548,16 +1563,6 @@ msgstr "Mensal"
 msgctxt "dqD39h"
 msgid "Yearly"
 msgstr "Anual"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Rw82_V"
-msgid "per month"
-msgstr "por mês"
-
-#: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
-msgctxt "Lxn0Fm"
-msgid "Price shown at checkout"
-msgstr "Preço mostrado ao finalizar a compra"
 
 #: src/app/[lang]/(settings)/subscription/plus-purchase.tsx
 msgctxt "DWdUaF"

--- a/apps/main/src/app/[lang]/(settings)/subscription/_utils/billing-prices.test.ts
+++ b/apps/main/src/app/[lang]/(settings)/subscription/_utils/billing-prices.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getMonthlyEquivalent, getYearlySavings } from "./billing-prices";
+import { getMonthlyEquivalent, getYearlyPriceComparison } from "./billing-prices";
 
 describe(getMonthlyEquivalent, () => {
   it("returns the yearly price divided across twelve months", () => {
@@ -23,37 +23,41 @@ describe(getMonthlyEquivalent, () => {
   });
 });
 
-describe(getYearlySavings, () => {
-  it("returns the proven yearly savings for Plus", () => {
-    const savings = getYearlySavings({
+describe(getYearlyPriceComparison, () => {
+  it("returns the monthly total, yearly price, and proven savings", () => {
+    const comparison = getYearlyPriceComparison({
       monthlyPrice: { amount: 2000, currency: "usd" },
       yearlyPrice: { amount: 18_000, currency: "usd" },
     });
 
-    expect(savings).toStrictEqual({ amount: 6000, currency: "usd" });
+    expect(comparison).toStrictEqual({
+      discountedPrice: { amount: 18_000, currency: "usd" },
+      originalPrice: { amount: 24_000, currency: "usd" },
+      savings: { amount: 6000, currency: "usd" },
+    });
   });
 
   it("returns null when either price is missing", () => {
-    const savings = getYearlySavings({ monthlyPrice: null, yearlyPrice: null });
+    const comparison = getYearlyPriceComparison({ monthlyPrice: null, yearlyPrice: null });
 
-    expect(savings).toBeNull();
+    expect(comparison).toBeNull();
   });
 
   it("does not compare prices in different currencies", () => {
-    const savings = getYearlySavings({
+    const comparison = getYearlyPriceComparison({
       monthlyPrice: { amount: 1000, currency: "usd" },
       yearlyPrice: { amount: 8000, currency: "brl" },
     });
 
-    expect(savings).toBeNull();
+    expect(comparison).toBeNull();
   });
 
   it("does not claim savings when yearly billing is not cheaper", () => {
-    const savings = getYearlySavings({
+    const comparison = getYearlyPriceComparison({
       monthlyPrice: { amount: 1000, currency: "usd" },
       yearlyPrice: { amount: 12_000, currency: "usd" },
     });
 
-    expect(savings).toBeNull();
+    expect(comparison).toBeNull();
   });
 });

--- a/apps/main/src/app/[lang]/(settings)/subscription/_utils/billing-prices.ts
+++ b/apps/main/src/app/[lang]/(settings)/subscription/_utils/billing-prices.ts
@@ -28,7 +28,7 @@ export function getMonthlyEquivalent({
  * that its monthly and yearly prices use the same currency and the annual total
  * is genuinely lower. Missing or incomparable prices produce no claim.
  */
-export function getYearlySavings({ monthlyPrice, yearlyPrice }: PlanPrices): PriceInfo | null {
+export function getYearlyPriceComparison({ monthlyPrice, yearlyPrice }: PlanPrices) {
   if (!monthlyPrice || !yearlyPrice) {
     return null;
   }
@@ -37,11 +37,16 @@ export function getYearlySavings({ monthlyPrice, yearlyPrice }: PlanPrices): Pri
     return null;
   }
 
-  const savedAmount = monthlyPrice.amount * MONTHS_PER_YEAR - yearlyPrice.amount;
+  const originalAmount = monthlyPrice.amount * MONTHS_PER_YEAR;
+  const savedAmount = originalAmount - yearlyPrice.amount;
 
   if (savedAmount <= 0) {
     return null;
   }
 
-  return { amount: savedAmount, currency: yearlyPrice.currency };
+  return {
+    discountedPrice: yearlyPrice,
+    originalPrice: { amount: originalAmount, currency: monthlyPrice.currency },
+    savings: { amount: savedAmount, currency: yearlyPrice.currency },
+  };
 }

--- a/apps/main/src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
+++ b/apps/main/src/app/[lang]/(settings)/subscription/billing-price-summary.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { type PriceInfo, formatPrice } from "@zoonk/utils/currency";
+import { useExtracted, useLocale } from "next-intl";
+import { getMonthlyEquivalent, getYearlyPriceComparison } from "./_utils/billing-prices";
+
+export type BillingPeriod = "monthly" | "yearly";
+
+function renderOriginalPrice(chunks: React.ReactNode) {
+  return <del>{chunks}</del>;
+}
+
+function renderDiscountedPrice(chunks: React.ReactNode) {
+  return <span className="text-foreground font-medium">{chunks}</span>;
+}
+
+/**
+ * Keeps the comparable monthly amount prominent while fitting the exact yearly
+ * charge and its crossed-out monthly total into one quiet secondary line.
+ */
+export function BillingPriceSummary({
+  monthlyPrice,
+  period,
+  yearlyPrice,
+}: {
+  monthlyPrice: PriceInfo | null;
+  period: BillingPeriod;
+  yearlyPrice: PriceInfo | null;
+}) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const price = period === "monthly" ? monthlyPrice : getMonthlyEquivalent({ yearlyPrice });
+  const yearlyComparison = getYearlyPriceComparison({ monthlyPrice, yearlyPrice });
+  const priceLabel = formatOptionalPrice({ locale, price });
+  const yearlyPriceLabel = formatOptionalPrice({ locale, price: yearlyPrice });
+
+  const yearlyOriginalPriceLabel = formatOptionalPrice({
+    locale,
+    price: yearlyComparison?.originalPrice ?? null,
+  });
+
+  const yearlyDiscountedPriceLabel = formatOptionalPrice({
+    locale,
+    price: yearlyComparison?.discountedPrice ?? null,
+  });
+
+  const yearlyBillingLabel = yearlyPriceLabel
+    ? t("{amount} billed yearly", { amount: yearlyPriceLabel })
+    : null;
+
+  const yearlyComparisonLabel =
+    yearlyOriginalPriceLabel && yearlyDiscountedPriceLabel
+      ? t.rich(
+          "From <original>{originalAmount}</original> to <discounted>{discountedAmount}</discounted> per year",
+          {
+            discounted: renderDiscountedPrice,
+            discountedAmount: yearlyDiscountedPriceLabel,
+            original: renderOriginalPrice,
+            originalAmount: yearlyOriginalPriceLabel,
+          },
+        )
+      : null;
+
+  return (
+    <div className="flex min-h-24 flex-col justify-center gap-1">
+      {priceLabel ? (
+        <p className="flex items-baseline gap-2">
+          <span className="text-4xl font-semibold tracking-tight tabular-nums">{priceLabel}</span>
+          <span className="text-muted-foreground text-sm">{t("per month")}</span>
+        </p>
+      ) : (
+        <p className="text-muted-foreground text-sm">{t("Price shown at checkout")}</p>
+      )}
+
+      <div className="min-h-5">
+        {period === "yearly" && (yearlyComparisonLabel || yearlyBillingLabel) && (
+          <p className="text-muted-foreground text-sm">
+            {yearlyComparisonLabel ?? yearlyBillingLabel}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatOptionalPrice({ locale, price }: { locale: string; price: PriceInfo | null }) {
+  return price ? formatPrice(price.amount, price.currency, locale) : null;
+}

--- a/apps/main/src/app/[lang]/(settings)/subscription/plus-purchase.tsx
+++ b/apps/main/src/app/[lang]/(settings)/subscription/plus-purchase.tsx
@@ -12,9 +12,9 @@ import { logError } from "@zoonk/utils/logger";
 import { Loader2Icon } from "lucide-react";
 import { useExtracted, useLocale } from "next-intl";
 import { useState } from "react";
-import { getMonthlyEquivalent, getYearlySavings } from "./_utils/billing-prices";
+import { getYearlyPriceComparison } from "./_utils/billing-prices";
+import { type BillingPeriod, BillingPriceSummary } from "./billing-price-summary";
 
-type BillingPeriod = "monthly" | "yearly";
 type RequestState = "error" | "idle" | "loading";
 type StripeLocaleOverride = "de" | "es" | "fr" | "pt-BR";
 
@@ -107,16 +107,12 @@ function AvailablePlusPurchase({
   const [requestState, setRequestState] = useState<RequestState>("idle");
   const t = useExtracted();
   const locale = useLocale();
-  const price = getDisplayedPrice({ monthlyPrice, period, yearlyPrice });
-  const yearlySavings = getYearlySavings({ monthlyPrice, yearlyPrice });
+  const yearlyComparison = getYearlyPriceComparison({ monthlyPrice, yearlyPrice });
   const valueComparisons = useValueComparisons();
   const isLoading = requestState === "loading";
-  const priceLabel = formatOptionalPrice({ locale, price });
-  const yearlyPriceLabel = formatOptionalPrice({ locale, price: yearlyPrice });
-  const yearlySavingsAmount = formatOptionalPrice({ locale, price: yearlySavings });
 
-  const yearlyBillingLabel = yearlyPriceLabel
-    ? t("{amount} billed yearly", { amount: yearlyPriceLabel })
+  const yearlySavingsAmount = yearlyComparison
+    ? formatPrice(yearlyComparison.savings.amount, yearlyComparison.savings.currency, locale)
     : null;
 
   const savingsLabel = yearlySavingsAmount
@@ -180,7 +176,7 @@ function AvailablePlusPurchase({
           {t("Yearly")}
           {yearlySavingsAmount && (
             <>
-              <Badge aria-hidden="true" className="font-mono" variant="success">
+              <Badge aria-hidden="true" className="text-foreground font-mono" variant="success">
                 −{yearlySavingsAmount}
               </Badge>
               <span className="sr-only">{savingsLabel}</span>
@@ -189,22 +185,7 @@ function AvailablePlusPurchase({
         </Button>
       </div>
 
-      <div className="flex min-h-24 flex-col justify-center gap-1">
-        {priceLabel ? (
-          <p className="flex items-baseline gap-2">
-            <span className="text-4xl font-semibold tracking-tight tabular-nums">{priceLabel}</span>
-            <span className="text-muted-foreground text-sm">{t("per month")}</span>
-          </p>
-        ) : (
-          <p className="text-muted-foreground text-sm">{t("Price shown at checkout")}</p>
-        )}
-
-        <div className="min-h-5">
-          {period === "yearly" && yearlyBillingLabel && (
-            <p className="text-muted-foreground text-sm">{yearlyBillingLabel}</p>
-          )}
-        </div>
-      </div>
+      <BillingPriceSummary monthlyPrice={monthlyPrice} period={period} yearlyPrice={yearlyPrice} />
 
       {monthlyPrice && (
         <div className="border-y py-4">
@@ -341,32 +322,4 @@ function CurrentPlusPurchase({
  */
 function getStripeLocaleOverride(locale: string): StripeLocaleOverride | undefined {
   return STRIPE_LOCALE_OVERRIDES[locale];
-}
-
-/**
- * Keeps both billing options comparable at a glance. Yearly billing uses its
- * monthly equivalent here while the exact charge remains visible below it.
- */
-function getDisplayedPrice({
-  monthlyPrice,
-  period,
-  yearlyPrice,
-}: {
-  monthlyPrice: PriceInfo | null;
-  period: BillingPeriod;
-  yearlyPrice: PriceInfo | null;
-}) {
-  if (period === "monthly") {
-    return monthlyPrice;
-  }
-
-  return getMonthlyEquivalent({ yearlyPrice });
-}
-
-/**
- * Keeps optional Stripe prices out of the UI until a complete amount and
- * currency are available to format together.
- */
-function formatOptionalPrice({ locale, price }: { locale: string; price: PriceInfo | null }) {
-  return price ? formatPrice(price.amount, price.currency, locale) : null;
 }

--- a/packages/utils/src/currency.test.ts
+++ b/packages/utils/src/currency.test.ts
@@ -35,6 +35,7 @@ describe(formatPrice, () => {
   it("formats USD prices correctly", () => {
     expect(formatPrice(999, "usd")).toBe("$9.99");
     expect(formatPrice(1000, "usd")).toBe("$10");
+    expect(formatPrice(1050, "usd")).toBe("$10.50");
     expect(formatPrice(2499, "usd")).toBe("$24.99");
   });
 
@@ -49,7 +50,7 @@ describe(formatPrice, () => {
 
   it("formats BRL", () => {
     const result = formatPrice(4990, "brl", "pt-BR");
-    expect(result).toContain("49,9");
+    expect(result).toContain("49,90");
   });
 
   it("omits decimals for whole amounts", () => {

--- a/packages/utils/src/currency.ts
+++ b/packages/utils/src/currency.ts
@@ -79,11 +79,12 @@ const ZERO_DECIMAL_CURRENCIES = new Set([
 export function formatPrice(amount: number, currency: string, locale = "en-US"): string {
   const normalizedCurrency = currency.toLowerCase();
   const value = ZERO_DECIMAL_CURRENCIES.has(normalizedCurrency) ? amount : amount / 100;
+  const fractionDigits = Number.isInteger(value) ? 0 : 2;
 
   return new Intl.NumberFormat(locale, {
     currency: currency.toUpperCase(),
-    maximumFractionDigits: Number.isInteger(value) ? 0 : 2,
-    minimumFractionDigits: 0,
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits,
     style: "currency",
   }).format(value);
 }


### PR DESCRIPTION
Shows the full monthly cost next to discounted yearly pricing and preserves two decimal places for fractional currency amounts.