### PR TITLE
feat(apple): add native progress screens

### DIFF
--- a/apps/apple/AGENTS.md
+++ b/apps/apple/AGENTS.md
@@ -11,6 +11,7 @@ These instructions apply to the native iPhone and iPad app in this directory and
 - Prefer system colors, semantic colors, system materials, system typography, native controls, and SF Symbols. Add custom colors, symbols, or controls only when a system component cannot express the product need.
 - Preserve Dynamic Type, VoiceOver semantics, sufficient contrast, system spacing, safe areas, keyboard behavior, focus behavior, and reduced-motion settings by relying on native components and avoiding fixed-size assumptions.
 - Keep grouped controls visually consistent in height, alignment, typography, shape, and prominence while still allowing localized labels and Dynamic Type to expand when needed.
+- For dense visualizations, separate visible mark size from the interaction surface. Make data explorable with simple touch, pointer, keyboard, and VoiceOver interactions instead of turning tiny marks into tiny controls.
 
 ## Platform Architecture
 
@@ -20,6 +21,8 @@ These instructions apply to the native iPhone and iPad app in this directory and
 - Keep UI-test fixtures in `ZoonkUITests` and limit app-side launch decoding to the Debug-only `Zoonk/Testing` boundary. Inject ordinary initial state through the app composition root; never parse test arguments or embed fixture data in product views, stores, or clients.
 - Extract stable, independently owned domains or sufficiently large features into local Swift packages when real module boundaries emerge.
 - Use Swift concurrency and value types by default. Keep observable state at the narrowest owning feature boundary and avoid introducing view models that only relay data without adding domain behavior.
+- Scope every asynchronous result and credential mutation to the full session identity that started it. Before publishing or deleting state, confirm that identity is still current and test meaningful request-order races.
+- Treat initial loading and refresh as different experiences. Deduplicate only in-flight work, preserve valid content during revalidation, and make authentication loss lead to a recoverable screen rather than stranded loading UI.
 
 ## Navigation and Presentation
 
@@ -36,6 +39,7 @@ These instructions apply to the native iPhone and iPad app in this directory and
 - Keep String Catalogs together in `Zoonk/Resources/Localization`, named by their owning feature or app surface, such as `Account.xcstrings` and `Navigation.xcstrings`. Keep catalog basenames unique and stable within the target; Eloqnt discovers every catalog in this directory automatically.
 - After building to extract changed strings, run `pnpm --filter apple i18n` from the repository root to translate them and `pnpm --filter apple i18n:lint` to validate the catalogs. Never edit generated translations in `.xcstrings` files manually.
 - Reuse the main app's established wording when it fits native Apple UI, but prefer concise platform-standard terminology when the web wording is not appropriate for a native control.
+- Treat dates, times, durations, and measurements as semantic values. Choose calendar and time-zone behavior intentionally, use native formatters, and test meaningful boundaries across locales.
 
 ## Verification
 

--- a/apps/apple/Zoonk/App/AppDependencies.swift
+++ b/apps/apple/Zoonk/App/AppDependencies.swift
@@ -1,17 +1,22 @@
 @MainActor
 struct AppDependencies {
+  let progressStore: ProgressStore
   let sessionStore: SessionStore
   let subscriptionStore: AppStoreSubscriptionStore
 
   static func live(configuration: AppConfiguration = .current) -> AppDependencies {
     let clients = APIClientFactory.live(baseURL: configuration.apiBaseURL)
     let accountAPI = AccountAPI(clients: clients)
+    let sessionStore = SessionStore(
+      api: accountAPI,
+      credentialStore: SessionCredentialStore(),
+      googleAuthentication: GoogleAuthenticationClient())
 
     return AppDependencies(
-      sessionStore: SessionStore(
-        api: accountAPI,
-        credentialStore: SessionCredentialStore(),
-        googleAuthentication: GoogleAuthenticationClient()),
+      progressStore: ProgressStore(
+        api: ProgressAPI(clients: clients),
+        session: sessionStore),
+      sessionStore: sessionStore,
       subscriptionStore: .live())
   }
 }

--- a/apps/apple/Zoonk/App/AppView.swift
+++ b/apps/apple/Zoonk/App/AppView.swift
@@ -5,6 +5,7 @@ struct AppView: View {
   @Environment(SessionStore.self) private var session
   @Environment(AppStoreSubscriptionStore.self) private var subscriptions
   @State private var isAccountPresented: Bool
+  @State private var navigationPaths: [AppSection: NavigationPath] = [:]
   @State private var selectedSection = AppSection.home
 
   init(initiallyPresentsAccount: Bool = false) {
@@ -15,14 +16,16 @@ struct AppView: View {
     TabView(selection: $selectedSection) {
       ForEach(AppSection.allCases) { section in
         Tab(value: section, role: section.tabRole) {
-          NavigationStack {
-            section.tabContent
-              .navigationTitle(Text(section.title))
-              .toolbarTitleDisplayMode(.inlineLarge)
-              .modifier(AdaptiveNavigationTitle())
-              .toolbar {
-                accountToolbarItem
-              }
+          NavigationStack(path: navigationPath(for: section)) {
+            section.tabContent {
+              isAccountPresented = true
+            }
+            .navigationTitle(Text(section.title))
+            .toolbarTitleDisplayMode(.inlineLarge)
+            .modifier(AdaptiveNavigationTitle())
+            .toolbar {
+              accountToolbarItem
+            }
           }
         } label: {
           Label {
@@ -67,6 +70,13 @@ struct AppView: View {
     .onChange(of: scenePhase) { _, scenePhase in
       reconcileSessionWhenActive(scenePhase)
     }
+    .onChange(of: session.authenticatedSession) { previousSession, currentSession in
+      guard previousSession != nil, currentSession == nil else {
+        return
+      }
+
+      navigationPaths[.progress] = NavigationPath()
+    }
   }
 
   @ToolbarContentBuilder
@@ -87,6 +97,12 @@ struct AppView: View {
     AccountToolbarButton {
       isAccountPresented = true
     }
+  }
+
+  private func navigationPath(for section: AppSection) -> Binding<NavigationPath> {
+    Binding(
+      get: { navigationPaths[section] ?? NavigationPath() },
+      set: { navigationPaths[section] = $0 })
   }
 
   /// Rechecks iCloud Keychain whenever the app returns to the foreground so a login or logout from another Apple device updates this UI without a process restart.
@@ -110,7 +126,11 @@ private struct AdaptiveNavigationTitle: ViewModifier {
 }
 
 #Preview {
+  let session = SessionStore.preview()
+  let clients = APIClientFactory.live(baseURL: AppConfiguration.current.apiBaseURL)
+
   AppView()
-    .environment(SessionStore.preview())
+    .environment(ProgressStore(api: ProgressAPI(clients: clients), session: session))
+    .environment(session)
     .environment(AppStoreSubscriptionStore.live())
 }

--- a/apps/apple/Zoonk/App/ZoonkApp.swift
+++ b/apps/apple/Zoonk/App/ZoonkApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @main
 struct ZoonkApp: App {
+  @State private var progress: ProgressStore
   @State private var session: SessionStore
   @State private var subscriptions: AppStoreSubscriptionStore
   private let initiallyPresentsAccount: Bool
@@ -9,6 +10,7 @@ struct ZoonkApp: App {
   init() {
     #if DEBUG
       if let configuration = UITestConfiguration.current {
+        _progress = State(initialValue: configuration.progress)
         _session = State(initialValue: configuration.session)
         _subscriptions = State(initialValue: .live())
         initiallyPresentsAccount = configuration.initiallyPresentsAccount
@@ -17,6 +19,7 @@ struct ZoonkApp: App {
     #endif
 
     let dependencies = AppDependencies.live()
+    _progress = State(initialValue: dependencies.progressStore)
     _session = State(initialValue: dependencies.sessionStore)
     _subscriptions = State(initialValue: dependencies.subscriptionStore)
     initiallyPresentsAccount = false
@@ -25,6 +28,7 @@ struct ZoonkApp: App {
   var body: some Scene {
     WindowGroup {
       AppView(initiallyPresentsAccount: initiallyPresentsAccount)
+        .environment(progress)
         .environment(session)
         .environment(subscriptions)
         .onOpenURL { url in

--- a/apps/apple/Zoonk/Features/Account/SessionStore.swift
+++ b/apps/apple/Zoonk/Features/Account/SessionStore.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Observation
 
+struct AuthenticatedSession: Hashable, Sendable {
+  let accountID: String
+  let bearerToken: String
+}
+
 @MainActor
 @Observable
 final class SessionStore {
@@ -49,6 +54,42 @@ final class SessionStore {
     }
 
     return account
+  }
+
+  var authenticatedSession: AuthenticatedSession? {
+    guard let account, let token else {
+      return nil
+    }
+
+    return AuthenticatedSession(accountID: account.user.id, bearerToken: token)
+  }
+
+  /// Clears an expired bearer token only when both memory and the synchronized Keychain still contain that session, preventing a late response from deleting a newer credential from another device.
+  func expire(_ authenticatedSession: AuthenticatedSession) async {
+    guard self.authenticatedSession == authenticatedSession else {
+      return
+    }
+
+    do {
+      guard try credentialStore.read() == authenticatedSession.bearerToken else {
+        guard !isReconciling else {
+          return
+        }
+
+        isReconciling = true
+        defer { isReconciling = false }
+        _ = await loadLatestCredential()
+        return
+      }
+    } catch {
+      failure = .network
+      state = .unavailable
+      return
+    }
+
+    markInteractiveOperationStarted()
+    failure = nil
+    _ = clearLocalSession()
   }
 
   var isGoogleSignInAvailable: Bool {
@@ -194,24 +235,43 @@ final class SessionStore {
 
   /// Saves first-time setup and later profile edits through the same authenticated product API.
   func updateProfile(name: String, username: String) async -> Bool {
-    guard let token else {
+    guard let authenticatedSession else {
       state = .signedOut
       return false
     }
 
     markInteractiveOperationStarted()
+    let profileRevision = interactiveOperationRevision
     isWorking = true
     failure = nil
     defer { isWorking = false }
 
     do {
-      state = .signedIn(
-        try await api.updateProfile(token: token, name: name, username: username))
+      let updatedAccount = try await api.updateProfile(
+        token: authenticatedSession.bearerToken,
+        name: name,
+        username: username)
+
+      guard
+        self.authenticatedSession == authenticatedSession,
+        interactiveOperationRevision == profileRevision
+      else {
+        return false
+      }
+
+      state = .signedIn(updatedAccount)
       return true
     } catch AccountAPIError.unauthorized {
-      _ = clearLocalSession()
+      await expire(authenticatedSession)
       return false
     } catch {
+      guard
+        self.authenticatedSession == authenticatedSession,
+        interactiveOperationRevision == profileRevision
+      else {
+        return false
+      }
+
       failure = getFailure(error)
       return false
     }

--- a/apps/apple/Zoonk/Features/Progress/ActivityProgressView.swift
+++ b/apps/apple/Zoonk/Features/Progress/ActivityProgressView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct ActivityProgressView: View {
+  @Environment(ProgressStore.self) private var progress
+
+  var body: some View {
+    ProgressDetailLoadStateView(
+      state: progress.activityState,
+      emptyTitle: LocalizedStringResource(
+        "No activity yet",
+        table: "Progress",
+        comment: "Title shown before the learner completes a lesson"),
+      emptyDescription: LocalizedStringResource(
+        "Complete a lesson to start building your learning history.",
+        table: "Progress",
+        comment: "Guidance shown before the learner has activity progress"),
+      systemImage: "chart.bar.xaxis",
+      retry: { await progress.loadActivity(force: true) }
+    ) { activity in
+      ActivityProgressContent(activity: activity)
+    }
+    .refreshesProgress {
+      await progress.loadActivity()
+    }
+  }
+}
+
+private struct ActivityProgressContent: View {
+  let activity: ActivityProgress
+
+  private var contributions: [ProgressContributionPoint] {
+    ProgressChartData.activityContributions(from: activity.days)
+  }
+
+  private var contributionWeeks: [ProgressContributionWeek] {
+    ProgressChartData.contributionWeeks(from: contributions)
+  }
+
+  var body: some View {
+    ProgressDetailPage {
+      ProgressDetailHero(
+        title: Text(
+          "Lessons completed",
+          tableName: "Progress",
+          comment: "Label above the learner's lifetime completed lesson count"),
+        value: Text(activity.summary.totalLessonCompletions, format: .number),
+        description: Text(
+          "Your lifetime learning activity.",
+          tableName: "Progress",
+          comment: "Description below the lifetime activity total"),
+        systemImage: "checkmark.circle.fill",
+        tint: ProgressDestination.activity.tint)
+
+      ProgressDetailSection(
+        title: Text(
+          "Learning activity",
+          tableName: "Progress",
+          comment: "Title above the completed lesson contribution calendar"),
+        subtitle: Text(
+          "Past 12 months.",
+          tableName: "Progress",
+          comment: "Period shown above the completed lesson contribution calendar")
+      ) {
+        if contributionWeeks.isEmpty {
+          ProgressDetailNoChartData()
+        } else {
+          ProgressContributionCalendar(
+            weeks: contributionWeeks,
+            maximumIntensity: ProgressChartData.activityMaximumIntensity,
+            tint: ProgressDestination.activity.tint,
+            lowLabel: Text(
+              "Less",
+              tableName: "Progress",
+              comment: "Low end of the learning activity contribution legend"),
+            highLabel: Text(
+              "More",
+              tableName: "Progress",
+              comment: "High end of the learning activity contribution legend"),
+            accessibilityLabel: Text(
+              "Learning activity over the past 12 months",
+              tableName: "Progress",
+              comment: "Accessibility label for the completed lesson contribution calendar"),
+            accessibilityValue: { point in
+              Text(
+                "Lessons completed: \(Int(point.value ?? 0))",
+                tableName: "Progress",
+                comment: "Accessible daily completed lesson value in the activity calendar")
+            })
+        }
+      }
+
+      ProgressDetailMetricGrid {
+        ProgressDetailMetric(
+          label: Text(
+            "Learning days",
+            tableName: "Progress",
+            comment: "Label for the number of days on which the learner studied"),
+          value: Text(activity.summary.learningDays, format: .number),
+          systemImage: "calendar",
+          tint: ProgressDestination.activity.tint)
+
+        ProgressDetailMetric(
+          label: Text(
+            "Time learning",
+            tableName: "Progress",
+            comment: "Label for the learner's total study duration"),
+          value: Text(
+            verbatim: progressLearningTime(activity.summary.totalLearningSeconds)),
+          systemImage: "clock",
+          tint: ProgressDestination.activity.tint)
+      }
+
+      ProgressDetailExplanation(
+        title: Text(
+          "A lasting record",
+          tableName: "Progress",
+          comment: "Title explaining how completed lessons are counted"),
+        description: Text(
+          "Each completed lesson counts once, even when you return to review it.",
+          tableName: "Progress",
+          comment: "Explains that activity counts unique completed lessons"),
+        systemImage: "book.closed",
+        tint: ProgressDestination.activity.tint)
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/EnergyProgressView.swift
+++ b/apps/apple/Zoonk/Features/Progress/EnergyProgressView.swift
@@ -44,7 +44,7 @@ private struct EnergyProgressContent: View {
           tableName: "Progress",
           comment: "Label above the learner's current Energy value"),
         value: Text(
-          energy.currentEnergy / 100,
+          energy.displayedCurrentEnergy / 100,
           format: .percent.precision(.fractionLength(0))),
         description: energyDescription,
         systemImage: "bolt.fill",
@@ -59,7 +59,9 @@ private struct EnergyProgressContent: View {
             comment: "Accessibility label for the current Energy progress bar")
         )
         .accessibilityValue(
-          Text(energy.currentEnergy / 100, format: .percent.precision(.fractionLength(0))))
+          Text(
+            energy.displayedCurrentEnergy / 100,
+            format: .percent.precision(.fractionLength(0))))
 
       ProgressDetailSection(
         title: Text(
@@ -151,7 +153,7 @@ private struct EnergyProgressContent: View {
   }
 
   private var energyDescription: Text {
-    if energy.currentEnergy >= 100 {
+    if energy.displayedCurrentEnergy >= 100 {
       return Text(
         "You're fully energized.",
         tableName: "Progress",

--- a/apps/apple/Zoonk/Features/Progress/EnergyProgressView.swift
+++ b/apps/apple/Zoonk/Features/Progress/EnergyProgressView.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+
+struct EnergyProgressView: View {
+  @Environment(ProgressStore.self) private var progress
+
+  var body: some View {
+    ProgressDetailLoadStateView(
+      state: progress.energyState,
+      emptyTitle: LocalizedStringResource(
+        "No Energy yet",
+        table: "Progress",
+        comment: "Title shown before the learner has an Energy value"),
+      emptyDescription: LocalizedStringResource(
+        "Complete lessons to start building your Energy.",
+        table: "Progress",
+        comment: "Guidance shown before the learner has Energy progress"),
+      systemImage: "bolt.fill",
+      retry: { await progress.loadEnergy(force: true) }
+    ) { energy in
+      EnergyProgressContent(energy: energy)
+    }
+    .refreshesProgress {
+      await progress.loadEnergy()
+    }
+  }
+}
+
+private struct EnergyProgressContent: View {
+  let energy: EnergyProgress
+
+  private var contributions: [ProgressContributionPoint] {
+    ProgressChartData.energyContributions(from: energy.days)
+  }
+
+  private var contributionWeeks: [ProgressContributionWeek] {
+    ProgressChartData.contributionWeeks(from: contributions)
+  }
+
+  var body: some View {
+    ProgressDetailPage {
+      ProgressDetailHero(
+        title: Text(
+          "Current Energy",
+          tableName: "Progress",
+          comment: "Label above the learner's current Energy value"),
+        value: Text(
+          energy.currentEnergy / 100,
+          format: .percent.precision(.fractionLength(0))),
+        description: energyDescription,
+        systemImage: "bolt.fill",
+        tint: ProgressDestination.energy.tint)
+
+      ProgressView(value: energy.currentEnergy, total: 100)
+        .tint(ProgressDestination.energy.tint)
+        .accessibilityLabel(
+          Text(
+            "Current Energy",
+            tableName: "Progress",
+            comment: "Accessibility label for the current Energy progress bar")
+        )
+        .accessibilityValue(
+          Text(energy.currentEnergy / 100, format: .percent.precision(.fractionLength(0))))
+
+      ProgressDetailSection(
+        title: Text(
+          "Energy history",
+          tableName: "Progress",
+          comment: "Title above the Energy contribution calendar"),
+        subtitle: Text(
+          "Past 12 months. Days without an Energy value stay empty.",
+          tableName: "Progress",
+          comment: "Period and missing-value behavior for the Energy contribution calendar")
+      ) {
+        if contributionWeeks.isEmpty {
+          ProgressDetailNoChartData()
+        } else {
+          ProgressContributionCalendar(
+            weeks: contributionWeeks,
+            maximumIntensity: ProgressChartData.energyMaximumIntensity,
+            tint: ProgressDestination.energy.tint,
+            lowLabel: Text(
+              "Low",
+              tableName: "Progress",
+              comment: "Low end of the Energy contribution legend"),
+            highLabel: Text(
+              "High",
+              tableName: "Progress",
+              comment: "High end of the Energy contribution legend"),
+            accessibilityLabel: Text(
+              "Energy history over the past 12 months",
+              tableName: "Progress",
+              comment: "Accessibility label for the Energy contribution calendar"),
+            accessibilityValue: energyAccessibilityValue)
+        }
+      }
+
+      if let insights = energy.insights {
+        ProgressDetailMetricGrid {
+          ProgressDetailMetric(
+            label: Text(
+              "Average Energy",
+              tableName: "Progress",
+              comment: "Label for the learner's average recorded Energy"),
+            value: Text(
+              insights.averageEnergy / 100,
+              format: .percent.precision(.fractionLength(0))),
+            systemImage: "chart.line.uptrend.xyaxis",
+            tint: ProgressDestination.energy.tint)
+
+          ProgressDetailMetric(
+            label: Text(
+              "Days at 100% Energy",
+              tableName: "Progress",
+              comment: "Label for the number of days the learner reached full Energy"),
+            value: Text(insights.fullEnergyDays, format: .number),
+            systemImage: "bolt.circle",
+            tint: ProgressDestination.energy.tint)
+        }
+      }
+
+      VStack(alignment: .leading, spacing: 20) {
+        ProgressDetailExplanation(
+          title: Text(
+            "How do I increase my Energy?",
+            tableName: "Progress",
+            comment: "Title explaining how to increase Energy"),
+          description: Text(
+            "Complete lessons and answer questions correctly to increase your Energy.",
+            tableName: "Progress",
+            comment: "Explanation of how learning increases Energy"),
+          systemImage: "arrow.up.circle",
+          tint: ProgressDestination.energy.tint)
+
+        VStack(alignment: .leading, spacing: 6) {
+          Text(
+            "Missed a day?",
+            tableName: "Progress",
+            comment: "Title explaining what happens to Energy after a missed day"
+          )
+          .font(.headline)
+
+          Text(
+            "Your Energy drops a little. Complete lessons to fill it back up.",
+            tableName: "Progress",
+            comment: "Explanation of how to recover Energy after missing a day"
+          )
+          .foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+
+  private var energyDescription: Text {
+    if energy.currentEnergy >= 100 {
+      return Text(
+        "You're fully energized.",
+        tableName: "Progress",
+        comment: "Encouragement shown when the learner reaches full Energy.")
+    }
+
+    return Text(
+      "Keep learning to reach 100%.",
+      tableName: "Progress",
+      comment: "Encouragement shown while the learner builds Energy.")
+  }
+
+  private func energyAccessibilityValue(_ point: ProgressContributionPoint) -> Text {
+    guard let energy = point.value else {
+      return Text(
+        "No Energy recorded",
+        tableName: "Progress",
+        comment: "Accessible value for a day without recorded Energy")
+    }
+
+    return Text(
+      "Energy: \(energy / 100, format: .percent.precision(.fractionLength(0)))",
+      tableName: "Progress",
+      comment: "Accessible daily value in the Energy contribution calendar")
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/LevelProgressView.swift
+++ b/apps/apple/Zoonk/Features/Progress/LevelProgressView.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+
+struct LevelProgressView: View {
+  @Environment(ProgressStore.self) private var progress
+
+  var body: some View {
+    ProgressDetailLoadStateView(
+      state: progress.levelState,
+      emptyTitle: LocalizedStringResource(
+        "No level yet",
+        table: "Progress",
+        comment: "Title shown before the learner earns Brain Power"),
+      emptyDescription: LocalizedStringResource(
+        "Complete a lesson to earn Brain Power and reach your first level.",
+        table: "Progress",
+        comment: "Guidance shown before the learner has a level"),
+      systemImage: "brain.head.profile",
+      retry: { await progress.loadLevel(force: true) }
+    ) { level in
+      LevelProgressContent(level: level)
+    }
+    .refreshesProgress {
+      await progress.loadLevel()
+    }
+  }
+}
+
+private struct LevelProgressContent: View {
+  let level: LevelProgress
+
+  private var milestoneDescription: Text {
+    if level.isMaxLevel {
+      return Text(
+        "Maximum level reached.",
+        tableName: "Progress",
+        comment: "Description shown after reaching the maximum level")
+    }
+
+    return Text(
+      "\(level.bpToNextLevel) BP to the next level",
+      tableName: "Progress",
+      comment: "Brain Power remaining before the learner reaches the next level")
+  }
+
+  var body: some View {
+    ProgressDetailPage {
+      ProgressDetailHero(
+        title: Text(level.belt.localizedTitle),
+        value: Text(
+          "Level \(level.level)",
+          tableName: "Progress",
+          comment: "Learner's current numbered level"),
+        description: milestoneDescription,
+        systemImage: "brain.head.profile",
+        tint: level.belt.accentColor)
+
+      ProgressDetailSection(
+        title: Text(
+          "Level progress",
+          tableName: "Progress",
+          comment: "Title above progress toward the next level")
+      ) {
+        VStack(alignment: .leading, spacing: 10) {
+          HStack(alignment: .firstTextBaseline) {
+            if level.isMaxLevel {
+              Text(
+                "Max level reached",
+                tableName: "Progress",
+                comment: "Status shown after reaching the maximum level")
+            } else {
+              Text(
+                "\(level.progressInLevel) of \(level.bpPerLevel) BP",
+                tableName: "Progress",
+                comment: "Brain Power earned within the current level")
+            }
+
+            Spacer()
+
+            if level.isMaxLevel {
+              Text(
+                "Complete",
+                tableName: "Progress",
+                comment: "Completion value for the maximum level"
+              )
+              .foregroundStyle(.secondary)
+            } else {
+              Text(
+                "\(level.bpToNextLevel) BP left",
+                tableName: "Progress",
+                comment: "Short Brain Power amount remaining before the next level"
+              )
+              .foregroundStyle(.secondary)
+            }
+          }
+          .font(.subheadline)
+
+          ProgressView(value: level.progressValue, total: level.progressTotal)
+            .tint(level.belt.progressColor)
+            .accessibilityLabel(
+              Text(
+                "Progress to the next level",
+                tableName: "Progress",
+                comment: "Accessibility label for level progress")
+            )
+            .accessibilityValue(milestoneDescription)
+        }
+      }
+
+      ProgressDetailMetricGrid {
+        ProgressDetailMetric(
+          label: Text(
+            "Total Brain Power",
+            tableName: "Progress",
+            comment: "Label for the learner's lifetime Brain Power"),
+          value: Text(
+            "\(level.totalBrainPower) BP",
+            tableName: "Progress",
+            comment: "Learner's lifetime Brain Power value"),
+          systemImage: "brain",
+          tint: level.belt.accentColor)
+
+        ProgressDetailMetric(
+          label: Text(
+            "Brain Power per level",
+            tableName: "Progress",
+            comment: "Label for the Brain Power required to advance one level"),
+          value: Text(
+            "\(level.bpPerLevel) BP",
+            tableName: "Progress",
+            comment: "Brain Power required to advance one level"),
+          systemImage: "arrow.up.forward",
+          tint: level.belt.accentColor)
+      }
+
+      ProgressDetailSection(
+        title: Text(
+          "Belt journey",
+          tableName: "Progress",
+          comment: "Title above the sequence of learning belts"),
+        subtitle: Text(
+          "Every ten levels unlocks the next belt.",
+          tableName: "Progress",
+          comment: "Explains when the learner advances to a new belt")
+      ) {
+        LazyVGrid(
+          columns: [GridItem(.adaptive(minimum: 88, maximum: 120), spacing: 10)],
+          spacing: 14
+        ) {
+          ForEach(ProgressBelt.allCases, id: \.self) { belt in
+            BeltMilestone(belt: belt, isCurrent: belt == level.belt)
+          }
+        }
+      }
+
+      ProgressDetailExplanation(
+        title: Text(
+          "How levels work",
+          tableName: "Progress",
+          comment: "Title explaining how learners progress through levels"),
+        description: Text(
+          "Every completed lesson earns 10 BP. Brain Power never goes down, so each lesson moves you closer to the next level.",
+          tableName: "Progress",
+          comment: "Explains how much Brain Power a lesson earns and that it never decreases."),
+        systemImage: "brain.head.profile",
+        tint: level.belt.accentColor)
+    }
+  }
+}
+
+private struct BeltMilestone: View {
+  let belt: ProgressBelt
+  let isCurrent: Bool
+
+  var body: some View {
+    VStack(spacing: 8) {
+      BeltBadge(belt: belt, isCurrent: isCurrent, size: 34)
+
+      Text(belt.localizedTitle)
+        .font(.caption)
+        .fontWeight(isCurrent ? .semibold : .regular)
+        .multilineTextAlignment(.center)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 8)
+    .background(
+      isCurrent ? belt.progressColor.opacity(0.09) : .clear,
+      in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+    )
+    .accessibilityElement(children: .combine)
+    .accessibilityValue(
+      isCurrent
+        ? Text(
+          "Current belt",
+          tableName: "Progress",
+          comment: "Accessibility value identifying the learner's current belt")
+        : Text(
+          "Belt milestone",
+          tableName: "Progress",
+          comment: "Accessibility value identifying another belt milestone"))
+  }
+}
+
+private struct BeltBadge: View {
+  let belt: ProgressBelt
+  let isCurrent: Bool
+  let size: CGFloat
+
+  var body: some View {
+    Circle()
+      .fill(belt.color)
+      .overlay {
+        Circle()
+          .stroke(.secondary.opacity(0.35), lineWidth: 1)
+      }
+      .overlay {
+        if isCurrent {
+          Image(systemName: "checkmark")
+            .font(.system(size: size * 0.36, weight: .bold))
+            .foregroundStyle(checkmarkColor)
+        }
+      }
+      .frame(width: size, height: size)
+      .accessibilityHidden(true)
+  }
+
+  private var checkmarkColor: Color {
+    switch belt {
+    case .white, .yellow, .orange:
+      .black
+    case .green, .blue, .purple, .brown, .red, .gray, .black:
+      .white
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/LevelProgressView.swift
+++ b/apps/apple/Zoonk/Features/Progress/LevelProgressView.swift
@@ -98,7 +98,7 @@ private struct LevelProgressContent: View {
             .tint(level.belt.progressColor)
             .accessibilityLabel(
               Text(
-                "Progress to the next level",
+                level.isMaxLevel ? "Level progress" : "Progress to the next level",
                 tableName: "Progress",
                 comment: "Accessibility label for level progress")
             )

--- a/apps/apple/Zoonk/Features/Progress/ProgressAPI.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressAPI.swift
@@ -1,0 +1,453 @@
+import Foundation
+import OpenAPIRuntime
+
+enum ProgressAPIError: Error, Equatable {
+  case invalidResponse
+  case network
+  case unauthorized
+}
+
+protocol ProgressAPIClient {
+  func getOverview(token: String) async throws -> ProgressOverview
+  func getActivity(token: String) async throws -> ActivityProgress
+  func getEnergy(token: String) async throws -> EnergyProgress?
+  func getLevel(token: String) async throws -> LevelProgress?
+  func getScore(token: String) async throws -> ScoreProgress?
+  func getScorePatterns(token: String) async throws -> ScorePatterns?
+}
+
+struct ProgressAPI {
+  private let clients: APIClientFactory
+
+  init(clients: APIClientFactory) {
+    self.clients = clients
+  }
+
+  func getOverview(token: String) async throws -> ProgressOverview {
+    try await perform(token: token) { client in
+      let output = try await client.getCurrentUserProgress(.init())
+
+      switch output {
+      case .ok(let response):
+        return try makeProgressOverview(try response.body.json)
+      case .unauthorized:
+        throw ProgressAPIError.unauthorized
+      case .internalServerError, .undocumented:
+        throw ProgressAPIError.invalidResponse
+      }
+    }
+  }
+
+  func getActivity(token: String) async throws -> ActivityProgress {
+    try await perform(token: token) { client in
+      let output = try await client.getCurrentUserActivity(.init())
+
+      switch output {
+      case .ok(let response):
+        return try makeActivityProgress(try response.body.json)
+      case .unauthorized:
+        throw ProgressAPIError.unauthorized
+      case .internalServerError, .undocumented:
+        throw ProgressAPIError.invalidResponse
+      }
+    }
+  }
+
+  func getEnergy(token: String) async throws -> EnergyProgress? {
+    try await perform(token: token) { client in
+      let output = try await client.getCurrentUserEnergy(.init())
+
+      switch output {
+      case .ok(let response):
+        return try makeEnergyProgress(try response.body.json)
+      case .unauthorized:
+        throw ProgressAPIError.unauthorized
+      case .internalServerError, .undocumented:
+        throw ProgressAPIError.invalidResponse
+      }
+    }
+  }
+
+  func getLevel(token: String) async throws -> LevelProgress? {
+    try await perform(token: token) { client in
+      let output = try await client.getCurrentUserLevel(.init())
+
+      switch output {
+      case .ok(let response):
+        return try makeLevelProgress(try response.body.json)
+      case .unauthorized:
+        throw ProgressAPIError.unauthorized
+      case .internalServerError, .undocumented:
+        throw ProgressAPIError.invalidResponse
+      }
+    }
+  }
+
+  func getScore(token: String) async throws -> ScoreProgress? {
+    try await perform(token: token) { client in
+      let output = try await client.getCurrentUserScore(.init())
+
+      switch output {
+      case .ok(let response):
+        return try makeScoreProgress(try response.body.json)
+      case .unauthorized:
+        throw ProgressAPIError.unauthorized
+      case .internalServerError, .undocumented:
+        throw ProgressAPIError.invalidResponse
+      }
+    }
+  }
+
+  func getScorePatterns(token: String) async throws -> ScorePatterns? {
+    try await perform(token: token) { client in
+      let output = try await client.getCurrentUserScorePatterns(.init())
+
+      switch output {
+      case .ok(let response):
+        return try makeScorePatterns(try response.body.json)
+      case .unauthorized:
+        throw ProgressAPIError.unauthorized
+      case .internalServerError, .undocumented:
+        throw ProgressAPIError.invalidResponse
+      }
+    }
+  }
+
+  /// Keeps generated transport and decoding details behind the progress feature's stable recovery states.
+  private func perform<Output: Sendable>(
+    token: String,
+    operation: @Sendable (Client) async throws -> Output
+  ) async throws -> Output {
+    do {
+      return try await operation(clients.makeClient(token: token))
+    } catch {
+      if isRequestCancellation(error) {
+        throw CancellationError()
+      }
+
+      if let error = error as? ProgressAPIError {
+        throw error
+      }
+
+      if isNetworkError(error) {
+        throw ProgressAPIError.network
+      }
+
+      throw ProgressAPIError.invalidResponse
+    }
+  }
+
+  private func isRequestCancellation(_ error: Error) -> Bool {
+    if error is CancellationError {
+      return true
+    }
+
+    if let urlError = error as? URLError {
+      return urlError.code == .cancelled
+    }
+
+    if let clientError = error as? ClientError {
+      return isRequestCancellation(clientError.underlyingError)
+    }
+
+    return false
+  }
+
+  private func isNetworkError(_ error: Error) -> Bool {
+    if error is URLError {
+      return true
+    }
+
+    if let clientError = error as? ClientError {
+      return isNetworkError(clientError.underlyingError)
+    }
+
+    return false
+  }
+}
+
+extension ProgressAPI: ProgressAPIClient {}
+
+private func makeProgressOverview(
+  _ response: Components.Schemas.CurrentUserProgressResponse
+) throws -> ProgressOverview {
+  ProgressOverview(
+    activity: makeOverviewActivitySummary(response.activity),
+    energy: response.energy?.currentEnergy,
+    level: try response.level.map(makeOverviewLevelProgress),
+    score: response.score.map(makeOverviewScorePerformance),
+    strongestDaypart: try makeOverviewStrongestDaypart(response.scorePatterns),
+    strongestWeekday: try makeOverviewStrongestWeekday(response.scorePatterns))
+}
+
+private func makeOverviewActivitySummary(
+  _ payload: Components.Schemas.CurrentUserProgressResponse.ActivityPayload
+) -> ActivitySummary {
+  ActivitySummary(
+    learningDays: payload.learningDays,
+    totalLearningSeconds: payload.totalLearningSeconds,
+    totalLessonCompletions: payload.totalLessonCompletions)
+}
+
+private func makeOverviewLevelProgress(
+  _ payload: Components.Schemas.CurrentUserProgressResponse.LevelPayload
+) throws -> LevelProgress {
+  LevelProgress(
+    belt: try makeDomainValue(payload.belt),
+    bpPerLevel: payload.bpPerLevel,
+    bpToNextLevel: payload.bpToNextLevel,
+    isMaxLevel: payload.isMaxLevel,
+    level: payload.level,
+    progressInLevel: payload.progressInLevel,
+    totalBrainPower: payload.totalBrainPower)
+}
+
+private func makeOverviewScorePerformance(
+  _ payload: Components.Schemas.CurrentUserProgressResponse.ScorePayload
+) -> ScorePerformance {
+  makeScorePerformance(
+    .init(
+      correctAnswers: payload.correctAnswers,
+      incorrectAnswers: payload.incorrectAnswers,
+      score: payload.score,
+      totalAnswers: payload.totalAnswers))
+}
+
+private func makeOverviewStrongestDaypart(
+  _ payload: Components.Schemas.CurrentUserProgressResponse.ScorePatternsPayload?
+) throws -> DaypartScorePattern? {
+  guard let strongestTime = payload?.strongestTime else {
+    return nil
+  }
+
+  return DaypartScorePattern(
+    daypart: try makeDomainValue(strongestTime.period),
+    performance: makeScorePerformance(
+      .init(
+        correctAnswers: strongestTime.correctAnswers,
+        incorrectAnswers: strongestTime.incorrectAnswers,
+        score: strongestTime.score,
+        totalAnswers: strongestTime.totalAnswers)))
+}
+
+private func makeOverviewStrongestWeekday(
+  _ payload: Components.Schemas.CurrentUserProgressResponse.ScorePatternsPayload?
+) throws -> WeekdayScorePattern? {
+  guard let strongestWeekday = payload?.strongestWeekday else {
+    return nil
+  }
+
+  return WeekdayScorePattern(
+    performance: makeScorePerformance(
+      .init(
+        correctAnswers: strongestWeekday.correctAnswers,
+        incorrectAnswers: strongestWeekday.incorrectAnswers,
+        score: strongestWeekday.score,
+        totalAnswers: strongestWeekday.totalAnswers)),
+    weekday: try makeDomainValue(strongestWeekday.dayOfWeek))
+}
+
+private func makeActivityProgress(
+  _ response: Components.Schemas.CurrentUserActivityResponse
+) throws -> ActivityProgress {
+  ActivityProgress(
+    days: try response.activity.days.map(makeActivityProgressDay),
+    summary: ActivitySummary(
+      learningDays: response.activity.learningDays,
+      totalLearningSeconds: response.activity.totalLearningSeconds,
+      totalLessonCompletions: response.activity.totalLessonCompletions))
+}
+
+private func makeActivityProgressDay(
+  _ payload: Components.Schemas.CurrentUserActivityResponse.ActivityPayload.DaysPayloadPayload
+) throws -> ActivityProgressDay {
+  ActivityProgressDay(
+    date: try makeProgressDate(payload.date),
+    lessonCompletions: payload.lessonCompletions)
+}
+
+private func makeEnergyProgress(
+  _ response: Components.Schemas.CurrentUserEnergyResponse
+) throws -> EnergyProgress? {
+  guard let energy = response.energy else {
+    return nil
+  }
+
+  return EnergyProgress(
+    currentEnergy: energy.currentEnergy,
+    days: try energy.days.map(makeEnergyProgressDay),
+    insights: energy.insights.map(makeEnergyInsights))
+}
+
+private func makeEnergyProgressDay(
+  _ payload: Components.Schemas.CurrentUserEnergyResponse.EnergyPayload.DaysPayloadPayload
+) throws -> EnergyProgressDay {
+  EnergyProgressDay(
+    date: try makeProgressDate(payload.date),
+    energy: payload.energy)
+}
+
+private func makeEnergyInsights(
+  _ payload: Components.Schemas.CurrentUserEnergyResponse.EnergyPayload.InsightsPayload
+) -> EnergyInsights {
+  EnergyInsights(
+    averageEnergy: payload.averageEnergy,
+    fullEnergyDays: payload.fullEnergyDays)
+}
+
+private func makeLevelProgress(
+  _ response: Components.Schemas.CurrentUserLevelResponse
+) throws -> LevelProgress? {
+  try response.level.map(makeDetailedLevelProgress)
+}
+
+private func makeDetailedLevelProgress(
+  _ payload: Components.Schemas.CurrentUserLevelResponse.LevelPayload
+) throws -> LevelProgress {
+  LevelProgress(
+    belt: try makeDomainValue(payload.belt),
+    bpPerLevel: payload.bpPerLevel,
+    bpToNextLevel: payload.bpToNextLevel,
+    isMaxLevel: payload.isMaxLevel,
+    level: payload.level,
+    progressInLevel: payload.progressInLevel,
+    totalBrainPower: payload.totalBrainPower)
+}
+
+private func makeScoreProgress(
+  _ response: Components.Schemas.CurrentUserScoreResponse
+) throws -> ScoreProgress? {
+  guard let score = response.score else {
+    return nil
+  }
+
+  return ScoreProgress(
+    dataPoints: try score.dataPoints.map(makeScoreProgressPoint),
+    performance: makeScorePerformance(
+      .init(
+        correctAnswers: score.correctAnswers,
+        incorrectAnswers: score.incorrectAnswers,
+        score: score.score,
+        totalAnswers: score.totalAnswers)),
+    periodEnd: try makeProgressDate(score.periodEnd),
+    periodStart: try makeProgressDate(score.periodStart))
+}
+
+private func makeScoreProgressPoint(
+  _ payload: Components.Schemas.CurrentUserScoreResponse.ScorePayload.DataPointsPayloadPayload
+) throws -> ScoreProgressPoint {
+  ScoreProgressPoint(
+    date: try makeProgressDate(payload.date),
+    performance: makeScorePerformance(
+      .init(
+        correctAnswers: payload.correctAnswers,
+        incorrectAnswers: payload.incorrectAnswers,
+        score: payload.score,
+        totalAnswers: payload.totalAnswers)))
+}
+
+private func makeScorePatterns(
+  _ response: Components.Schemas.CurrentUserScorePatternsResponse
+) throws -> ScorePatterns? {
+  guard let patterns = response.patterns else {
+    return nil
+  }
+
+  return ScorePatterns(
+    dayparts: try patterns.times.map(makeDaypartScorePattern),
+    strongestDaypart: try patterns.strongestTime.map(makeStrongestDaypartScorePattern),
+    strongestWeekday: try patterns.strongestWeekday.map(makeStrongestWeekdayScorePattern),
+    weekdays: try patterns.weekdays.map(makeWeekdayScorePattern))
+}
+
+private typealias GeneratedScorePatterns =
+  Components.Schemas.CurrentUserScorePatternsResponse.PatternsPayload
+
+private func makeDaypartScorePattern(
+  _ payload: GeneratedScorePatterns.TimesPayloadPayload
+) throws -> DaypartScorePattern {
+  DaypartScorePattern(
+    daypart: try makeDomainValue(payload.period),
+    performance: makeScorePerformance(
+      .init(
+        correctAnswers: payload.correctAnswers,
+        incorrectAnswers: payload.incorrectAnswers,
+        score: payload.score,
+        totalAnswers: payload.totalAnswers)))
+}
+
+private func makeStrongestDaypartScorePattern(
+  _ payload: GeneratedScorePatterns.StrongestTimePayload
+) throws -> DaypartScorePattern {
+  DaypartScorePattern(
+    daypart: try makeDomainValue(payload.period),
+    performance: makeScorePerformance(
+      .init(
+        correctAnswers: payload.correctAnswers,
+        incorrectAnswers: payload.incorrectAnswers,
+        score: payload.score,
+        totalAnswers: payload.totalAnswers)))
+}
+
+private func makeStrongestWeekdayScorePattern(
+  _ payload: GeneratedScorePatterns.StrongestWeekdayPayload
+) throws -> WeekdayScorePattern {
+  WeekdayScorePattern(
+    performance: makeScorePerformance(
+      .init(
+        correctAnswers: payload.correctAnswers,
+        incorrectAnswers: payload.incorrectAnswers,
+        score: payload.score,
+        totalAnswers: payload.totalAnswers)),
+    weekday: try makeDomainValue(payload.dayOfWeek))
+}
+
+private func makeWeekdayScorePattern(
+  _ payload: GeneratedScorePatterns.WeekdaysPayloadPayload
+) throws -> WeekdayScorePattern {
+  WeekdayScorePattern(
+    performance: makeScorePerformance(
+      .init(
+        correctAnswers: payload.correctAnswers,
+        incorrectAnswers: payload.incorrectAnswers,
+        score: payload.score,
+        totalAnswers: payload.totalAnswers)),
+    weekday: try makeDomainValue(payload.dayOfWeek))
+}
+
+private struct ScorePerformanceValues {
+  let correctAnswers: Int
+  let incorrectAnswers: Int
+  let score: Double
+  let totalAnswers: Int
+}
+
+private func makeScorePerformance(_ values: ScorePerformanceValues) -> ScorePerformance {
+  ScorePerformance(
+    correctAnswers: values.correctAnswers,
+    incorrectAnswers: values.incorrectAnswers,
+    score: values.score,
+    totalAnswers: values.totalAnswers)
+}
+
+private func makeProgressDate(_ rawValue: String) throws -> ProgressDate {
+  guard let date = ProgressDate(rawValue) else {
+    throw ProgressAPIError.invalidResponse
+  }
+
+  return date
+}
+
+private func makeDomainValue<Source, Destination>(_ source: Source) throws -> Destination
+where
+  Source: RawRepresentable,
+  Destination: RawRepresentable,
+  Source.RawValue == String,
+  Destination.RawValue == String
+{
+  guard let destination = Destination(rawValue: source.rawValue) else {
+    throw ProgressAPIError.invalidResponse
+  }
+
+  return destination
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressChartData.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressChartData.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+struct ProgressContributionPoint: Equatable, Identifiable, Sendable {
+  let date: ProgressDate
+  let intensity: Int
+  let value: Double?
+
+  var id: ProgressDate { date }
+
+  init(date: ProgressDate, intensity: Int, value: Double? = nil) {
+    self.date = date
+    self.intensity = intensity
+    self.value = value
+  }
+}
+
+struct ProgressContributionSlot: Equatable, Identifiable, Sendable {
+  let date: ProgressDate
+  let point: ProgressContributionPoint?
+
+  var id: ProgressDate { date }
+}
+
+struct ProgressContributionWeek: Equatable, Identifiable, Sendable {
+  let slots: [ProgressContributionSlot]
+  let startDate: ProgressDate
+
+  var id: ProgressDate { startDate }
+
+  var monthLabelDate: ProgressDate? {
+    slots.first { $0.date.day == 1 }?.date
+  }
+}
+
+enum ProgressChartData {
+  static let activityMaximumIntensity = 4
+  static let energyMaximumIntensity = 5
+
+  static func activityContributions(
+    from days: [ActivityProgressDay]
+  ) -> [ProgressContributionPoint] {
+    let maximumLessonCompletions = max(0, days.map(\.lessonCompletions).max() ?? 0)
+
+    return days.map { day in
+      ProgressContributionPoint(
+        date: day.date,
+        intensity: activityIntensity(
+          lessonCompletions: day.lessonCompletions,
+          maximumLessonCompletions: maximumLessonCompletions),
+        value: Double(day.lessonCompletions))
+    }
+  }
+
+  static func energyContributions(
+    from days: [EnergyProgressDay]
+  ) -> [ProgressContributionPoint] {
+    days.map { day in
+      ProgressContributionPoint(
+        date: day.date,
+        intensity: energyIntensity(day.energy),
+        value: day.energy)
+    }
+  }
+
+  static func contributionWeeks(
+    from points: [ProgressContributionPoint]
+  ) -> [ProgressContributionWeek] {
+    let sortedPoints = points.sorted { $0.date < $1.date }
+
+    guard let firstDate = sortedPoints.first?.date, let lastDate = sortedPoints.last?.date else {
+      return []
+    }
+
+    let pointByDate = Dictionary(
+      sortedPoints.map { ($0.date, $0) },
+      uniquingKeysWith: { _, latest in latest })
+    let slots = contributionDates(from: weekStart(containing: firstDate), through: lastDate).map {
+      ProgressContributionSlot(date: $0, point: pointByDate[$0])
+    }
+
+    return stride(from: 0, to: slots.count, by: 7).map { startIndex in
+      let endIndex = min(startIndex + 7, slots.count)
+      let weekSlots = Array(slots[startIndex..<endIndex])
+
+      return ProgressContributionWeek(
+        slots: weekSlots,
+        startDate: weekSlots[0].date)
+    }
+  }
+
+  private static func activityIntensity(
+    lessonCompletions: Int,
+    maximumLessonCompletions: Int
+  ) -> Int {
+    guard lessonCompletions > 0, maximumLessonCompletions > 0 else {
+      return 0
+    }
+
+    let relativeIntensity = ceil(
+      Double(lessonCompletions) / Double(maximumLessonCompletions)
+        * Double(activityMaximumIntensity))
+
+    return min(max(Int(relativeIntensity), 1), activityMaximumIntensity)
+  }
+
+  private static func energyIntensity(_ energy: Double?) -> Int {
+    guard let energy, energy > 0 else {
+      return 0
+    }
+
+    if energy >= 100 {
+      return energyMaximumIntensity
+    }
+
+    return min(max(Int(ceil(energy / 25)), 1), energyMaximumIntensity - 1)
+  }
+
+  private static func weekStart(containing date: ProgressDate) -> ProgressDate {
+    guard let foundationDate = date.date(in: utcTimeZone) else {
+      preconditionFailure("A valid progress date must convert to a Foundation date")
+    }
+
+    let daysSinceSunday = utcCalendar.component(.weekday, from: foundationDate) - 1
+
+    guard
+      let weekStart = utcCalendar.date(
+        byAdding: .day,
+        value: -daysSinceSunday,
+        to: foundationDate)
+    else {
+      preconditionFailure("A valid progress date must have a calendar week start")
+    }
+
+    return progressDate(from: weekStart)
+  }
+
+  private static func contributionDates(
+    from startDate: ProgressDate,
+    through endDate: ProgressDate
+  ) -> [ProgressDate] {
+    guard
+      let start = startDate.date(in: utcTimeZone),
+      let end = endDate.date(in: utcTimeZone),
+      let dayCount = utcCalendar.dateComponents([.day], from: start, to: end).day
+    else {
+      preconditionFailure("Valid progress dates must define a calendar range")
+    }
+
+    return (0...max(dayCount, 0)).map { dayOffset in
+      guard let date = utcCalendar.date(byAdding: .day, value: dayOffset, to: start) else {
+        preconditionFailure("A valid calendar range must contain every intermediate day")
+      }
+
+      return progressDate(from: date)
+    }
+  }
+
+  private static func progressDate(from date: Date) -> ProgressDate {
+    let components = utcCalendar.dateComponents([.year, .month, .day], from: date)
+
+    guard
+      let year = components.year,
+      let month = components.month,
+      let day = components.day,
+      let progressDate = ProgressDate(String(format: "%04d-%02d-%02d", year, month, day))
+    else {
+      preconditionFailure("A valid Foundation date must convert to a progress date")
+    }
+
+    return progressDate
+  }
+
+  private static var utcCalendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = utcTimeZone
+    return calendar
+  }
+
+  private static var utcTimeZone: TimeZone {
+    TimeZone(secondsFromGMT: 0)!
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressContributionCalendar.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressContributionCalendar.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+struct ProgressContributionCalendar: View {
+  let weeks: [ProgressContributionWeek]
+  let maximumIntensity: Int
+  let tint: Color
+  let lowLabel: Text
+  let highLabel: Text
+  let accessibilityLabel: Text
+  let accessibilityValue: (ProgressContributionPoint) -> Text
+
+  @State private var selectedPoint: ProgressContributionPoint?
+  @ScaledMetric(relativeTo: .caption) private var markSize: CGFloat = 15
+  private let markSpacing: CGFloat = 3
+  private let monthHeaderHeight: CGFloat = 20
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      GeometryReader { geometry in
+        ScrollView(.horizontal) {
+          HStack(alignment: .top, spacing: 0) {
+            ForEach(weeks) { week in
+              weekColumn(week)
+            }
+          }
+          .contentShape(.rect)
+          .simultaneousGesture(
+            SpatialTapGesture()
+              .onEnded { gesture in
+                selectedPoint = ProgressContributionSelection.nearestPoint(
+                  to: gesture.location,
+                  in: weeks,
+                  cellSize: cellSize,
+                  headerHeight: monthHeaderHeight)
+              })
+        }
+        .frame(width: fittedPlotWidth(availableWidth: geometry.size.width))
+        .frame(maxWidth: .infinity, alignment: .trailing)
+      }
+      .frame(height: plotHeight)
+      .defaultScrollAnchor(.trailing)
+
+      legend
+    }
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(accessibilityLabel)
+  }
+
+  private func weekColumn(_ week: ProgressContributionWeek) -> some View {
+    VStack(spacing: 0) {
+      ForEach(week.slots) { slot in
+        contributionSlot(slot)
+      }
+    }
+    .padding(.top, monthHeaderHeight)
+    .overlay(alignment: .topLeading) {
+      if let monthLabelDate = week.monthLabelDate, let month = monthLabelDate.date() {
+        Text(month, format: .dateTime.month(.abbreviated))
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .fixedSize()
+          .accessibilityHidden(true)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func contributionSlot(_ slot: ProgressContributionSlot) -> some View {
+    if let point = slot.point {
+      RoundedRectangle(cornerRadius: 3, style: .continuous)
+        .fill(fillColor(for: point.intensity))
+        .frame(width: markSize, height: markSize)
+        .frame(width: cellSize, height: cellSize)
+        .contentShape(.rect)
+        .accessibilityElement()
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(dateLabel(point.date))
+        .accessibilityValue(accessibilityValue(point))
+        .accessibilityAction {
+          selectedPoint = point
+        }
+        .popover(
+          isPresented: selectionBinding(for: point),
+          attachmentAnchor: .rect(.bounds),
+          arrowEdge: .bottom
+        ) {
+          contributionDetails(point)
+            .presentationCompactAdaptation(.popover)
+        }
+    } else {
+      Color.clear
+        .frame(width: cellSize, height: cellSize)
+        .accessibilityHidden(true)
+    }
+  }
+
+  private func contributionDetails(_ point: ProgressContributionPoint) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      dateLabel(point.date)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      accessibilityValue(point)
+        .font(.subheadline.bold())
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 10)
+    .fixedSize()
+    .accessibilityElement(children: .combine)
+  }
+
+  private var legend: some View {
+    HStack(spacing: 5) {
+      lowLabel
+
+      ForEach(0...maximumIntensity, id: \.self) { intensity in
+        RoundedRectangle(cornerRadius: 2, style: .continuous)
+          .fill(fillColor(for: intensity))
+          .frame(width: 10, height: 10)
+      }
+
+      highLabel
+    }
+    .font(.caption2)
+    .foregroundStyle(.secondary)
+    .frame(maxWidth: .infinity, alignment: .trailing)
+    .accessibilityHidden(true)
+  }
+
+  private func fillColor(for intensity: Int) -> Color {
+    guard intensity > 0 else {
+      return Color(uiColor: .tertiarySystemFill)
+    }
+
+    let opacity = intensity >= maximumIntensity ? 1 : Double(intensity) * 0.2
+    return tint.opacity(opacity)
+  }
+
+  private var plotHeight: CGFloat {
+    monthHeaderHeight + cellSize * 7
+  }
+
+  private func fittedPlotWidth(availableWidth: CGFloat) -> CGFloat {
+    let columnCount = max(floor(availableWidth / cellSize), 1)
+    return min(columnCount * cellSize, availableWidth)
+  }
+
+  private var cellSize: CGFloat {
+    markSize + markSpacing
+  }
+
+  private func selectionBinding(for point: ProgressContributionPoint) -> Binding<Bool> {
+    Binding(
+      get: { selectedPoint?.id == point.id },
+      set: { isPresented in
+        if !isPresented, selectedPoint?.id == point.id {
+          selectedPoint = nil
+        }
+      })
+  }
+
+  private func dateLabel(_ date: ProgressDate) -> Text {
+    guard let foundationDate = date.date() else {
+      return Text(verbatim: date.id)
+    }
+
+    return Text(foundationDate, format: .dateTime.month(.wide).day().year())
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressContributionSelection.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressContributionSelection.swift
@@ -1,0 +1,70 @@
+import CoreGraphics
+
+enum ProgressContributionSelection {
+  static func nearestPoint(
+    to location: CGPoint,
+    in weeks: [ProgressContributionWeek],
+    cellSize: CGFloat,
+    headerHeight: CGFloat
+  ) -> ProgressContributionPoint? {
+    guard cellSize > 0, location.y >= headerHeight else {
+      return nil
+    }
+
+    return candidates(
+      in: weeks,
+      cellSize: cellSize,
+      headerHeight: headerHeight
+    )
+    .min { lhs, rhs in
+      lhs.distanceSquared(to: location) < rhs.distanceSquared(to: location)
+    }?
+    .point
+  }
+
+  private static func candidates(
+    in weeks: [ProgressContributionWeek],
+    cellSize: CGFloat,
+    headerHeight: CGFloat
+  ) -> [Candidate] {
+    weeks.enumerated().flatMap { weekIndex, week in
+      week.slots.enumerated().compactMap { dayIndex, slot in
+        candidate(
+          for: slot,
+          weekIndex: weekIndex,
+          dayIndex: dayIndex,
+          cellSize: cellSize,
+          headerHeight: headerHeight)
+      }
+    }
+  }
+
+  private static func candidate(
+    for slot: ProgressContributionSlot,
+    weekIndex: Int,
+    dayIndex: Int,
+    cellSize: CGFloat,
+    headerHeight: CGFloat
+  ) -> Candidate? {
+    guard let point = slot.point else {
+      return nil
+    }
+
+    return Candidate(
+      point: point,
+      center: CGPoint(
+        x: (CGFloat(weekIndex) + 0.5) * cellSize,
+        y: headerHeight + (CGFloat(dayIndex) + 0.5) * cellSize))
+  }
+}
+
+private struct Candidate {
+  let point: ProgressContributionPoint
+  let center: CGPoint
+
+  func distanceSquared(to location: CGPoint) -> CGFloat {
+    let horizontalDistance = center.x - location.x
+    let verticalDistance = center.y - location.y
+    return horizontalDistance * horizontalDistance + verticalDistance * verticalDistance
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressDate.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressDate.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Preserves the API's learner-local calendar day without treating it as a timezone-shifting instant.
+struct ProgressDate: Codable, Comparable, Hashable, Identifiable, Sendable {
+  let day: Int
+  let month: Int
+  let year: Int
+
+  var id: String { rawValue }
+
+  private var rawValue: String {
+    String(format: "%04d-%02d-%02d", year, month, day)
+  }
+
+  init?(_ rawValue: String) {
+    let components = rawValue.split(separator: "-", omittingEmptySubsequences: false)
+
+    guard
+      rawValue.count == 10,
+      components.count == 3,
+      components[0].count == 4,
+      components[1].count == 2,
+      components[2].count == 2,
+      let year = Int(components[0]),
+      let month = Int(components[1]),
+      let day = Int(components[2]),
+      Self.isValid(year: year, month: month, day: day)
+    else {
+      return nil
+    }
+
+    self.day = day
+    self.month = month
+    self.year = year
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let rawValue = try container.decode(String.self)
+
+    guard let date = ProgressDate(rawValue) else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Expected a valid YYYY-MM-DD calendar date")
+    }
+
+    self = date
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+
+  func date(in timeZone: TimeZone = .autoupdatingCurrent) -> Date? {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timeZone
+
+    return calendar.date(
+      from: DateComponents(
+        timeZone: timeZone,
+        year: year,
+        month: month,
+        day: day,
+        hour: 12))
+  }
+
+  static func < (lhs: ProgressDate, rhs: ProgressDate) -> Bool {
+    (lhs.year, lhs.month, lhs.day) < (rhs.year, rhs.month, rhs.day)
+  }
+
+  private static func isValid(year: Int, month: Int, day: Int) -> Bool {
+    guard year > 0 else {
+      return false
+    }
+
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    let components = DateComponents(year: year, month: month, day: day, hour: 12)
+
+    guard let date = calendar.date(from: components) else {
+      return false
+    }
+
+    return calendar.dateComponents([.year, .month, .day], from: date)
+      == DateComponents(year: year, month: month, day: day)
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressDestination.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressDestination.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+enum ProgressDestination: CaseIterable, Hashable, Identifiable {
+  case activity
+  case score
+  case patterns
+  case level
+  case energy
+
+  var id: Self { self }
+
+  var title: LocalizedStringResource {
+    switch self {
+    case .activity:
+      LocalizedStringResource(
+        "Activity",
+        table: "Progress",
+        comment: "Title for the learner's completed lessons and learning time progress.")
+    case .score:
+      LocalizedStringResource(
+        "Score",
+        table: "Progress",
+        comment: "Title for the learner's answer accuracy progress.")
+    case .patterns:
+      LocalizedStringResource(
+        "Patterns",
+        table: "Progress",
+        comment: "Title for insights about when the learner answers best.")
+    case .level:
+      LocalizedStringResource(
+        "Level",
+        table: "Progress",
+        comment: "Title for the learner's Brain Power level progress.")
+    case .energy:
+      LocalizedStringResource(
+        "Energy",
+        table: "Progress",
+        comment: "Title for the learner's Energy progress.")
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .activity:
+      "chart.bar.xaxis"
+    case .score:
+      "target"
+    case .patterns:
+      "waveform.path.ecg"
+    case .level:
+      "brain.head.profile"
+    case .energy:
+      "bolt.fill"
+    }
+  }
+
+  var tint: Color {
+    switch self {
+    case .activity:
+      .blue
+    case .score:
+      .green
+    case .patterns:
+      .green
+    case .level:
+      .orange
+    case .energy:
+      .orange
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressDetailComponents.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressDetailComponents.swift
@@ -1,0 +1,318 @@
+import SwiftUI
+
+struct ProgressDetailLoadStateView<Value, Content>: View
+where Value: Equatable & Sendable, Content: View {
+  let state: ProgressLoadState<Value>
+  let emptyTitle: LocalizedStringResource
+  let emptyDescription: LocalizedStringResource
+  let systemImage: String
+  let retry: @MainActor () async -> Void
+  @ViewBuilder let content: (Value) -> Content
+
+  var body: some View {
+    switch state {
+    case .idle, .loading:
+      ProgressDetailLoadingView(systemImage: systemImage)
+    case .loaded(let value):
+      content(value)
+    case .empty:
+      ProgressDetailUnavailableView(
+        title: emptyTitle,
+        description: emptyDescription,
+        systemImage: systemImage)
+    case .failed(let failure):
+      ProgressDetailFailureView(failure: failure, retry: retry)
+    }
+  }
+}
+
+struct ProgressDetailPage<Content: View>: View {
+  @ViewBuilder let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 24) {
+        content
+      }
+      .frame(maxWidth: 760, alignment: .leading)
+      .padding(.horizontal, 20)
+      .padding(.vertical, 24)
+      .frame(maxWidth: .infinity)
+    }
+    .background(Color(uiColor: .systemGroupedBackground))
+    .scrollBounceBehavior(.basedOnSize)
+  }
+}
+
+struct ProgressDetailHero: View {
+  let title: Text
+  let value: Text
+  let description: Text
+  let systemImage: String
+  let tint: Color
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Label {
+        title
+          .font(.headline)
+          .foregroundStyle(.secondary)
+      } icon: {
+        Image(systemName: systemImage)
+          .foregroundStyle(tint)
+      }
+
+      value
+        .font(.system(.largeTitle, design: .rounded, weight: .bold))
+        .contentTransition(.numericText())
+        .monospacedDigit()
+
+      description
+        .font(.body)
+        .foregroundStyle(.secondary)
+    }
+    .accessibilityElement(children: .combine)
+  }
+}
+
+struct ProgressDetailSection<Content: View>: View {
+  let title: Text
+  let subtitle: Text?
+  @ViewBuilder let content: Content
+
+  init(title: Text, subtitle: Text? = nil, @ViewBuilder content: () -> Content) {
+    self.title = title
+    self.subtitle = subtitle
+    self.content = content()
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: 4) {
+        title
+          .font(.title3.bold())
+
+        if let subtitle {
+          subtitle
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
+      }
+
+      content
+    }
+    .padding(18)
+    .background(.background, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+  }
+}
+
+struct ProgressDetailMetricGrid<Content: View>: View {
+  @ViewBuilder let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    LazyVGrid(
+      columns: [GridItem(.adaptive(minimum: 160, maximum: 360), spacing: 12)],
+      alignment: .leading,
+      spacing: 12
+    ) {
+      content
+    }
+  }
+}
+
+struct ProgressDetailMetric: View {
+  let label: Text
+  let value: Text
+  let systemImage: String
+  let tint: Color
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Label {
+        label
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+      } icon: {
+        Image(systemName: systemImage)
+          .foregroundStyle(tint)
+      }
+
+      Spacer(minLength: 10)
+
+      value
+        .font(.title2.bold())
+        .monospacedDigit()
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .background(.background, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    .accessibilityElement(children: .combine)
+  }
+}
+
+struct ProgressDetailExplanation: View {
+  let title: Text
+  let description: Text
+  let systemImage: String
+  let tint: Color
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Divider()
+
+      Label {
+        title
+          .font(.headline)
+      } icon: {
+        Image(systemName: systemImage)
+          .foregroundStyle(tint)
+      }
+      .padding(.top, 8)
+
+      description
+        .foregroundStyle(.secondary)
+    }
+  }
+}
+
+struct ProgressDetailNoChartData: View {
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        Text(
+          "Not enough data yet",
+          tableName: "Progress",
+          comment: "Title shown when a progress chart has no recorded data")
+      } icon: {
+        Image(systemName: "chart.xyaxis.line")
+      }
+    } description: {
+      Text(
+        "Keep learning to see your trend here.",
+        tableName: "Progress",
+        comment: "Guidance shown when a progress chart has no recorded data")
+    }
+  }
+}
+
+private struct ProgressDetailLoadingView: View {
+  let systemImage: String
+
+  var body: some View {
+    ProgressDetailPage {
+      ProgressDetailHero(
+        title: Text(verbatim: "Loading"),
+        value: Text(verbatim: "88%"),
+        description: Text(verbatim: "Your progress will appear here."),
+        systemImage: systemImage,
+        tint: .secondary)
+
+      ProgressDetailSection(title: Text(verbatim: "Progress over time")) {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .fill(.quaternary)
+          .frame(height: 220)
+      }
+
+      ProgressDetailMetricGrid {
+        ProgressDetailMetric(
+          label: Text(verbatim: "Progress"),
+          value: Text(verbatim: "88"),
+          systemImage: "chart.bar",
+          tint: .secondary)
+        ProgressDetailMetric(
+          label: Text(verbatim: "Learning"),
+          value: Text(verbatim: "24"),
+          systemImage: "book.closed",
+          tint: .secondary)
+      }
+    }
+    .redacted(reason: .placeholder)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(
+      Text(
+        "Loading progress",
+        tableName: "Progress",
+        comment: "Accessibility label for a loading progress detail screen"))
+  }
+}
+
+private struct ProgressDetailUnavailableView: View {
+  let title: LocalizedStringResource
+  let description: LocalizedStringResource
+  let systemImage: String
+
+  var body: some View {
+    ContentUnavailableView {
+      Label(title, systemImage: systemImage)
+    } description: {
+      Text(description)
+    }
+  }
+}
+
+private struct ProgressDetailFailureView: View {
+  let failure: ProgressFailure
+  let retry: @MainActor () async -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        failureTitle
+      } icon: {
+        Image(systemName: failure == .network ? "wifi.exclamationmark" : "exclamationmark.triangle")
+      }
+    } description: {
+      failureDescription
+    } actions: {
+      Button {
+        Task {
+          await retry()
+        }
+      } label: {
+        Text(
+          "Try again",
+          tableName: "Progress",
+          comment: "Retries loading a progress detail screen")
+      }
+      .buttonStyle(.borderedProminent)
+    }
+  }
+
+  private var failureTitle: Text {
+    switch failure {
+    case .network:
+      Text(
+        "You're offline",
+        tableName: "Progress",
+        comment: "Title shown when progress cannot load without a network connection")
+    case .unavailable:
+      Text(
+        "Progress unavailable",
+        tableName: "Progress",
+        comment: "Title shown when progress cannot load because of a service error")
+    }
+  }
+
+  private var failureDescription: Text {
+    switch failure {
+    case .network:
+      Text(
+        "Check your connection and try again.",
+        tableName: "Progress",
+        comment: "Recovery guidance for a progress network error")
+    case .unavailable:
+      Text(
+        "We couldn't load this progress right now. Try again in a moment.",
+        tableName: "Progress",
+        comment: "Recovery guidance for a progress service error")
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressModels.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressModels.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+struct ProgressOverview: Codable, Equatable, Sendable {
+  let activity: ActivitySummary
+  let energy: Double?
+  let level: LevelProgress?
+  let score: ScorePerformance?
+  let strongestDaypart: DaypartScorePattern?
+  let strongestWeekday: WeekdayScorePattern?
+
+  var isEmpty: Bool {
+    activity.isEmpty
+      && energy == nil
+      && level == nil
+      && score == nil
+      && strongestDaypart == nil
+      && strongestWeekday == nil
+  }
+}
+
+struct ActivitySummary: Codable, Equatable, Sendable {
+  let learningDays: Int
+  let totalLearningSeconds: Int
+  let totalLessonCompletions: Int
+
+  var isEmpty: Bool {
+    learningDays == 0
+      && totalLearningSeconds == 0
+      && totalLessonCompletions == 0
+  }
+}
+
+struct ActivityProgress: Codable, Equatable, Sendable {
+  let days: [ActivityProgressDay]
+  let summary: ActivitySummary
+
+  var isEmpty: Bool {
+    summary.isEmpty
+  }
+}
+
+struct ActivityProgressDay: Codable, Equatable, Identifiable, Sendable {
+  let date: ProgressDate
+  let lessonCompletions: Int
+
+  var id: ProgressDate { date }
+}
+
+struct EnergyProgress: Codable, Equatable, Sendable {
+  let currentEnergy: Double
+  let days: [EnergyProgressDay]
+  let insights: EnergyInsights?
+}
+
+struct EnergyProgressDay: Codable, Equatable, Identifiable, Sendable {
+  let date: ProgressDate
+  let energy: Double?
+
+  var id: ProgressDate { date }
+}
+
+struct EnergyInsights: Codable, Equatable, Sendable {
+  let averageEnergy: Double
+  let fullEnergyDays: Int
+}
+
+struct LevelProgress: Codable, Equatable, Sendable {
+  let belt: ProgressBelt
+  let bpPerLevel: Int
+  let bpToNextLevel: Int
+  let isMaxLevel: Bool
+  let level: Int
+  let progressInLevel: Int
+  let totalBrainPower: Int
+}
+
+enum ProgressBelt: String, CaseIterable, Codable, Equatable, Sendable {
+  case white
+  case yellow
+  case orange
+  case green
+  case blue
+  case purple
+  case brown
+  case red
+  case gray
+  case black
+}
+
+struct ScorePerformance: Codable, Equatable, Sendable {
+  let correctAnswers: Int
+  let incorrectAnswers: Int
+  let score: Double
+  let totalAnswers: Int
+
+  var hasAnswers: Bool { totalAnswers > 0 }
+}
+
+struct ScoreProgress: Codable, Equatable, Sendable {
+  let dataPoints: [ScoreProgressPoint]
+  let performance: ScorePerformance
+  let periodEnd: ProgressDate
+  let periodStart: ProgressDate
+}
+
+struct ScoreProgressPoint: Codable, Equatable, Identifiable, Sendable {
+  let date: ProgressDate
+  let performance: ScorePerformance
+
+  var id: ProgressDate { date }
+}
+
+struct ScorePatterns: Codable, Equatable, Sendable {
+  let dayparts: [DaypartScorePattern]
+  let strongestDaypart: DaypartScorePattern?
+  let strongestWeekday: WeekdayScorePattern?
+  let weekdays: [WeekdayScorePattern]
+}
+
+struct DaypartScorePattern: Codable, Equatable, Identifiable, Sendable {
+  let daypart: ProgressDaypart
+  let performance: ScorePerformance
+
+  var id: ProgressDaypart { daypart }
+}
+
+enum ProgressDaypart: String, CaseIterable, Codable, Equatable, Sendable {
+  case night
+  case morning
+  case afternoon
+  case evening
+}
+
+struct WeekdayScorePattern: Codable, Equatable, Identifiable, Sendable {
+  let performance: ScorePerformance
+  let weekday: ProgressWeekday
+
+  var id: ProgressWeekday { weekday }
+}
+
+enum ProgressWeekday: String, CaseIterable, Codable, Equatable, Sendable {
+  case sunday
+  case monday
+  case tuesday
+  case wednesday
+  case thursday
+  case friday
+  case saturday
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressOverviewView.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressOverviewView.swift
@@ -1,11 +1,593 @@
 import SwiftUI
 
 struct ProgressOverviewView: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @Environment(ProgressStore.self) private var progress
+  @Environment(SessionStore.self) private var session
+
+  let onSignIn: () -> Void
+
   var body: some View {
-    Color.clear
+    Group {
+      switch session.state {
+      case .restoring:
+        ProgressOverviewLoadingView()
+      case .signedOut:
+        signedOutView
+      case .signedIn:
+        signedInView
+      case .unavailable:
+        sessionUnavailableView
+      }
+    }
+    .background(Color(.systemGroupedBackground))
+    .navigationDestination(for: ProgressDestination.self) { destination in
+      destinationView(destination)
+        .navigationTitle(Text(destination.title))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(removing: horizontalSizeClass == .regular ? .title : nil)
+    }
+    .refreshesProgress {
+      await progress.loadOverview()
+    }
+  }
+
+  @ViewBuilder
+  private var signedInView: some View {
+    switch progress.overviewState {
+    case .idle, .loading:
+      ProgressOverviewLoadingView()
+    case .loaded(let overview):
+      ProgressOverviewContent(overview: overview)
+    case .empty:
+      ProgressUnavailableView(
+        title: Text(
+          "Your progress starts here",
+          tableName: "Progress",
+          comment: "Title shown when a signed-in learner has no progress yet."),
+        description: Text(
+          "Complete a lesson to start tracking your activity, Score, level, and Energy.",
+          tableName: "Progress",
+          comment: "Guidance shown when a signed-in learner has no progress yet."),
+        systemImage: "chart.line.uptrend.xyaxis")
+    case .failed(let failure):
+      progressFailureView(failure)
+    }
+  }
+
+  private var signedOutView: some View {
+    ContentUnavailableView {
+      Label {
+        Text(
+          "Sign in to see your progress",
+          tableName: "Progress",
+          comment: "Title shown when progress requires the learner to sign in.")
+      } icon: {
+        Image(systemName: "chart.line.uptrend.xyaxis")
+      }
+    } description: {
+      Text(
+        "Your activity, Score, patterns, level, and Energy stay connected to your account.",
+        tableName: "Progress",
+        comment: "Explains why signing in is required to view progress.")
+    } actions: {
+      Button(action: onSignIn) {
+        Text(
+          "Sign in",
+          tableName: "Progress",
+          comment: "Action that opens account sign-in from the Progress tab.")
+      }
+      .buttonStyle(.borderedProminent)
+    }
+  }
+
+  private var sessionUnavailableView: some View {
+    ContentUnavailableView {
+      Label {
+        Text(
+          "Account unavailable",
+          tableName: "Progress",
+          comment: "Title shown when the saved account could not be restored.")
+      } icon: {
+        Image(systemName: "person.crop.circle.badge.exclamationmark")
+      }
+    } description: {
+      Text(
+        "Check your connection, then try again.",
+        tableName: "Progress",
+        comment: "Recovery guidance when the saved account could not be restored.")
+    } actions: {
+      Button {
+        Task {
+          await session.retryRestore()
+        }
+      } label: {
+        Text(
+          "Try again",
+          tableName: "Progress",
+          comment: "Retries restoring the account from the Progress tab.")
+      }
+      .buttonStyle(.borderedProminent)
+    }
+  }
+
+  private func progressFailureView(_ failure: ProgressFailure) -> some View {
+    ProgressUnavailableView(
+      title: progressFailureTitle(failure),
+      description: Text(
+        "Your progress is safe. Try loading it again.",
+        tableName: "Progress",
+        comment: "Recovery guidance when progress cannot be loaded."),
+      systemImage: failure == .network ? "wifi.exclamationmark" : "exclamationmark.triangle",
+      retry: {
+        await progress.loadOverview(force: true)
+      })
+  }
+
+  private func progressFailureTitle(_ failure: ProgressFailure) -> Text {
+    switch failure {
+    case .network:
+      Text(
+        "You're offline",
+        tableName: "Progress",
+        comment: "Title shown when progress cannot load because the network is unavailable.")
+    case .unavailable:
+      Text(
+        "Progress is unavailable",
+        tableName: "Progress",
+        comment: "Title shown when the progress service cannot provide data.")
+    }
+  }
+
+  @ViewBuilder
+  private func destinationView(_ destination: ProgressDestination) -> some View {
+    switch destination {
+    case .activity:
+      ActivityProgressView()
+    case .score:
+      ScoreProgressView()
+    case .patterns:
+      ScorePatternsView()
+    case .level:
+      LevelProgressView()
+    case .energy:
+      EnergyProgressView()
+    }
   }
 }
 
-#Preview {
-  ProgressOverviewView()
+private struct ProgressOverviewContent: View {
+  let overview: ProgressOverview
+
+  private let columns = [
+    GridItem(.adaptive(minimum: 280, maximum: 420), spacing: 16, alignment: .top)
+  ]
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text(
+            "At a glance",
+            tableName: "Progress",
+            comment: "Heading above the learner's progress summary cards."
+          )
+          .font(.title2.bold())
+
+          Text(
+            "See what you've accomplished and where you're building momentum.",
+            tableName: "Progress",
+            comment: "Description above the learner's progress summary cards."
+          )
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+        }
+
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
+          activityCard
+          scoreCard
+          patternsCard
+          levelCard
+          energyCard
+        }
+      }
+      .frame(maxWidth: 1_040, alignment: .leading)
+      .padding(.horizontal)
+      .padding(.vertical, 20)
+      .frame(maxWidth: .infinity)
+    }
+  }
+
+  private var activityCard: some View {
+    ProgressOverviewCard(destination: .activity) {
+      ProgressOverviewMetric(
+        value: overview.activity.totalLessonCompletions.formatted(),
+        label: Text(
+          "Lessons completed",
+          tableName: "Progress",
+          comment: "Label for the learner's lifetime completed lesson count."))
+
+      ProgressOverviewSupportingMetrics {
+        ProgressOverviewSupportingMetric(
+          value: overview.activity.learningDays.formatted(),
+          label: Text(
+            "Learning days",
+            tableName: "Progress",
+            comment: "Label for the learner's lifetime count of days with learning activity."))
+        ProgressOverviewSupportingMetric(
+          value: overviewLearningTime(overview.activity.totalLearningSeconds),
+          label: Text(
+            "Learning time",
+            tableName: "Progress",
+            comment: "Label for the learner's lifetime lesson time."))
+      }
+    }
+  }
+
+  private var scoreCard: some View {
+    ProgressOverviewCard(destination: .score) {
+      if let score = overview.score {
+        ProgressOverviewMetric(
+          value: overviewPercent(score.score),
+          label: Text(
+            "Answer accuracy",
+            tableName: "Progress",
+            comment: "Label for the learner's Score accuracy over the last 90 days."))
+
+        ProgressOverviewSupportingMetric(
+          value: score.totalAnswers.formatted(),
+          label: Text(
+            "Answers in the last 90 days",
+            tableName: "Progress",
+            comment: "Label for the answer count used to calculate Score."))
+      } else {
+        ProgressOverviewMissingMetric(
+          description: Text(
+            "Answer questions to see your Score.",
+            tableName: "Progress",
+            comment: "Guidance when the learner does not have a Score yet."))
+      }
+    }
+  }
+
+  private var patternsCard: some View {
+    ProgressOverviewCard(destination: .patterns) {
+      if let weekday = overview.strongestWeekday {
+        ProgressOverviewMetric(
+          value: weekday.weekday.localizedTitle,
+          label: Text(
+            "Best day",
+            tableName: "Progress",
+            comment: "Label for the weekday when the learner has their strongest Score."))
+
+        ProgressOverviewSupportingMetrics {
+          ProgressOverviewSupportingMetric(
+            value: overview.strongestDaypart.map { String(localized: $0.daypart.localizedTitle) }
+              ?? "—",
+            label: Text(
+              "Best time",
+              tableName: "Progress",
+              comment: "Label for the daypart when the learner has their strongest Score."))
+          ProgressOverviewSupportingMetric(
+            value: weekday.performance.totalAnswers.formatted(),
+            label: Text(
+              "Answers on that day",
+              tableName: "Progress",
+              comment: "Label for the sample size behind the learner's strongest weekday."))
+        }
+      } else if let daypart = overview.strongestDaypart {
+        ProgressOverviewMetric(
+          value: String(localized: daypart.daypart.localizedTitle),
+          label: Text(
+            "Best time",
+            tableName: "Progress",
+            comment: "Label for the daypart when the learner has their strongest Score."))
+
+        ProgressOverviewSupportingMetric(
+          value: daypart.performance.totalAnswers.formatted(),
+          label: Text(
+            "Answers in the last 90 days",
+            tableName: "Progress",
+            comment: "Label for the answer count used to calculate Score."))
+      } else {
+        ProgressOverviewMissingMetric(
+          description: Text(
+            "Keep answering to discover your strongest learning patterns.",
+            tableName: "Progress",
+            comment: "Guidance when the learner does not have Score patterns yet."))
+      }
+    }
+  }
+
+  private var levelCard: some View {
+    ProgressOverviewCard(
+      destination: .level,
+      tint: overview.level?.belt.progressColor ?? ProgressDestination.level.tint
+    ) {
+      if let level = overview.level {
+        ProgressOverviewMetric(
+          value: String(localized: level.belt.localizedTitle),
+          label: Text(
+            "Level \(level.level)",
+            tableName: "Progress",
+            comment: "Learner's level number within their current belt."))
+
+        ProgressView(
+          value: level.progressValue,
+          total: level.progressTotal
+        )
+        .tint(level.belt.progressColor)
+        .accessibilityLabel(
+          Text(
+            level.isMaxLevel ? "Level progress" : "Progress to the next level",
+            tableName: "Progress",
+            comment: "Accessibility label for level progress.")
+        )
+        .accessibilityValue(
+          level.isMaxLevel
+            ? Text(
+              "Complete",
+              tableName: "Progress",
+              comment: "Value shown when the learner has reached the maximum level")
+            : Text(
+              "\(level.progressInLevel) of \(level.bpPerLevel) BP",
+              tableName: "Progress",
+              comment: "Accessibility value describing Brain Power earned toward the next level."))
+      } else {
+        ProgressOverviewMissingMetric(
+          description: Text(
+            "Complete a lesson to begin earning Brain Power.",
+            tableName: "Progress",
+            comment: "Guidance when the learner has not unlocked a level yet."))
+      }
+    }
+  }
+
+  private var energyCard: some View {
+    ProgressOverviewCard(destination: .energy) {
+      if let energy = overview.energy {
+        ProgressOverviewMetric(
+          value: overviewPercent(energy),
+          label: Text(
+            "Current Energy",
+            tableName: "Progress",
+            comment: "Label for the learner's current Energy value."))
+
+        ProgressView(value: energy, total: 100)
+          .tint(ProgressDestination.energy.tint)
+          .accessibilityLabel(
+            Text(
+              "Current Energy",
+              tableName: "Progress",
+              comment: "Accessibility label for the learner's current Energy.")
+          )
+          .accessibilityValue(overviewPercent(energy))
+      } else {
+        ProgressOverviewMissingMetric(
+          description: Text(
+            "Complete a lesson to start building Energy.",
+            tableName: "Progress",
+            comment: "Guidance when the learner does not have an Energy value yet."))
+      }
+    }
+  }
+}
+
+private struct ProgressOverviewCard<Content: View>: View {
+  let destination: ProgressDestination
+  let tint: Color
+  @ViewBuilder let content: Content
+
+  init(
+    destination: ProgressDestination,
+    tint: Color? = nil,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.destination = destination
+    self.tint = tint ?? destination.tint
+    self.content = content()
+  }
+
+  var body: some View {
+    NavigationLink(value: destination) {
+      VStack(alignment: .leading, spacing: 16) {
+        HStack(spacing: 12) {
+          Image(systemName: destination.systemImage)
+            .font(.headline)
+            .foregroundStyle(tint)
+            .frame(width: 34, height: 34)
+            .background(tint.opacity(0.12), in: Circle())
+
+          Text(destination.title)
+            .font(.headline)
+
+          Spacer(minLength: 8)
+
+          Image(systemName: "chevron.forward")
+            .font(.caption.bold())
+            .foregroundStyle(.tertiary)
+            .accessibilityHidden(true)
+        }
+
+        content
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(20)
+      .background(.background, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+      .contentShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .accessibilityHint(
+      Text(
+        "View details",
+        tableName: "Progress",
+        comment: "Accessibility hint for opening a progress metric's detail screen."))
+  }
+}
+
+private struct ProgressOverviewMetric: View {
+  let value: String
+  let label: Text
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(value)
+        .font(.title.bold())
+        .foregroundStyle(.primary)
+        .monospacedDigit()
+      label
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+    }
+  }
+}
+
+private struct ProgressOverviewSupportingMetrics<Content: View>: View {
+  @ViewBuilder let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(alignment: .top, spacing: 24) {
+        content
+      }
+
+      VStack(alignment: .leading, spacing: 12) {
+        content
+      }
+    }
+  }
+}
+
+private struct ProgressOverviewSupportingMetric: View {
+  let value: String
+  let label: Text
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(value)
+        .font(.headline)
+        .monospacedDigit()
+      label
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+private struct ProgressOverviewMissingMetric: View {
+  let description: Text
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text("—")
+        .font(.title.bold())
+      description
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+    }
+  }
+}
+
+private struct ProgressOverviewLoadingView: View {
+  private let columns = [
+    GridItem(.adaptive(minimum: 280, maximum: 420), spacing: 16, alignment: .top)
+  ]
+
+  var body: some View {
+    ScrollView {
+      LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
+        ForEach(ProgressDestination.allCases) { destination in
+          VStack(alignment: .leading, spacing: 16) {
+            Label {
+              Text(destination.title)
+            } icon: {
+              Image(systemName: destination.systemImage)
+            }
+            .font(.headline)
+
+            Text("88%")
+              .font(.title.bold())
+            Text("Progress summary")
+              .font(.subheadline)
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(20)
+          .background(.background, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+          .redacted(reason: .placeholder)
+          .accessibilityHidden(true)
+        }
+      }
+      .frame(maxWidth: 1_040, alignment: .leading)
+      .padding(.horizontal)
+      .padding(.vertical, 20)
+      .frame(maxWidth: .infinity)
+    }
+    .accessibilityLabel(
+      Text(
+        "Loading progress",
+        tableName: "Progress",
+        comment: "Accessibility status while the progress overview loads."))
+  }
+}
+
+struct ProgressUnavailableView: View {
+  let title: Text
+  let description: Text
+  let systemImage: String
+  var retry: (() async -> Void)?
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        title
+      } icon: {
+        Image(systemName: systemImage)
+      }
+    } description: {
+      description
+    } actions: {
+      if let retry {
+        Button {
+          Task {
+            await retry()
+          }
+        } label: {
+          Text(
+            "Try again",
+            tableName: "Progress",
+            comment: "Retries loading a progress screen.")
+        }
+        .buttonStyle(.borderedProminent)
+      }
+    }
+  }
+}
+
+private func overviewPercent(_ value: Double) -> String {
+  (value / 100).formatted(.percent.precision(.fractionLength(0)))
+}
+
+private func overviewLearningTime(_ totalSeconds: Int) -> String {
+  progressLearningTime(totalSeconds)
+}
+
+#Preview("Signed out") {
+  let session = SessionStore.preview()
+  let clients = APIClientFactory.live(baseURL: AppConfiguration.current.apiBaseURL)
+
+  NavigationStack {
+    ProgressOverviewView(onSignIn: {})
+      .navigationTitle(
+        Text(
+          "Progress",
+          tableName: "Navigation",
+          comment: "Navigation title for the learner's progress overview."))
+  }
+  .environment(ProgressStore(api: ProgressAPI(clients: clients), session: session))
+  .environment(session)
 }

--- a/apps/apple/Zoonk/Features/Progress/ProgressPresentation.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressPresentation.swift
@@ -37,6 +37,12 @@ func progressLearningTime(
     .locale(locale))
 }
 
+extension EnergyProgress {
+  var displayedCurrentEnergy: Double {
+    currentEnergy.rounded()
+  }
+}
+
 extension LevelProgress {
   var progressTotal: Double {
     Double(max(bpPerLevel, 1))
@@ -273,6 +279,15 @@ extension ProgressWeekday {
   }
 
   var order: Int {
+    order(in: .autoupdatingCurrent)
+  }
+
+  func order(in calendar: Calendar) -> Int {
+    (foundationWeekdayIndex - (calendar.firstWeekday - 1) + Self.allCases.count)
+      % Self.allCases.count
+  }
+
+  private var foundationWeekdayIndex: Int {
     switch self {
     case .sunday:
       0
@@ -292,6 +307,7 @@ extension ProgressWeekday {
   }
 
   private func weekdayName(from names: [String]) -> String {
-    names.indices.contains(order) ? names[order] : rawValue.capitalized
+    names.indices.contains(foundationWeekdayIndex)
+      ? names[foundationWeekdayIndex] : rawValue.capitalized
   }
 }

--- a/apps/apple/Zoonk/Features/Progress/ProgressPresentation.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressPresentation.swift
@@ -1,0 +1,297 @@
+import Foundation
+import SwiftUI
+
+func progressLearningTime(
+  _ totalSeconds: Int,
+  locale: Locale = .autoupdatingCurrent
+) -> String {
+  let seconds = max(totalSeconds, 0)
+
+  if seconds == 0 {
+    return Duration.seconds(0).formatted(
+      .units(
+        allowed: [.minutes],
+        width: .abbreviated,
+        maximumUnitCount: 1,
+        zeroValueUnits: .show(length: 1)
+      )
+      .locale(locale))
+  }
+
+  if seconds < 60 {
+    return Duration.seconds(seconds).formatted(
+      .units(
+        allowed: [.seconds],
+        width: .abbreviated,
+        maximumUnitCount: 1
+      )
+      .locale(locale))
+  }
+
+  return Duration.seconds(seconds).formatted(
+    .units(
+      allowed: [.hours, .minutes],
+      width: .abbreviated,
+      maximumUnitCount: 2
+    )
+    .locale(locale))
+}
+
+extension LevelProgress {
+  var progressTotal: Double {
+    Double(max(bpPerLevel, 1))
+  }
+
+  var progressValue: Double {
+    if isMaxLevel {
+      return progressTotal
+    }
+
+    return Double(min(max(progressInLevel, 0), max(bpPerLevel, 1)))
+  }
+}
+
+extension ProgressBelt {
+  var localizedTitle: LocalizedStringResource {
+    switch self {
+    case .white:
+      LocalizedStringResource(
+        "White Belt",
+        table: "Progress",
+        comment: "Name of the white learning belt.")
+    case .yellow:
+      LocalizedStringResource(
+        "Yellow Belt",
+        table: "Progress",
+        comment: "Name of the yellow learning belt.")
+    case .orange:
+      LocalizedStringResource(
+        "Orange Belt",
+        table: "Progress",
+        comment: "Name of the orange learning belt.")
+    case .green:
+      LocalizedStringResource(
+        "Green Belt",
+        table: "Progress",
+        comment: "Name of the green learning belt.")
+    case .blue:
+      LocalizedStringResource(
+        "Blue Belt",
+        table: "Progress",
+        comment: "Name of the blue learning belt.")
+    case .purple:
+      LocalizedStringResource(
+        "Purple Belt",
+        table: "Progress",
+        comment: "Name of the purple learning belt.")
+    case .brown:
+      LocalizedStringResource(
+        "Brown Belt",
+        table: "Progress",
+        comment: "Name of the brown learning belt.")
+    case .red:
+      LocalizedStringResource(
+        "Red Belt",
+        table: "Progress",
+        comment: "Name of the red learning belt.")
+    case .gray:
+      LocalizedStringResource(
+        "Gray Belt",
+        table: "Progress",
+        comment: "Name of the gray learning belt.")
+    case .black:
+      LocalizedStringResource(
+        "Black Belt",
+        table: "Progress",
+        comment: "Name of the black learning belt.")
+    }
+  }
+
+  var color: Color {
+    switch self {
+    case .white:
+      .white
+    case .yellow:
+      .yellow
+    case .orange:
+      .orange
+    case .green:
+      .green
+    case .blue:
+      .blue
+    case .purple:
+      .purple
+    case .brown:
+      .brown
+    case .red:
+      .red
+    case .gray:
+      .gray
+    case .black:
+      .black
+    }
+  }
+
+  var accentColor: Color {
+    switch self {
+    case .white, .black:
+      .primary
+    case .yellow, .orange:
+      .brown
+    case .green:
+      .green
+    case .blue:
+      .blue
+    case .purple:
+      .purple
+    case .brown:
+      .brown
+    case .red:
+      .red
+    case .gray:
+      .secondary
+    }
+  }
+
+  var progressColor: Color {
+    switch self {
+    case .white, .gray:
+      .gray
+    case .yellow:
+      .yellow
+    case .orange:
+      .orange
+    case .green:
+      .green
+    case .blue:
+      .blue
+    case .purple:
+      .purple
+    case .brown:
+      .brown
+    case .red:
+      .red
+    case .black:
+      .primary
+    }
+  }
+}
+
+extension ProgressDaypart {
+  var localizedTitle: LocalizedStringResource {
+    switch self {
+    case .night:
+      LocalizedStringResource(
+        "Night",
+        table: "Progress",
+        comment: "Name of the midnight-to-morning score period")
+    case .morning:
+      LocalizedStringResource(
+        "Morning",
+        table: "Progress",
+        comment: "Name of the morning score period")
+    case .afternoon:
+      LocalizedStringResource(
+        "Afternoon",
+        table: "Progress",
+        comment: "Name of the afternoon score period")
+    case .evening:
+      LocalizedStringResource(
+        "Evening",
+        table: "Progress",
+        comment: "Name of the evening score period")
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .night:
+      "moon.stars"
+    case .morning:
+      "sunrise"
+    case .afternoon:
+      "sun.max"
+    case .evening:
+      "moon"
+    }
+  }
+
+  var localizedTimeRange: String {
+    localizedTimeRange(locale: .autoupdatingCurrent)
+  }
+
+  func localizedTimeRange(locale: Locale) -> String {
+    let timeZone = TimeZone(secondsFromGMT: 0)!
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timeZone
+    let startOfDay = Date(timeIntervalSinceReferenceDate: 0)
+    let startDate = calendar.date(byAdding: .hour, value: startHour, to: startOfDay)!
+    let endDate = calendar.date(byAdding: .hour, value: endHour, to: startOfDay)!
+    let formatter = DateFormatter()
+    formatter.calendar = calendar
+    formatter.locale = locale
+    formatter.timeZone = timeZone
+    formatter.dateStyle = .none
+    formatter.timeStyle = .short
+    return "\(formatter.string(from: startDate))–\(formatter.string(from: endDate))"
+  }
+
+  private var startHour: Int {
+    switch self {
+    case .night:
+      0
+    case .morning:
+      6
+    case .afternoon:
+      12
+    case .evening:
+      18
+    }
+  }
+
+  private var endHour: Int {
+    switch self {
+    case .night:
+      6
+    case .morning:
+      12
+    case .afternoon:
+      18
+    case .evening:
+      24
+    }
+  }
+}
+
+extension ProgressWeekday {
+  var localizedTitle: String {
+    weekdayName(from: DateFormatter().weekdaySymbols)
+  }
+
+  var shortLocalizedTitle: String {
+    weekdayName(from: DateFormatter().veryShortWeekdaySymbols)
+  }
+
+  var order: Int {
+    switch self {
+    case .sunday:
+      0
+    case .monday:
+      1
+    case .tuesday:
+      2
+    case .wednesday:
+      3
+    case .thursday:
+      4
+    case .friday:
+      5
+    case .saturday:
+      6
+    }
+  }
+
+  private func weekdayName(from names: [String]) -> String {
+    names.indices.contains(order) ? names[order] : rawValue.capitalized
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressRefreshModifier.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressRefreshModifier.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+private struct ProgressRefreshModifier: ViewModifier {
+  @Environment(\.scenePhase) private var scenePhase
+  @Environment(SessionStore.self) private var session
+
+  let refresh: @MainActor () async -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .task(id: session.authenticatedSession) {
+        guard scenePhase == .active else {
+          return
+        }
+
+        await refresh()
+      }
+      .onChange(of: scenePhase) { _, newScenePhase in
+        guard newScenePhase == .active else {
+          return
+        }
+
+        Task {
+          await refresh()
+        }
+      }
+      .refreshable {
+        await refresh()
+      }
+  }
+}
+
+extension View {
+  func refreshesProgress(
+    _ refresh: @escaping @MainActor () async -> Void
+  ) -> some View {
+    modifier(ProgressRefreshModifier(refresh: refresh))
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ProgressStore.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressStore.swift
@@ -62,7 +62,8 @@ final class ProgressStore {
     }
 
     let requestIdentity = beginRequest(for: .overview)
-    overviewState = loadingState(from: overviewState)
+    let previousState = overviewState
+    overviewState = loadingState(from: previousState)
     let state = await load(
       ProgressRequest(
         isEmpty: { $0.isEmpty },
@@ -72,7 +73,7 @@ final class ProgressStore {
       return
     }
 
-    overviewState = state
+    overviewState = state ?? stateAfterCancellation(from: previousState)
   }
 
   func loadActivity(force: Bool = false) async {
@@ -83,7 +84,8 @@ final class ProgressStore {
     }
 
     let requestIdentity = beginRequest(for: .activity)
-    activityState = loadingState(from: activityState)
+    let previousState = activityState
+    activityState = loadingState(from: previousState)
     let state = await load(
       ProgressRequest(
         isEmpty: { $0.isEmpty },
@@ -93,7 +95,7 @@ final class ProgressStore {
       return
     }
 
-    activityState = state
+    activityState = state ?? stateAfterCancellation(from: previousState)
   }
 
   func loadEnergy(force: Bool = false) async {
@@ -104,7 +106,8 @@ final class ProgressStore {
     }
 
     let requestIdentity = beginRequest(for: .energy)
-    energyState = loadingState(from: energyState)
+    let previousState = energyState
+    energyState = loadingState(from: previousState)
     let state = await load(
       ProgressRequest(
         isEmpty: { _ in false },
@@ -114,7 +117,7 @@ final class ProgressStore {
       return
     }
 
-    energyState = state
+    energyState = state ?? stateAfterCancellation(from: previousState)
   }
 
   func loadLevel(force: Bool = false) async {
@@ -125,7 +128,8 @@ final class ProgressStore {
     }
 
     let requestIdentity = beginRequest(for: .level)
-    levelState = loadingState(from: levelState)
+    let previousState = levelState
+    levelState = loadingState(from: previousState)
     let state = await load(
       ProgressRequest(
         isEmpty: { _ in false },
@@ -135,7 +139,7 @@ final class ProgressStore {
       return
     }
 
-    levelState = state
+    levelState = state ?? stateAfterCancellation(from: previousState)
   }
 
   func loadScore(force: Bool = false) async {
@@ -146,7 +150,8 @@ final class ProgressStore {
     }
 
     let requestIdentity = beginRequest(for: .score)
-    scoreState = loadingState(from: scoreState)
+    let previousState = scoreState
+    scoreState = loadingState(from: previousState)
     let state = await load(
       ProgressRequest(
         isEmpty: { _ in false },
@@ -156,7 +161,7 @@ final class ProgressStore {
       return
     }
 
-    scoreState = state
+    scoreState = state ?? stateAfterCancellation(from: previousState)
   }
 
   func loadPatterns(force: Bool = false) async {
@@ -167,7 +172,8 @@ final class ProgressStore {
     }
 
     let requestIdentity = beginRequest(for: .patterns)
-    patternsState = loadingState(from: patternsState)
+    let previousState = patternsState
+    patternsState = loadingState(from: previousState)
     let state = await load(
       ProgressRequest(
         isEmpty: { _ in false },
@@ -177,7 +183,7 @@ final class ProgressStore {
       return
     }
 
-    patternsState = state
+    patternsState = state ?? stateAfterCancellation(from: previousState)
   }
 
   private func beginRequest(for resource: ProgressResource) -> ProgressRequestIdentity {
@@ -190,7 +196,7 @@ final class ProgressStore {
     requestRevisions[requestIdentity.resource] == requestIdentity.revision
   }
 
-  private func load<Value>(_ request: ProgressRequest<Value>) async -> ProgressLoadState<Value> {
+  private func load<Value>(_ request: ProgressRequest<Value>) async -> ProgressLoadState<Value>? {
     guard let authenticatedSession = session.authenticatedSession else {
       return .idle
     }
@@ -209,7 +215,7 @@ final class ProgressStore {
 
       return .loaded(value)
     } catch is CancellationError {
-      return .idle
+      return session.authenticatedSession == authenticatedSession ? nil : .idle
     } catch ProgressAPIError.unauthorized {
       await session.expire(authenticatedSession)
       synchronizeSession()
@@ -253,6 +259,17 @@ final class ProgressStore {
       state
     case .idle, .loading, .failed:
       .loading
+    }
+  }
+
+  private func stateAfterCancellation<Value>(
+    from state: ProgressLoadState<Value>
+  ) -> ProgressLoadState<Value> {
+    switch state {
+    case .empty, .failed, .loaded:
+      state
+    case .idle, .loading:
+      .idle
     }
   }
 }

--- a/apps/apple/Zoonk/Features/Progress/ProgressStore.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressStore.swift
@@ -1,0 +1,258 @@
+import Foundation
+import Observation
+
+enum ProgressFailure: Equatable, Sendable {
+  case network
+  case unavailable
+}
+
+enum ProgressLoadState<Value: Equatable & Sendable>: Equatable, Sendable {
+  case idle
+  case loading
+  case loaded(Value)
+  case empty
+  case failed(ProgressFailure)
+}
+
+private struct ProgressRequest<Value: Equatable & Sendable>: Sendable {
+  let isEmpty: @Sendable (Value) -> Bool
+  let load: @Sendable (any ProgressAPIClient, String) async throws -> Value?
+}
+
+private enum ProgressResource: Hashable, Sendable {
+  case activity
+  case energy
+  case level
+  case overview
+  case patterns
+  case score
+}
+
+private struct ProgressRequestIdentity: Sendable {
+  let resource: ProgressResource
+  let revision: UUID
+}
+
+@MainActor
+@Observable
+final class ProgressStore {
+  private(set) var activityState: ProgressLoadState<ActivityProgress> = .idle
+  private(set) var energyState: ProgressLoadState<EnergyProgress> = .idle
+  private(set) var levelState: ProgressLoadState<LevelProgress> = .idle
+  private(set) var overviewState: ProgressLoadState<ProgressOverview> = .idle
+  private(set) var patternsState: ProgressLoadState<ScorePatterns> = .idle
+  private(set) var scoreState: ProgressLoadState<ScoreProgress> = .idle
+
+  private let api: any ProgressAPIClient
+  private let session: SessionStore
+  private var sessionIdentity: AuthenticatedSession?
+  private var requestRevisions: [ProgressResource: UUID] = [:]
+
+  init(api: any ProgressAPIClient, session: SessionStore) {
+    self.api = api
+    self.session = session
+    sessionIdentity = session.authenticatedSession
+  }
+
+  func loadOverview(force: Bool = false) async {
+    synchronizeSession()
+
+    guard canBeginRequest(state: overviewState, force: force) else {
+      return
+    }
+
+    let requestIdentity = beginRequest(for: .overview)
+    overviewState = loadingState(from: overviewState)
+    let state = await load(
+      ProgressRequest(
+        isEmpty: { $0.isEmpty },
+        load: { api, token in try await api.getOverview(token: token) }))
+
+    guard isCurrent(requestIdentity) else {
+      return
+    }
+
+    overviewState = state
+  }
+
+  func loadActivity(force: Bool = false) async {
+    synchronizeSession()
+
+    guard canBeginRequest(state: activityState, force: force) else {
+      return
+    }
+
+    let requestIdentity = beginRequest(for: .activity)
+    activityState = loadingState(from: activityState)
+    let state = await load(
+      ProgressRequest(
+        isEmpty: { $0.isEmpty },
+        load: { api, token in try await api.getActivity(token: token) }))
+
+    guard isCurrent(requestIdentity) else {
+      return
+    }
+
+    activityState = state
+  }
+
+  func loadEnergy(force: Bool = false) async {
+    synchronizeSession()
+
+    guard canBeginRequest(state: energyState, force: force) else {
+      return
+    }
+
+    let requestIdentity = beginRequest(for: .energy)
+    energyState = loadingState(from: energyState)
+    let state = await load(
+      ProgressRequest(
+        isEmpty: { _ in false },
+        load: { api, token in try await api.getEnergy(token: token) }))
+
+    guard isCurrent(requestIdentity) else {
+      return
+    }
+
+    energyState = state
+  }
+
+  func loadLevel(force: Bool = false) async {
+    synchronizeSession()
+
+    guard canBeginRequest(state: levelState, force: force) else {
+      return
+    }
+
+    let requestIdentity = beginRequest(for: .level)
+    levelState = loadingState(from: levelState)
+    let state = await load(
+      ProgressRequest(
+        isEmpty: { _ in false },
+        load: { api, token in try await api.getLevel(token: token) }))
+
+    guard isCurrent(requestIdentity) else {
+      return
+    }
+
+    levelState = state
+  }
+
+  func loadScore(force: Bool = false) async {
+    synchronizeSession()
+
+    guard canBeginRequest(state: scoreState, force: force) else {
+      return
+    }
+
+    let requestIdentity = beginRequest(for: .score)
+    scoreState = loadingState(from: scoreState)
+    let state = await load(
+      ProgressRequest(
+        isEmpty: { _ in false },
+        load: { api, token in try await api.getScore(token: token) }))
+
+    guard isCurrent(requestIdentity) else {
+      return
+    }
+
+    scoreState = state
+  }
+
+  func loadPatterns(force: Bool = false) async {
+    synchronizeSession()
+
+    guard canBeginRequest(state: patternsState, force: force) else {
+      return
+    }
+
+    let requestIdentity = beginRequest(for: .patterns)
+    patternsState = loadingState(from: patternsState)
+    let state = await load(
+      ProgressRequest(
+        isEmpty: { _ in false },
+        load: { api, token in try await api.getScorePatterns(token: token) }))
+
+    guard isCurrent(requestIdentity) else {
+      return
+    }
+
+    patternsState = state
+  }
+
+  private func beginRequest(for resource: ProgressResource) -> ProgressRequestIdentity {
+    let requestIdentity = ProgressRequestIdentity(resource: resource, revision: UUID())
+    requestRevisions[resource] = requestIdentity.revision
+    return requestIdentity
+  }
+
+  private func isCurrent(_ requestIdentity: ProgressRequestIdentity) -> Bool {
+    requestRevisions[requestIdentity.resource] == requestIdentity.revision
+  }
+
+  private func load<Value>(_ request: ProgressRequest<Value>) async -> ProgressLoadState<Value> {
+    guard let authenticatedSession = session.authenticatedSession else {
+      return .idle
+    }
+
+    do {
+      let value = try await request.load(api, authenticatedSession.bearerToken)
+
+      guard session.authenticatedSession == authenticatedSession else {
+        synchronizeSession()
+        return .idle
+      }
+
+      guard let value, !request.isEmpty(value) else {
+        return .empty
+      }
+
+      return .loaded(value)
+    } catch is CancellationError {
+      return .idle
+    } catch ProgressAPIError.unauthorized {
+      await session.expire(authenticatedSession)
+      synchronizeSession()
+      return .idle
+    } catch ProgressAPIError.network {
+      return session.authenticatedSession == authenticatedSession ? .failed(.network) : .idle
+    } catch {
+      return session.authenticatedSession == authenticatedSession ? .failed(.unavailable) : .idle
+    }
+  }
+
+  private func synchronizeSession() {
+    let currentSessionIdentity = session.authenticatedSession
+
+    guard currentSessionIdentity != sessionIdentity else {
+      return
+    }
+
+    sessionIdentity = currentSessionIdentity
+    requestRevisions.removeAll()
+    activityState = .idle
+    energyState = .idle
+    levelState = .idle
+    overviewState = .idle
+    patternsState = .idle
+    scoreState = .idle
+  }
+
+  private func canBeginRequest<Value>(
+    state: ProgressLoadState<Value>,
+    force: Bool
+  ) -> Bool {
+    force || state != .loading
+  }
+
+  private func loadingState<Value>(
+    from state: ProgressLoadState<Value>
+  ) -> ProgressLoadState<Value> {
+    switch state {
+    case .loaded, .empty:
+      state
+    case .idle, .loading, .failed:
+      .loading
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ScorePatternsView.swift
+++ b/apps/apple/Zoonk/Features/Progress/ScorePatternsView.swift
@@ -241,7 +241,7 @@ private struct WeekdayPatternChart: View {
       }
     }
     .chartXAxis {
-      AxisMarks(values: ProgressWeekday.allCases.map(\.rawValue)) { value in
+      AxisMarks(values: patterns.map(\.weekday.rawValue)) { value in
         AxisValueLabel {
           if let rawValue = value.as(String.self),
             let weekday = ProgressWeekday(rawValue: rawValue)

--- a/apps/apple/Zoonk/Features/Progress/ScorePatternsView.swift
+++ b/apps/apple/Zoonk/Features/Progress/ScorePatternsView.swift
@@ -1,0 +1,359 @@
+import Charts
+import SwiftUI
+
+struct ScorePatternsView: View {
+  @Environment(ProgressStore.self) private var progress
+
+  var body: some View {
+    ProgressDetailLoadStateView(
+      state: progress.patternsState,
+      emptyTitle: LocalizedStringResource(
+        "No patterns yet",
+        table: "Progress",
+        comment: "Title shown before the learner has enough answers for score patterns"),
+      emptyDescription: LocalizedStringResource(
+        "Answer questions to discover when you perform best.",
+        table: "Progress",
+        comment: "Guidance shown before the learner has score patterns"),
+      systemImage: "chart.xyaxis.line",
+      retry: { await progress.loadPatterns(force: true) }
+    ) { patterns in
+      ScorePatternsContent(patterns: patterns)
+    }
+    .refreshesProgress {
+      await progress.loadPatterns()
+    }
+  }
+}
+
+private struct ScorePatternsContent: View {
+  let patterns: ScorePatterns
+
+  private var weekdays: [WeekdayScorePattern] {
+    patterns.weekdays.sorted { $0.weekday.order < $1.weekday.order }
+  }
+
+  var body: some View {
+    ProgressDetailPage {
+      PatternHero(patterns: patterns)
+
+      if patterns.strongestWeekday != nil || patterns.strongestDaypart != nil {
+        ProgressDetailMetricGrid {
+          if let strongestWeekday = patterns.strongestWeekday {
+            ProgressDetailMetric(
+              label: Text(
+                "Strongest weekday",
+                tableName: "Progress",
+                comment: "Label for the weekday with the learner's strongest accuracy"),
+              value: Text(verbatim: strongestWeekday.weekday.localizedTitle),
+              systemImage: "calendar",
+              tint: ProgressDestination.patterns.tint)
+          }
+
+          if let strongestDaypart = patterns.strongestDaypart {
+            ProgressDetailMetric(
+              label: Text(
+                "Strongest time",
+                tableName: "Progress",
+                comment: "Label for the time of day with the learner's strongest accuracy"),
+              value: Text(strongestDaypart.daypart.localizedTitle),
+              systemImage: strongestDaypart.daypart.systemImage,
+              tint: ProgressDestination.patterns.tint)
+          }
+        }
+      }
+
+      ProgressDetailSection(
+        title: Text(
+          "Weekly rhythm",
+          tableName: "Progress",
+          comment: "Title above accuracy grouped by weekday"),
+        subtitle: Text(
+          "Accuracy by weekday over the past 90 days.",
+          tableName: "Progress",
+          comment: "Description of the weekday accuracy chart")
+      ) {
+        WeekdayPatternChart(
+          patterns: weekdays,
+          strongestWeekday: patterns.strongestWeekday?.weekday)
+      }
+
+      ProgressDetailSection(
+        title: Text(
+          "Throughout the day",
+          tableName: "Progress",
+          comment: "Title above accuracy grouped by time of day"),
+        subtitle: Text(
+          "Accuracy by time of day over the past 90 days.",
+          tableName: "Progress",
+          comment: "Description of the time-of-day accuracy patterns")
+      ) {
+        VStack(spacing: 0) {
+          ForEach(patterns.dayparts) { pattern in
+            DaypartPatternRow(
+              pattern: pattern,
+              isStrongest: pattern.daypart == patterns.strongestDaypart?.daypart)
+
+            if pattern.id != patterns.dayparts.last?.id {
+              Divider()
+                .padding(.leading, 46)
+            }
+          }
+        }
+      }
+
+      ProgressDetailExplanation(
+        title: Text(
+          "Your learning rhythm",
+          tableName: "Progress",
+          comment: "Title explaining how score patterns can be used"),
+        description: Text(
+          "Patterns use your answers from the past 90 days. Use them as a guide, not a rule—learning at any time still moves you forward.",
+          tableName: "Progress",
+          comment: "Explains the rolling window and purpose of score patterns"),
+        systemImage: "sparkles",
+        tint: ProgressDestination.patterns.tint)
+    }
+  }
+}
+
+private struct PatternHero: View {
+  let patterns: ScorePatterns
+
+  var body: some View {
+    if let strongestDaypart = patterns.strongestDaypart {
+      ProgressDetailHero(
+        title: Text(
+          "Your strongest time",
+          tableName: "Progress",
+          comment: "Label above the learner's strongest time of day"),
+        value: Text(strongestDaypart.daypart.localizedTitle),
+        description: Text(
+          "Accuracy: \(strongestDaypart.performance.score / 100, format: .percent.precision(.fractionLength(0))) · Answers: \(strongestDaypart.performance.totalAnswers)",
+          tableName: "Progress",
+          comment: "Accuracy and answer count for the learner's strongest time of day"),
+        systemImage: strongestDaypart.daypart.systemImage,
+        tint: ProgressDestination.patterns.tint)
+    } else if let strongestWeekday = patterns.strongestWeekday {
+      ProgressDetailHero(
+        title: Text(
+          "Your strongest weekday",
+          tableName: "Progress",
+          comment: "Label above the learner's strongest weekday"),
+        value: Text(verbatim: strongestWeekday.weekday.localizedTitle),
+        description: Text(
+          "Accuracy: \(strongestWeekday.performance.score / 100, format: .percent.precision(.fractionLength(0))) · Answers: \(strongestWeekday.performance.totalAnswers)",
+          tableName: "Progress",
+          comment: "Accuracy and answer count for the learner's strongest weekday"),
+        systemImage: "calendar",
+        tint: ProgressDestination.patterns.tint)
+    } else {
+      ProgressDetailHero(
+        title: Text(
+          "Past 90 days",
+          tableName: "Progress",
+          comment: "Fixed period label above the empty score patterns summary"),
+        value: Text(
+          "No patterns yet",
+          tableName: "Progress",
+          comment: "Headline shown when no weekday or daypart has answers"),
+        description: Text(
+          "Answer questions to discover when you perform best.",
+          tableName: "Progress",
+          comment: "Guidance shown when no weekday or daypart has answers"),
+        systemImage: "chart.xyaxis.line",
+        tint: ProgressDestination.patterns.tint)
+    }
+  }
+}
+
+private struct WeekdayPatternChart: View {
+  let patterns: [WeekdayScorePattern]
+  let strongestWeekday: ProgressWeekday?
+
+  var body: some View {
+    Chart(patterns) { pattern in
+      if pattern.performance.hasAnswers {
+        BarMark(
+          x: .value(
+            String(
+              localized: "Weekday",
+              table: "Progress",
+              comment: "Chart axis value describing a weekday"),
+            pattern.weekday.rawValue),
+          y: .value(
+            String(
+              localized: "Accuracy",
+              table: "Progress",
+              comment: "Chart axis value describing answer accuracy"),
+            pattern.performance.score)
+        )
+        .foregroundStyle(
+          pattern.weekday == strongestWeekday
+            ? ProgressDestination.patterns.tint
+            : ProgressDestination.patterns.tint.opacity(0.42)
+        )
+        .cornerRadius(4)
+        .accessibilityLabel(Text(verbatim: pattern.weekday.localizedTitle))
+        .accessibilityValue(
+          Text(
+            "Accuracy: \(pattern.performance.score / 100, format: .percent.precision(.fractionLength(0))) · Answers: \(pattern.performance.totalAnswers)",
+            tableName: "Progress",
+            comment: "Accessible weekday accuracy and answer count in the patterns chart"))
+      } else {
+        PointMark(
+          x: .value(
+            String(
+              localized: "Weekday",
+              table: "Progress",
+              comment: "Chart axis value describing a weekday"),
+            pattern.weekday.rawValue),
+          y: .value(
+            String(
+              localized: "No answers",
+              table: "Progress",
+              comment: "Chart value indicating a weekday has no answers"),
+            5)
+        )
+        .foregroundStyle(.clear)
+        .annotation(position: .overlay) {
+          Text(verbatim: "—")
+            .font(.headline)
+            .foregroundStyle(.secondary)
+        }
+        .accessibilityLabel(Text(verbatim: pattern.weekday.localizedTitle))
+        .accessibilityValue(
+          Text(
+            "No answers",
+            tableName: "Progress",
+            comment: "Accessible value for a weekday with no answers"))
+      }
+    }
+    .chartYScale(domain: 0...100)
+    .chartYAxis {
+      AxisMarks(position: .leading, values: [0.0, 25.0, 50.0, 75.0, 100.0]) { value in
+        AxisGridLine()
+        AxisValueLabel {
+          if let score = value.as(Double.self) {
+            Text(score / 100, format: .percent.precision(.fractionLength(0)))
+          }
+        }
+      }
+    }
+    .chartXAxis {
+      AxisMarks(values: ProgressWeekday.allCases.map(\.rawValue)) { value in
+        AxisValueLabel {
+          if let rawValue = value.as(String.self),
+            let weekday = ProgressWeekday(rawValue: rawValue)
+          {
+            Text(verbatim: weekday.shortLocalizedTitle)
+          }
+        }
+      }
+    }
+    .chartPlotStyle { plotArea in
+      plotArea.clipped()
+    }
+    .frame(height: 240)
+    .accessibilityLabel(
+      Text(
+        "Accuracy by weekday",
+        tableName: "Progress",
+        comment: "Accessibility label for the weekday accuracy chart"))
+  }
+}
+
+private struct DaypartPatternRow: View {
+  let pattern: DaypartScorePattern
+  let isStrongest: Bool
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(alignment: .top, spacing: 12) {
+        icon
+        identity
+        Spacer(minLength: 12)
+        performance(alignment: .trailing)
+      }
+
+      HStack(alignment: .top, spacing: 12) {
+        icon
+
+        VStack(alignment: .leading, spacing: 8) {
+          identity
+          performance(alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    }
+    .padding(.vertical, 10)
+    .accessibilityElement(children: .combine)
+  }
+
+  private var icon: some View {
+    Image(systemName: pattern.daypart.systemImage)
+      .frame(width: 34, height: 34)
+      .foregroundStyle(isStrongest ? .white : ProgressDestination.patterns.tint)
+      .background(
+        isStrongest
+          ? ProgressDestination.patterns.tint
+          : ProgressDestination.patterns.tint.opacity(0.12),
+        in: Circle()
+      )
+      .accessibilityHidden(true)
+  }
+
+  private var identity: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(pattern.daypart.localizedTitle)
+        .font(.headline)
+
+      Text(verbatim: pattern.daypart.localizedTimeRange)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+
+      if isStrongest {
+        Label {
+          Text(
+            "Strongest",
+            tableName: "Progress",
+            comment: "Badge identifying the learner's strongest score pattern")
+        } icon: {
+          Image(systemName: "star.fill")
+        }
+        .font(.caption2.bold())
+        .foregroundStyle(ProgressDestination.patterns.tint)
+      }
+    }
+  }
+
+  private func performance(alignment: HorizontalAlignment) -> some View {
+    VStack(alignment: alignment, spacing: 2) {
+      if pattern.performance.hasAnswers {
+        Text(
+          pattern.performance.score / 100,
+          format: .percent.precision(.fractionLength(0))
+        )
+        .font(.headline)
+        .foregroundStyle(ProgressDestination.patterns.tint)
+
+        Text(
+          "Answers: \(pattern.performance.totalAnswers)",
+          tableName: "Progress",
+          comment: "Answer count for a time-of-day score pattern"
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      } else {
+        Text(
+          "No answers",
+          tableName: "Progress",
+          comment: "Value shown when a time-of-day pattern has no answers"
+        )
+        .font(.subheadline.weight(.semibold))
+        .foregroundStyle(.secondary)
+      }
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Progress/ScoreProgressView.swift
+++ b/apps/apple/Zoonk/Features/Progress/ScoreProgressView.swift
@@ -1,0 +1,190 @@
+import Charts
+import SwiftUI
+
+struct ScoreProgressView: View {
+  @Environment(ProgressStore.self) private var progress
+
+  var body: some View {
+    ProgressDetailLoadStateView(
+      state: progress.scoreState,
+      emptyTitle: LocalizedStringResource(
+        "No Score yet",
+        table: "Progress",
+        comment: "Title shown before the learner answers a question"),
+      emptyDescription: LocalizedStringResource(
+        "Answer questions in your lessons to see your Score.",
+        table: "Progress",
+        comment: "Guidance shown before the learner has a Score"),
+      systemImage: "target",
+      retry: { await progress.loadScore(force: true) }
+    ) { score in
+      ScoreProgressContent(score: score)
+    }
+    .refreshesProgress {
+      await progress.loadScore()
+    }
+  }
+}
+
+private struct ScoreProgressContent: View {
+  let score: ScoreProgress
+
+  private var recordedPoints: [ScoreProgressPoint] {
+    score.dataPoints.filter(\.performance.hasAnswers)
+  }
+
+  var body: some View {
+    if score.performance.hasAnswers {
+      ProgressDetailPage {
+        ProgressDetailHero(
+          title: Text(
+            "Past 90 days",
+            tableName: "Progress",
+            comment: "Fixed period label above the learner's Score"),
+          value: Text(
+            score.performance.score / 100,
+            format: .percent.precision(.fractionLength(0))),
+          description: Text(
+            "Correct answers: \(score.performance.correctAnswers) of \(score.performance.totalAnswers)",
+            tableName: "Progress",
+            comment: "Summary of correct and total answers in the Score period"),
+          systemImage: "target",
+          tint: ProgressDestination.score.tint)
+
+        ProgressDetailSection(
+          title: Text(
+            "Weekly trend",
+            tableName: "Progress",
+            comment: "Title above the weekly Score chart"),
+          subtitle: Text(
+            "Answer accuracy over the past 90 days.",
+            tableName: "Progress",
+            comment: "Description of the weekly Score chart")
+        ) {
+          if recordedPoints.isEmpty {
+            ProgressDetailNoChartData()
+          } else {
+            ScoreTrendChart(points: recordedPoints)
+          }
+        }
+
+        ProgressDetailMetricGrid {
+          ProgressDetailMetric(
+            label: Text(
+              "Correct answers",
+              tableName: "Progress",
+              comment: "Label for correct answers in the Score period"),
+            value: Text(score.performance.correctAnswers, format: .number),
+            systemImage: "checkmark.circle",
+            tint: ProgressDestination.score.tint)
+
+          ProgressDetailMetric(
+            label: Text(
+              "Incorrect answers",
+              tableName: "Progress",
+              comment: "Label for incorrect answers in the Score period"),
+            value: Text(score.performance.incorrectAnswers, format: .number),
+            systemImage: "xmark.circle",
+            tint: .orange)
+
+          ProgressDetailMetric(
+            label: Text(
+              "Total answers",
+              tableName: "Progress",
+              comment: "Label for all answers in the Score period"),
+            value: Text(score.performance.totalAnswers, format: .number),
+            systemImage: "text.bubble",
+            tint: ProgressDestination.score.tint)
+        }
+
+        ProgressDetailExplanation(
+          title: Text(
+            "What is Score?",
+            tableName: "Progress",
+            comment: "Title explaining the Score metric"),
+          description: Text(
+            "Score is the percentage of questions you answered correctly over the past 90 days. Every answer counts equally, so harder lessons can lower it for a while. That's part of learning.",
+            tableName: "Progress",
+            comment: "Explanation of how the rolling Score is calculated"),
+          systemImage: "target",
+          tint: ProgressDestination.score.tint)
+      }
+    } else {
+      ContentUnavailableView {
+        Label {
+          Text(
+            "No Score yet",
+            tableName: "Progress",
+            comment: "Title shown when a Score response has no answered questions")
+        } icon: {
+          Image(systemName: "target")
+        }
+      } description: {
+        Text(
+          "Answer questions in your lessons to see your Score.",
+          tableName: "Progress",
+          comment: "Guidance shown when a Score response has no answered questions")
+      }
+    }
+  }
+}
+
+private struct ScoreTrendChart: View {
+  let points: [ScoreProgressPoint]
+
+  var body: some View {
+    Chart(points) { point in
+      if let date = point.date.date() {
+        LineMark(
+          x: .value(
+            String(
+              localized: "Week",
+              table: "Progress",
+              comment: "Chart axis value describing a Score week"),
+            date),
+          y: .value(
+            String(
+              localized: "Score",
+              table: "Progress",
+              comment: "Chart axis value describing answer accuracy"),
+            point.performance.score)
+        )
+        .foregroundStyle(ProgressDestination.score.tint)
+        .lineStyle(StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
+        .symbol(.circle)
+        .accessibilityLabel(
+          Text(date, format: .dateTime.month(.wide).day().year())
+        )
+        .accessibilityValue(
+          Text(
+            "Accuracy: \(point.performance.score / 100, format: .percent.precision(.fractionLength(0)))",
+            tableName: "Progress",
+            comment: "Accessible weekly accuracy value in the Score chart"))
+      }
+    }
+    .chartYScale(domain: 0...100)
+    .chartYAxis {
+      AxisMarks(position: .leading, values: [0.0, 25.0, 50.0, 75.0, 100.0]) { value in
+        AxisGridLine()
+        AxisValueLabel {
+          if let score = value.as(Double.self) {
+            Text(score / 100, format: .percent.precision(.fractionLength(0)))
+          }
+        }
+      }
+    }
+    .chartXAxis {
+      AxisMarks(values: .stride(by: .month)) {
+        AxisGridLine()
+        AxisTick()
+        AxisValueLabel(format: .dateTime.month(.abbreviated), centered: true)
+      }
+    }
+    .frame(height: 240)
+    .accessibilityLabel(
+      Text(
+        "Weekly Score trend",
+        tableName: "Progress",
+        comment: "Accessibility label for the weekly answer accuracy chart"))
+  }
+}

--- a/apps/apple/Zoonk/Navigation/AppSection+Tab.swift
+++ b/apps/apple/Zoonk/Navigation/AppSection+Tab.swift
@@ -5,8 +5,9 @@ extension AppSection {
     self == .search ? .search : nil
   }
 
+  @MainActor
   @ViewBuilder
-  var tabContent: some View {
+  func tabContent(onPresentAccount: @escaping () -> Void) -> some View {
     switch self {
     case .home:
       HomeView()
@@ -15,7 +16,7 @@ extension AppSection {
     case .courses:
       CoursesView()
     case .progress:
-      ProgressOverviewView()
+      ProgressOverviewView(onSignIn: onPresentAccount)
     case .search:
       SearchView()
     }

--- a/apps/apple/Zoonk/Resources/Localization/Progress.xcstrings
+++ b/apps/apple/Zoonk/Resources/Localization/Progress.xcstrings
@@ -1,0 +1,3910 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "%lld BP" : {
+      "comment" : "Brain Power required to advance one level\nLearner's lifetime Brain Power value",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld BP"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld PM"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld PM"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld PM"
+          }
+        }
+      }
+    },
+    "%lld BP left" : {
+      "comment" : "Short Brain Power amount remaining before the next level",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld BP übrig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quedan %lld PM"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encore %lld PM"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faltam %lld PM"
+          }
+        }
+      }
+    },
+    "%lld BP to the next level" : {
+      "comment" : "Brain Power remaining before the learner reaches the next level",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld BP bis zum nächsten Level"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld PM para el siguiente nivel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld PM avant le niveau suivant"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld PM para o próximo nível"
+          }
+        }
+      }
+    },
+    "%lld of %lld BP" : {
+      "comment" : "Accessibility value describing Brain Power earned toward the next level.\nBrain Power earned within the current level",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld von %2$lld BP"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld of %2$lld BP"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld PM"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld sur %2$lld PM"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld de %2$lld PM"
+          }
+        }
+      }
+    },
+    "A lasting record" : {
+      "comment" : "Title explaining how completed lessons are counted",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dauerhaft festgehalten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un registro permanente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un historique durable"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Um registro permanente"
+          }
+        }
+      }
+    },
+    "Account unavailable" : {
+      "comment" : "Title shown when the saved account could not be restored.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konto nicht verfügbar"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuenta no disponible"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compte indisponible"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conta indisponível"
+          }
+        }
+      }
+    },
+    "Accuracy" : {
+      "comment" : "Chart axis value describing answer accuracy",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genauigkeit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precisión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taux de réussite"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de acertos"
+          }
+        }
+      }
+    },
+    "Accuracy by time of day over the past 90 days." : {
+      "comment" : "Description of the time-of-day accuracy patterns",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genauigkeit nach Tageszeit in den letzten 90 Tagen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precisión según la hora del día en los últimos 90 días."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taux de réussite selon le moment de la journée au cours des 90 derniers jours."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de acertos por período do dia nos últimos 90 dias."
+          }
+        }
+      }
+    },
+    "Accuracy by weekday" : {
+      "comment" : "Accessibility label for the weekday accuracy chart",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genauigkeit nach Wochentag"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precisión por día de la semana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taux de réussite selon le jour de la semaine"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de acertos por dia da semana"
+          }
+        }
+      }
+    },
+    "Accuracy by weekday over the past 90 days." : {
+      "comment" : "Description of the weekday accuracy chart",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genauigkeit nach Wochentag in den letzten 90 Tagen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precisión por día de la semana en los últimos 90 días."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taux de réussite selon le jour de la semaine au cours des 90 derniers jours."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de acertos por dia da semana nos últimos 90 dias."
+          }
+        }
+      }
+    },
+    "Accuracy: %@" : {
+      "comment" : "Accessible weekly accuracy value in the Score chart",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genauigkeit: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precisión: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taux de réussite : %@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de acertos: %@"
+          }
+        }
+      }
+    },
+    "Accuracy: %@ · Answers: %lld" : {
+      "comment" : "Accessible weekday accuracy and answer count in the patterns chart\nAccuracy and answer count for the learner's strongest time of day\nAccuracy and answer count for the learner's strongest weekday",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genauigkeit: %1$@ · Antworten: %2$lld"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Accuracy: %1$@ · Answers: %2$lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precisión: %1$@ · Respuestas: %2$lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taux de réussite : %1$@ · Réponses : %2$lld"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de acertos: %1$@ · Respostas: %2$lld"
+          }
+        }
+      }
+    },
+    "Activity" : {
+      "comment" : "Title for the learner's completed lessons and learning time progress.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivität"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activité"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atividade"
+          }
+        }
+      }
+    },
+    "Afternoon" : {
+      "comment" : "Name of the afternoon score period",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nachmittag"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarde"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Après-midi"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarde"
+          }
+        }
+      }
+    },
+    "Answer accuracy" : {
+      "comment" : "Label for the learner's Score accuracy over the last 90 days.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antwortgenauigkeit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precisión de las respuestas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taux de bonnes réponses"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de acertos"
+          }
+        }
+      }
+    },
+    "Answer accuracy over the past 90 days." : {
+      "comment" : "Description of the weekly Score chart",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antwortgenauigkeit in den letzten 90 Tagen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precisión de las respuestas en los últimos 90 días."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taux de bonnes réponses au cours des 90 derniers jours."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taxa de acertos nos últimos 90 dias."
+          }
+        }
+      }
+    },
+    "Answer questions in your lessons to see your Score." : {
+      "comment" : "Guidance shown before the learner has a Score\nGuidance shown when a Score response has no answered questions",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beantworte Fragen in deinen Lektionen, um deinen Score zu sehen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responde preguntas en tus lecciones para ver tu puntuación."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponds aux questions de tes leçons pour voir ton score."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responda às perguntas nas suas aulas para ver sua Pontuação."
+          }
+        }
+      }
+    },
+    "Answer questions to discover when you perform best." : {
+      "comment" : "Guidance shown before the learner has score patterns\nGuidance shown when no weekday or daypart has answers",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beantworte Fragen, um herauszufinden, wann du am besten abschneidest."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responde preguntas para descubrir cuándo rindes mejor."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponds aux questions pour découvrir quand tu réussis le mieux."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responda às perguntas para descobrir quando você se sai melhor."
+          }
+        }
+      }
+    },
+    "Answer questions to see your Score." : {
+      "comment" : "Guidance when the learner does not have a Score yet.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beantworte Fragen, um deinen Score zu sehen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responde preguntas para ver tu puntuación."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponds aux questions pour voir ton score."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Responda às perguntas para ver sua Pontuação."
+          }
+        }
+      }
+    },
+    "Answers in the last 90 days" : {
+      "comment" : "Label for the answer count used to calculate Score.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antworten in den letzten 90 Tagen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuestas en los últimos 90 días"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponses au cours des 90 derniers jours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respostas nos últimos 90 dias"
+          }
+        }
+      }
+    },
+    "Answers on that day" : {
+      "comment" : "Label for the sample size behind the learner's strongest weekday.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antworten an diesem Wochentag"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuestas de ese día"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponses ce jour-là"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respostas nesse dia"
+          }
+        }
+      }
+    },
+    "Answers: %lld" : {
+      "comment" : "Answer count for a time-of-day score pattern",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antworten: %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuestas: %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponses : %lld"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respostas: %lld"
+          }
+        }
+      }
+    },
+    "At a glance" : {
+      "comment" : "Heading above the learner's progress summary cards.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auf einen Blick"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De un vistazo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En un coup d’œil"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visão geral"
+          }
+        }
+      }
+    },
+    "Average Energy" : {
+      "comment" : "Label for the learner's average recorded Energy",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durchschnittliche Energie"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Promedio de Energía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Énergie moyenne"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energia média"
+          }
+        }
+      }
+    },
+    "Belt journey" : {
+      "comment" : "Title above the sequence of learning belts",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weg durch die Gürtelstufen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Camino de cinturones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parcours des ceintures"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jornada das faixas"
+          }
+        }
+      }
+    },
+    "Belt milestone" : {
+      "comment" : "Accessibility value identifying another belt milestone",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gürtel-Meilenstein"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hito de cinturón"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Palier de ceinture"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marco de faixa"
+          }
+        }
+      }
+    },
+    "Best day" : {
+      "comment" : "Label for the weekday when the learner has their strongest Score.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bester Tag"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mejor día"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meilleur jour"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melhor dia"
+          }
+        }
+      }
+    },
+    "Best time" : {
+      "comment" : "Label for the daypart when the learner has their strongest Score.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beste Tageszeit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mejor momento del día"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meilleur moment"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melhor período"
+          }
+        }
+      }
+    },
+    "Black Belt" : {
+      "comment" : "Name of the black learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schwarzer Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón negro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Noire"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Preta"
+          }
+        }
+      }
+    },
+    "Blue Belt" : {
+      "comment" : "Name of the blue learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blauer Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón azul"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Bleue"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Azul"
+          }
+        }
+      }
+    },
+    "Brain Power per level" : {
+      "comment" : "Label for the Brain Power required to advance one level",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brain Power pro Level"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poder Mental por nivel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puissance Mentale par niveau"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poder Mental por nível"
+          }
+        }
+      }
+    },
+    "Brown Belt" : {
+      "comment" : "Name of the brown learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brauner Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón marrón"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Marron"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Marrom"
+          }
+        }
+      }
+    },
+    "Check your connection and try again." : {
+      "comment" : "Recovery guidance for a progress network error",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prüfe deine Verbindung und versuche es erneut."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprueba tu conexión e inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifie ta connexion et réessaie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confira sua conexão e tente de novo."
+          }
+        }
+      }
+    },
+    "Check your connection, then try again." : {
+      "comment" : "Recovery guidance when the saved account could not be restored.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prüfe deine Verbindung und versuche es dann erneut."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprueba tu conexión y luego vuelve a intentarlo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifie ta connexion, puis réessaie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confira sua conexão e tente de novo."
+          }
+        }
+      }
+    },
+    "Complete" : {
+      "comment" : "Completion value for the maximum level\nValue shown when the learner has reached the maximum level",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abgeschlossen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminé"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completo"
+          }
+        }
+      }
+    },
+    "Complete a lesson to begin earning Brain Power." : {
+      "comment" : "Guidance when the learner has not unlocked a level yet.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließe eine Lektion ab, um erstmals Brain Power zu sammeln."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completa una lección para empezar a ganar Poder Mental."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termine une leçon pour commencer à gagner de la Puissance Mentale."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete uma aula para começar a ganhar Poder Mental."
+          }
+        }
+      }
+    },
+    "Complete a lesson to earn Brain Power and reach your first level." : {
+      "comment" : "Guidance shown before the learner has a level",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließe eine Lektion ab, um Brain Power zu sammeln und dein erstes Level zu erreichen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completa una lección para ganar Poder Mental y alcanzar tu primer nivel."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termine une leçon pour gagner de la Puissance Mentale et atteindre ton premier niveau."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete uma aula para ganhar Poder Mental e alcançar seu primeiro nível."
+          }
+        }
+      }
+    },
+    "Complete a lesson to start building Energy." : {
+      "comment" : "Guidance when the learner does not have an Energy value yet.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließe eine Lektion ab, um Energie aufzubauen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completa una lección para empezar a aumentar tu Energía."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termine une leçon pour commencer à augmenter ton Énergie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete uma aula para começar a ganhar Energia."
+          }
+        }
+      }
+    },
+    "Complete a lesson to start building your learning history." : {
+      "comment" : "Guidance shown before the learner has activity progress",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließe eine Lektion ab, um deinen Lernverlauf zu beginnen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completa una lección para empezar a crear tu historial de estudio."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termine une leçon pour commencer à créer ton historique d’apprentissage."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete uma aula para começar a criar seu histórico de estudos."
+          }
+        }
+      }
+    },
+    "Complete a lesson to start tracking your activity, Score, level, and Energy." : {
+      "comment" : "Guidance shown when a signed-in learner has no progress yet.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließe eine Lektion ab, um deine Aktivität, deinen Score, dein Level und deine Energie zu verfolgen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completa una lección para empezar a registrar tu actividad, puntuación, nivel y Energía."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termine une leçon pour commencer à suivre ton activité, ton score, ton niveau et ton Énergie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete uma aula para começar a acompanhar sua atividade, Pontuação, nível e Energia."
+          }
+        }
+      }
+    },
+    "Complete lessons and answer questions correctly to increase your Energy." : {
+      "comment" : "Explanation of how learning increases Energy",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließe Lektionen ab und beantworte Fragen richtig, um deine Energie zu steigern."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completa lecciones y responde preguntas correctamente para aumentar tu Energía."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termine des leçons et réponds correctement aux questions pour augmenter ton Énergie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete aulas e responda às perguntas corretamente para aumentar sua Energia."
+          }
+        }
+      }
+    },
+    "Complete lessons to start building your Energy." : {
+      "comment" : "Guidance shown before the learner has Energy progress",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließe Lektionen ab, um deine Energie aufzubauen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completa lecciones para empezar a aumentar tu Energía."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termine des leçons pour commencer à augmenter ton Énergie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete aulas para começar a ganhar Energia."
+          }
+        }
+      }
+    },
+    "Correct answers" : {
+      "comment" : "Label for correct answers in the Score period",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Richtige Antworten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuestas correctas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bonnes réponses"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respostas corretas"
+          }
+        }
+      }
+    },
+    "Correct answers: %lld of %lld" : {
+      "comment" : "Summary of correct and total answers in the Score period",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Richtige Antworten: %1$lld von %2$lld"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Correct answers: %1$lld of %2$lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuestas correctas: %1$lld de %2$lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bonnes réponses : %1$lld sur %2$lld"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respostas corretas: %1$lld de %2$lld"
+          }
+        }
+      }
+    },
+    "Current belt" : {
+      "comment" : "Accessibility value identifying the learner's current belt",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktueller Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón actual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture actuelle"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa atual"
+          }
+        }
+      }
+    },
+    "Current Energy" : {
+      "comment" : "Accessibility label for the current Energy progress bar\nAccessibility label for the learner's current Energy.\nLabel above the learner's current Energy value\nLabel for the learner's current Energy value.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuelle Energie"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energía actual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Énergie actuelle"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energia atual"
+          }
+        }
+      }
+    },
+    "Days at 100% Energy" : {
+      "comment" : "Label for the number of days the learner reached full Energy",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tage mit 100 % Energie"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Días con Energía al 100 %"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jours à 100 % d’Énergie"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dias com 100% de Energia"
+          }
+        }
+      }
+    },
+    "Each completed lesson counts once, even when you return to review it." : {
+      "comment" : "Explains that activity counts unique completed lessons",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jede abgeschlossene Lektion zählt nur einmal, auch wenn du sie später wiederholst."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cada lección completada cuenta una sola vez, aunque vuelvas a repasarla."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chaque leçon terminée ne compte qu’une fois, même si tu y reviens pour réviser."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cada aula que você completou conta apenas uma vez, mesmo que você volte para revisar."
+          }
+        }
+      }
+    },
+    "Energy" : {
+      "comment" : "Title for the learner's Energy progress.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energie"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Énergie"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energia"
+          }
+        }
+      }
+    },
+    "Energy history" : {
+      "comment" : "Title above the Energy contribution calendar",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energieverlauf"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historial de Energía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historique de l’Énergie"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Histórico de Energia"
+          }
+        }
+      }
+    },
+    "Energy history over the past 12 months" : {
+      "comment" : "Accessibility label for the Energy contribution calendar",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energieverlauf der letzten 12 Monate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historial de Energía de los últimos 12 meses"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historique de l’Énergie sur les 12 derniers mois"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Histórico de Energia nos últimos 12 meses"
+          }
+        }
+      }
+    },
+    "Energy: %@" : {
+      "comment" : "Accessible daily value in the Energy contribution calendar",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energie: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energía: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Énergie : %@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energia: %@"
+          }
+        }
+      }
+    },
+    "Evening" : {
+      "comment" : "Name of the evening score period",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abend"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarde"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soir"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noite"
+          }
+        }
+      }
+    },
+    "Every completed lesson earns 10 BP. Brain Power never goes down, so each lesson moves you closer to the next level." : {
+      "comment" : "Explains how much Brain Power a lesson earns and that it never decreases.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Für jede abgeschlossene Lektion bekommst du 10 BP. Brain Power sinkt nie, also bringt dich jede Lektion dem nächsten Level näher."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Por cada lección que completas, ganas 10 PM. Tu Poder Mental nunca disminuye, así que cada lección te acerca al siguiente nivel."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chaque leçon terminée te rapporte 10 PM. Ta Puissance Mentale ne diminue jamais, alors chaque leçon te rapproche du niveau suivant."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cada aula que você completa vale 10 PM. O Poder Mental nunca diminui, então cada aula te deixa mais perto do próximo nível."
+          }
+        }
+      }
+    },
+    "Every ten levels unlocks the next belt." : {
+      "comment" : "Explains when the learner advances to a new belt",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nach jeweils zehn Leveln schaltest du den nächsten Gürtel frei."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cada diez niveles desbloqueas el siguiente cinturón."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les dix niveaux, tu débloques la ceinture suivante."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A cada dez níveis, você desbloqueia a próxima faixa."
+          }
+        }
+      }
+    },
+    "Gray Belt" : {
+      "comment" : "Name of the gray learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grauer Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón gris"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Grise"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Cinza"
+          }
+        }
+      }
+    },
+    "Green Belt" : {
+      "comment" : "Name of the green learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grüner Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón verde"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Verte"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Verde"
+          }
+        }
+      }
+    },
+    "High" : {
+      "comment" : "High end of the Energy contribution legend",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hoch"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Élevée"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alta"
+          }
+        }
+      }
+    },
+    "How do I increase my Energy?" : {
+      "comment" : "Title explaining how to increase Energy",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wie steigere ich meine Energie?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Cómo puedo aumentar mi Energía?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comment augmenter mon Énergie ?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Como aumentar minha Energia?"
+          }
+        }
+      }
+    },
+    "How levels work" : {
+      "comment" : "Title explaining how learners progress through levels",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "So funktionieren Level"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cómo funcionan los niveles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comment fonctionnent les niveaux"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Como os níveis funcionam"
+          }
+        }
+      }
+    },
+    "Incorrect answers" : {
+      "comment" : "Label for incorrect answers in the Score period",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falsche Antworten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuestas incorrectas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réponses incorrectes"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respostas erradas"
+          }
+        }
+      }
+    },
+    "Keep answering to discover your strongest learning patterns." : {
+      "comment" : "Guidance when the learner does not have Score patterns yet.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beantworte weitere Fragen und entdecke, wann du am besten lernst."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sigue respondiendo para descubrir en qué momentos estudias mejor."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue à répondre pour découvrir quand tu apprends le mieux."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue respondendo para descobrir quando você aprende melhor."
+          }
+        }
+      }
+    },
+    "Keep learning to reach 100%." : {
+      "comment" : "Encouragement shown while the learner builds Energy.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lerne weiter, um 100 % zu erreichen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sigue estudiando para llegar al 100 %."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue à apprendre pour atteindre 100 %."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue estudando para chegar a 100%."
+          }
+        }
+      }
+    },
+    "Keep learning to see your trend here." : {
+      "comment" : "Guidance shown when a progress chart has no recorded data",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lerne weiter, dann siehst du hier deinen Trend."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sigue estudiando y aquí verás tu tendencia."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue à apprendre pour voir ton évolution ici."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continue estudando para ver sua evolução aqui."
+          }
+        }
+      }
+    },
+    "Learning activity" : {
+      "comment" : "Title above the completed lesson contribution calendar",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lernaktivität"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividad de estudio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activité d’apprentissage"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atividade de estudo"
+          }
+        }
+      }
+    },
+    "Learning activity over the past 12 months" : {
+      "comment" : "Accessibility label for the completed lesson contribution calendar",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lernaktivität der letzten 12 Monate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividad de estudio de los últimos 12 meses"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activité d’apprentissage sur les 12 derniers mois"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atividade de estudo nos últimos 12 meses"
+          }
+        }
+      }
+    },
+    "Learning days" : {
+      "comment" : "Label for the learner's lifetime count of days with learning activity.\nLabel for the number of days on which the learner studied",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lerntage"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Días de estudio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jours d’apprentissage"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dias de estudo"
+          }
+        }
+      }
+    },
+    "Learning time" : {
+      "comment" : "Label for the learner's lifetime lesson time.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lernzeit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de estudio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps d’apprentissage"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo de estudo"
+          }
+        }
+      }
+    },
+    "Less" : {
+      "comment" : "Low end of the learning activity contribution legend",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weniger"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moins"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menos"
+          }
+        }
+      }
+    },
+    "Lessons completed" : {
+      "comment" : "Label above the learner's lifetime completed lesson count\nLabel for the learner's lifetime completed lesson count.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abgeschlossene Lektionen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecciones completadas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leçons terminées"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aulas completadas"
+          }
+        }
+      }
+    },
+    "Lessons completed: %lld" : {
+      "comment" : "Accessible daily completed lesson value in the activity calendar",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abgeschlossene Lektionen: %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecciones completadas: %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leçons terminées : %lld"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aulas completadas: %lld"
+          }
+        }
+      }
+    },
+    "Level" : {
+      "comment" : "Title for the learner's Brain Power level progress.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Level"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nível"
+          }
+        }
+      }
+    },
+    "Level %lld" : {
+      "comment" : "Learner's current numbered level\nLearner's level number within their current belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Level %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivel %lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau %lld"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nível %lld"
+          }
+        }
+      }
+    },
+    "Level progress" : {
+      "comment" : "Title above progress toward the next level",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Levelfortschritt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso del nivel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progression vers le niveau suivant"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progresso no nível"
+          }
+        }
+      }
+    },
+    "Loading progress" : {
+      "comment" : "Accessibility label for a loading progress detail screen\nAccessibility status while the progress overview loads.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortschritt wird geladen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando el progreso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chargement de la progression"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carregando o progresso"
+          }
+        }
+      }
+    },
+    "Low" : {
+      "comment" : "Low end of the Energy contribution legend",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niedrig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baja"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faible"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baixa"
+          }
+        }
+      }
+    },
+    "Max level reached" : {
+      "comment" : "Status shown after reaching the maximum level",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Höchstes Level erreicht"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivel máximo alcanzado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau maximal atteint"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nível máximo alcançado"
+          }
+        }
+      }
+    },
+    "Maximum level reached." : {
+      "comment" : "Description shown after reaching the maximum level",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du hast das höchste Level erreicht."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Has alcanzado el nivel máximo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Niveau maximal atteint."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Você alcançou o nível máximo."
+          }
+        }
+      }
+    },
+    "Missed a day?" : {
+      "comment" : "Title explaining what happens to Energy after a missed day",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einen Tag verpasst?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Pasaste un día sin estudiar?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu as manqué une journée ?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ficou um dia sem estudar?"
+          }
+        }
+      }
+    },
+    "More" : {
+      "comment" : "High end of the learning activity contribution legend",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mehr"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mais"
+          }
+        }
+      }
+    },
+    "Morning" : {
+      "comment" : "Name of the morning score period",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Morgen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mañana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Matin"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manhã"
+          }
+        }
+      }
+    },
+    "Night" : {
+      "comment" : "Name of the midnight-to-morning score period",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nacht"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Madrugada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuit"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Madrugada"
+          }
+        }
+      }
+    },
+    "No activity yet" : {
+      "comment" : "Title shown before the learner completes a lesson",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Aktivität"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay actividad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas encore d’activité"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda sem atividade"
+          }
+        }
+      }
+    },
+    "No answers" : {
+      "comment" : "Accessible value for a weekday with no answers\nChart value indicating a weekday has no answers\nValue shown when a time-of-day pattern has no answers",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Antworten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin respuestas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune réponse"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhuma resposta"
+          }
+        }
+      }
+    },
+    "No Energy recorded" : {
+      "comment" : "Accessible value for a day without recorded Energy",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Energie erfasst"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se registró Energía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune Énergie enregistrée"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhuma Energia registrada"
+          }
+        }
+      }
+    },
+    "No Energy yet" : {
+      "comment" : "Title shown before the learner has an Energy value",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Energie"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no tienes Energía"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas encore d’Énergie"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda sem Energia"
+          }
+        }
+      }
+    },
+    "No level yet" : {
+      "comment" : "Title shown before the learner earns Brain Power",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch kein Level"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no tienes nivel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas encore de niveau"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda sem nível"
+          }
+        }
+      }
+    },
+    "No patterns yet" : {
+      "comment" : "Headline shown when no weekday or daypart has answers\nTitle shown before the learner has enough answers for score patterns",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch keine Lernmuster"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay patrones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas encore de tendances"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda sem padrões"
+          }
+        }
+      }
+    },
+    "No Score yet" : {
+      "comment" : "Title shown before the learner answers a question\nTitle shown when a Score response has no answered questions",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch kein Score"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no tienes puntuación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas encore de score"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda sem Pontuação"
+          }
+        }
+      }
+    },
+    "Not enough data yet" : {
+      "comment" : "Title shown when a progress chart has no recorded data",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noch nicht genug Daten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay datos suficientes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas encore assez de données"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ainda não há dados suficientes"
+          }
+        }
+      }
+    },
+    "Orange Belt" : {
+      "comment" : "Name of the orange learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oranger Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón naranja"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Orange"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Laranja"
+          }
+        }
+      }
+    },
+    "Past 12 months." : {
+      "comment" : "Period shown above the completed lesson contribution calendar",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 12 Monate."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 12 meses."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 derniers mois."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 12 meses."
+          }
+        }
+      }
+    },
+    "Past 12 months. Days without an Energy value stay empty." : {
+      "comment" : "Period and missing-value behavior for the Energy contribution calendar",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 12 Monate. Tage ohne Energiewert bleiben leer."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 12 meses. Los días sin un valor de Energía quedan vacíos."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 derniers mois. Les jours sans valeur d’Énergie restent vides."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 12 meses. Dias sem valor de Energia ficam vazios."
+          }
+        }
+      }
+    },
+    "Past 90 days" : {
+      "comment" : "Fixed period label above the empty score patterns summary\nFixed period label above the learner's Score",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 90 Tage"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 90 días"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "90 derniers jours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Últimos 90 dias"
+          }
+        }
+      }
+    },
+    "Patterns" : {
+      "comment" : "Title for insights about when the learner answers best.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lernmuster"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Patrones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tendances"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Padrões"
+          }
+        }
+      }
+    },
+    "Patterns use your answers from the past 90 days. Use them as a guide, not a rule—learning at any time still moves you forward." : {
+      "comment" : "Explains the rolling window and purpose of score patterns",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Lernmuster basieren auf deinen Antworten aus den letzten 90 Tagen. Nutze sie als Orientierung, nicht als Regel – du kommst immer voran, egal wann du lernst."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los patrones se basan en tus respuestas de los últimos 90 días. Úsalos como guía, no como regla: estudiar a cualquier hora también te ayuda a avanzar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les tendances reposent sur tes réponses des 90 derniers jours. Utilise-les comme un repère, pas comme une règle : apprendre à tout moment te fait quand même progresser."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os padrões consideram suas respostas dos últimos 90 dias. Eles servem como guia, não como regra — estudar a qualquer hora ainda te faz avançar."
+          }
+        }
+      }
+    },
+    "Progress is unavailable" : {
+      "comment" : "Title shown when the progress service cannot provide data.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortschritt ist nicht verfügbar"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El progreso no está disponible"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La progression n’est pas disponible"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O progresso não está disponível"
+          }
+        }
+      }
+    },
+    "Progress to the next level" : {
+      "comment" : "Accessibility label for level progress",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortschritt zum nächsten Level"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso hacia el siguiente nivel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progression vers le niveau suivant"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progresso até o próximo nível"
+          }
+        }
+      }
+    },
+    "Progress unavailable" : {
+      "comment" : "Title shown when progress cannot load because of a service error",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortschritt nicht verfügbar"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso no disponible"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progression indisponible"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progresso indisponível"
+          }
+        }
+      }
+    },
+    "Purple Belt" : {
+      "comment" : "Name of the purple learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Violetter Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón morado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Violette"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Roxa"
+          }
+        }
+      }
+    },
+    "Red Belt" : {
+      "comment" : "Name of the red learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roter Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón rojo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Rouge"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Vermelha"
+          }
+        }
+      }
+    },
+    "Score" : {
+      "comment" : "Chart axis value describing answer accuracy\nTitle for the learner's answer accuracy progress.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Score"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puntuación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Score"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pontuação"
+          }
+        }
+      }
+    },
+    "Score is the percentage of questions you answered correctly over the past 90 days. Every answer counts equally, so harder lessons can lower it for a while. That's part of learning." : {
+      "comment" : "Explanation of how the rolling Score is calculated",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Score ist der Prozentsatz der Fragen, die du in den letzten 90 Tagen richtig beantwortet hast. Jede Antwort zählt gleich viel, daher können schwierigere Lektionen deinen Score eine Zeit lang senken. Das gehört zum Lernen dazu."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La puntuación es el porcentaje de preguntas que respondiste correctamente en los últimos 90 días. Cada respuesta cuenta por igual, así que las lecciones más difíciles pueden hacer que baje durante un tiempo. Eso forma parte del estudio."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le score correspond au pourcentage de questions auxquelles tu as répondu correctement au cours des 90 derniers jours. Chaque réponse compte autant, donc les leçons plus difficiles peuvent faire baisser ton score pendant un certain temps. Ça fait partie de l’apprentissage."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pontuação é a porcentagem de perguntas que você acertou nos últimos 90 dias. Cada resposta tem o mesmo peso, então aulas mais difíceis podem baixar sua Pontuação por um tempo. Isso faz parte do estudo."
+          }
+        }
+      }
+    },
+    "See what you've accomplished and where you're building momentum." : {
+      "comment" : "Description above the learner's progress summary cards.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sieh, was du erreicht hast und wo du gerade richtig vorankommst."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mira lo que has logrado y dónde estás avanzando."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Découvre ce que tu as accompli et les domaines où tu progresses."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veja o que você já conquistou e onde está ganhando ritmo."
+          }
+        }
+      }
+    },
+    "Sign in" : {
+      "comment" : "Action that opens account sign-in from the Progress tab.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anmelden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar sesión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrar"
+          }
+        }
+      }
+    },
+    "Sign in to see your progress" : {
+      "comment" : "Title shown when progress requires the learner to sign in.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melde dich an, um deinen Fortschritt zu sehen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicia sesión para ver tu progreso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecte-toi pour voir tes progrès"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entre para ver seu progresso"
+          }
+        }
+      }
+    },
+    "Strongest" : {
+      "comment" : "Badge identifying the learner's strongest score pattern",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Am stärksten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mejor"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Point fort"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melhor"
+          }
+        }
+      }
+    },
+    "Strongest time" : {
+      "comment" : "Label for the time of day with the learner's strongest accuracy",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beste Tageszeit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mejor momento del día"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meilleur moment"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melhor horário"
+          }
+        }
+      }
+    },
+    "Strongest weekday" : {
+      "comment" : "Label for the weekday with the learner's strongest accuracy",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bester Wochentag"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mejor día de la semana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meilleur jour de la semaine"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melhor dia da semana"
+          }
+        }
+      }
+    },
+    "Throughout the day" : {
+      "comment" : "Title above accuracy grouped by time of day",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Im Tagesverlauf"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A lo largo del día"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Au fil de la journée"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ao longo do dia"
+          }
+        }
+      }
+    },
+    "Time learning" : {
+      "comment" : "Label for the learner's total study duration",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lernzeit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de estudio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps d’apprentissage"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo de estudo"
+          }
+        }
+      }
+    },
+    "Total answers" : {
+      "comment" : "Label for all answers in the Score period",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Antworten insgesamt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Respuestas totales"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total des réponses"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total de respostas"
+          }
+        }
+      }
+    },
+    "Total Brain Power" : {
+      "comment" : "Label for the learner's lifetime Brain Power",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brain Power insgesamt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poder Mental total"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puissance Mentale totale"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poder Mental total"
+          }
+        }
+      }
+    },
+    "Try again" : {
+      "comment" : "Retries loading a progress detail screen\nRetries loading a progress screen.\nRetries restoring the account from the Progress tab.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erneut versuchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reintentar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réessayer"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tente de novo"
+          }
+        }
+      }
+    },
+    "View details" : {
+      "comment" : "Accessibility hint for opening a progress metric's detail screen.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Details anzeigen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver detalles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voir les détails"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver detalhes"
+          }
+        }
+      }
+    },
+    "We couldn't load this progress right now. Try again in a moment." : {
+      "comment" : "Recovery guidance for a progress service error",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dein Fortschritt konnte gerade nicht geladen werden. Versuch es gleich noch einmal."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No pudimos cargar este progreso ahora mismo. Inténtalo de nuevo en un momento."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de charger cette progression pour le moment. Réessaie dans un instant."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível carregar seu progresso agora. Tente de novo daqui a pouco."
+          }
+        }
+      }
+    },
+    "Week" : {
+      "comment" : "Chart axis value describing a Score week",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Woche"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semaine"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semana"
+          }
+        }
+      }
+    },
+    "Weekday" : {
+      "comment" : "Chart axis value describing a weekday",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wochentag"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Día de la semana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jour de la semaine"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dia da semana"
+          }
+        }
+      }
+    },
+    "Weekly rhythm" : {
+      "comment" : "Title above accuracy grouped by weekday",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wochenrhythmus"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ritmo semanal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rythme hebdomadaire"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ritmo semanal"
+          }
+        }
+      }
+    },
+    "Weekly Score trend" : {
+      "comment" : "Accessibility label for the weekly answer accuracy chart",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wöchentlicher Score-Verlauf"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tendencia semanal de la puntuación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Évolution hebdomadaire du score"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tendência semanal da Pontuação"
+          }
+        }
+      }
+    },
+    "Weekly trend" : {
+      "comment" : "Title above the weekly Score chart",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wöchentlicher Verlauf"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tendencia semanal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Évolution hebdomadaire"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tendência semanal"
+          }
+        }
+      }
+    },
+    "What is Score?" : {
+      "comment" : "Title explaining the Score metric",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Was ist der Score?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Qué es la puntuación?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qu’est-ce que le score ?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O que é Pontuação?"
+          }
+        }
+      }
+    },
+    "White Belt" : {
+      "comment" : "Name of the white learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weißer Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón blanco"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Blanche"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Branca"
+          }
+        }
+      }
+    },
+    "Yellow Belt" : {
+      "comment" : "Name of the yellow learning belt.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gelber Gürtel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cinturón amarillo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ceinture Jaune"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faixa Amarela"
+          }
+        }
+      }
+    },
+    "You're fully energized." : {
+      "comment" : "Encouragement shown when the learner reaches full Energy.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du hast volle Energie."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu Energía está al máximo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ton Énergie est au maximum."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sua Energia está no máximo."
+          }
+        }
+      }
+    },
+    "You're offline" : {
+      "comment" : "Title shown when progress cannot load because the network is unavailable.\nTitle shown when progress cannot load without a network connection",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du bist offline"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No tienes conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu es hors ligne"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Você está sem internet"
+          }
+        }
+      }
+    },
+    "Your activity, Score, patterns, level, and Energy stay connected to your account." : {
+      "comment" : "Explains why signing in is required to view progress.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Aktivität, dein Score, deine Lernmuster, dein Level und deine Energie bleiben mit deinem Konto verknüpft."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu actividad, puntuación, patrones, nivel y Energía quedan vinculados a tu cuenta."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ton activité, ton score, tes habitudes, ton niveau et ton Énergie restent associés à ton compte."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sua atividade, Pontuação, padrões, nível e Energia ficam vinculados à sua conta."
+          }
+        }
+      }
+    },
+    "Your Energy drops a little. Complete lessons to fill it back up." : {
+      "comment" : "Explanation of how to recover Energy after missing a day",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Energie sinkt ein wenig. Schließe Lektionen ab, um sie wieder aufzufüllen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu Energía baja un poco. Completa lecciones para recuperarla."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ton Énergie baisse un peu. Termine des leçons pour la recharger."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sua Energia cai um pouco. Complete aulas para recuperar ela."
+          }
+        }
+      }
+    },
+    "Your learning rhythm" : {
+      "comment" : "Title explaining how score patterns can be used",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dein Lernrhythmus"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu ritmo de estudio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ton rythme d’apprentissage"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seu ritmo de estudo"
+          }
+        }
+      }
+    },
+    "Your lifetime learning activity." : {
+      "comment" : "Description below the lifetime activity total",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine gesamte bisherige Lernaktivität."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toda tu actividad de estudio hasta hoy."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ton activité d’apprentissage depuis tes débuts."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sua atividade de estudo desde o início."
+          }
+        }
+      }
+    },
+    "Your progress is safe. Try loading it again." : {
+      "comment" : "Recovery guidance when progress cannot be loaded.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dein Fortschritt ist sicher gespeichert. Versuch, ihn noch einmal zu laden."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu progreso está a salvo. Intenta cargarlo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tes progrès sont bien enregistrés. Essaie de les charger à nouveau."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seu progresso está salvo. Tente carregar de novo."
+          }
+        }
+      }
+    },
+    "Your progress starts here" : {
+      "comment" : "Title shown when a signed-in learner has no progress yet.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hier beginnt dein Fortschritt"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu progreso empieza aquí"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tes progrès commencent ici"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seu progresso começa aqui"
+          }
+        }
+      }
+    },
+    "Your strongest time" : {
+      "comment" : "Label above the learner's strongest time of day",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine beste Tageszeit"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu mejor momento del día"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ton meilleur moment"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seu melhor horário"
+          }
+        }
+      }
+    },
+    "Your strongest weekday" : {
+      "comment" : "Label above the learner's strongest weekday",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dein bester Wochentag"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu mejor día de la semana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ton meilleur jour de la semaine"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seu melhor dia da semana"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/apps/apple/Zoonk/Testing/UITestConfiguration.swift
+++ b/apps/apple/Zoonk/Testing/UITestConfiguration.swift
@@ -4,6 +4,7 @@
   @MainActor
   struct UITestConfiguration {
     let initiallyPresentsAccount: Bool
+    let progress: ProgressStore
     let session: SessionStore
 
     static var current: UITestConfiguration? {
@@ -13,9 +14,15 @@
         return nil
       }
 
+      let session = SessionStore.preview(
+        account: account(from: ProcessInfo.processInfo.environment))
+
       return UITestConfiguration(
         initiallyPresentsAccount: arguments.contains("--ui-testing-account-sheet"),
-        session: SessionStore.preview(account: account(from: ProcessInfo.processInfo.environment)))
+        progress: ProgressStore(
+          api: progressAPI(from: ProcessInfo.processInfo.environment),
+          session: session),
+        session: session)
     }
 
     /// Decodes fixture data supplied by the UI-test target so the Debug app can compose isolated state without owning concrete test users.
@@ -29,6 +36,81 @@
       } catch {
         preconditionFailure("ZOONK_UI_TEST_ACCOUNT must contain a valid CurrentAccount payload")
       }
+    }
+
+    private static func progressAPI(from environment: [String: String]) -> any ProgressAPIClient {
+      guard let progressJSON = environment["ZOONK_UI_TEST_PROGRESS"] else {
+        let clients = APIClientFactory.live(baseURL: AppConfiguration.current.apiBaseURL)
+        return ProgressAPI(clients: clients)
+      }
+
+      do {
+        let snapshot = try JSONDecoder().decode(
+          UITestProgressSnapshot.self,
+          from: Data(progressJSON.utf8))
+        return UITestProgressAPI(
+          failure: environment["ZOONK_UI_TEST_PROGRESS_FAILURE"]
+            .flatMap(UITestProgressFailure.init(rawValue:)),
+          snapshot: snapshot)
+      } catch {
+        preconditionFailure("ZOONK_UI_TEST_PROGRESS must contain a valid progress snapshot")
+      }
+    }
+  }
+
+  private struct UITestProgressSnapshot: Decodable, Sendable {
+    let activity: ActivityProgress
+    let energy: EnergyProgress?
+    let level: LevelProgress?
+    let overview: ProgressOverview
+    let patterns: ScorePatterns?
+    let score: ScoreProgress?
+  }
+
+  private enum UITestProgressFailure: String, Sendable {
+    case activityUnauthorized = "activity-unauthorized"
+    case overviewNetwork = "overview-network"
+  }
+
+  private actor UITestProgressAPI: ProgressAPIClient {
+    let failure: UITestProgressFailure?
+    let snapshot: UITestProgressSnapshot
+
+    init(failure: UITestProgressFailure?, snapshot: UITestProgressSnapshot) {
+      self.failure = failure
+      self.snapshot = snapshot
+    }
+
+    func getOverview(token: String) async throws -> ProgressOverview {
+      if failure == .overviewNetwork {
+        throw ProgressAPIError.network
+      }
+
+      return snapshot.overview
+    }
+
+    func getActivity(token: String) async throws -> ActivityProgress {
+      if failure == .activityUnauthorized {
+        throw ProgressAPIError.unauthorized
+      }
+
+      return snapshot.activity
+    }
+
+    func getEnergy(token: String) async throws -> EnergyProgress? {
+      snapshot.energy
+    }
+
+    func getLevel(token: String) async throws -> LevelProgress? {
+      snapshot.level
+    }
+
+    func getScore(token: String) async throws -> ScoreProgress? {
+      snapshot.score
+    }
+
+    func getScorePatterns(token: String) async throws -> ScorePatterns? {
+      snapshot.patterns
     }
   }
 #endif

--- a/apps/apple/ZoonkTests/ProgressAPITests.swift
+++ b/apps/apple/ZoonkTests/ProgressAPITests.swift
@@ -1,0 +1,426 @@
+import HTTPTypes
+import OpenAPIRuntime
+import XCTest
+
+@testable import Zoonk
+
+final class ProgressAPITests: XCTestCase {
+  func testOverviewMapsGeneratedProgressPayload() async throws {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserProgress",
+        status: .ok,
+        responseBody:
+          #"""
+          {
+            "activity": {
+              "learningDays": 12,
+              "totalLearningSeconds": 7200,
+              "totalLessonCompletions": 24
+            },
+            "energy": { "currentEnergy": 82.5 },
+            "level": {
+              "belt": "green",
+              "bpPerLevel": 1000,
+              "bpToNextLevel": 240,
+              "isMaxLevel": false,
+              "level": 4,
+              "progressInLevel": 760,
+              "totalBrainPower": 3760
+            },
+            "score": {
+              "correctAnswers": 41,
+              "incorrectAnswers": 9,
+              "score": 82,
+              "totalAnswers": 50
+            },
+            "scorePatterns": {
+              "strongestTime": {
+                "correctAnswers": 20,
+                "incorrectAnswers": 2,
+                "score": 90.9,
+                "totalAnswers": 22,
+                "period": "morning"
+              },
+              "strongestWeekday": {
+                "correctAnswers": 14,
+                "incorrectAnswers": 1,
+                "score": 93.3,
+                "totalAnswers": 15,
+                "dayOfWeek": "tuesday"
+              }
+            }
+          }
+          """#))
+
+    let overview = try await api.getOverview(token: "test-session")
+
+    XCTAssertEqual(overview.activity.learningDays, 12)
+    XCTAssertEqual(overview.energy, 82.5)
+    XCTAssertEqual(overview.level?.belt, .green)
+    XCTAssertEqual(overview.level?.totalBrainPower, 3_760)
+    XCTAssertEqual(overview.score?.correctAnswers, 41)
+    XCTAssertEqual(overview.strongestDaypart?.daypart, .morning)
+    XCTAssertEqual(overview.strongestWeekday?.weekday, .tuesday)
+  }
+
+  func testActivityMapsLogicalCalendarDates() async throws {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserActivity",
+        status: .ok,
+        responseBody:
+          #"""
+          {
+            "activity": {
+              "learningDays": 2,
+              "totalLearningSeconds": 600,
+              "totalLessonCompletions": 3,
+              "days": [
+                { "date": "2026-08-19", "lessonCompletions": 1 },
+                { "date": "2026-08-20", "lessonCompletions": 2 }
+              ]
+            }
+          }
+          """#))
+
+    let activity = try await api.getActivity(token: "test-session")
+    let expectedDate = try XCTUnwrap(ProgressDate("2026-08-19"))
+
+    XCTAssertEqual(activity.days.first?.date, expectedDate)
+    XCTAssertEqual(activity.days.last?.lessonCompletions, 2)
+    XCTAssertEqual(activity.summary.totalLessonCompletions, 3)
+  }
+
+  func testEnergyPreservesDaysWithoutMeasurements() async throws {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserEnergy",
+        status: .ok,
+        responseBody:
+          #"""
+          {
+            "energy": {
+              "currentEnergy": 88,
+              "days": [
+                { "date": "2026-08-19", "energy": null },
+                { "date": "2026-08-20", "energy": 88 }
+              ],
+              "insights": { "averageEnergy": 88, "fullEnergyDays": 1 }
+            }
+          }
+          """#))
+
+    let response = try await api.getEnergy(token: "test-session")
+    let energy = try XCTUnwrap(response)
+    let expectedDate = try XCTUnwrap(ProgressDate("2026-08-19"))
+
+    XCTAssertEqual(energy.days.first?.date, expectedDate)
+    XCTAssertNil(energy.days.first?.energy)
+    XCTAssertEqual(energy.insights?.fullEnergyDays, 1)
+  }
+
+  func testEnergyMapsMissingProgressToNil() async throws {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserEnergy",
+        status: .ok,
+        responseBody: #"{"energy":null}"#))
+
+    let energy = try await api.getEnergy(token: "test-session")
+
+    XCTAssertNil(energy)
+  }
+
+  func testLevelMapsGeneratedProgressPayload() async throws {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserLevel",
+        status: .ok,
+        responseBody:
+          #"""
+          {
+            "level": {
+              "belt": "black",
+              "bpPerLevel": 1000,
+              "bpToNextLevel": 0,
+              "isMaxLevel": true,
+              "level": 10,
+              "progressInLevel": 1000,
+              "totalBrainPower": 2167500
+            }
+          }
+          """#))
+
+    let response = try await api.getLevel(token: "test-session")
+    let level = try XCTUnwrap(response)
+
+    XCTAssertEqual(level.belt, .black)
+    XCTAssertEqual(level.level, 10)
+    XCTAssertTrue(level.isMaxLevel)
+    XCTAssertEqual(level.totalBrainPower, 2_167_500)
+  }
+
+  func testScoreMapsGeneratedProgressPayload() async throws {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserScore",
+        status: .ok,
+        responseBody:
+          #"""
+          {
+            "score": {
+              "correctAnswers": 21,
+              "incorrectAnswers": 4,
+              "score": 84,
+              "totalAnswers": 25,
+              "periodStart": "2026-05-23",
+              "periodEnd": "2026-08-20",
+              "dataPoints": [
+                {
+                  "date": "2026-08-10",
+                  "correctAnswers": 8,
+                  "incorrectAnswers": 2,
+                  "score": 80,
+                  "totalAnswers": 10
+                },
+                {
+                  "date": "2026-08-17",
+                  "correctAnswers": 13,
+                  "incorrectAnswers": 2,
+                  "score": 86.7,
+                  "totalAnswers": 15
+                }
+              ]
+            }
+          }
+          """#))
+
+    let response = try await api.getScore(token: "test-session")
+    let score = try XCTUnwrap(response)
+
+    XCTAssertEqual(score.performance.totalAnswers, 25)
+    XCTAssertEqual(score.dataPoints.count, 2)
+    XCTAssertEqual(score.dataPoints.last?.performance.score, 86.7)
+    XCTAssertEqual(score.periodStart, ProgressDate("2026-05-23"))
+    XCTAssertEqual(score.periodEnd, ProgressDate("2026-08-20"))
+  }
+
+  func testPatternsMapEverySemanticCategory() async throws {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserScorePatterns",
+        status: .ok,
+        responseBody:
+          #"""
+          {
+            "patterns": {
+              "strongestTime": {
+                "correctAnswers": 9,
+                "incorrectAnswers": 1,
+                "score": 90,
+                "totalAnswers": 10,
+                "period": "morning"
+              },
+              "strongestWeekday": {
+                "correctAnswers": 9,
+                "incorrectAnswers": 1,
+                "score": 90,
+                "totalAnswers": 10,
+                "dayOfWeek": "tuesday"
+              },
+              "times": [
+                { "correctAnswers": 0, "incorrectAnswers": 0, "score": 0, "totalAnswers": 0, "period": "night" },
+                { "correctAnswers": 9, "incorrectAnswers": 1, "score": 90, "totalAnswers": 10, "period": "morning" },
+                { "correctAnswers": 3, "incorrectAnswers": 1, "score": 75, "totalAnswers": 4, "period": "afternoon" },
+                { "correctAnswers": 2, "incorrectAnswers": 1, "score": 66.7, "totalAnswers": 3, "period": "evening" }
+              ],
+              "weekdays": [
+                { "correctAnswers": 0, "incorrectAnswers": 0, "score": 0, "totalAnswers": 0, "dayOfWeek": "sunday" },
+                { "correctAnswers": 3, "incorrectAnswers": 1, "score": 75, "totalAnswers": 4, "dayOfWeek": "monday" },
+                { "correctAnswers": 9, "incorrectAnswers": 1, "score": 90, "totalAnswers": 10, "dayOfWeek": "tuesday" },
+                { "correctAnswers": 2, "incorrectAnswers": 1, "score": 66.7, "totalAnswers": 3, "dayOfWeek": "wednesday" },
+                { "correctAnswers": 1, "incorrectAnswers": 1, "score": 50, "totalAnswers": 2, "dayOfWeek": "thursday" },
+                { "correctAnswers": 4, "incorrectAnswers": 1, "score": 80, "totalAnswers": 5, "dayOfWeek": "friday" },
+                { "correctAnswers": 3, "incorrectAnswers": 2, "score": 60, "totalAnswers": 5, "dayOfWeek": "saturday" }
+              ]
+            }
+          }
+          """#))
+
+    let response = try await api.getScorePatterns(token: "test-session")
+    let patterns = try XCTUnwrap(response)
+
+    XCTAssertEqual(patterns.dayparts.map(\.daypart), ProgressDaypart.allCases)
+    XCTAssertEqual(patterns.weekdays.map(\.weekday), ProgressWeekday.allCases)
+    XCTAssertEqual(patterns.strongestDaypart?.daypart, .morning)
+    XCTAssertEqual(patterns.strongestWeekday?.weekday, .tuesday)
+    XCTAssertFalse(patterns.weekdays.first?.performance.hasAnswers ?? true)
+  }
+
+  func testUnauthorizedResponseMapsToUnauthorized() async {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserProgress",
+        status: .unauthorized,
+        responseBody:
+          #"{"error":{"code":"UNAUTHORIZED","message":"Sign in to continue"}}"#))
+
+    do {
+      _ = try await api.getOverview(token: "test-session")
+      XCTFail("Expected an unauthorized error")
+    } catch let error as ProgressAPIError {
+      XCTAssertEqual(error, .unauthorized)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testURLFailureMapsToNetwork() async {
+    let api = makeProgressAPI(
+      transport: ProgressFailureTransport(failure: .network))
+
+    do {
+      _ = try await api.getOverview(token: "test-session")
+      XCTFail("Expected a network error")
+    } catch let error as ProgressAPIError {
+      XCTAssertEqual(error, .network)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testCancellationErrorIsPreserved() async {
+    let api = makeProgressAPI(
+      transport: ProgressFailureTransport(failure: .cancellation))
+
+    do {
+      _ = try await api.getOverview(token: "test-session")
+      XCTFail("Expected cancellation")
+    } catch is CancellationError {
+      return
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testCancelledURLRequestIsPreservedAsCancellation() async {
+    let api = makeProgressAPI(
+      transport: ProgressFailureTransport(failure: .cancelledURL))
+
+    do {
+      _ = try await api.getOverview(token: "test-session")
+      XCTFail("Expected cancellation")
+    } catch is CancellationError {
+      return
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testInvalidLogicalDateMapsToInvalidResponse() async {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserActivity",
+        status: .ok,
+        responseBody:
+          #"""
+          {
+            "activity": {
+              "learningDays": 1,
+              "totalLearningSeconds": 300,
+              "totalLessonCompletions": 1,
+              "days": [{ "date": "2026-02-30", "lessonCompletions": 1 }]
+            }
+          }
+          """#))
+
+    do {
+      _ = try await api.getActivity(token: "test-session")
+      XCTFail("Expected an invalid response error")
+    } catch let error as ProgressAPIError {
+      XCTAssertEqual(error, .invalidResponse)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testServerErrorMapsToInvalidResponse() async {
+    let api = makeProgressAPI(
+      transport: ProgressResponseTransport(
+        expectedOperationID: "getCurrentUserProgress",
+        status: .internalServerError,
+        responseBody:
+          #"{"error":{"code":"INTERNAL_SERVER_ERROR","message":"Try again later"}}"#))
+
+    do {
+      _ = try await api.getOverview(token: "test-session")
+      XCTFail("Expected an invalid response error")
+    } catch let error as ProgressAPIError {
+      XCTAssertEqual(error, .invalidResponse)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+}
+
+private func makeProgressAPI(transport: any ClientTransport) -> ProgressAPI {
+  ProgressAPI(
+    clients: APIClientFactory(
+      baseURL: URL(string: "https://api.zoonk.test")!,
+      transport: transport))
+}
+
+/// Exercises generated operation selection and shared native authentication without an external server.
+private struct ProgressResponseTransport: ClientTransport {
+  let expectedOperationID: String
+  let status: HTTPResponse.Status
+  let responseBody: String
+
+  func send(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    XCTAssertEqual(baseURL, URL(string: "https://api.zoonk.test/v1"))
+    XCTAssertEqual(operationID, expectedOperationID)
+    XCTAssertEqual(request.method, .get)
+    XCTAssertEqual(request.headerFields[.authorization], "Bearer test-session")
+    XCTAssertNotNil(request.headerFields[.acceptLanguage])
+
+    var headerFields = HTTPFields()
+    headerFields[.contentType] = "application/json"
+
+    return (
+      HTTPResponse(status: status, headerFields: headerFields),
+      HTTPBody(responseBody)
+    )
+  }
+}
+
+private enum ProgressTransportFailure: Sendable {
+  case cancellation
+  case cancelledURL
+  case network
+}
+
+private struct ProgressFailureTransport: ClientTransport {
+  let failure: ProgressTransportFailure
+
+  func send(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    switch failure {
+    case .cancellation:
+      throw CancellationError()
+    case .cancelledURL:
+      throw URLError(.cancelled)
+    case .network:
+      throw URLError(.notConnectedToInternet)
+    }
+  }
+}

--- a/apps/apple/ZoonkTests/ProgressChartDataTests.swift
+++ b/apps/apple/ZoonkTests/ProgressChartDataTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+@testable import Zoonk
+
+final class ProgressChartDataTests: XCTestCase {
+  func testActivityContributionIntensityUsesLearnerRelativeBands() {
+    let days = [
+      ActivityProgressDay(date: ProgressDate("2026-08-16")!, lessonCompletions: 0),
+      ActivityProgressDay(date: ProgressDate("2026-08-17")!, lessonCompletions: 2),
+      ActivityProgressDay(date: ProgressDate("2026-08-18")!, lessonCompletions: 3),
+      ActivityProgressDay(date: ProgressDate("2026-08-19")!, lessonCompletions: 5),
+      ActivityProgressDay(date: ProgressDate("2026-08-20")!, lessonCompletions: 8),
+    ]
+
+    XCTAssertEqual(
+      ProgressChartData.activityContributions(from: days).map(\.intensity),
+      [0, 1, 2, 3, 4])
+  }
+
+  func testEnergyContributionIntensityUsesStableEnergyBands() {
+    let values: [Double?] = [nil, 0, 1, 25, 26, 50, 51, 75, 76, 99, 100]
+    let days = values.enumerated().map { index, energy in
+      EnergyProgressDay(
+        date: ProgressDate(String(format: "2026-08-%02d", index + 1))!,
+        energy: energy)
+    }
+
+    XCTAssertEqual(
+      ProgressChartData.energyContributions(from: days).map(\.intensity),
+      [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5])
+  }
+
+  func testContributionWeeksAlignDatesFromSundayAndPreserveMissingDays() {
+    let points = [
+      ProgressContributionPoint(date: ProgressDate("2026-08-16")!, intensity: 1),
+      ProgressContributionPoint(date: ProgressDate("2026-08-18")!, intensity: 2),
+      ProgressContributionPoint(date: ProgressDate("2026-08-23")!, intensity: 3),
+    ]
+
+    let weeks = ProgressChartData.contributionWeeks(from: points)
+
+    XCTAssertEqual(weeks.count, 2)
+    XCTAssertEqual(weeks[0].startDate, ProgressDate("2026-08-16")!)
+    XCTAssertEqual(weeks[0].slots.count, 7)
+    XCTAssertEqual(weeks[0].slots[0].point, points[0])
+    XCTAssertNil(weeks[0].slots[1].point)
+    XCTAssertEqual(weeks[0].slots[2].point, points[1])
+    XCTAssertEqual(weeks[1].slots.count, 1)
+    XCTAssertEqual(weeks[1].slots[0].point, points[2])
+  }
+
+  func testContributionWeekFindsMonthLabelFromItsCalendarSlots() {
+    let points = [
+      ProgressContributionPoint(date: ProgressDate("2026-07-31")!, intensity: 1),
+      ProgressContributionPoint(date: ProgressDate("2026-08-02")!, intensity: 2),
+    ]
+
+    let weeks = ProgressChartData.contributionWeeks(from: points)
+
+    XCTAssertEqual(weeks.first?.monthLabelDate, ProgressDate("2026-08-01")!)
+  }
+}

--- a/apps/apple/ZoonkTests/ProgressContributionSelectionTests.swift
+++ b/apps/apple/ZoonkTests/ProgressContributionSelectionTests.swift
@@ -1,0 +1,39 @@
+import CoreGraphics
+import XCTest
+
+@testable import Zoonk
+
+final class ProgressContributionSelectionTests: XCTestCase {
+  func testSelectionUsesTheNearestRecordedDayAcrossThePlot() {
+    let sunday = ProgressContributionPoint(
+      date: ProgressDate("2026-08-16")!,
+      intensity: 1)
+    let tuesday = ProgressContributionPoint(
+      date: ProgressDate("2026-08-18")!,
+      intensity: 2)
+    let weeks = ProgressChartData.contributionWeeks(from: [sunday, tuesday])
+
+    let selection = ProgressContributionSelection.nearestPoint(
+      to: CGPoint(x: 16, y: 67),
+      in: weeks,
+      cellSize: 18,
+      headerHeight: 20)
+
+    XCTAssertEqual(selection, tuesday)
+  }
+
+  func testSelectionIgnoresTheMonthHeader() {
+    let point = ProgressContributionPoint(
+      date: ProgressDate("2026-08-16")!,
+      intensity: 1)
+    let weeks = ProgressChartData.contributionWeeks(from: [point])
+
+    let selection = ProgressContributionSelection.nearestPoint(
+      to: CGPoint(x: 9, y: 10),
+      in: weeks,
+      cellSize: 18,
+      headerHeight: 20)
+
+    XCTAssertNil(selection)
+  }
+}

--- a/apps/apple/ZoonkTests/ProgressDateTests.swift
+++ b/apps/apple/ZoonkTests/ProgressDateTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+
+@testable import Zoonk
+
+final class ProgressDateTests: XCTestCase {
+  func testLogicalDateKeepsItsCalendarDayAcrossTimeZones() throws {
+    let logicalDate = try XCTUnwrap(ProgressDate("2026-07-27"))
+
+    for timeZoneIdentifier in ["Pacific/Kiritimati", "Pacific/Pago_Pago"] {
+      let timeZone = try XCTUnwrap(TimeZone(identifier: timeZoneIdentifier))
+      let date = try XCTUnwrap(logicalDate.date(in: timeZone))
+      var calendar = Calendar(identifier: .gregorian)
+      calendar.timeZone = timeZone
+
+      XCTAssertEqual(calendar.component(.year, from: date), 2026)
+      XCTAssertEqual(calendar.component(.month, from: date), 7)
+      XCTAssertEqual(calendar.component(.day, from: date), 27)
+    }
+  }
+
+  func testLogicalDateRejectsInvalidCalendarValues() {
+    XCTAssertNil(ProgressDate("2026-02-30"))
+    XCTAssertNil(ProgressDate("July 27, 2026"))
+  }
+
+  func testDaypartTimeRangesUseTheExpectedClockBoundaries() {
+    let locale = Locale(identifier: "en_US")
+    let expectedRanges = [
+      "12:00 AM–6:00 AM",
+      "6:00 AM–12:00 PM",
+      "12:00 PM–6:00 PM",
+      "6:00 PM–12:00 AM",
+    ]
+
+    XCTAssertEqual(
+      ProgressDaypart.allCases.map {
+        normalizedWhitespace($0.localizedTimeRange(locale: locale))
+      },
+      expectedRanges)
+  }
+
+  private func normalizedWhitespace(_ value: String) -> String {
+    value.replacingOccurrences(
+      of: #"\s+"#,
+      with: " ",
+      options: .regularExpression)
+  }
+}

--- a/apps/apple/ZoonkTests/ProgressPresentationTests.swift
+++ b/apps/apple/ZoonkTests/ProgressPresentationTests.swift
@@ -36,4 +36,26 @@ final class ProgressPresentationTests: XCTestCase {
     XCTAssertEqual(level.progressValue, 100_000)
     XCTAssertEqual(level.progressTotal, 100_000)
   }
+
+  func testDisplayedEnergyUsesTheSameWholePercentageAsTheHero() {
+    let belowFullEnergy = EnergyProgress(currentEnergy: 99.49, days: [], insights: nil)
+    let displayedAsFullEnergy = EnergyProgress(currentEnergy: 99.5, days: [], insights: nil)
+
+    XCTAssertEqual(belowFullEnergy.displayedCurrentEnergy, 99)
+    XCTAssertEqual(displayedAsFullEnergy.displayedCurrentEnergy, 100)
+  }
+
+  func testWeekdayOrderUsesTheCalendarsFirstWeekday() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.firstWeekday = 2
+
+    let weekdays = ProgressWeekday.allCases.sorted {
+      $0.order(in: calendar) < $1.order(in: calendar)
+    }
+    let expectedWeekdays: [ProgressWeekday] = [
+      .monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday,
+    ]
+
+    XCTAssertEqual(weekdays, expectedWeekdays)
+  }
 }

--- a/apps/apple/ZoonkTests/ProgressPresentationTests.swift
+++ b/apps/apple/ZoonkTests/ProgressPresentationTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+
+@testable import Zoonk
+
+final class ProgressPresentationTests: XCTestCase {
+  func testLearningTimeUsesTheSmallestUsefulLocalizedUnits() {
+    let locale = Locale(identifier: "en_US")
+    let expectations = [
+      (seconds: 0, label: "0 min"),
+      (seconds: 30, label: "30 sec"),
+      (seconds: 59, label: "59 sec"),
+      (seconds: 60, label: "1 min"),
+      (seconds: 3_599, label: "1 hr"),
+      (seconds: 3_600, label: "1 hr"),
+      (seconds: 3_660, label: "1 hr, 1 min"),
+    ]
+
+    for expectation in expectations {
+      XCTAssertEqual(
+        progressLearningTime(expectation.seconds, locale: locale),
+        expectation.label)
+    }
+  }
+
+  func testMaximumLevelPresentsACompleteProgressValue() {
+    let level = LevelProgress(
+      belt: .black,
+      bpPerLevel: 100_000,
+      bpToNextLevel: 0,
+      isMaxLevel: true,
+      level: 10,
+      progressInLevel: 0,
+      totalBrainPower: 3_067_500)
+
+    XCTAssertEqual(level.progressValue, 100_000)
+    XCTAssertEqual(level.progressTotal, 100_000)
+  }
+}

--- a/apps/apple/ZoonkTests/ProgressStoreTests.swift
+++ b/apps/apple/ZoonkTests/ProgressStoreTests.swift
@@ -1,0 +1,495 @@
+import XCTest
+
+@testable import Zoonk
+
+@MainActor
+final class ProgressStoreTests: XCTestCase {
+  func testOverviewPublishesLoadedProgress() async {
+    let overview = ProgressOverview.testFixture
+    let store = makeStore(overviewResults: [.success(overview)])
+
+    await store.loadOverview()
+
+    XCTAssertEqual(store.overviewState, .loaded(overview))
+  }
+
+  func testEmptyOverviewPublishesEmptyState() async {
+    let store = makeStore(overviewResults: [.success(.emptyTestFixture)])
+
+    await store.loadOverview()
+
+    XCTAssertEqual(store.overviewState, .empty)
+  }
+
+  func testOverviewWithLearningTimePublishesLoadedState() async {
+    let overview = ProgressOverview.learningTimeTestFixture
+    let store = makeStore(overviewResults: [.success(overview)])
+
+    await store.loadOverview()
+
+    XCTAssertEqual(store.overviewState, .loaded(overview))
+  }
+
+  func testActivityWithLearningTimePublishesLoadedState() async {
+    let activity = ActivityProgress(
+      days: [],
+      summary: .learningTimeTestFixture)
+    let store = ProgressStore(
+      api: ProgressAPIStub(activityResult: .success(activity)),
+      session: .preview(account: .progressTestFixture))
+
+    await store.loadActivity()
+
+    XCTAssertEqual(store.activityState, .loaded(activity))
+  }
+
+  func testUnauthorizedOverviewExpiresTheMatchingSession() async {
+    let session = SessionStore.preview(account: .progressTestFixture)
+    let store = ProgressStore(
+      api: ProgressAPIStub(
+        overviewResults: [.failure(ProgressAPIError.unauthorized)]),
+      session: session)
+
+    await store.loadOverview()
+
+    XCTAssertNil(session.account)
+    XCTAssertEqual(store.overviewState, .idle)
+  }
+
+  func testOverviewCanRetryAfterNetworkFailure() async {
+    let overview = ProgressOverview.testFixture
+    let store = makeStore(
+      overviewResults: [
+        .failure(ProgressAPIError.network),
+        .success(overview),
+      ])
+
+    await store.loadOverview()
+    XCTAssertEqual(store.overviewState, .failed(.network))
+
+    await store.loadOverview(force: true)
+    XCTAssertEqual(store.overviewState, .loaded(overview))
+  }
+
+  func testOverviewReloadsProgressForTheSameSession() async {
+    let initialOverview = ProgressOverview.testFixture
+    let refreshedOverview = ProgressOverview.learningTimeTestFixture
+    let store = makeStore(
+      overviewResults: [
+        .success(initialOverview),
+        .success(refreshedOverview),
+      ])
+
+    await store.loadOverview()
+    await store.loadOverview()
+
+    XCTAssertEqual(store.overviewState, .loaded(refreshedOverview))
+  }
+
+  func testCancelledOverviewDoesNotPublishAnError() async {
+    let store = makeStore(overviewResults: [.failure(CancellationError())])
+
+    await store.loadOverview()
+
+    XCTAssertEqual(store.overviewState, .idle)
+  }
+
+  func testMissingEnergyPublishesEmptyState() async {
+    let store = ProgressStore(
+      api: ProgressAPIStub(energyResult: .success(nil)),
+      session: .preview(account: .progressTestFixture))
+
+    await store.loadEnergy()
+
+    XCTAssertEqual(store.energyState, .empty)
+  }
+
+  func testLateOverviewDoesNotOverwriteANewerRequest() async {
+    let firstRequestStarted = expectation(description: "First overview request started")
+    let secondRequestStarted = expectation(description: "Second overview request started")
+    let api = SuspendedOverviewAPIStub { requestCount in
+      if requestCount == 1 {
+        firstRequestStarted.fulfill()
+      } else if requestCount == 2 {
+        secondRequestStarted.fulfill()
+      }
+    }
+    let store = ProgressStore(
+      api: api,
+      session: .preview(account: .progressTestFixture))
+
+    let firstRequest = Task { await store.loadOverview() }
+    await fulfillment(of: [firstRequestStarted], timeout: 1)
+
+    guard await api.requestCount == 1 else {
+      firstRequest.cancel()
+      await api.cancelAllRequests()
+      await firstRequest.value
+      return
+    }
+
+    let secondRequest = Task { await store.loadOverview(force: true) }
+    await fulfillment(of: [secondRequestStarted], timeout: 1)
+
+    guard await api.requestCount == 2 else {
+      firstRequest.cancel()
+      secondRequest.cancel()
+      await api.cancelAllRequests()
+      await firstRequest.value
+      await secondRequest.value
+      return
+    }
+
+    await api.resolveRequest(at: 1, with: .testFixture)
+    await secondRequest.value
+    await api.resolveRequest(at: 0, with: .emptyTestFixture)
+    await firstRequest.value
+
+    XCTAssertEqual(store.overviewState, .loaded(.testFixture))
+  }
+
+  func testSameAccountCredentialReplacementStartsANewOverviewRequest() async {
+    let credentialStore = RotatingProgressCredentialStore(token: "old-session")
+    let session = SessionStore(
+      api: ProgressAccountAPIStub(account: .progressTestFixture),
+      credentialStore: credentialStore,
+      googleAuthentication: GoogleAuthenticationClient())
+    await session.restore()
+
+    let firstRequestStarted = expectation(description: "Old credential request started")
+    let secondRequestStarted = expectation(description: "New credential request started")
+    let api = SuspendedOverviewAPIStub { requestCount in
+      if requestCount == 1 {
+        firstRequestStarted.fulfill()
+      } else if requestCount == 2 {
+        secondRequestStarted.fulfill()
+      }
+    }
+    let store = ProgressStore(api: api, session: session)
+    let firstRequest = Task { await store.loadOverview() }
+    await fulfillment(of: [firstRequestStarted], timeout: 1)
+
+    guard await api.requestCount == 1 else {
+      firstRequest.cancel()
+      await api.cancelAllRequests()
+      await firstRequest.value
+      return
+    }
+
+    credentialStore.token = "new-session"
+    await session.reconcileSynchronizedCredential()
+
+    let secondRequest = Task { await store.loadOverview() }
+    await fulfillment(of: [secondRequestStarted], timeout: 1)
+
+    let requestCount = await api.requestCount
+    XCTAssertEqual(requestCount, 2)
+
+    guard requestCount == 2 else {
+      firstRequest.cancel()
+      secondRequest.cancel()
+      await api.cancelAllRequests()
+      await firstRequest.value
+      await secondRequest.value
+      return
+    }
+
+    await api.resolveRequest(at: 1, with: .testFixture)
+    await secondRequest.value
+    await api.resolveRequest(at: 0, with: .emptyTestFixture)
+    await firstRequest.value
+
+    let requestTokens = await api.requestTokens
+    XCTAssertEqual(requestTokens, ["old-session", "new-session"])
+    XCTAssertEqual(store.overviewState, .loaded(.testFixture))
+  }
+
+  private func makeStore(overviewResults: [Result<ProgressOverview, Error>]) -> ProgressStore {
+    ProgressStore(
+      api: ProgressAPIStub(overviewResults: overviewResults),
+      session: .preview(account: .progressTestFixture))
+  }
+}
+
+private actor SuspendedOverviewAPIStub: ProgressAPIClient {
+  private struct Request {
+    let continuation: CheckedContinuation<ProgressOverview, any Error>
+    let id: UUID
+  }
+
+  private let requestDidStart: @Sendable (Int) -> Void
+  private var overviewRequests: [Request?] = []
+  private(set) var requestTokens: [String] = []
+
+  init(requestDidStart: @escaping @Sendable (Int) -> Void = { _ in }) {
+    self.requestDidStart = requestDidStart
+  }
+
+  var requestCount: Int { overviewRequests.count }
+
+  func resolveRequest(at index: Int, with overview: ProgressOverview) {
+    overviewRequests[index]?.continuation.resume(returning: overview)
+    overviewRequests[index] = nil
+  }
+
+  func cancelAllRequests() {
+    for request in overviewRequests.compactMap(\.self) {
+      request.continuation.resume(throwing: CancellationError())
+    }
+
+    overviewRequests = overviewRequests.map { _ in nil }
+  }
+
+  func getOverview(token: String) async throws -> ProgressOverview {
+    let requestID = UUID()
+
+    return try await withTaskCancellationHandler {
+      try Task.checkCancellation()
+
+      return try await withCheckedThrowingContinuation { continuation in
+        guard !Task.isCancelled else {
+          continuation.resume(throwing: CancellationError())
+          return
+        }
+
+        requestTokens.append(token)
+        overviewRequests.append(Request(continuation: continuation, id: requestID))
+        requestDidStart(overviewRequests.count)
+      }
+    } onCancel: {
+      Task {
+        await self.cancelRequest(id: requestID)
+      }
+    }
+  }
+
+  private func cancelRequest(id: UUID) {
+    guard let index = overviewRequests.firstIndex(where: { $0?.id == id }) else {
+      return
+    }
+
+    overviewRequests[index]?.continuation.resume(throwing: CancellationError())
+    overviewRequests[index] = nil
+  }
+
+  func getActivity(token: String) async throws -> ActivityProgress {
+    throw ProgressAPIError.invalidResponse
+  }
+
+  func getEnergy(token: String) async throws -> EnergyProgress? {
+    throw ProgressAPIError.invalidResponse
+  }
+
+  func getLevel(token: String) async throws -> LevelProgress? {
+    throw ProgressAPIError.invalidResponse
+  }
+
+  func getScore(token: String) async throws -> ScoreProgress? {
+    throw ProgressAPIError.invalidResponse
+  }
+
+  func getScorePatterns(token: String) async throws -> ScorePatterns? {
+    throw ProgressAPIError.invalidResponse
+  }
+}
+
+private actor ProgressAPIStub: ProgressAPIClient {
+  private let activityResult: Result<ActivityProgress, Error>
+  private let energyResult: Result<EnergyProgress?, Error>
+  private var overviewResults: [Result<ProgressOverview, Error>]
+
+  init(overviewResults: [Result<ProgressOverview, Error>]) {
+    activityResult = .failure(ProgressAPIError.invalidResponse)
+    energyResult = .failure(ProgressAPIError.invalidResponse)
+    self.overviewResults = overviewResults
+  }
+
+  init(activityResult: Result<ActivityProgress, Error>) {
+    self.activityResult = activityResult
+    energyResult = .failure(ProgressAPIError.invalidResponse)
+    overviewResults = []
+  }
+
+  init(energyResult: Result<EnergyProgress?, Error>) {
+    activityResult = .failure(ProgressAPIError.invalidResponse)
+    self.energyResult = energyResult
+    overviewResults = []
+  }
+
+  func getOverview(token: String) async throws -> ProgressOverview {
+    guard !overviewResults.isEmpty else {
+      throw ProgressAPIError.invalidResponse
+    }
+
+    return try overviewResults.removeFirst().get()
+  }
+
+  func getActivity(token: String) async throws -> ActivityProgress {
+    try activityResult.get()
+  }
+
+  func getEnergy(token: String) async throws -> EnergyProgress? {
+    try energyResult.get()
+  }
+
+  func getLevel(token: String) async throws -> LevelProgress? {
+    throw ProgressAPIError.invalidResponse
+  }
+
+  func getScore(token: String) async throws -> ScoreProgress? {
+    throw ProgressAPIError.invalidResponse
+  }
+
+  func getScorePatterns(token: String) async throws -> ScorePatterns? {
+    throw ProgressAPIError.invalidResponse
+  }
+}
+
+private final class RotatingProgressCredentialStore: SessionCredentialStoring {
+  var token: String?
+
+  init(token: String?) {
+    self.token = token
+  }
+
+  func delete() throws {
+    token = nil
+  }
+
+  func read() throws -> String? {
+    token
+  }
+
+  func save(_ token: String) throws {
+    self.token = token
+  }
+}
+
+private final class ProgressAccountAPIStub: AccountAPIClient, @unchecked Sendable {
+  let account: CurrentAccount
+
+  init(account: CurrentAccount) {
+    self.account = account
+  }
+
+  func deleteAccount(
+    token: String,
+    appleCredentials: AppleSignInCredentials?,
+    emailCredentials: EmailReauthenticationCredentials?
+  ) async throws -> AccountDeletionResponse {
+    throw AccountAPIError.invalidResponse
+  }
+
+  func getCurrentAccount(token: String) async throws -> CurrentAccount {
+    account
+  }
+
+  func sendEmailCode(email: String) async throws {
+    throw AccountAPIError.invalidResponse
+  }
+
+  func signInWithApple(_ credentials: AppleSignInCredentials) async throws -> String {
+    throw AccountAPIError.invalidResponse
+  }
+
+  func signInWithEmailCode(email: String, code: String) async throws -> String {
+    throw AccountAPIError.invalidResponse
+  }
+
+  func signInWithGoogle(idToken: String) async throws -> String {
+    throw AccountAPIError.invalidResponse
+  }
+
+  func signOut(token: String) async throws {
+    throw AccountAPIError.invalidResponse
+  }
+
+  func synchronizeAppleSubscription(
+    token: String,
+    signedTransaction: String
+  ) async throws -> AppleSubscriptionSynchronization {
+    throw AccountAPIError.invalidResponse
+  }
+
+  func updateProfile(token: String, name: String, username: String) async throws
+    -> CurrentAccount
+  {
+    throw AccountAPIError.invalidResponse
+  }
+}
+
+extension ProgressOverview {
+  fileprivate static let emptyTestFixture = ProgressOverview(
+    activity: ActivitySummary(
+      learningDays: 0,
+      totalLearningSeconds: 0,
+      totalLessonCompletions: 0),
+    energy: nil,
+    level: nil,
+    score: nil,
+    strongestDaypart: nil,
+    strongestWeekday: nil)
+
+  fileprivate static let testFixture = ProgressOverview(
+    activity: ActivitySummary(
+      learningDays: 12,
+      totalLearningSeconds: 7_200,
+      totalLessonCompletions: 24),
+    energy: 82,
+    level: LevelProgress(
+      belt: .green,
+      bpPerLevel: 1_000,
+      bpToNextLevel: 240,
+      isMaxLevel: false,
+      level: 4,
+      progressInLevel: 760,
+      totalBrainPower: 3_760),
+    score: ScorePerformance(
+      correctAnswers: 41,
+      incorrectAnswers: 9,
+      score: 82,
+      totalAnswers: 50),
+    strongestDaypart: DaypartScorePattern(
+      daypart: .morning,
+      performance: ScorePerformance(
+        correctAnswers: 20,
+        incorrectAnswers: 2,
+        score: 90.9,
+        totalAnswers: 22)),
+    strongestWeekday: WeekdayScorePattern(
+      performance: ScorePerformance(
+        correctAnswers: 14,
+        incorrectAnswers: 1,
+        score: 93.3,
+        totalAnswers: 15),
+      weekday: .tuesday))
+
+  fileprivate static let learningTimeTestFixture = ProgressOverview(
+    activity: .learningTimeTestFixture,
+    energy: nil,
+    level: nil,
+    score: nil,
+    strongestDaypart: nil,
+    strongestWeekday: nil)
+}
+
+extension ActivitySummary {
+  fileprivate static let learningTimeTestFixture = ActivitySummary(
+    learningDays: 1,
+    totalLearningSeconds: 120,
+    totalLessonCompletions: 0)
+}
+
+extension CurrentAccount {
+  fileprivate static let progressTestFixture = CurrentAccount(
+    account: AccountAccess(
+      deletion: AccountDeletionRequirements(hasAppleAccount: false),
+      subscription: nil),
+    user: AccountUser(
+      displayUsername: "learner",
+      email: "learner@zoonk.test",
+      id: "progress-test-user",
+      image: nil,
+      name: "Learner",
+      username: "learner"))
+}

--- a/apps/apple/ZoonkTests/ProgressStoreTests.swift
+++ b/apps/apple/ZoonkTests/ProgressStoreTests.swift
@@ -94,6 +94,71 @@ final class ProgressStoreTests: XCTestCase {
     XCTAssertEqual(store.overviewState, .idle)
   }
 
+  func testCancelledOverviewRefreshPreservesLoadedProgress() async {
+    let overview = ProgressOverview.testFixture
+    let store = makeStore(
+      overviewResults: [
+        .success(overview),
+        .failure(CancellationError()),
+      ])
+
+    await store.loadOverview()
+    await store.loadOverview(force: true)
+
+    XCTAssertEqual(store.overviewState, .loaded(overview))
+  }
+
+  func testCancelledForcedOverviewLoadDoesNotRemainLoading() async {
+    let firstRequestStarted = expectation(description: "First overview request started")
+    let secondRequestStarted = expectation(description: "Second overview request started")
+    let api = SuspendedOverviewAPIStub { requestCount in
+      if requestCount == 1 {
+        firstRequestStarted.fulfill()
+      } else if requestCount == 2 {
+        secondRequestStarted.fulfill()
+      }
+    }
+    let store = ProgressStore(
+      api: api,
+      session: .preview(account: .progressTestFixture))
+
+    let firstRequest = Task { await store.loadOverview() }
+    await fulfillment(of: [firstRequestStarted], timeout: 1)
+
+    let firstRequestCount = await api.requestCount
+
+    guard firstRequestCount == 1 else {
+      XCTFail("Expected 1 overview request, received \(firstRequestCount)")
+      firstRequest.cancel()
+      await api.cancelAllRequests()
+      await firstRequest.value
+      return
+    }
+
+    let secondRequest = Task { await store.loadOverview(force: true) }
+    await fulfillment(of: [secondRequestStarted], timeout: 1)
+
+    let secondRequestCount = await api.requestCount
+
+    guard secondRequestCount == 2 else {
+      XCTFail("Expected 2 overview requests, received \(secondRequestCount)")
+      firstRequest.cancel()
+      secondRequest.cancel()
+      await api.cancelAllRequests()
+      await firstRequest.value
+      await secondRequest.value
+      return
+    }
+
+    secondRequest.cancel()
+    await secondRequest.value
+
+    XCTAssertEqual(store.overviewState, .idle)
+
+    firstRequest.cancel()
+    await firstRequest.value
+  }
+
   func testMissingEnergyPublishesEmptyState() async {
     let store = ProgressStore(
       api: ProgressAPIStub(energyResult: .success(nil)),
@@ -121,7 +186,10 @@ final class ProgressStoreTests: XCTestCase {
     let firstRequest = Task { await store.loadOverview() }
     await fulfillment(of: [firstRequestStarted], timeout: 1)
 
-    guard await api.requestCount == 1 else {
+    let firstRequestCount = await api.requestCount
+
+    guard firstRequestCount == 1 else {
+      XCTFail("Expected 1 overview request, received \(firstRequestCount)")
       firstRequest.cancel()
       await api.cancelAllRequests()
       await firstRequest.value
@@ -131,7 +199,10 @@ final class ProgressStoreTests: XCTestCase {
     let secondRequest = Task { await store.loadOverview(force: true) }
     await fulfillment(of: [secondRequestStarted], timeout: 1)
 
-    guard await api.requestCount == 2 else {
+    let secondRequestCount = await api.requestCount
+
+    guard secondRequestCount == 2 else {
+      XCTFail("Expected 2 overview requests, received \(secondRequestCount)")
       firstRequest.cancel()
       secondRequest.cancel()
       await api.cancelAllRequests()
@@ -169,7 +240,10 @@ final class ProgressStoreTests: XCTestCase {
     let firstRequest = Task { await store.loadOverview() }
     await fulfillment(of: [firstRequestStarted], timeout: 1)
 
-    guard await api.requestCount == 1 else {
+    let firstRequestCount = await api.requestCount
+
+    guard firstRequestCount == 1 else {
+      XCTFail("Expected 1 overview request, received \(firstRequestCount)")
       firstRequest.cancel()
       await api.cancelAllRequests()
       await firstRequest.value
@@ -182,10 +256,10 @@ final class ProgressStoreTests: XCTestCase {
     let secondRequest = Task { await store.loadOverview() }
     await fulfillment(of: [secondRequestStarted], timeout: 1)
 
-    let requestCount = await api.requestCount
-    XCTAssertEqual(requestCount, 2)
+    let secondRequestCount = await api.requestCount
 
-    guard requestCount == 2 else {
+    guard secondRequestCount == 2 else {
+      XCTFail("Expected 2 overview requests, received \(secondRequestCount)")
       firstRequest.cancel()
       secondRequest.cancel()
       await api.cancelAllRequests()

--- a/apps/apple/ZoonkTests/SessionStoreTests.swift
+++ b/apps/apple/ZoonkTests/SessionStoreTests.swift
@@ -429,6 +429,54 @@ final class SessionStoreTests: XCTestCase {
   }
 
   @MainActor
+  func testExpiringAnOldSessionPreservesANewerSynchronizedCredential() async throws {
+    let accountA = makeAccount(userID: "account-a")
+    let accountB = makeAccount(userID: "account-b")
+    let credentialStore = SessionCredentialStoreSpy(token: "account-a-session")
+    let api = SessionStoreAPIStub(currentAccountResult: .success(accountA))
+    let session = makeSession(api: api, credentialStore: credentialStore)
+    await session.restore()
+    let expiredSession = try XCTUnwrap(session.authenticatedSession)
+
+    credentialStore.token = "account-b-session"
+    api.currentAccountResult = .success(accountB)
+    await session.expire(expiredSession)
+
+    XCTAssertEqual(credentialStore.token, "account-b-session")
+    XCTAssertEqual(credentialStore.deleteCallCount, 0)
+    XCTAssertEqual(session.authenticatedSession?.accountID, "account-b")
+    XCTAssertEqual(session.authenticatedSession?.bearerToken, "account-b-session")
+  }
+
+  @MainActor
+  func testExpiredSessionWinsAgainstALateProfileResponse() async throws {
+    let account = makeAccount()
+    let updatedAccount = makeAccount(name: "Updated learner")
+    let profileUpdate = CurrentAccountRequestGate()
+    let credentialStore = SessionCredentialStoreSpy(token: "stored-session")
+    let api = SessionStoreAPIStub(currentAccountResult: .success(account))
+    api.updateProfileHandler = { _, _, _ in
+      await profileUpdate.load()
+    }
+    let session = makeSession(api: api, credentialStore: credentialStore)
+    await session.restore()
+    let expiredSession = try XCTUnwrap(session.authenticatedSession)
+
+    let updateTask = Task {
+      await session.updateProfile(name: "Updated learner", username: "learner")
+    }
+    await profileUpdate.waitUntilStarted()
+    await session.expire(expiredSession)
+    profileUpdate.resume(returning: updatedAccount)
+
+    let didUpdateProfile = await updateTask.value
+
+    XCTAssertFalse(didUpdateProfile)
+    XCTAssertEqual(session.state, .signedOut)
+    XCTAssertNil(session.authenticatedSession)
+  }
+
+  @MainActor
   func testNewKeychainAccountWinsAgainstAppleSynchronizationForThePreviousAccount() async {
     let accountA = makeAccount(userID: "account-a")
     let accountASubscription = makeAccount(
@@ -507,6 +555,7 @@ private final class SessionStoreAPIStub: AccountAPIClient, @unchecked Sendable {
   var currentAccountHandler: (@MainActor (String) async throws -> CurrentAccount)?
   var emailSignInResult: Result<String, AccountAPIError> = .failure(.invalidResponse)
   var signOutResult: Result<Void, AccountAPIError> = .failure(.invalidResponse)
+  var updateProfileHandler: (@MainActor (String, String, String) async throws -> CurrentAccount)?
   var updateProfileResult: Result<CurrentAccount, AccountAPIError> = .failure(.invalidResponse)
 
   init(
@@ -558,7 +607,11 @@ private final class SessionStoreAPIStub: AccountAPIClient, @unchecked Sendable {
   }
 
   func updateProfile(token: String, name: String, username: String) async throws -> CurrentAccount {
-    try updateProfileResult.get()
+    if let updateProfileHandler {
+      return try await updateProfileHandler(token, name, username)
+    }
+
+    return try updateProfileResult.get()
   }
 }
 

--- a/apps/apple/ZoonkUITests/ProgressUITestFixture.swift
+++ b/apps/apple/ZoonkUITests/ProgressUITestFixture.swift
@@ -1,0 +1,273 @@
+let progressUITestSnapshotJSON =
+  #"""
+  {
+    "overview": {
+      "activity": {
+        "learningDays": 12,
+        "totalLearningSeconds": 7200,
+        "totalLessonCompletions": 24
+      },
+      "energy": 82,
+      "level": {
+        "belt": "green",
+        "bpPerLevel": 1000,
+        "bpToNextLevel": 240,
+        "isMaxLevel": false,
+        "level": 4,
+        "progressInLevel": 760,
+        "totalBrainPower": 3760
+      },
+      "score": {
+        "correctAnswers": 41,
+        "incorrectAnswers": 9,
+        "score": 82,
+        "totalAnswers": 50
+      },
+      "strongestDaypart": {
+        "daypart": "morning",
+        "performance": {
+          "correctAnswers": 20,
+          "incorrectAnswers": 2,
+          "score": 90.9,
+          "totalAnswers": 22
+        }
+      },
+      "strongestWeekday": {
+        "performance": {
+          "correctAnswers": 14,
+          "incorrectAnswers": 1,
+          "score": 93.3,
+          "totalAnswers": 15
+        },
+        "weekday": "tuesday"
+      }
+    },
+    "activity": {
+      "days": [
+        { "date": "2026-05-31", "lessonCompletions": 2 },
+        { "date": "2026-06-30", "lessonCompletions": 5 },
+        { "date": "2026-07-31", "lessonCompletions": 8 },
+        { "date": "2026-08-20", "lessonCompletions": 9 }
+      ],
+      "summary": {
+        "learningDays": 12,
+        "totalLearningSeconds": 7200,
+        "totalLessonCompletions": 24
+      }
+    },
+    "energy": {
+      "currentEnergy": 82,
+      "days": [
+        { "date": "2026-05-31", "energy": null },
+        { "date": "2026-06-30", "energy": 64 },
+        { "date": "2026-07-31", "energy": 73 },
+        { "date": "2026-08-20", "energy": 82 }
+      ],
+      "insights": { "averageEnergy": 73, "fullEnergyDays": 3 }
+    },
+    "level": {
+      "belt": "green",
+      "bpPerLevel": 1000,
+      "bpToNextLevel": 240,
+      "isMaxLevel": false,
+      "level": 4,
+      "progressInLevel": 760,
+      "totalBrainPower": 3760
+    },
+    "score": {
+      "dataPoints": [
+        {
+          "date": "2026-06-01",
+          "performance": {
+            "correctAnswers": 8,
+            "incorrectAnswers": 4,
+            "score": 66.7,
+            "totalAnswers": 12
+          }
+        },
+        {
+          "date": "2026-07-06",
+          "performance": {
+            "correctAnswers": 13,
+            "incorrectAnswers": 3,
+            "score": 81.3,
+            "totalAnswers": 16
+          }
+        },
+        {
+          "date": "2026-08-17",
+          "performance": {
+            "correctAnswers": 20,
+            "incorrectAnswers": 2,
+            "score": 90.9,
+            "totalAnswers": 22
+          }
+        }
+      ],
+      "performance": {
+        "correctAnswers": 41,
+        "incorrectAnswers": 9,
+        "score": 82,
+        "totalAnswers": 50
+      },
+      "periodEnd": "2026-08-20",
+      "periodStart": "2026-05-23"
+    },
+    "patterns": {
+      "dayparts": [
+        {
+          "daypart": "night",
+          "performance": {
+            "correctAnswers": 0,
+            "incorrectAnswers": 0,
+            "score": 0,
+            "totalAnswers": 0
+          }
+        },
+        {
+          "daypart": "morning",
+          "performance": {
+            "correctAnswers": 20,
+            "incorrectAnswers": 2,
+            "score": 90.9,
+            "totalAnswers": 22
+          }
+        },
+        {
+          "daypart": "afternoon",
+          "performance": {
+            "correctAnswers": 12,
+            "incorrectAnswers": 4,
+            "score": 75,
+            "totalAnswers": 16
+          }
+        },
+        {
+          "daypart": "evening",
+          "performance": {
+            "correctAnswers": 9,
+            "incorrectAnswers": 3,
+            "score": 75,
+            "totalAnswers": 12
+          }
+        }
+      ],
+      "strongestDaypart": {
+        "daypart": "morning",
+        "performance": {
+          "correctAnswers": 20,
+          "incorrectAnswers": 2,
+          "score": 90.9,
+          "totalAnswers": 22
+        }
+      },
+      "strongestWeekday": {
+        "performance": {
+          "correctAnswers": 14,
+          "incorrectAnswers": 1,
+          "score": 93.3,
+          "totalAnswers": 15
+        },
+        "weekday": "tuesday"
+      },
+      "weekdays": [
+        {
+          "performance": { "correctAnswers": 0, "incorrectAnswers": 0, "score": 0, "totalAnswers": 0 },
+          "weekday": "sunday"
+        },
+        {
+          "performance": { "correctAnswers": 5, "incorrectAnswers": 2, "score": 71.4, "totalAnswers": 7 },
+          "weekday": "monday"
+        },
+        {
+          "performance": { "correctAnswers": 14, "incorrectAnswers": 1, "score": 93.3, "totalAnswers": 15 },
+          "weekday": "tuesday"
+        },
+        {
+          "performance": { "correctAnswers": 7, "incorrectAnswers": 2, "score": 77.8, "totalAnswers": 9 },
+          "weekday": "wednesday"
+        },
+        {
+          "performance": { "correctAnswers": 6, "incorrectAnswers": 2, "score": 75, "totalAnswers": 8 },
+          "weekday": "thursday"
+        },
+        {
+          "performance": { "correctAnswers": 5, "incorrectAnswers": 1, "score": 83.3, "totalAnswers": 6 },
+          "weekday": "friday"
+        },
+        {
+          "performance": { "correctAnswers": 4, "incorrectAnswers": 1, "score": 80, "totalAnswers": 5 },
+          "weekday": "saturday"
+        }
+      ]
+    }
+  }
+  """#
+
+let progressDaypartOnlyUITestSnapshotJSON =
+  #"""
+  {
+    "overview": {
+      "activity": {
+        "learningDays": 0,
+        "totalLearningSeconds": 0,
+        "totalLessonCompletions": 0
+      },
+      "energy": null,
+      "level": null,
+      "score": null,
+      "strongestDaypart": {
+        "daypart": "morning",
+        "performance": {
+          "correctAnswers": 9,
+          "incorrectAnswers": 1,
+          "score": 90,
+          "totalAnswers": 10
+        }
+      },
+      "strongestWeekday": null
+    },
+    "activity": {
+      "days": [],
+      "summary": {
+        "learningDays": 0,
+        "totalLearningSeconds": 0,
+        "totalLessonCompletions": 0
+      }
+    },
+    "energy": null,
+    "level": null,
+    "patterns": null,
+    "score": null
+  }
+  """#
+
+let progressEmptyUITestSnapshotJSON =
+  #"""
+  {
+    "overview": {
+      "activity": {
+        "learningDays": 0,
+        "totalLearningSeconds": 0,
+        "totalLessonCompletions": 0
+      },
+      "energy": null,
+      "level": null,
+      "score": null,
+      "strongestDaypart": null,
+      "strongestWeekday": null
+    },
+    "activity": {
+      "days": [],
+      "summary": {
+        "learningDays": 0,
+        "totalLearningSeconds": 0,
+        "totalLessonCompletions": 0
+      }
+    },
+    "energy": null,
+    "level": null,
+    "patterns": null,
+    "score": null
+  }
+  """#

--- a/apps/apple/ZoonkUITests/ZoonkUITests.swift
+++ b/apps/apple/ZoonkUITests/ZoonkUITests.swift
@@ -1,10 +1,16 @@
 import StoreKitTest
+import UIKit
 import XCTest
 
 private enum UITestScenario: Equatable {
   case appleSubscription
   case freeSubscription
   case googleSubscription
+  case progress
+  case progressActivityUnauthorized
+  case progressDaypartOnly
+  case progressEmpty
+  case progressOverviewFailure
   case requiredSetup
   case signedOut
 
@@ -18,6 +24,9 @@ private enum UITestScenario: Equatable {
       accountJSON(provider: nil)
     case .googleSubscription:
       accountJSON(provider: "google")
+    case .progress, .progressActivityUnauthorized, .progressDaypartOnly, .progressEmpty,
+      .progressOverviewFailure:
+      accountJSON(provider: nil)
     case .signedOut:
       nil
     }
@@ -26,6 +35,31 @@ private enum UITestScenario: Equatable {
   var launchArguments: [String] {
     ["-AppleLanguages", "(en)", "-AppleLocale", "en_US", "--ui-testing"]
       + (self == .requiredSetup ? ["--ui-testing-account-sheet"] : [])
+  }
+
+  var progressJSON: String? {
+    switch self {
+    case .progress, .progressActivityUnauthorized, .progressOverviewFailure:
+      progressUITestSnapshotJSON
+    case .progressDaypartOnly:
+      progressDaypartOnlyUITestSnapshotJSON
+    case .progressEmpty:
+      progressEmptyUITestSnapshotJSON
+    case .appleSubscription, .freeSubscription, .googleSubscription, .requiredSetup, .signedOut:
+      nil
+    }
+  }
+
+  var progressFailure: String? {
+    switch self {
+    case .progressActivityUnauthorized:
+      "activity-unauthorized"
+    case .progressOverviewFailure:
+      "overview-network"
+    case .appleSubscription, .freeSubscription, .googleSubscription, .progress,
+      .progressDaypartOnly, .progressEmpty, .requiredSetup, .signedOut:
+      nil
+    }
   }
 
   private var requiredSetupAccountJSON: String {
@@ -384,6 +418,149 @@ final class ZoonkUITests: XCTestCase {
     }
   }
 
+  @MainActor
+  func testProgressSignInActionPresentsTheAccountSheet() {
+    continueAfterFailure = false
+
+    let app = makeApp()
+    app.launch()
+    app.buttons["Progress"].firstMatch.tap()
+    app.buttons["Sign in"].tap()
+
+    XCTAssertTrue(
+      app.buttons["Continue with Apple"].waitForExistence(timeout: 5),
+      "Expected Progress sign-in to present the account sheet")
+  }
+
+  @MainActor
+  func testProgressOverviewPresentsAnAvailableDaypartWithoutAWeekday() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .progressDaypartOnly)
+    app.launch()
+    app.buttons["Progress"].firstMatch.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["Morning"].waitForExistence(timeout: 5),
+      "Expected the overview to preserve an available strongest time")
+    XCTAssertFalse(
+      app.staticTexts["Keep answering to discover your strongest learning patterns."].exists,
+      "Expected valid daypart data to avoid the missing-pattern state")
+  }
+
+  @MainActor
+  func testProgressOverviewPresentsEmptyAndFailureRecoveryStates() {
+    continueAfterFailure = false
+
+    let emptyApp = makeApp(for: .progressEmpty)
+    emptyApp.launch()
+    emptyApp.buttons["Progress"].firstMatch.tap()
+    XCTAssertTrue(
+      emptyApp.staticTexts["Your progress starts here"].waitForExistence(timeout: 5),
+      "Expected an empty learner to receive progress guidance")
+    emptyApp.terminate()
+
+    let failedApp = makeApp(for: .progressOverviewFailure)
+    failedApp.launch()
+    failedApp.buttons["Progress"].firstMatch.tap()
+    XCTAssertTrue(
+      failedApp.staticTexts["You're offline"].waitForExistence(timeout: 5),
+      "Expected a network failure to show a recoverable state")
+    XCTAssertTrue(failedApp.buttons["Try again"].exists, "Expected an explicit retry action")
+  }
+
+  @MainActor
+  func testProgressAuthenticationLossReturnsToSignInRecovery() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .progressActivityUnauthorized)
+    app.launch()
+    app.buttons["Progress"].firstMatch.tap()
+    XCTAssertTrue(app.staticTexts["At a glance"].waitForExistence(timeout: 5))
+    app.staticTexts["Activity"].firstMatch.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["Sign in to see your progress"].waitForExistence(timeout: 5),
+      "Expected authentication loss to leave the loading detail and return to recovery")
+  }
+
+  @MainActor
+  func testProgressDetailTitleAdaptsToTheDevice() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .progress)
+    app.launch()
+    app.buttons["Progress"].firstMatch.tap()
+    XCTAssertTrue(app.staticTexts["At a glance"].waitForExistence(timeout: 5))
+    app.staticTexts["Level"].firstMatch.tap()
+    XCTAssertTrue(app.staticTexts["Belt journey"].waitForExistence(timeout: 5))
+
+    let title = app.navigationBars.firstMatch.staticTexts["Level"]
+
+    if UIDevice.current.userInterfaceIdiom == .pad {
+      XCTAssertFalse(title.exists, "Expected iPad to omit the centered detail title")
+    } else {
+      XCTAssertTrue(title.exists, "Expected iPhone to keep the title aligned with its back action")
+    }
+  }
+
+  /// Proves that the native Progress summary exposes every metric and pushes details within the existing tab's navigation stack.
+  @MainActor
+  func testProgressOverviewNavigatesToEveryMetric() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .progress)
+    app.launch()
+
+    app.buttons["Progress"].firstMatch.tap()
+    XCTAssertTrue(
+      app.staticTexts["At a glance"].waitForExistence(timeout: 5),
+      "Expected the loaded Progress summary to appear")
+
+    let destinations = [
+      (title: "Activity", loadedContent: "Learning activity"),
+      (title: "Score", loadedContent: "Weekly trend"),
+      (title: "Patterns", loadedContent: "Weekly rhythm"),
+      (title: "Level", loadedContent: "Belt journey"),
+      (title: "Energy", loadedContent: "Energy history"),
+    ]
+
+    for destination in destinations {
+      let destinationTitle = app.staticTexts[destination.title].firstMatch
+      XCTAssertTrue(
+        destinationTitle.waitForExistence(timeout: 5),
+        "Expected the Progress summary to include \(destination.title)")
+      destinationTitle.tap()
+
+      XCTAssertTrue(
+        app.navigationBars.firstMatch.waitForExistence(timeout: 5),
+        "Expected \(destination.title) to open in the native navigation stack")
+      XCTAssertTrue(
+        app.staticTexts[destination.loadedContent].waitForExistence(timeout: 5),
+        "Expected \(destination.title) to finish loading its fixture content")
+      let backButton = app.navigationBars.firstMatch.buttons["Progress"]
+      XCTAssertTrue(
+        backButton.exists,
+        "Expected \(destination.title) to retain the native Progress back action")
+      backButton.tap()
+    }
+  }
+
+  /// Proves contribution days expose their exact date and value through the same tap interaction on both progress calendars.
+  @MainActor
+  func testProgressContributionCalendarsRevealSelectedDayDetails() {
+    continueAfterFailure = false
+
+    assertContributionDetails(
+      destination: "Activity",
+      date: "August 20, 2026",
+      details: "Lessons completed: 9")
+    assertContributionDetails(
+      destination: "Energy",
+      date: "August 20, 2026",
+      details: "Energy: 82%")
+  }
+
   /// Creates one isolated app process from scenario data owned by the UI-test target rather than the distributable app.
   @MainActor
   private func makeApp(for scenario: UITestScenario = .signedOut) -> XCUIApplication {
@@ -394,7 +571,39 @@ final class ZoonkUITests: XCTestCase {
       app.launchEnvironment["ZOONK_UI_TEST_ACCOUNT"] = accountJSON
     }
 
+    if let progressJSON = scenario.progressJSON {
+      app.launchEnvironment["ZOONK_UI_TEST_PROGRESS"] = progressJSON
+    }
+
+    if let progressFailure = scenario.progressFailure {
+      app.launchEnvironment["ZOONK_UI_TEST_PROGRESS_FAILURE"] = progressFailure
+    }
+
     return app
+  }
+
+  @MainActor
+  private func assertContributionDetails(destination: String, date: String, details: String) {
+    let app = makeApp(for: .progress)
+    app.launch()
+
+    app.buttons["Progress"].firstMatch.tap()
+    XCTAssertTrue(
+      app.staticTexts["At a glance"].waitForExistence(timeout: 5),
+      "Expected the loaded Progress summary to appear")
+    app.staticTexts[destination].firstMatch.tap()
+
+    let contributionDay = app.buttons[date]
+    XCTAssertTrue(
+      contributionDay.waitForExistence(timeout: 5),
+      "Expected the \(destination) calendar to expose \(date) as an interactive day")
+    contributionDay.tap()
+
+    XCTAssertTrue(
+      app.staticTexts[details].waitForExistence(timeout: 5),
+      "Expected the selected \(destination) day to reveal its exact value")
+
+    app.terminate()
   }
 
   @MainActor

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -318,7 +318,7 @@ msgstr "Fortschritt"
 #: src/app/[lang]/(progress)/score/page.tsx
 msgctxt "oLkLww"
 msgid "Score"
-msgstr "Punktestand"
+msgstr "Score"
 
 #: src/app/[lang]/(catalog)/(home)/score.tsx
 msgctxt "_lCW0j"
@@ -1264,12 +1264,12 @@ msgstr "Sieh, wie viele Fragen du richtig beantwortest"
 #: src/app/[lang]/(progress)/score/score-chart-client.tsx
 msgctxt "33eat_"
 msgid "Weekly score trend"
-msgstr "Wöchentlicher Punktetrend"
+msgstr "Wöchentliche Score-Entwicklung"
 
 #: src/app/[lang]/(progress)/score/score-chart-client.tsx
 msgctxt "22eTjk"
 msgid "Weekly score"
-msgstr "Wöchentliche Punktzahl"
+msgstr "Wöchentlicher Score"
 
 #: src/app/[lang]/(progress)/score/score-chart-client.tsx
 #: src/app/[lang]/(progress)/score/score-stats.tsx
@@ -1285,17 +1285,17 @@ msgstr "{label}: {score} bei {count, plural, one {# Antwort} other {# Antworten}
 #: src/app/[lang]/(progress)/score/score-explanation.tsx
 msgctxt "bIZaXJ"
 msgid "What is Score?"
-msgstr "Was ist die Punktzahl?"
+msgstr "Was ist der Score?"
 
 #: src/app/[lang]/(progress)/score/score-explanation.tsx
 msgctxt "TiNLLD"
 msgid "Score is the percentage of questions you answered correctly over the past 90 days. Every answer counts equally, so harder lessons can lower your Score for a while. That’s part of learning."
-msgstr "Deine Punktzahl zeigt, wie viel Prozent der Fragen du in den letzten 90 Tagen richtig beantwortet hast. Jede Antwort zählt gleich viel. Deshalb können schwierigere Lektionen deine Punktzahl eine Zeit lang senken. Das gehört zum Lernen dazu."
+msgstr "Der Score ist der Prozentsatz der Fragen, die du in den letzten 90 Tagen richtig beantwortet hast. Jede Antwort zählt gleich viel. Deshalb kann dein Score durch schwierigere Lektionen eine Zeit lang sinken. Das gehört zum Lernen dazu."
 
 #: src/app/[lang]/(progress)/score/score-stats.tsx
 msgctxt "b-bOob"
 msgid "Score summary"
-msgstr "Punktzahl im Überblick"
+msgstr "Score-Übersicht"
 
 #: src/app/[lang]/(progress)/score/score-stats.tsx
 msgctxt "WCq9Lo"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -1290,7 +1290,7 @@ msgstr "¿Qué es la puntuación?"
 #: src/app/[lang]/(progress)/score/score-explanation.tsx
 msgctxt "TiNLLD"
 msgid "Score is the percentage of questions you answered correctly over the past 90 days. Every answer counts equally, so harder lessons can lower your Score for a while. That’s part of learning."
-msgstr "La puntuación es el porcentaje de preguntas que respondiste correctamente en los últimos 90 días. Todas las respuestas cuentan por igual, así que las lecciones más difíciles pueden reducir tu puntuación durante un tiempo. Es parte del aprendizaje."
+msgstr "La puntuación es el porcentaje de preguntas que has respondido correctamente en los últimos 90 días. Todas las respuestas cuentan por igual, así que las lecciones más difíciles pueden bajar tu puntuación durante un tiempo. Eso es parte de aprender."
 
 #: src/app/[lang]/(progress)/score/score-stats.tsx
 msgctxt "b-bOob"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -1264,12 +1264,12 @@ msgstr "Découvre ton taux de bonnes réponses"
 #: src/app/[lang]/(progress)/score/score-chart-client.tsx
 msgctxt "33eat_"
 msgid "Weekly score trend"
-msgstr "Évolution du score chaque semaine"
+msgstr "Évolution hebdomadaire du score"
 
 #: src/app/[lang]/(progress)/score/score-chart-client.tsx
 msgctxt "22eTjk"
 msgid "Weekly score"
-msgstr "Score de la semaine"
+msgstr "Score hebdomadaire"
 
 #: src/app/[lang]/(progress)/score/score-chart-client.tsx
 #: src/app/[lang]/(progress)/score/score-stats.tsx
@@ -1285,12 +1285,12 @@ msgstr "{label} : {score} sur {count, plural, one {# réponse} other {# réponse
 #: src/app/[lang]/(progress)/score/score-explanation.tsx
 msgctxt "bIZaXJ"
 msgid "What is Score?"
-msgstr "Qu'est-ce que le score ?"
+msgstr "Qu’est-ce que le score ?"
 
 #: src/app/[lang]/(progress)/score/score-explanation.tsx
 msgctxt "TiNLLD"
 msgid "Score is the percentage of questions you answered correctly over the past 90 days. Every answer counts equally, so harder lessons can lower your Score for a while. That’s part of learning."
-msgstr "Le score est le pourcentage de questions auxquelles tu as bien répondu sur les 90 derniers jours. Chaque réponse compte autant, donc les leçons plus difficiles peuvent faire baisser ton score pendant un moment. Ça fait partie de l’apprentissage."
+msgstr "Le score correspond au pourcentage de questions auxquelles tu as répondu correctement au cours des 90 derniers jours. Chaque réponse compte autant, donc les leçons plus difficiles peuvent faire baisser ton score pendant quelque temps. Ça fait partie de l’apprentissage."
 
 #: src/app/[lang]/(progress)/score/score-stats.tsx
 msgctxt "b-bOob"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -1264,7 +1264,7 @@ msgstr "Veja com que precisão você responde às perguntas"
 #: src/app/[lang]/(progress)/score/score-chart-client.tsx
 msgctxt "33eat_"
 msgid "Weekly score trend"
-msgstr "Tendência semanal da pontuação"
+msgstr "Evolução semanal da Pontuação"
 
 #: src/app/[lang]/(progress)/score/score-chart-client.tsx
 msgctxt "22eTjk"
@@ -1290,12 +1290,12 @@ msgstr "O que é Pontuação?"
 #: src/app/[lang]/(progress)/score/score-explanation.tsx
 msgctxt "TiNLLD"
 msgid "Score is the percentage of questions you answered correctly over the past 90 days. Every answer counts equally, so harder lessons can lower your Score for a while. That’s part of learning."
-msgstr "A pontuação é a porcentagem de perguntas que você respondeu corretamente nos últimos 90 dias. Todas as respostas têm o mesmo peso, então aulas mais difíceis podem diminuir sua pontuação por um tempo. Isso faz parte do estudo."
+msgstr "A Pontuação é a porcentagem de perguntas que você respondeu corretamente nos últimos 90 dias. Cada resposta tem o mesmo peso, então aulas mais difíceis podem diminuir sua Pontuação por um tempo. Isso faz parte de aprender."
 
 #: src/app/[lang]/(progress)/score/score-stats.tsx
 msgctxt "b-bOob"
 msgid "Score summary"
-msgstr "Resumo da pontuação"
+msgstr "Resumo da Pontuação"
 
 #: src/app/[lang]/(progress)/score/score-stats.tsx
 msgctxt "WCq9Lo"

--- a/packages/i18n/.eloqnt/styleguide.de.md
+++ b/packages/i18n/.eloqnt/styleguide.de.md
@@ -12,6 +12,7 @@
 - "Brain Power": "Brain Power"
 - "BP": "BP"
 - "Energy": "Energie"
+- "score": "Score"
 - "listening": "Hören"
 - "level": "Level"
 

--- a/packages/i18n/.eloqnt/styleguide.es.md
+++ b/packages/i18n/.eloqnt/styleguide.es.md
@@ -11,6 +11,7 @@
 - "Brain Power": "Poder Mental"
 - "BP": "PM"
 - "Energy": "Energía"
+- "score": "Puntuación"
 - "learning": "estudio" (eg "learning days" = "días de estudio")
 - "listening": "escucha"
 

--- a/packages/i18n/.eloqnt/styleguide.fr.md
+++ b/packages/i18n/.eloqnt/styleguide.fr.md
@@ -13,6 +13,7 @@
 - "Brain Power": "Puissance Mentale"
 - "BP": "PM"
 - "Energy": "Énergie"
+- "score": "Score"
 - "listening": "écoute"
 
 ## Special Cases

--- a/packages/i18n/.eloqnt/styleguide.pt.md
+++ b/packages/i18n/.eloqnt/styleguide.pt.md
@@ -30,6 +30,7 @@
 - "we": "a gente"
 - "quiz": "quiz"
 - "language": "idioma"
+- "score": "Pontuação"
 
 ## Special Cases
 

--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -426,7 +426,7 @@ msgstr "Fortschritt wird nicht gespeichert"
 #: src/components/unauthenticated-progress-prompt.tsx
 msgctxt "JDumQX"
 msgid "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
-msgstr "Du kannst diese Lektion ohne Konto ausprobieren, aber deine Punktzahl, Kursfortschritt, Levels und Energie werden nicht gespeichert."
+msgstr "Du kannst diese Lektion ohne Konto ausprobieren, aber dein Score, dein Kursfortschritt, deine Level und deine Energie werden nicht gespeichert."
 
 #: src/components/verdict-label.tsx
 msgctxt "xmF49T"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -426,7 +426,7 @@ msgstr "No se guardará el progreso"
 #: src/components/unauthenticated-progress-prompt.tsx
 msgctxt "JDumQX"
 msgid "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
-msgstr "Puedes probar esta lección sin una cuenta, pero no se guardarán tu puntuación, el progreso del curso, los niveles ni la Energía."
+msgstr "Puedes probar esta lección sin tener una cuenta, pero no se guardarán tu puntuación, tu progreso en el curso, tus niveles ni tu Energía."
 
 #: src/components/verdict-label.tsx
 msgctxt "xmF49T"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -426,7 +426,7 @@ msgstr "La progression ne sera pas sauvegardée"
 #: src/components/unauthenticated-progress-prompt.tsx
 msgctxt "JDumQX"
 msgid "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
-msgstr "Tu peux essayer cette leçon sans compte, mais ton score, ta progression dans le cours, tes niveaux et ton Énergie ne seront pas sauvegardés."
+msgstr "Tu peux essayer cette leçon sans compte, mais ton score, ta progression dans le cours, tes niveaux et ton Énergie ne seront pas enregistrés."
 
 #: src/components/verdict-label.tsx
 msgctxt "xmF49T"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -426,7 +426,7 @@ msgstr "O progresso não será salvo"
 #: src/components/unauthenticated-progress-prompt.tsx
 msgctxt "JDumQX"
 msgid "You can try this lesson without an account, but your score, course progress, levels, and Energy won't be saved."
-msgstr "Você pode testar esta aula sem uma conta, mas sua pontuação, progresso no curso, níveis e Energia não serão salvos."
+msgstr "Você pode experimentar esta aula sem criar uma conta, mas sua Pontuação, progresso no curso, níveis e Energia não serão salvos."
 
 #: src/components/verdict-label.tsx
 msgctxt "xmF49T"


### PR DESCRIPTION
## Summary

- add an adaptive native Progress experience for iPhone and iPad
- include Activity, Score, Patterns, Level, and Energy details with resilient session and refresh behavior
- align Score terminology across supported translations and locale guidance