### PR TITLE
fix(apple): correct storekit configuration path

### DIFF
--- a/apps/apple/Zoonk.xcodeproj/xcshareddata/xcschemes/Zoonk.xcscheme
+++ b/apps/apple/Zoonk.xcodeproj/xcshareddata/xcschemes/Zoonk.xcscheme
@@ -74,7 +74,7 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <StoreKitConfigurationFileReference
-         identifier = "../Zoonk/Resources/StoreKit/Subscriptions.storekit">
+         identifier = "../../Zoonk/Resources/StoreKit/Subscriptions.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
Correct the shared Zoonk scheme's StoreKit configuration path so Xcode resolves the existing subscription configuration without reporting a missing file.