### PR TITLE
feat(admin): add leaderboard period filters

### DIFF
--- a/apps/admin/src/app/(private)/leaderboard/brain-power-leaderboard.tsx
+++ b/apps/admin/src/app/(private)/leaderboard/brain-power-leaderboard.tsx
@@ -17,8 +17,13 @@ import {
   TableRow,
 } from "@zoonk/ui/components/table";
 import Link from "next/link";
+import {
+  type LeaderboardPeriod,
+  getLeaderboardPeriodDays,
+  leaderboardPeriodDescriptions,
+  parseLeaderboardPeriod,
+} from "./leaderboard-period";
 
-const LEADERBOARD_DAYS = 7;
 const TABLE_COLUMN_COUNT = 4;
 
 /**
@@ -32,8 +37,9 @@ export async function BrainPowerLeaderboard({
 }) {
   const params = await searchParams;
   const { limit, offset, page } = parseSearchParams(params);
+  const period = parseLeaderboardPeriod(params.period);
 
-  return <CachedBrainPowerLeaderboard limit={limit} offset={offset} page={page} />;
+  return <CachedBrainPowerLeaderboard limit={limit} offset={offset} page={page} period={period} />;
 }
 
 /**
@@ -44,15 +50,17 @@ async function CachedBrainPowerLeaderboard({
   limit,
   offset,
   page,
+  period,
 }: {
   limit: number;
   offset: number;
   page: number;
+  period: LeaderboardPeriod;
 }) {
   "use cache: private";
 
   const { currentPeriodStart } = getRollingUtcDateWindowStarts({
-    days: LEADERBOARD_DAYS,
+    days: getLeaderboardPeriodDays(period),
     now: new Date(),
   });
 
@@ -63,17 +71,19 @@ async function CachedBrainPowerLeaderboard({
   });
 
   const totalPages = Math.ceil(total / limit);
+  const periodDescription = leaderboardPeriodDescriptions[period];
+  const userCountLabel = getLeaderboardUserCountLabel(total);
 
   return (
     <>
       <p className="text-muted-foreground text-sm">
-        {total.toLocaleString()} users earned Brain Power in the past 7 days.
+        {total.toLocaleString()} {userCountLabel} earned Brain Power {periodDescription}.
       </p>
 
       <div className="overflow-x-auto rounded-lg border">
         <Table>
           <TableCaption className="sr-only">
-            Brain Power leaderboard for the past 7 days
+            Brain Power leaderboard {periodDescription}
           </TableCaption>
           <BrainPowerLeaderboardHeader />
 
@@ -83,15 +93,25 @@ async function CachedBrainPowerLeaderboard({
                 <BrainPowerLeaderboardRow key={leader.user.id} leader={leader} />
               ))
             ) : (
-              <BrainPowerLeaderboardEmptyRow />
+              <BrainPowerLeaderboardEmptyRow periodDescription={periodDescription} />
             )}
           </TableBody>
         </Table>
       </div>
 
-      <AdminPagination basePath="/leaderboard" limit={limit} page={page} totalPages={totalPages} />
+      <AdminPagination
+        basePath="/leaderboard"
+        limit={limit}
+        page={page}
+        queryParams={{ period: period === "today" ? undefined : period }}
+        totalPages={totalPages}
+      />
     </>
   );
+}
+
+function getLeaderboardUserCountLabel(total: number): "user" | "users" {
+  return total === 1 ? "user" : "users";
 }
 
 /**
@@ -137,11 +157,11 @@ function BrainPowerLeaderboardHeader() {
  * An empty row keeps the table visible when no one earned Brain Power during
  * the rolling window, making the absence of activity explicit.
  */
-function BrainPowerLeaderboardEmptyRow() {
+function BrainPowerLeaderboardEmptyRow({ periodDescription }: { periodDescription: string }) {
   return (
     <TableRow>
       <TableCell className="text-muted-foreground" colSpan={TABLE_COLUMN_COUNT}>
-        No Brain Power earned in the past 7 days.
+        No Brain Power earned {periodDescription}.
       </TableCell>
     </TableRow>
   );

--- a/apps/admin/src/app/(private)/leaderboard/leaderboard-period-filter.tsx
+++ b/apps/admin/src/app/(private)/leaderboard/leaderboard-period-filter.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@zoonk/ui/components/button";
+import Link from "next/link";
+import {
+  type LeaderboardPeriod,
+  leaderboardPeriodLabels,
+  leaderboardPeriods,
+} from "./leaderboard-period";
+
+/** URL-backed links keep leaderboard periods shareable without adding client state. */
+export function LeaderboardPeriodFilter({ period }: { period: LeaderboardPeriod }) {
+  return (
+    <nav aria-label="Leaderboard period filter" className="flex flex-wrap gap-1">
+      {leaderboardPeriods.map((item) => (
+        <Button
+          key={item}
+          nativeButton={false}
+          render={
+            <Link
+              aria-current={period === item ? "page" : undefined}
+              href={getLeaderboardPeriodHref(item)}
+              prefetch
+            />
+          }
+          size="sm"
+          variant={period === item ? "default" : "outline"}
+        >
+          {leaderboardPeriodLabels[item]}
+        </Button>
+      ))}
+    </nav>
+  );
+}
+
+/** Switching periods resets pagination so a shorter period cannot open an empty page. */
+function getLeaderboardPeriodHref(
+  period: LeaderboardPeriod,
+): "/leaderboard" | `/leaderboard?${string}` {
+  return period === "today" ? "/leaderboard" : `/leaderboard?period=${period}`;
+}

--- a/apps/admin/src/app/(private)/leaderboard/leaderboard-period.ts
+++ b/apps/admin/src/app/(private)/leaderboard/leaderboard-period.ts
@@ -1,0 +1,28 @@
+export const leaderboardPeriods = ["today", "7d", "30d"] as const;
+
+export type LeaderboardPeriod = (typeof leaderboardPeriods)[number];
+
+export const leaderboardPeriodLabels: Record<LeaderboardPeriod, string> = {
+  "30d": "30 days",
+  "7d": "7 days",
+  today: "Today",
+};
+
+export const leaderboardPeriodDescriptions: Record<LeaderboardPeriod, string> = {
+  "30d": "in the past 30 days",
+  "7d": "in the past 7 days",
+  today: "today",
+};
+
+const leaderboardPeriodDays: Record<LeaderboardPeriod, number> = { "30d": 30, "7d": 7, today: 1 };
+
+/** Invalid or repeated URL values fall back to the default Today leaderboard. */
+export function parseLeaderboardPeriod(value: string | string[] | undefined): LeaderboardPeriod {
+  const period = Array.isArray(value) ? value[0] : value;
+
+  return leaderboardPeriods.find((item) => item === period) ?? "today";
+}
+
+export function getLeaderboardPeriodDays(period: LeaderboardPeriod): number {
+  return leaderboardPeriodDays[period];
+}

--- a/apps/admin/src/app/(private)/leaderboard/page.tsx
+++ b/apps/admin/src/app/(private)/leaderboard/page.tsx
@@ -1,3 +1,4 @@
+import { ButtonSkeleton } from "@zoonk/ui/components/button";
 import {
   Container,
   ContainerBody,
@@ -9,6 +10,8 @@ import {
 import { type Metadata } from "next";
 import { Suspense } from "react";
 import { BrainPowerLeaderboard, BrainPowerLeaderboardSkeleton } from "./brain-power-leaderboard";
+import { parseLeaderboardPeriod } from "./leaderboard-period";
+import { LeaderboardPeriodFilter } from "./leaderboard-period-filter";
 
 export const metadata: Metadata = { title: "Brain Power Leaderboard" };
 
@@ -23,16 +26,39 @@ export default function LeaderboardPage({ searchParams }: PageProps<"/leaderboar
         <ContainerHeaderGroup>
           <ContainerTitle>Brain Power Leaderboard</ContainerTitle>
           <ContainerDescription>
-            Users who earned the most Brain Power in the past 7 days.
+            Users who earned the most Brain Power during the selected period.
           </ContainerDescription>
         </ContainerHeaderGroup>
       </ContainerHeader>
 
       <ContainerBody>
+        <Suspense fallback={<LeaderboardPeriodFilterSkeleton />}>
+          <LeaderboardFilters searchParams={searchParams} />
+        </Suspense>
+
         <Suspense fallback={<BrainPowerLeaderboardSkeleton />}>
           <BrainPowerLeaderboard searchParams={searchParams} />
         </Suspense>
       </ContainerBody>
     </Container>
+  );
+}
+
+async function LeaderboardFilters({
+  searchParams,
+}: Pick<PageProps<"/leaderboard">, "searchParams">) {
+  const params = await searchParams;
+  const period = parseLeaderboardPeriod(params.period);
+
+  return <LeaderboardPeriodFilter period={period} />;
+}
+
+function LeaderboardPeriodFilterSkeleton() {
+  return (
+    <div className="flex gap-1">
+      <ButtonSkeleton size="sm">Today</ButtonSkeleton>
+      <ButtonSkeleton size="sm">7 days</ButtonSkeleton>
+      <ButtonSkeleton size="sm">30 days</ButtonSkeleton>
+    </div>
   );
 }

--- a/apps/admin/src/data/users/list-brain-power-leaders.ts
+++ b/apps/admin/src/data/users/list-brain-power-leaders.ts
@@ -32,8 +32,8 @@ const cachedListBrainPowerLeaders = cacheAdminData(
 
 /**
  * The leaderboard ranks users by Brain Power earned on or after the supplied
- * date. The start date stays explicit so the route owns what “past 7 days”
- * means and the cached database helper remains deterministic.
+ * date. The start date stays explicit so the route owns the selected period
+ * and the cached database helper remains deterministic.
  */
 export function listBrainPowerLeaders({
   limit,


### PR DESCRIPTION
Adds Today, 7-day, and 30-day filters to the admin Brain Power leaderboard. Today is the default, selected periods persist through pagination, and changing periods resets pagination.