### PR TITLE
feat(apple): add catalog

### DIFF
--- a/apps/apple/Zoonk.xcodeproj/project.pbxproj
+++ b/apps/apple/Zoonk.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		5A0A00020000000000000001 /* OpenAPIRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 5A0A00210000000000000001 /* OpenAPIRuntime */; };
 		5A0A00030000000000000001 /* OpenAPIURLSession in Frameworks */ = {isa = PBXBuildFile; productRef = 5A0A00220000000000000001 /* OpenAPIURLSession */; };
 		5A0A00040000000000000001 /* HTTPTypes in Frameworks */ = {isa = PBXBuildFile; productRef = 5A0A00230000000000000001 /* HTTPTypes */; };
-		5A0A00510000000000000001 /* Subscriptions.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 5A0A00500000000000000001 /* Subscriptions.storekit */; };
+		5A0A00510000000000000001 /* Zoonk/Resources/StoreKit/Subscriptions.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 5A0A00500000000000000001 /* Zoonk/Resources/StoreKit/Subscriptions.storekit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,9 +32,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		5A0A00400000000000000001 /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Configuration/Debug.xcconfig; sourceTree = "<group>"; };
-		5A0A00410000000000000001 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Configuration/Release.xcconfig; sourceTree = "<group>"; };
-		5A0A00500000000000000001 /* Subscriptions.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Zoonk/Resources/StoreKit/Subscriptions.storekit; sourceTree = "<group>"; };
+		5A0A00400000000000000001 /* Configuration/Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Configuration/Debug.xcconfig; sourceTree = "<group>"; };
+		5A0A00410000000000000001 /* Configuration/Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Configuration/Release.xcconfig; sourceTree = "<group>"; };
+		5A0A00500000000000000001 /* Zoonk/Resources/StoreKit/Subscriptions.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Zoonk/Resources/StoreKit/Subscriptions.storekit; sourceTree = "<group>"; };
 		5A0A01000000000000000001 /* ZoonkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZoonkTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEB8AB5E3022709A00E0E150 /* Zoonk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Zoonk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEB8AB773022709B00E0E150 /* ZoonkUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZoonkUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -101,11 +101,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5A0A00520000000000000001 /* UI Test Resources */ = {
+			isa = PBXGroup;
+			children = (
+				5A0A00500000000000000001 /* Zoonk/Resources/StoreKit/Subscriptions.storekit */,
+			);
+			name = "UI Test Resources";
+			sourceTree = "<group>";
+		};
 		BEB8AB553022709A00E0E150 = {
 			isa = PBXGroup;
 			children = (
-				5A0A00400000000000000001 /* Debug.xcconfig */,
-				5A0A00410000000000000001 /* Release.xcconfig */,
+				5A0A00400000000000000001 /* Configuration/Debug.xcconfig */,
+				5A0A00410000000000000001 /* Configuration/Release.xcconfig */,
 				5A0A00520000000000000001 /* UI Test Resources */,
 				BEB8AB603022709A00E0E150 /* Zoonk */,
 				5A0A01010000000000000001 /* ZoonkTests */,
@@ -122,14 +130,6 @@
 				BEB8AB773022709B00E0E150 /* ZoonkUITests.xctest */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		5A0A00520000000000000001 /* UI Test Resources */ = {
-			isa = PBXGroup;
-			children = (
-				5A0A00500000000000000001 /* Subscriptions.storekit */,
-			);
-			name = "UI Test Resources";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -244,8 +244,6 @@
 			);
 			mainGroup = BEB8AB553022709A00E0E150;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
-			productRefGroup = BEB8AB5F3022709A00E0E150 /* Products */;
 			packageReferences = (
 				5A0A00100000000000000001 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				5A0A00110000000000000001 /* XCRemoteSwiftPackageReference "swift-openapi-generator" */,
@@ -253,6 +251,8 @@
 				5A0A00130000000000000001 /* XCRemoteSwiftPackageReference "swift-openapi-urlsession" */,
 				5A0A00140000000000000001 /* XCRemoteSwiftPackageReference "swift-http-types" */,
 			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = BEB8AB5F3022709A00E0E150 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -282,7 +282,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5A0A00510000000000000001 /* Subscriptions.storekit in Resources */,
+				5A0A00510000000000000001 /* Zoonk/Resources/StoreKit/Subscriptions.storekit in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -313,14 +313,14 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		5A0A010B0000000000000001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 5A0A00240000000000000001 /* OpenAPIGenerator */;
-		};
 		5A0A01070000000000000001 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BEB8AB5D3022709A00E0E150 /* Zoonk */;
 			targetProxy = 5A0A01080000000000000001 /* PBXContainerItemProxy */;
+		};
+		5A0A010B0000000000000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 5A0A00240000000000000001 /* OpenAPIGenerator */;
 		};
 		BEB8AB793022709B00E0E150 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -496,7 +496,7 @@
 		};
 		BEB8AB823022709B00E0E150 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5A0A00400000000000000001 /* Debug.xcconfig */;
+			baseConfigurationReference = 5A0A00400000000000000001 /* Configuration/Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Zoonk/Zoonk.entitlements;
@@ -540,7 +540,7 @@
 		};
 		BEB8AB833022709B00E0E150 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5A0A00410000000000000001 /* Release.xcconfig */;
+			baseConfigurationReference = 5A0A00410000000000000001 /* Configuration/Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Zoonk/Zoonk.entitlements;
@@ -735,6 +735,6 @@
 			productName = "plugin:OpenAPIGenerator";
 		};
 /* End XCSwiftPackageProductDependency section */
-};
+	};
 	rootObject = BEB8AB563022709A00E0E150 /* Project object */;
 }

--- a/apps/apple/Zoonk/App/AppDependencies.swift
+++ b/apps/apple/Zoonk/App/AppDependencies.swift
@@ -1,5 +1,6 @@
 @MainActor
 struct AppDependencies {
+  let courseCatalogStore: CourseCatalogStore
   let progressStore: ProgressStore
   let sessionStore: SessionStore
   let subscriptionStore: AppStoreSubscriptionStore
@@ -13,6 +14,10 @@ struct AppDependencies {
       googleAuthentication: GoogleAuthenticationClient())
 
     return AppDependencies(
+      courseCatalogStore: CourseCatalogStore(
+        api: CourseCatalogAPI(clients: clients),
+        language: currentCourseCatalogLanguage(),
+        session: sessionStore),
       progressStore: ProgressStore(
         api: ProgressAPI(clients: clients),
         session: sessionStore),

--- a/apps/apple/Zoonk/App/AppView.swift
+++ b/apps/apple/Zoonk/App/AppView.swift
@@ -15,11 +15,13 @@ struct AppView: View {
   var body: some View {
     TabView(selection: $selectedSection) {
       ForEach(AppSection.allCases) { section in
-        Tab(value: section, role: section.tabRole) {
+        Tab(value: section) {
           NavigationStack(path: navigationPath(for: section)) {
-            section.tabContent {
-              isAccountPresented = true
-            }
+            section.tabContent(
+              actions: AppSectionActions(
+                presentAccount: { isAccountPresented = true },
+                selectSection: { selectedSection = $0 })
+            )
             .navigationTitle(Text(section.title))
             .toolbarTitleDisplayMode(.inlineLarge)
             .modifier(AdaptiveNavigationTitle())
@@ -130,6 +132,12 @@ private struct AdaptiveNavigationTitle: ViewModifier {
   let clients = APIClientFactory.live(baseURL: AppConfiguration.current.apiBaseURL)
 
   AppView()
+    .environment(
+      CourseCatalogStore(
+        api: CourseCatalogAPI(clients: clients),
+        language: currentCourseCatalogLanguage(),
+        session: session)
+    )
     .environment(ProgressStore(api: ProgressAPI(clients: clients), session: session))
     .environment(session)
     .environment(AppStoreSubscriptionStore.live())

--- a/apps/apple/Zoonk/App/ZoonkApp.swift
+++ b/apps/apple/Zoonk/App/ZoonkApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @main
 struct ZoonkApp: App {
+  @State private var courseCatalog: CourseCatalogStore
   @State private var progress: ProgressStore
   @State private var session: SessionStore
   @State private var subscriptions: AppStoreSubscriptionStore
@@ -10,6 +11,7 @@ struct ZoonkApp: App {
   init() {
     #if DEBUG
       if let configuration = UITestConfiguration.current {
+        _courseCatalog = State(initialValue: configuration.courseCatalog)
         _progress = State(initialValue: configuration.progress)
         _session = State(initialValue: configuration.session)
         _subscriptions = State(initialValue: .live())
@@ -19,6 +21,7 @@ struct ZoonkApp: App {
     #endif
 
     let dependencies = AppDependencies.live()
+    _courseCatalog = State(initialValue: dependencies.courseCatalogStore)
     _progress = State(initialValue: dependencies.progressStore)
     _session = State(initialValue: dependencies.sessionStore)
     _subscriptions = State(initialValue: dependencies.subscriptionStore)
@@ -28,6 +31,7 @@ struct ZoonkApp: App {
   var body: some Scene {
     WindowGroup {
       AppView(initiallyPresentsAccount: initiallyPresentsAccount)
+        .environment(courseCatalog)
         .environment(progress)
         .environment(session)
         .environment(subscriptions)

--- a/apps/apple/Zoonk/Features/Account/AccountSheet.swift
+++ b/apps/apple/Zoonk/Features/Account/AccountSheet.swift
@@ -20,7 +20,7 @@ struct AccountSheet: View {
   @State private var isGooglePlayManagementPresented = false
   @State private var path = [AccountDestination]()
 
-  let openCourses: () -> Void
+  let openCatalog: () -> Void
 
   var body: some View {
     NavigationStack(path: $path) {
@@ -115,7 +115,7 @@ struct AccountSheet: View {
           deleteAccount: { path.append(.deleteAccount(makeDeletionDestination(account))) },
           editProfile: { path.append(.profile) },
           manageAppStoreSubscription: { isAppStoreSubscriptionManagementPresented = true },
-          openCourses: showCourses,
+          openCatalog: showCatalog,
           openSubscription: { showSubscription(for: account) },
           showGooglePlayManagement: { isGooglePlayManagementPresented = true }
         )
@@ -174,10 +174,10 @@ struct AccountSheet: View {
     }
   }
 
-  /// Closes the modal before moving to the app's native courses section, matching the web account menu without opening a duplicate web surface.
-  private func showCourses() {
+  /// Closes the modal before moving to the app's native public catalog without opening a duplicate web surface.
+  private func showCatalog() {
     dismiss()
-    openCourses()
+    openCatalog()
   }
 
   private func showSubscription(for account: CurrentAccount) {
@@ -197,7 +197,7 @@ private struct SignedInAccountView: View {
   let deleteAccount: () -> Void
   let editProfile: () -> Void
   let manageAppStoreSubscription: () -> Void
-  let openCourses: () -> Void
+  let openCatalog: () -> Void
   let openSubscription: () -> Void
   let showGooglePlayManagement: () -> Void
 
@@ -221,12 +221,12 @@ private struct SignedInAccountView: View {
       }
 
       Section {
-        Button(action: openCourses) {
+        Button(action: openCatalog) {
           AccountRowLabel(
             title: Text(
-              "My courses",
+              "Browse courses",
               tableName: "Account",
-              comment: "Account option that opens the learner's courses"),
+              comment: "Account option that opens the public course catalog"),
             systemImage: "square.grid.2x2")
         }
       }

--- a/apps/apple/Zoonk/Features/Courses/CatalogActionsMenu.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogActionsMenu.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct CatalogActionsMenu: View {
+  let showFeedback: () -> Void
+
+  var body: some View {
+    Menu {
+      Button(action: showFeedback) {
+        Label {
+          Text(
+            "Send feedback",
+            tableName: "Courses",
+            comment: "Opens a form for sending feedback about catalog content.")
+        } icon: {
+          Image(systemName: "bubble.left")
+        }
+      }
+    } label: {
+      Image(systemName: "ellipsis")
+        .frame(width: 20, height: 20)
+    }
+    .buttonStyle(.bordered)
+    .buttonBorderShape(.circle)
+    .controlSize(.large)
+    .accessibilityLabel(
+      Text(
+        "More options",
+        tableName: "Courses",
+        comment: "Accessibility label for secondary catalog actions."))
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogContinueLink.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogContinueLink.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct CatalogContinueLink: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  let continuation: CatalogContinuationTarget?
+  let destination: CourseDestination
+  let percentComplete: Int?
+
+  var body: some View {
+    NavigationLink(value: destination) {
+      HStack(spacing: 8) {
+        Image(systemName: "play.fill")
+
+        actionTitle
+
+        if let percentComplete {
+          Spacer(minLength: 12)
+
+          Text(percentComplete, format: .percent.scale(1))
+            .font(.subheadline.weight(.semibold))
+            .monospacedDigit()
+        }
+      }
+      .frame(maxWidth: .infinity)
+    }
+    .buttonStyle(.borderedProminent)
+    .controlSize(.large)
+    .frame(maxWidth: horizontalSizeClass == .regular ? 280 : .infinity)
+    .accessibilityLabel(accessibilityTitle)
+  }
+
+  @ViewBuilder
+  private var actionTitle: some View {
+    switch catalogPrimaryAction(for: continuation) {
+    case .start:
+      Text(
+        "Start",
+        tableName: "Courses",
+        comment: "Starts a course or chapter that has no learner progress.")
+    case .continueLearning:
+      Text(
+        "Continue",
+        tableName: "Courses",
+        comment: "Continues a course or chapter from the learner's next lesson.")
+    case .review:
+      Text(
+        "Review",
+        tableName: "Courses",
+        comment: "Reviews a completed course or chapter.")
+    }
+  }
+
+  private var accessibilityTitle: Text {
+    switch (catalogPrimaryAction(for: continuation), percentComplete) {
+    case (.start, .some(let percentComplete)):
+      Text(
+        "Start, \(percentComplete)% complete",
+        tableName: "Courses",
+        comment: "Accessible start action followed by the course or chapter completion percent.")
+    case (.continueLearning, .some(let percentComplete)):
+      Text(
+        "Continue, \(percentComplete)% complete",
+        tableName: "Courses",
+        comment:
+          "Accessible continue action followed by the course or chapter completion percent.")
+    case (.review, .some(let percentComplete)):
+      Text(
+        "Review, \(percentComplete)% complete",
+        tableName: "Courses",
+        comment: "Accessible review action followed by the course or chapter completion percent.")
+    case (.start, nil):
+      Text(
+        "Start",
+        tableName: "Courses",
+        comment: "Starts a course or chapter that has no learner progress.")
+    case (.continueLearning, nil):
+      Text(
+        "Continue",
+        tableName: "Courses",
+        comment: "Continues a course or chapter from the learner's next lesson.")
+    case (.review, nil):
+      Text(
+        "Review",
+        tableName: "Courses",
+        comment: "Reviews a completed course or chapter.")
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogCurriculumHeader.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogCurriculumHeader.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct CatalogCurriculumHeader: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  let title: Text
+
+  var body: some View {
+    title
+      .font(.headline)
+      .foregroundStyle(.primary)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.horizontal, CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
+      .padding(
+        .vertical,
+        CatalogDetailLayout.curriculumHeaderVerticalInset(for: horizontalSizeClass)
+      )
+      .background(Color(uiColor: .systemBackground))
+      .accessibilityAddTraits(.isHeader)
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogDetailActions.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogDetailActions.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct CatalogDetailActions: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  let continuation: CatalogContinuationTarget?
+  let destination: CourseDestination?
+  let percentComplete: Int?
+  let showFeedback: () -> Void
+
+  var body: some View {
+    HStack(spacing: 8) {
+      if let destination {
+        CatalogContinueLink(
+          continuation: continuation,
+          destination: destination,
+          percentComplete: percentComplete)
+      } else {
+        Spacer(minLength: 0)
+      }
+
+      CatalogActionsMenu(showFeedback: showFeedback)
+
+      if horizontalSizeClass == .regular, destination != nil {
+        Spacer(minLength: 0)
+      }
+    }
+    .padding(
+      .leading,
+      CatalogDetailLayout.actionLeadingInset(
+        for: horizontalSizeClass,
+        dynamicTypeSize: dynamicTypeSize))
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogDetailLayout.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogDetailLayout.swift
@@ -4,4 +4,41 @@ enum CatalogDetailLayout {
   static func horizontalInset(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
     horizontalSizeClass == .regular ? 24 : 16
   }
+
+  static func heroArtworkSize(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+    horizontalSizeClass == .regular ? 112 : 80
+  }
+
+  static func heroSpacing(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+    horizontalSizeClass == .regular ? 20 : 12
+  }
+
+  static func actionLeadingInset(
+    for horizontalSizeClass: UserInterfaceSizeClass?,
+    dynamicTypeSize: DynamicTypeSize
+  ) -> CGFloat {
+    guard horizontalSizeClass == .regular, !dynamicTypeSize.isAccessibilitySize else {
+      return 0
+    }
+
+    return heroArtworkSize(for: horizontalSizeClass) + heroSpacing(for: horizontalSizeClass)
+  }
+
+  static func curriculumHeaderVerticalInset(
+    for horizontalSizeClass: UserInterfaceSizeClass?
+  ) -> CGFloat {
+    horizontalSizeClass == .regular ? 12 : 8
+  }
+
+  static func curriculumRowVerticalInset(
+    for horizontalSizeClass: UserInterfaceSizeClass?
+  ) -> CGFloat {
+    horizontalSizeClass == .regular ? 14 : 10
+  }
+
+  static func curriculumContentSpacing(
+    for horizontalSizeClass: UserInterfaceSizeClass?
+  ) -> CGFloat {
+    horizontalSizeClass == .regular ? 6 : 4
+  }
 }

--- a/apps/apple/Zoonk/Features/Courses/CatalogDetailLayout.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogDetailLayout.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+enum CatalogDetailLayout {
+  static func horizontalInset(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+    horizontalSizeClass == .regular ? 24 : 16
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogDetailTaskID.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogDetailTaskID.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct CatalogDetailTaskID: Equatable {
+  let resourceID: String
+  let session: AuthenticatedSession?
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogFailureRecoveryView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogFailureRecoveryView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+enum CatalogFailureContext {
+  case catalog
+  case chapter
+  case course
+}
+
+struct CatalogFailureRecoveryView: View {
+  let context: CatalogFailureContext
+  let failure: CourseCatalogFailure
+  let retry: @MainActor () async -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        title
+      } icon: {
+        Image(systemName: failure == .network ? "wifi.exclamationmark" : "exclamationmark.triangle")
+      }
+    } description: {
+      description
+    } actions: {
+      Button {
+        Task {
+          await retry()
+        }
+      } label: {
+        Text(
+          "Try again",
+          tableName: "Courses",
+          comment: "Retries loading catalog content after a failure.")
+      }
+      .buttonStyle(.borderedProminent)
+    }
+    .frame(maxWidth: .infinity, minHeight: 360)
+  }
+
+  @ViewBuilder
+  private var title: some View {
+    if failure == .network {
+      Text(
+        "You're offline",
+        tableName: "Courses",
+        comment: "Title when catalog content cannot load because the device is offline.")
+    } else {
+      unavailableTitle
+    }
+  }
+
+  @ViewBuilder
+  private var unavailableTitle: some View {
+    switch context {
+    case .catalog:
+      Text(
+        "Courses are unavailable",
+        tableName: "Courses",
+        comment: "Title when the public course catalog cannot be loaded.")
+    case .course:
+      if failure == .notFound {
+        Text(
+          "Course not found",
+          tableName: "Courses",
+          comment: "Title when a course cannot be found.")
+      } else {
+        Text(
+          "Course unavailable",
+          tableName: "Courses",
+          comment: "Title when a course cannot be loaded.")
+      }
+    case .chapter:
+      if failure == .notFound {
+        Text(
+          "Chapter not found",
+          tableName: "Courses",
+          comment: "Title when a chapter cannot be found.")
+      } else {
+        Text(
+          "Chapter unavailable",
+          tableName: "Courses",
+          comment: "Title when a chapter cannot be loaded.")
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var description: some View {
+    if failure == .network {
+      Text(
+        "Check your connection and try again.",
+        tableName: "Courses",
+        comment: "Recovery guidance for an offline catalog request.")
+    } else if failure == .notFound {
+      Text(
+        "This content may have moved or is no longer available.",
+        tableName: "Courses",
+        comment: "Guidance when a course or chapter cannot be found.")
+    } else {
+      Text(
+        "Please try again in a moment.",
+        tableName: "Courses",
+        comment: "Recovery guidance when catalog content is temporarily unavailable.")
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogHero.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogHero.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+struct CatalogDetailHeaderConfiguration {
+  let imageURL: URL?
+  let description: String?
+  let systemImage: String
+  let title: String
+}
+
+struct CatalogDetailHeader: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  let configuration: CatalogDetailHeaderConfiguration
+  var showInformation: (() -> Void)?
+
+  var body: some View {
+    if dynamicTypeSize.isAccessibilitySize {
+      accessibilityLayout
+    } else {
+      HStack(alignment: .top, spacing: horizontalSizeClass == .regular ? 20 : 12) {
+        artwork
+        textContent
+      }
+    }
+  }
+
+  private var artwork: some View {
+    CourseArtwork(
+      imageURL: configuration.imageURL,
+      systemImage: configuration.systemImage
+    )
+    .frame(width: artworkSize, height: artworkSize)
+  }
+
+  private var artworkSize: CGFloat {
+    horizontalSizeClass == .regular ? 112 : 80
+  }
+
+  private var accessibilityLayout: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      CourseArtwork(
+        imageURL: configuration.imageURL,
+        systemImage: configuration.systemImage
+      )
+      .frame(width: 72, height: 72)
+
+      interactiveTextContent
+    }
+  }
+
+  private var textContent: some View {
+    interactiveTextContent
+      .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  @ViewBuilder
+  private var interactiveTextContent: some View {
+    if let showInformation {
+      Button(action: showInformation) {
+        textContentBody(showsDisclosureIndicator: true)
+      }
+      .buttonStyle(.plain)
+      .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+      .contentShape(Rectangle())
+      .accessibilityAddTraits(.isHeader)
+      .accessibilityHint(
+        Text(
+          "Shows more information",
+          tableName: "Courses",
+          comment: "Accessibility hint for expandable course or chapter information."))
+    } else {
+      textContentBody(showsDisclosureIndicator: false)
+    }
+  }
+
+  private func textContentBody(showsDisclosureIndicator: Bool) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Text(configuration.title)
+          .font(horizontalSizeClass == .regular ? .title.bold() : .title2.bold())
+          .fixedSize(horizontal: false, vertical: true)
+
+        if showsDisclosureIndicator {
+          Spacer(minLength: 8)
+
+          Image(systemName: "chevron.right")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.tertiary)
+            .accessibilityHidden(true)
+        }
+      }
+
+      description
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  @ViewBuilder
+  private var description: some View {
+    if let description = catalogText(configuration.description) {
+      descriptionText(description)
+    }
+  }
+
+  private func descriptionText(_ description: String) -> some View {
+    Text(description)
+      .font(.subheadline)
+      .foregroundStyle(.secondary)
+      .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 3)
+      .fixedSize(horizontal: false, vertical: true)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .contentShape(Rectangle())
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogHero.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogHero.swift
@@ -18,7 +18,10 @@ struct CatalogDetailHeader: View {
     if dynamicTypeSize.isAccessibilitySize {
       accessibilityLayout
     } else {
-      HStack(alignment: .top, spacing: horizontalSizeClass == .regular ? 20 : 12) {
+      HStack(
+        alignment: .top,
+        spacing: CatalogDetailLayout.heroSpacing(for: horizontalSizeClass)
+      ) {
         artwork
         textContent
       }
@@ -30,11 +33,9 @@ struct CatalogDetailHeader: View {
       imageURL: configuration.imageURL,
       systemImage: configuration.systemImage
     )
-    .frame(width: artworkSize, height: artworkSize)
-  }
-
-  private var artworkSize: CGFloat {
-    horizontalSizeClass == .regular ? 112 : 80
+    .frame(
+      width: CatalogDetailLayout.heroArtworkSize(for: horizontalSizeClass),
+      height: CatalogDetailLayout.heroArtworkSize(for: horizontalSizeClass))
   }
 
   private var accessibilityLayout: some View {

--- a/apps/apple/Zoonk/Features/Courses/CatalogInformationView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogInformationView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct CatalogInformationView<Content: View>: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  let dismiss: () -> Void
+  let title: LocalizedStringResource
+  @ViewBuilder let content: Content
+
+  init(
+    dismiss: @escaping () -> Void,
+    title: LocalizedStringResource,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.dismiss = dismiss
+    self.title = title
+    self.content = content()
+  }
+
+  @ViewBuilder
+  var body: some View {
+    if horizontalSizeClass == .regular {
+      informationContent
+        .frame(width: 360)
+        .presentationSizing(.fitted)
+    } else {
+      informationContent
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+  }
+
+  private var informationContent: some View {
+    NavigationStack {
+      ScrollView {
+        content
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(20)
+      }
+      .navigationTitle(Text(title))
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .confirmationAction) {
+          Button(action: dismiss) {
+            Text(
+              "Done",
+              tableName: "Courses",
+              comment: "Closes catalog information presented in a popover or sheet.")
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogNumberedRow.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogNumberedRow.swift
@@ -7,6 +7,7 @@ struct CatalogNumberedRow<Metadata: View>: View {
   let description: String?
   let imageURL: URL?
   let number: Int
+  let symbolTint: Color?
   let systemImage: String
   let title: String
   @ViewBuilder let metadata: Metadata
@@ -15,6 +16,7 @@ struct CatalogNumberedRow<Metadata: View>: View {
     description: String?,
     imageURL: URL?,
     number: Int,
+    symbolTint: Color? = nil,
     systemImage: String,
     title: String,
     @ViewBuilder metadata: () -> Metadata
@@ -22,29 +24,30 @@ struct CatalogNumberedRow<Metadata: View>: View {
     self.description = description
     self.imageURL = imageURL
     self.number = number
+    self.symbolTint = symbolTint
     self.systemImage = systemImage
     self.title = title
     self.metadata = metadata()
   }
 
   var body: some View {
-    HStack(alignment: .top, spacing: 12) {
-      Text(number.formatted())
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
-        .monospacedDigit()
-        .frame(width: 20, alignment: .trailing)
-        .padding(.top, 2)
-
+    HStack(
+      alignment: .top,
+      spacing: horizontalSizeClass == .regular ? 16 : 12
+    ) {
       CourseArtwork(
         imageURL: imageURL,
         cornerRadius: 12,
+        symbolTint: symbolTint,
         systemImage: systemImage
       )
       .frame(width: artworkSize, height: artworkSize)
 
-      VStack(alignment: .leading, spacing: 4) {
-        Text(title)
+      VStack(
+        alignment: .leading,
+        spacing: CatalogDetailLayout.curriculumContentSpacing(for: horizontalSizeClass)
+      ) {
+        Text(numberedTitle)
           .font(.headline)
           .foregroundStyle(.primary)
 
@@ -66,5 +69,9 @@ struct CatalogNumberedRow<Metadata: View>: View {
 
   private var artworkSize: CGFloat {
     horizontalSizeClass == .regular && !dynamicTypeSize.isAccessibilitySize ? 64 : 56
+  }
+
+  private var numberedTitle: String {
+    "\(number.formatted()). \(title)"
   }
 }

--- a/apps/apple/Zoonk/Features/Courses/CatalogNumberedRow.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogNumberedRow.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct CatalogNumberedRow<Metadata: View>: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  let description: String?
+  let imageURL: URL?
+  let number: Int
+  let systemImage: String
+  let title: String
+  @ViewBuilder let metadata: Metadata
+
+  init(
+    description: String?,
+    imageURL: URL?,
+    number: Int,
+    systemImage: String,
+    title: String,
+    @ViewBuilder metadata: () -> Metadata
+  ) {
+    self.description = description
+    self.imageURL = imageURL
+    self.number = number
+    self.systemImage = systemImage
+    self.title = title
+    self.metadata = metadata()
+  }
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 12) {
+      Text(number.formatted())
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
+        .monospacedDigit()
+        .frame(width: 20, alignment: .trailing)
+        .padding(.top, 2)
+
+      CourseArtwork(
+        imageURL: imageURL,
+        cornerRadius: 12,
+        systemImage: systemImage
+      )
+      .frame(width: artworkSize, height: artworkSize)
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text(title)
+          .font(.headline)
+          .foregroundStyle(.primary)
+
+        if let description = catalogText(description) {
+          Text(description)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+        }
+
+        metadata
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .accessibilityElement(children: .combine)
+  }
+
+  private var artworkSize: CGFloat {
+    horizontalSizeClass == .regular && !dynamicTypeSize.isAccessibilitySize ? 64 : 56
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CatalogSearchPresentation.swift
+++ b/apps/apple/Zoonk/Features/Courses/CatalogSearchPresentation.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct CatalogDetailSearchPresentation: ViewModifier {
+  @Binding var text: String
+  @Binding var isPresented: Bool
+  let prompt: Text
+
+  func body(content: Content) -> some View {
+    Group {
+      if #available(iOS 26.0, *) {
+        content
+          .searchable(
+            text: $text,
+            isPresented: $isPresented,
+            placement: .toolbar,
+            prompt: prompt
+          )
+          .toolbar {
+            DefaultToolbarItem(kind: .search, placement: .topBarTrailing)
+          }
+          .searchToolbarBehavior(.minimize)
+      } else if isPresented {
+        content
+          .searchable(
+            text: $text,
+            isPresented: $isPresented,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: prompt
+          )
+      } else {
+        content
+          .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+              Button {
+                isPresented = true
+              } label: {
+                Image(systemName: "magnifyingglass")
+              }
+              .accessibilityLabel(
+                Text(
+                  "Search",
+                  tableName: "Navigation",
+                  comment: "Opens search on a catalog detail screen."))
+            }
+          }
+      }
+    }
+    .onChange(of: isPresented) { _, isPresented in
+      if !isPresented {
+        text = ""
+      }
+    }
+  }
+}
+
+extension View {
+  func catalogDetailSearchPresentation(
+    text: Binding<String>,
+    isPresented: Binding<Bool>,
+    prompt: Text
+  ) -> some View {
+    modifier(
+      CatalogDetailSearchPresentation(
+        text: text,
+        isPresented: isPresented,
+        prompt: prompt))
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/ChapterView.swift
+++ b/apps/apple/Zoonk/Features/Courses/ChapterView.swift
@@ -102,46 +102,47 @@ private struct ChapterDetailList: View {
         detailHeader
       }
 
+      CatalogCurriculumHeader(
+        title: Text(
+          "Lessons",
+          tableName: "Courses",
+          comment: "Heading above the ordered lesson list on a chapter screen."))
+
       List {
-        Section {
-          if filteredLessons.isEmpty {
-            emptyLessonsView
-              .listRowSeparator(.hidden)
-          } else {
-            ForEach(filteredLessons) { lesson in
-              NavigationLink(
-                value: CourseDestination.lesson(
-                  LessonReference((chapter: chapter, lesson: lesson)))
+        if filteredLessons.isEmpty {
+          emptyLessonsView
+            .listRowSeparator(.hidden)
+        } else {
+          ForEach(filteredLessons) { lesson in
+            NavigationLink(
+              value: CourseDestination.lesson(
+                LessonReference((chapter: chapter, lesson: lesson)))
+            ) {
+              CatalogNumberedRow(
+                description: lesson.displayDescription(),
+                imageURL: lesson.imageURL,
+                number: lesson.position + 1,
+                symbolTint: lesson.kind.symbolTint,
+                systemImage: lesson.kind.systemImage,
+                title: lesson.displayTitle()
               ) {
-                CatalogNumberedRow(
-                  description: lesson.displayDescription(),
-                  imageURL: lesson.imageURL,
-                  number: lesson.position + 1,
-                  systemImage: lesson.kind.systemImage,
-                  title: lesson.displayTitle()
-                ) {
-                  if let progress = catalogLessonProgress(
-                    lesson: lesson,
-                    progress: detail.progress)
-                  {
-                    CatalogProgressLabel(progress: progress)
-                  }
+                if let progress = catalogLessonProgress(
+                  lesson: lesson,
+                  progress: detail.progress)
+                {
+                  CatalogProgressLabel(progress: progress)
                 }
               }
-              .listRowInsets(
-                EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
             }
+            .listRowInsets(
+              EdgeInsets(
+                top: CatalogDetailLayout.curriculumRowVerticalInset(
+                  for: horizontalSizeClass),
+                leading: 0,
+                bottom: CatalogDetailLayout.curriculumRowVerticalInset(
+                  for: horizontalSizeClass),
+                trailing: 0))
           }
-        } header: {
-          Text(
-            "Lessons",
-            tableName: "Courses",
-            comment: "Heading above the ordered lesson list on a chapter screen."
-          )
-          .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-          .padding(
-            .leading,
-            CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
         }
       }
       .listStyle(.plain)
@@ -175,22 +176,11 @@ private struct ChapterDetailList: View {
         .presentationCompactAdaptation(.sheet)
       }
 
-      HStack(spacing: 8) {
-        if let continuationDestination {
-          CatalogContinueLink(
-            continuation: detail.continuation,
-            destination: continuationDestination,
-            percentComplete: detail.progress?.percentComplete)
-        } else {
-          Spacer(minLength: 0)
-        }
-
-        CatalogActionsMenu(showFeedback: showFeedback)
-
-        if horizontalSizeClass == .regular, continuationDestination != nil {
-          Spacer(minLength: 0)
-        }
-      }
+      CatalogDetailActions(
+        continuation: detail.continuation,
+        destination: continuationDestination,
+        percentComplete: detail.progress?.percentComplete,
+        showFeedback: showFeedback)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.horizontal, horizontalInset)
@@ -277,12 +267,13 @@ private struct ChapterInformationView: View {
 }
 
 private struct ChapterLoadingView: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
   let chapter: ChapterReference
 
   var body: some View {
-    List {
+    VStack(spacing: 0) {
       VStack(alignment: .leading, spacing: 16) {
         CatalogDetailHeader(
           configuration: CatalogDetailHeaderConfiguration(
@@ -299,32 +290,46 @@ private struct ChapterLoadingView: View {
           Image(systemName: "ellipsis")
             .frame(width: 44, height: 44)
         }
+        .padding(
+          .leading,
+          CatalogDetailLayout.actionLeadingInset(
+            for: horizontalSizeClass,
+            dynamicTypeSize: dynamicTypeSize))
       }
-      .listRowSeparator(.hidden)
+      .padding(.horizontal, CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
+      .padding(.top, 16)
+      .padding(.bottom, 12)
 
-      Section {
+      CatalogCurriculumHeader(title: Text(verbatim: "Lessons"))
+
+      List {
         ForEach(0..<5, id: \.self) { index in
           CatalogNumberedRow(
             description: "A short lesson description",
             imageURL: nil,
             number: index + 1,
+            symbolTint: .orange,
             systemImage: "lightbulb",
             title: "Lesson title"
           ) {
             Text(verbatim: "Not started")
           }
           .listRowInsets(
-            EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
+            EdgeInsets(
+              top: CatalogDetailLayout.curriculumRowVerticalInset(
+                for: horizontalSizeClass),
+              leading: 0,
+              bottom: CatalogDetailLayout.curriculumRowVerticalInset(
+                for: horizontalSizeClass),
+              trailing: 0))
         }
-      } header: {
-        Text(verbatim: "Lessons")
-          .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-          .padding(
-            .leading,
-            CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
       }
+      .listStyle(.plain)
+      .contentMargins(
+        .horizontal,
+        CatalogDetailLayout.horizontalInset(for: horizontalSizeClass),
+        for: .scrollContent)
     }
-    .listStyle(.plain)
     .frame(maxWidth: 900)
     .frame(maxWidth: .infinity)
     .redacted(reason: .placeholder)

--- a/apps/apple/Zoonk/Features/Courses/ChapterView.swift
+++ b/apps/apple/Zoonk/Features/Courses/ChapterView.swift
@@ -34,7 +34,7 @@ struct ChapterView: View {
         resourceID: chapter.id,
         session: session.authenticatedSession)
     ) {
-      await catalog.loadChapter(id: chapter.id, force: true)
+      await catalog.loadChapterIfNeeded(id: chapter.id)
     }
     .refreshable {
       await catalog.loadChapter(id: chapter.id, force: true)
@@ -134,6 +134,7 @@ private struct ChapterDetailList: View {
                 }
               }
             }
+            .accessibilityValue(Text(lesson.kind.localizedTitle))
             .listRowInsets(
               EdgeInsets(
                 top: CatalogDetailLayout.curriculumRowVerticalInset(

--- a/apps/apple/Zoonk/Features/Courses/ChapterView.swift
+++ b/apps/apple/Zoonk/Features/Courses/ChapterView.swift
@@ -1,0 +1,338 @@
+import SwiftUI
+
+struct ChapterView: View {
+  @Environment(CourseCatalogStore.self) private var catalog
+  @Environment(SessionStore.self) private var session
+  @State private var searchText = ""
+
+  let chapter: ChapterReference
+
+  var body: some View {
+    Group {
+      switch catalog.chapterState(for: chapter.id) {
+      case .idle, .loading:
+        ChapterLoadingView(chapter: chapter)
+      case .loaded(let detail):
+        ChapterDetailContent(
+          chapter: chapter,
+          detail: detail,
+          searchText: $searchText)
+      case .empty:
+        ChapterDetailContent(
+          chapter: chapter,
+          detail: ChapterDetail(lessons: []),
+          searchText: $searchText)
+      case .failed(let failure):
+        CatalogFailureRecoveryView(context: .chapter, failure: failure) {
+          await catalog.loadChapter(id: chapter.id, force: true)
+        }
+      }
+    }
+    .background(Color(uiColor: .systemBackground))
+    .task(
+      id: CatalogDetailTaskID(
+        resourceID: chapter.id,
+        session: session.authenticatedSession)
+    ) {
+      await catalog.loadChapter(id: chapter.id, force: true)
+    }
+    .refreshable {
+      await catalog.loadChapter(id: chapter.id, force: true)
+    }
+  }
+}
+
+private struct ChapterDetailContent: View {
+  @Environment(SessionStore.self) private var session
+  @State private var isFeedbackPresented = false
+  @State private var isInformationPresented = false
+  @State private var isSearchPresented = false
+
+  let chapter: ChapterReference
+  let detail: ChapterDetail
+  @Binding var searchText: String
+
+  var body: some View {
+    ChapterDetailList(
+      chapter: resolvedChapter,
+      detail: detail,
+      isInformationPresented: $isInformationPresented,
+      searchText: $searchText,
+      showFeedback: { isFeedbackPresented = true },
+      showInformation: { isInformationPresented = true }
+    )
+    .catalogDetailSearchPresentation(
+      text: $searchText,
+      isPresented: $isSearchPresented,
+      prompt: Text(
+        "Search lessons",
+        tableName: "Courses",
+        comment: "Placeholder for searching within a chapter's lessons.")
+    )
+    .sheet(isPresented: $isFeedbackPresented) {
+      FeedbackSheet(
+        api: FeedbackAPI.live(),
+        defaultEmail: session.account?.user.email)
+    }
+  }
+
+  private var resolvedChapter: ChapterReference {
+    guard let canonicalChapter = detail.chapter else {
+      return chapter
+    }
+
+    return ChapterReference((reference: chapter, chapter: canonicalChapter))
+  }
+}
+
+private struct ChapterDetailList: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @Environment(\.isSearching) private var isSearching
+
+  let chapter: ChapterReference
+  let detail: ChapterDetail
+  @Binding var isInformationPresented: Bool
+  @Binding var searchText: String
+  let showFeedback: () -> Void
+  let showInformation: () -> Void
+
+  var body: some View {
+    VStack(spacing: 0) {
+      if !showsSearchResultsOnly {
+        detailHeader
+      }
+
+      List {
+        Section {
+          if filteredLessons.isEmpty {
+            emptyLessonsView
+              .listRowSeparator(.hidden)
+          } else {
+            ForEach(filteredLessons) { lesson in
+              NavigationLink(
+                value: CourseDestination.lesson(
+                  LessonReference((chapter: chapter, lesson: lesson)))
+              ) {
+                CatalogNumberedRow(
+                  description: lesson.displayDescription(),
+                  imageURL: lesson.imageURL,
+                  number: lesson.position + 1,
+                  systemImage: lesson.kind.systemImage,
+                  title: lesson.displayTitle()
+                ) {
+                  if let progress = catalogLessonProgress(
+                    lesson: lesson,
+                    progress: detail.progress)
+                  {
+                    CatalogProgressLabel(progress: progress)
+                  }
+                }
+              }
+              .listRowInsets(
+                EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
+            }
+          }
+        } header: {
+          Text(
+            "Lessons",
+            tableName: "Courses",
+            comment: "Heading above the ordered lesson list on a chapter screen."
+          )
+          .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+          .padding(
+            .leading,
+            CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
+        }
+      }
+      .listStyle(.plain)
+      .scrollContentBackground(.hidden)
+      .contentMargins(
+        .horizontal,
+        CatalogDetailLayout.horizontalInset(for: horizontalSizeClass),
+        for: .scrollContent)
+    }
+    .frame(maxWidth: 900)
+    .frame(maxWidth: .infinity)
+  }
+
+  private var detailHeader: some View {
+    let horizontalInset = CatalogDetailLayout.horizontalInset(for: horizontalSizeClass)
+
+    return VStack(alignment: .leading, spacing: 16) {
+      CatalogDetailHeader(
+        configuration: CatalogDetailHeaderConfiguration(
+          imageURL: chapter.imageURL,
+          description: chapter.description,
+          systemImage: "rectangle.stack.fill",
+          title: numberedTitle),
+        showInformation: showInformation
+      )
+      .popover(isPresented: $isInformationPresented) {
+        ChapterInformationView(
+          chapter: chapter,
+          dismiss: { isInformationPresented = false }
+        )
+        .presentationCompactAdaptation(.sheet)
+      }
+
+      HStack(spacing: 8) {
+        if let continuationDestination {
+          CatalogContinueLink(
+            continuation: detail.continuation,
+            destination: continuationDestination,
+            percentComplete: detail.progress?.percentComplete)
+        } else {
+          Spacer(minLength: 0)
+        }
+
+        CatalogActionsMenu(showFeedback: showFeedback)
+
+        if horizontalSizeClass == .regular, continuationDestination != nil {
+          Spacer(minLength: 0)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.horizontal, horizontalInset)
+    .padding(.top, 16)
+    .padding(.bottom, 12)
+  }
+
+  private var numberedTitle: String {
+    guard let position = chapter.position else {
+      return chapter.title
+    }
+
+    return "\((position + 1).formatted()). \(chapter.title)"
+  }
+
+  private var showsSearchResultsOnly: Bool {
+    isSearching || catalogText(searchText) != nil
+  }
+
+  private var continuationDestination: CourseDestination? {
+    chapterContinuationDestination(chapter: chapter, detail: detail)
+  }
+
+  private var filteredLessons: [CourseLesson] {
+    filterCourseLessons(CatalogSearchRequest(items: detail.lessons, query: searchText))
+  }
+
+  @ViewBuilder
+  private var emptyLessonsView: some View {
+    if catalogText(searchText) != nil {
+      ContentUnavailableView.search(text: searchText)
+    } else {
+      ContentUnavailableView {
+        Label {
+          Text(
+            "No lessons yet",
+            tableName: "Courses",
+            comment: "Title when a chapter does not have any published lessons.")
+        } icon: {
+          Image(systemName: "list.bullet.rectangle")
+        }
+      } description: {
+        Text(
+          "This chapter's lessons will appear here when they're available.",
+          tableName: "Courses",
+          comment: "Guidance when a chapter does not have any published lessons.")
+      }
+    }
+  }
+}
+
+private struct ChapterInformationView: View {
+  let chapter: ChapterReference
+  let dismiss: () -> Void
+
+  var body: some View {
+    CatalogInformationView(
+      dismiss: dismiss,
+      title: LocalizedStringResource(
+        "Chapter information",
+        table: "Courses",
+        comment: "Title for secondary information about a chapter.")
+    ) {
+      VStack(alignment: .leading, spacing: 16) {
+        if let description = catalogText(chapter.description) {
+          Text(description)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+
+        if chapter.organizationSlug == "ai" {
+          Label {
+            Text(
+              "Created with AI",
+              tableName: "Courses",
+              comment: "Disclosure that a public course or chapter was created with AI.")
+          } icon: {
+            Image(systemName: "sparkles")
+          }
+          .foregroundStyle(.secondary)
+        }
+      }
+    }
+  }
+}
+
+private struct ChapterLoadingView: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  let chapter: ChapterReference
+
+  var body: some View {
+    List {
+      VStack(alignment: .leading, spacing: 16) {
+        CatalogDetailHeader(
+          configuration: CatalogDetailHeaderConfiguration(
+            imageURL: chapter.imageURL,
+            description: chapter.description,
+            systemImage: "rectangle.stack.fill",
+            title: chapter.position.map { "\(($0 + 1).formatted()). \(chapter.title)" }
+              ?? chapter.title))
+
+        HStack(spacing: 8) {
+          Text(verbatim: "Start")
+            .frame(maxWidth: horizontalSizeClass == .regular ? 260 : .infinity)
+            .frame(minHeight: 44)
+          Image(systemName: "ellipsis")
+            .frame(width: 44, height: 44)
+        }
+      }
+      .listRowSeparator(.hidden)
+
+      Section {
+        ForEach(0..<5, id: \.self) { index in
+          CatalogNumberedRow(
+            description: "A short lesson description",
+            imageURL: nil,
+            number: index + 1,
+            systemImage: "lightbulb",
+            title: "Lesson title"
+          ) {
+            Text(verbatim: "Not started")
+          }
+          .listRowInsets(
+            EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
+        }
+      } header: {
+        Text(verbatim: "Lessons")
+          .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+          .padding(
+            .leading,
+            CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
+      }
+    }
+    .listStyle(.plain)
+    .frame(maxWidth: 900)
+    .frame(maxWidth: .infinity)
+    .redacted(reason: .placeholder)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(
+      Text(
+        "Loading chapter",
+        tableName: "Courses",
+        comment: "Accessibility status while a chapter loads."))
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseArtwork.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseArtwork.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct CourseArtwork: View {
   let imageURL: URL?
   var cornerRadius: CGFloat = 16
+  var symbolTint: Color?
   var systemImage = "book.closed.fill"
 
   var body: some View {
@@ -35,13 +36,17 @@ struct CourseArtwork: View {
 
   private var fallback: some View {
     ZStack {
-      Color(uiColor: .tertiarySystemFill)
+      fallbackBackground
 
       Image(systemName: systemImage)
         .font(.system(.largeTitle, design: .rounded, weight: .medium))
         .symbolRenderingMode(.hierarchical)
-        .foregroundStyle(.secondary)
+        .foregroundStyle(symbolTint ?? Color(uiColor: .secondaryLabel))
     }
+  }
+
+  private var fallbackBackground: Color {
+    symbolTint?.opacity(0.12) ?? Color(uiColor: .tertiarySystemFill)
   }
 }
 

--- a/apps/apple/Zoonk/Features/Courses/CourseArtwork.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseArtwork.swift
@@ -41,12 +41,16 @@ struct CourseArtwork: View {
       Image(systemName: systemImage)
         .font(.system(.largeTitle, design: .rounded, weight: .medium))
         .symbolRenderingMode(.hierarchical)
-        .foregroundStyle(symbolTint ?? Color(uiColor: .secondaryLabel))
+        .foregroundStyle(fallbackForeground)
     }
   }
 
   private var fallbackBackground: Color {
     symbolTint?.opacity(0.12) ?? Color(uiColor: .tertiarySystemFill)
+  }
+
+  private var fallbackForeground: Color {
+    symbolTint?.mix(with: .primary, by: 0.35) ?? Color(uiColor: .secondaryLabel)
   }
 }
 

--- a/apps/apple/Zoonk/Features/Courses/CourseArtwork.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseArtwork.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct CourseArtwork: View {
+  let imageURL: URL?
+  var cornerRadius: CGFloat = 16
+  var systemImage = "book.closed.fill"
+
+  var body: some View {
+    Group {
+      if let imageURL {
+        AsyncImage(url: imageURL) { phase in
+          switch phase {
+          case .success(let image):
+            image
+              .resizable()
+              .scaledToFill()
+          case .empty:
+            fallback.redacted(reason: .placeholder)
+          case .failure:
+            fallback
+          @unknown default:
+            fallback
+          }
+        }
+      } else {
+        fallback
+      }
+    }
+    .aspectRatio(1, contentMode: .fit)
+    .background(Color(uiColor: .secondarySystemGroupedBackground))
+    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+    .accessibilityHidden(true)
+  }
+
+  private var fallback: some View {
+    ZStack {
+      Color(uiColor: .tertiarySystemFill)
+
+      Image(systemName: systemImage)
+        .font(.system(.largeTitle, design: .rounded, weight: .medium))
+        .symbolRenderingMode(.hierarchical)
+        .foregroundStyle(.secondary)
+    }
+  }
+}
+
+#Preview {
+  CourseArtwork(imageURL: nil)
+    .frame(width: 80)
+    .padding()
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogAPI.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogAPI.swift
@@ -1,0 +1,482 @@
+import Foundation
+import OpenAPIRuntime
+
+protocol CourseCatalogAPIClient: Sendable {
+  func listCourses(query: CourseCatalogQuery) async throws -> CourseCatalogPage
+  func getCourse(id: String) async throws -> Course
+  func getChapter(id: String) async throws -> CourseChapter
+  func listCourseChapters(courseID: String) async throws -> [CourseChapter]
+  func listChapterLessons(chapterID: String) async throws -> [CourseLesson]
+  func getCourseNextLesson(courseID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  func getChapterNextLesson(chapterID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  func getCourseProgress(courseID: String, token: String?) async throws -> CourseProgress
+  func getChapterProgress(chapterID: String, token: String?) async throws -> ChapterProgress
+  func searchCatalog(query: CatalogSearchQuery) async throws -> CatalogSearchResults
+}
+
+struct CourseCatalogAPI: CourseCatalogAPIClient, @unchecked Sendable {
+  private let clients: APIClientFactory
+
+  init(clients: APIClientFactory) {
+    self.clients = clients
+  }
+
+  func listCourses(query: CourseCatalogQuery) async throws -> CourseCatalogPage {
+    try await perform { client in
+      let output = try await client.listCourses(
+        .init(
+          query: .init(
+            category: query.category.map(makeGeneratedCourseCategory),
+            cursor: query.cursor,
+            language: query.language,
+            limit: query.limit)))
+
+      switch output {
+      case .ok(let response):
+        return makeCourseCatalogPage(try response.body.json)
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  func getCourse(id: String) async throws -> Course {
+    try await perform { client in
+      let output = try await client.getCourse(.init(path: .init(courseId: id)))
+
+      switch output {
+      case .ok(let response):
+        return try makeCourse(try response.body.json)
+      case .notFound:
+        throw CourseCatalogFailure.notFound
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  func getChapter(id: String) async throws -> CourseChapter {
+    try await perform { client in
+      let output = try await client.getChapter(.init(path: .init(chapterId: id)))
+
+      switch output {
+      case .ok(let response):
+        return makeCourseChapter(try response.body.json)
+      case .notFound:
+        throw CourseCatalogFailure.notFound
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  func listCourseChapters(courseID: String) async throws -> [CourseChapter] {
+    try await perform { client in
+      let output = try await client.listCourseChapters(
+        .init(path: .init(courseId: courseID)))
+
+      switch output {
+      case .ok(let response):
+        return try response.body.json.data.map(makeCourseChapter)
+      case .notFound:
+        throw CourseCatalogFailure.notFound
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  func listChapterLessons(chapterID: String) async throws -> [CourseLesson] {
+    try await perform { client in
+      let output = try await client.listChapterLessons(
+        .init(path: .init(chapterId: chapterID)))
+
+      switch output {
+      case .ok(let response):
+        return try response.body.json.data.map(makeCourseLesson)
+      case .notFound:
+        throw CourseCatalogFailure.notFound
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  func getCourseNextLesson(courseID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  {
+    try await perform(token: token) { client in
+      let output = try await client.getCourseNextLesson(
+        .init(path: .init(courseId: courseID)))
+
+      switch output {
+      case .ok(let response):
+        return makeCatalogContinuationTarget(try response.body.json)
+      case .notFound:
+        throw CourseCatalogFailure.notFound
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  func getChapterNextLesson(chapterID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  {
+    try await perform(token: token) { client in
+      let output = try await client.getChapterNextLesson(
+        .init(path: .init(chapterId: chapterID)))
+
+      switch output {
+      case .ok(let response):
+        return makeCatalogContinuationTarget(try response.body.json)
+      case .notFound:
+        throw CourseCatalogFailure.notFound
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  func getCourseProgress(courseID: String, token: String?) async throws -> CourseProgress {
+    try await perform(token: token) { client in
+      let output = try await client.getCourseProgress(
+        .init(path: .init(courseId: courseID)))
+
+      switch output {
+      case .ok(let response):
+        return makeCourseProgress(try response.body.json)
+      case .notFound:
+        throw CourseCatalogFailure.notFound
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  func getChapterProgress(chapterID: String, token: String?) async throws -> ChapterProgress {
+    try await perform(token: token) { client in
+      let output = try await client.getChapterProgress(
+        .init(path: .init(chapterId: chapterID)))
+
+      switch output {
+      case .ok(let response):
+        return makeChapterProgress(try response.body.json)
+      case .notFound:
+        throw CourseCatalogFailure.notFound
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  func searchCatalog(query: CatalogSearchQuery) async throws -> CatalogSearchResults {
+    try await perform { client in
+      let output = try await client.searchCatalog(
+        .init(query: .init(language: query.language, query: query.query)))
+
+      switch output {
+      case .ok(let response):
+        return makeCatalogSearchResults(try response.body.json)
+      case .badRequest, .internalServerError, .undocumented:
+        throw CourseCatalogFailure.unavailable
+      }
+    }
+  }
+
+  /// Keeps generated transport failures behind stable recovery states while preserving task cancellation.
+  private func perform<Output: Sendable>(
+    token: String? = nil,
+    operation: @Sendable (Client) async throws -> Output
+  ) async throws -> Output {
+    do {
+      return try await operation(clients.makeClient(token: token))
+    } catch {
+      if isRequestCancellation(error) {
+        throw CancellationError()
+      }
+
+      if let failure = error as? CourseCatalogFailure {
+        throw failure
+      }
+
+      if isNetworkError(error) {
+        throw CourseCatalogFailure.network
+      }
+
+      throw CourseCatalogFailure.unavailable
+    }
+  }
+
+  private func isRequestCancellation(_ error: Error) -> Bool {
+    if error is CancellationError {
+      return true
+    }
+
+    if let urlError = error as? URLError {
+      return urlError.code == .cancelled
+    }
+
+    if let clientError = error as? ClientError {
+      return isRequestCancellation(clientError.underlyingError)
+    }
+
+    return false
+  }
+
+  private func isNetworkError(_ error: Error) -> Bool {
+    if error is URLError {
+      return true
+    }
+
+    if let clientError = error as? ClientError {
+      return isNetworkError(clientError.underlyingError)
+    }
+
+    return false
+  }
+}
+
+private func makeGeneratedCourseCategory(
+  _ category: CourseCategory
+) -> Operations.ListCourses.Input.Query.CategoryPayload {
+  switch category {
+  case .arts: .arts
+  case .business: .business
+  case .communication: .communication
+  case .culture: .culture
+  case .economics: .economics
+  case .engineering: .engineering
+  case .geography: .geography
+  case .health: .health
+  case .history: .history
+  case .languages: .languages
+  case .law: .law
+  case .math: .math
+  case .science: .science
+  case .society: .society
+  case .tech: .tech
+  }
+}
+
+private func makeCourseCatalogPage(
+  _ payload: Operations.ListCourses.Output.Ok.Body.JsonPayload
+) -> CourseCatalogPage {
+  CourseCatalogPage(
+    courses: payload.data.map(makeCourseSummary),
+    hasMore: payload.pagination.hasMore,
+    nextCursor: payload.pagination.nextCursor)
+}
+
+private func makeCourseSummary(
+  _ payload: Components.Schemas.CourseResult
+) -> CourseSummary {
+  CourseSummary(
+    description: payload.description,
+    id: payload.id,
+    imageURL: payload.imageUrl.flatMap(URL.init(string:)),
+    language: payload.language,
+    organization: makeCourseOrganization(payload.organization),
+    slug: payload.slug,
+    title: payload.title)
+}
+
+private func makeCourse(
+  _ payload: Components.Schemas.CourseResource
+) throws -> Course {
+  Course(
+    categories: try payload.categories.map(makeCourseCategory),
+    description: payload.description,
+    id: payload.id,
+    imageURL: payload.imageUrl.flatMap(URL.init(string:)),
+    language: payload.language,
+    organization: makeCourseOrganization(payload.organization),
+    slug: payload.slug,
+    targetLanguage: payload.targetLanguage,
+    title: payload.title)
+}
+
+private func makeCourseCategory(
+  _ payload: Components.Schemas.CourseResource.CategoriesPayloadPayload
+) throws -> CourseCategory {
+  guard let category = CourseCategory(rawValue: payload.rawValue) else {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  return category
+}
+
+private func makeCourseOrganization(
+  _ payload: Components.Schemas.OrganizationSummary
+) -> CourseOrganization {
+  CourseOrganization(
+    id: payload.id,
+    logoURL: payload.logo.flatMap(URL.init(string:)),
+    name: payload.name,
+    slug: payload.slug)
+}
+
+private func makeCourseChapter(
+  _ payload: Components.Schemas.CourseChapter
+) -> CourseChapter {
+  CourseChapter(
+    courseID: payload.courseId,
+    description: payload.description,
+    id: payload.id,
+    imageURL: payload.imageUrl.flatMap(URL.init(string:)),
+    language: payload.language,
+    lessonCount: payload.lessonCount,
+    position: payload.position,
+    slug: payload.slug,
+    title: payload.title)
+}
+
+private func makeCourseChapter(
+  _ payload: Components.Schemas.ChapterResource
+) -> CourseChapter {
+  CourseChapter(
+    courseID: payload.courseId,
+    description: payload.description,
+    id: payload.id,
+    imageURL: payload.imageUrl.flatMap(URL.init(string:)),
+    language: payload.language,
+    lessonCount: nil,
+    position: payload.position,
+    slug: payload.slug,
+    title: payload.title)
+}
+
+private func makeCourseLesson(
+  _ payload: Components.Schemas.LessonResource
+) throws -> CourseLesson {
+  CourseLesson(
+    chapterID: payload.chapterId,
+    courseID: payload.courseId,
+    description: payload.description,
+    id: payload.id,
+    imageURL: payload.imageUrl.flatMap(URL.init(string:)),
+    kind: try makeLessonKind(payload.kind),
+    language: payload.language,
+    position: payload.position,
+    slug: payload.slug,
+    title: payload.title)
+}
+
+private func makeLessonKind(
+  _ payload: Components.Schemas.LessonResource.KindPayload
+) throws -> LessonKind {
+  guard let kind = LessonKind(rawValue: payload.rawValue) else {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  return kind
+}
+
+private func makeCatalogContinuationTarget(
+  _ payload: Components.Schemas.NextLessonResponse
+) -> CatalogContinuationTarget {
+  switch payload {
+  case .chapter(let target):
+    .chapter(
+      CatalogChapterContinuation(
+        canPrefetch: target.canPrefetch,
+        chapterID: target.chapterId,
+        chapterSlug: target.chapterSlug,
+        completed: target.completed,
+        courseID: target.courseId,
+        courseSlug: target.courseSlug,
+        hasStarted: target.hasStarted,
+        organizationSlug: target.organizationSlug))
+  case .empty(let target):
+    .empty(
+      CatalogEmptyContinuation(
+        completed: target.completed,
+        hasStarted: target.hasStarted))
+  case .lesson(let target):
+    .lesson(
+      CatalogLessonContinuation(
+        canPrefetch: target.canPrefetch,
+        chapterID: target.chapterId,
+        chapterSlug: target.chapterSlug,
+        completed: target.completed,
+        courseID: target.courseId,
+        courseSlug: target.courseSlug,
+        hasStarted: target.hasStarted,
+        lessonID: target.lessonId,
+        lessonPosition: target.lessonPosition,
+        lessonSlug: target.lessonSlug,
+        organizationSlug: target.organizationSlug))
+  }
+}
+
+private func makeCourseProgress(
+  _ payload: Components.Schemas.CourseCompletionResponse
+) -> CourseProgress {
+  CourseProgress(
+    chapters: payload.chapters.map(makeCourseChapterProgress),
+    percentComplete: payload.percentComplete)
+}
+
+private func makeCourseChapterProgress(
+  _ payload: Components.Schemas.CourseCompletionResponse.ChaptersPayloadPayload
+) -> CourseChapterProgress {
+  CourseChapterProgress(
+    chapterID: payload.chapterId,
+    completedLessons: payload.completedLessons,
+    totalLessons: payload.totalLessons)
+}
+
+private func makeChapterProgress(
+  _ payload: Components.Schemas.ChapterCompletionResponse
+) -> ChapterProgress {
+  ChapterProgress(
+    lessons: payload.lessons.map(makeChapterLessonProgress),
+    percentComplete: payload.percentComplete)
+}
+
+private func makeChapterLessonProgress(
+  _ payload: Components.Schemas.ChapterCompletionResponse.LessonsPayloadPayload
+) -> ChapterLessonProgress {
+  ChapterLessonProgress(
+    isCompleted: payload.isCompleted,
+    lessonID: payload.lessonId)
+}
+
+private func makeCatalogSearchResults(
+  _ payload: Components.Schemas.CatalogSearchResponse
+) -> CatalogSearchResults {
+  CatalogSearchResults(
+    chapters: payload.chapters.map(makeCatalogChapterSearchResult),
+    courses: payload.courses.map(makeCatalogCourseSearchResult))
+}
+
+private func makeCatalogChapterSearchResult(
+  _ payload: Components.Schemas.CatalogSearchResponse.ChaptersPayloadPayload
+) -> CatalogChapterSearchResult {
+  CatalogChapterSearchResult(
+    courseID: payload.courseId,
+    courseSlug: payload.courseSlug,
+    courseTitle: payload.courseTitle,
+    description: payload.description,
+    id: payload.id,
+    imageURL: payload.imageUrl.flatMap(URL.init(string:)),
+    language: payload.language,
+    organizationSlug: payload.organizationSlug,
+    slug: payload.slug,
+    title: payload.title)
+}
+
+private func makeCatalogCourseSearchResult(
+  _ payload: Components.Schemas.CatalogSearchResponse.CoursesPayloadPayload
+) -> CatalogCourseSearchResult {
+  CatalogCourseSearchResult(
+    description: payload.description,
+    id: payload.id,
+    imageURL: payload.imageUrl.flatMap(URL.init(string:)),
+    language: payload.language,
+    organizationSlug: payload.organizationSlug,
+    slug: payload.slug,
+    title: payload.title)
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogGrid.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogGrid.swift
@@ -84,18 +84,8 @@ private struct CourseCatalogLoadingItem: View {
   let artworkSize: CGFloat
 
   var body: some View {
-    HStack(alignment: .top, spacing: 12) {
-      CourseArtwork(imageURL: nil)
-        .frame(width: artworkSize, height: artworkSize)
-
+    CourseCatalogRow(imageURL: nil, artworkSize: artworkSize) {
       textContent
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-    .padding(.bottom, 14)
-    .overlay(alignment: .bottom) {
-      Color(uiColor: .separator)
-        .frame(height: 0.5)
-        .padding(.leading, artworkSize + 12)
     }
     .redacted(reason: .placeholder)
   }
@@ -118,18 +108,8 @@ private struct CourseCatalogItem: View {
 
   var body: some View {
     NavigationLink(value: CourseDestination.course(CourseReference(course))) {
-      HStack(alignment: .top, spacing: 12) {
-        CourseArtwork(imageURL: course.imageURL)
-          .frame(width: artworkSize, height: artworkSize)
-
+      CourseCatalogRow(imageURL: course.imageURL, artworkSize: artworkSize) {
         textContent
-          .frame(maxWidth: .infinity, alignment: .leading)
-      }
-      .padding(.bottom, 14)
-      .overlay(alignment: .bottom) {
-        Color(uiColor: .separator)
-          .frame(height: 0.5)
-          .padding(.leading, artworkSize + 12)
       }
       .contentShape(Rectangle())
     }
@@ -155,6 +135,36 @@ private struct CourseCatalogItem: View {
           .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
       }
     }
+  }
+}
+
+private struct CourseCatalogRow<Content: View>: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  let imageURL: URL?
+  let artworkSize: CGFloat
+  @ViewBuilder let content: Content
+
+  var body: some View {
+    HStack(alignment: usesBalancedRegularLayout ? .center : .top, spacing: 12) {
+      CourseArtwork(imageURL: imageURL)
+        .frame(width: artworkSize, height: artworkSize)
+
+      content
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(.top, usesBalancedRegularLayout ? 8 : 0)
+    .padding(.bottom, usesBalancedRegularLayout ? 8 : 14)
+    .overlay(alignment: .bottom) {
+      Color(uiColor: .separator)
+        .frame(height: 0.5)
+        .padding(.leading, artworkSize + 12)
+    }
+  }
+
+  private var usesBalancedRegularLayout: Bool {
+    horizontalSizeClass == .regular && !dynamicTypeSize.isAccessibilitySize
   }
 }
 

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogGrid.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogGrid.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+
+struct CourseCatalogGrid: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @Environment(CourseCatalogStore.self) private var catalog
+
+  let category: CourseCategory?
+  let page: CourseCatalogPage
+
+  var body: some View {
+    LazyVGrid(columns: layout.columns, alignment: .leading, spacing: 14) {
+      ForEach(page.courses) { course in
+        courseItem(course)
+      }
+    }
+
+    if page.canLoadMore {
+      CourseCatalogLoadMoreView(
+        category: category,
+        failure: catalog.loadMoreFailure,
+        isLoading: catalog.isLoadingMore)
+    }
+  }
+
+  private var layout: CourseCatalogLayout {
+    CourseCatalogLayout(
+      dynamicTypeSize: dynamicTypeSize,
+      horizontalSizeClass: horizontalSizeClass)
+  }
+
+  @ViewBuilder
+  private func courseItem(_ course: CourseSummary) -> some View {
+    if page.canLoadMore, course.id == page.courses.last?.id {
+      CourseCatalogItem(course: course, artworkSize: layout.artworkSize)
+        .task(
+          id: CourseCatalogPaginationTaskID(
+            cursor: page.nextCursor,
+            isLoadingCourses: catalog.isLoadingCourses)
+        ) {
+          guard !catalog.isLoadingCourses else {
+            return
+          }
+
+          await catalog.loadMoreCourses(category: category, force: true)
+        }
+    } else {
+      CourseCatalogItem(course: course, artworkSize: layout.artworkSize)
+    }
+  }
+}
+
+private struct CourseCatalogPaginationTaskID: Equatable {
+  let cursor: String?
+  let isLoadingCourses: Bool
+}
+
+struct CourseCatalogLoadingGrid: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  var body: some View {
+    LazyVGrid(columns: layout.columns, alignment: .leading, spacing: 14) {
+      ForEach(0..<8, id: \.self) { _ in
+        CourseCatalogLoadingItem(artworkSize: layout.artworkSize)
+      }
+    }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(
+      Text(
+        "Loading courses",
+        tableName: "Courses",
+        comment: "Accessibility status while the course catalog loads."))
+  }
+
+  private var layout: CourseCatalogLayout {
+    CourseCatalogLayout(
+      dynamicTypeSize: dynamicTypeSize,
+      horizontalSizeClass: horizontalSizeClass)
+  }
+}
+
+private struct CourseCatalogLoadingItem: View {
+  let artworkSize: CGFloat
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 12) {
+      CourseArtwork(imageURL: nil)
+        .frame(width: artworkSize, height: artworkSize)
+
+      textContent
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(.bottom, 14)
+    .overlay(alignment: .bottom) {
+      Color(uiColor: .separator)
+        .frame(height: 0.5)
+        .padding(.leading, artworkSize + 12)
+    }
+    .redacted(reason: .placeholder)
+  }
+
+  private var textContent: some View {
+    VStack(alignment: .leading, spacing: 3) {
+      Text(verbatim: "A course title")
+        .font(.headline)
+      Text(verbatim: "A short description of this course")
+        .font(.subheadline)
+    }
+  }
+}
+
+private struct CourseCatalogItem: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+  let course: CourseSummary
+  let artworkSize: CGFloat
+
+  var body: some View {
+    NavigationLink(value: CourseDestination.course(CourseReference(course))) {
+      HStack(alignment: .top, spacing: 12) {
+        CourseArtwork(imageURL: course.imageURL)
+          .frame(width: artworkSize, height: artworkSize)
+
+        textContent
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+      .padding(.bottom, 14)
+      .overlay(alignment: .bottom) {
+        Color(uiColor: .separator)
+          .frame(height: 0.5)
+          .padding(.leading, artworkSize + 12)
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .accessibilityHint(
+      Text(
+        "Opens the course",
+        tableName: "Courses",
+        comment: "Accessibility hint for a course in the catalog."))
+  }
+
+  private var textContent: some View {
+    VStack(alignment: .leading, spacing: 3) {
+      Text(course.title)
+        .font(.headline)
+        .foregroundStyle(.primary)
+        .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+
+      if let description = catalogText(course.description) {
+        Text(description)
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+          .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+      }
+    }
+  }
+}
+
+private struct CourseCatalogLayout {
+  let dynamicTypeSize: DynamicTypeSize
+  let horizontalSizeClass: UserInterfaceSizeClass?
+
+  var artworkSize: CGFloat {
+    horizontalSizeClass == .regular && !dynamicTypeSize.isAccessibilitySize ? 88 : 80
+  }
+
+  var columns: [GridItem] {
+    guard horizontalSizeClass == .regular, !dynamicTypeSize.isAccessibilitySize else {
+      return [GridItem(.flexible(), alignment: .top)]
+    }
+
+    return [GridItem(.adaptive(minimum: 300, maximum: 420), spacing: 24, alignment: .top)]
+  }
+}
+
+private struct CourseCatalogLoadMoreView: View {
+  @Environment(CourseCatalogStore.self) private var catalog
+
+  let category: CourseCategory?
+  let failure: CourseCatalogFailure?
+  let isLoading: Bool
+
+  var body: some View {
+    Group {
+      if let failure {
+        VStack(spacing: 10) {
+          Label {
+            failureDescription(failure)
+          } icon: {
+            Image(
+              systemName: failure == .network
+                ? "wifi.exclamationmark" : "exclamationmark.triangle")
+          }
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+
+          Button {
+            Task {
+              await catalog.loadMoreCourses(category: category)
+            }
+          } label: {
+            Text(
+              "Try again",
+              tableName: "Courses",
+              comment: "Retries loading catalog content after a failure.")
+          }
+          .buttonStyle(.bordered)
+        }
+      } else if isLoading {
+        ProgressView()
+          .accessibilityLabel(
+            Text(
+              "Loading more courses",
+              tableName: "Courses",
+              comment: "Accessibility status while the next course page loads."))
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 16)
+  }
+
+  @ViewBuilder
+  private func failureDescription(_ failure: CourseCatalogFailure) -> some View {
+    switch failure {
+    case .network:
+      Text(
+        "Couldn't load more while offline.",
+        tableName: "Courses",
+        comment: "Message when another course page cannot load because the device is offline.")
+    case .notFound, .unavailable:
+      Text(
+        "Couldn't load more courses.",
+        tableName: "Courses",
+        comment: "Message when another course page cannot be loaded.")
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogLanguage.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogLanguage.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+private let supportedCourseCatalogLanguages = Set(["de", "en", "es", "fr", "pt"])
+
+func currentCourseCatalogLanguage() -> String {
+  courseCatalogLanguage(preferredLocalizations: Bundle.main.preferredLocalizations)
+}
+
+func courseCatalogLanguage(preferredLocalizations: [String]) -> String {
+  preferredLocalizations
+    .lazy
+    .map(baseLanguage)
+    .first(where: supportedCourseCatalogLanguages.contains) ?? "en"
+}
+
+private func baseLanguage(_ localization: String) -> String {
+  localization
+    .lowercased()
+    .split(whereSeparator: { $0 == "-" || $0 == "_" })
+    .first
+    .map(String.init) ?? ""
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogModels.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogModels.swift
@@ -1,0 +1,279 @@
+import Foundation
+
+enum CourseCategory: String, CaseIterable, Codable, Equatable, Sendable {
+  case arts
+  case business
+  case communication
+  case culture
+  case economics
+  case engineering
+  case geography
+  case health
+  case history
+  case languages
+  case law
+  case math
+  case science
+  case society
+  case tech
+}
+
+struct CourseOrganization: Codable, Equatable, Identifiable, Sendable {
+  let id: String
+  let logoURL: URL?
+  let name: String
+  let slug: String
+}
+
+struct CourseSummary: Codable, Equatable, Identifiable, Sendable {
+  let description: String?
+  let id: String
+  let imageURL: URL?
+  let language: String
+  let organization: CourseOrganization
+  let slug: String
+  let title: String
+}
+
+struct Course: Codable, Equatable, Identifiable, Sendable {
+  let categories: [CourseCategory]
+  let description: String?
+  let id: String
+  let imageURL: URL?
+  let language: String
+  let organization: CourseOrganization
+  let slug: String
+  let targetLanguage: String?
+  let title: String
+}
+
+struct CourseChapter: Codable, Equatable, Identifiable, Sendable {
+  let courseID: String
+  let description: String
+  let id: String
+  let imageURL: URL?
+  let language: String
+  let lessonCount: Int?
+  let position: Int
+  let slug: String
+  let title: String
+}
+
+enum LessonKind: String, CaseIterable, Codable, Equatable, Sendable {
+  case alphabet
+  case custom
+  case explanation
+  case grammar
+  case listening
+  case practice
+  case quiz
+  case reading
+  case review
+  case translation
+  case tutorial
+  case vocabulary
+}
+
+struct CourseLesson: Codable, Equatable, Identifiable, Sendable {
+  let chapterID: String
+  let courseID: String
+  let description: String?
+  let id: String
+  let imageURL: URL?
+  let kind: LessonKind
+  let language: String
+  let position: Int
+  let slug: String
+  let title: String?
+}
+
+struct CourseCatalogPage: Codable, Equatable, Sendable {
+  let courses: [CourseSummary]
+  let hasMore: Bool
+  let nextCursor: String?
+
+  var canLoadMore: Bool {
+    hasMore && nextCursor != nil
+  }
+}
+
+struct CatalogChapterContinuation: Codable, Equatable, Sendable {
+  let canPrefetch: Bool
+  let chapterID: String
+  let chapterSlug: String
+  let completed: Bool
+  let courseID: String
+  let courseSlug: String
+  let hasStarted: Bool
+  let organizationSlug: String
+}
+
+struct CatalogEmptyContinuation: Codable, Equatable, Sendable {
+  let completed: Bool
+  let hasStarted: Bool
+}
+
+struct CatalogLessonContinuation: Codable, Equatable, Sendable {
+  let canPrefetch: Bool
+  let chapterID: String
+  let chapterSlug: String
+  let completed: Bool
+  let courseID: String
+  let courseSlug: String
+  let hasStarted: Bool
+  let lessonID: String
+  let lessonPosition: Int
+  let lessonSlug: String
+  let organizationSlug: String
+}
+
+enum CatalogContinuationTarget: Codable, Equatable, Sendable {
+  case chapter(CatalogChapterContinuation)
+  case empty(CatalogEmptyContinuation)
+  case lesson(CatalogLessonContinuation)
+
+  var completed: Bool {
+    switch self {
+    case .chapter(let target): target.completed
+    case .empty(let target): target.completed
+    case .lesson(let target): target.completed
+    }
+  }
+
+  var hasStarted: Bool {
+    switch self {
+    case .chapter(let target): target.hasStarted
+    case .empty(let target): target.hasStarted
+    case .lesson(let target): target.hasStarted
+    }
+  }
+}
+
+struct CourseChapterProgress: Codable, Equatable, Sendable {
+  let chapterID: String
+  let completedLessons: Int
+  let totalLessons: Int
+}
+
+struct CourseProgress: Codable, Equatable, Sendable {
+  let chapters: [CourseChapterProgress]
+  let percentComplete: Int?
+}
+
+struct ChapterLessonProgress: Codable, Equatable, Sendable {
+  let isCompleted: Bool
+  let lessonID: String
+}
+
+struct ChapterProgress: Codable, Equatable, Sendable {
+  let lessons: [ChapterLessonProgress]
+  let percentComplete: Int?
+}
+
+struct CourseDetail: Codable, Equatable, Sendable {
+  let continuation: CatalogContinuationTarget?
+  let course: Course
+  let chapters: [CourseChapter]
+  let progress: CourseProgress?
+
+  init(
+    continuation: CatalogContinuationTarget? = nil,
+    course: Course,
+    chapters: [CourseChapter],
+    progress: CourseProgress? = nil
+  ) {
+    self.continuation = continuation
+    self.course = course
+    self.chapters = chapters
+    self.progress = progress
+  }
+}
+
+struct ChapterDetail: Codable, Equatable, Sendable {
+  let chapter: CourseChapter?
+  let continuation: CatalogContinuationTarget?
+  let lessons: [CourseLesson]
+  let progress: ChapterProgress?
+
+  init(
+    chapter: CourseChapter? = nil,
+    continuation: CatalogContinuationTarget? = nil,
+    lessons: [CourseLesson],
+    progress: ChapterProgress? = nil
+  ) {
+    self.chapter = chapter
+    self.continuation = continuation
+    self.lessons = lessons
+    self.progress = progress
+  }
+}
+
+struct CatalogCourseSearchResult: Codable, Equatable, Identifiable, Sendable {
+  let description: String?
+  let id: String
+  let imageURL: URL?
+  let language: String
+  let organizationSlug: String
+  let slug: String
+  let title: String
+}
+
+struct CatalogChapterSearchResult: Codable, Equatable, Identifiable, Sendable {
+  let courseID: String
+  let courseSlug: String
+  let courseTitle: String
+  let description: String
+  let id: String
+  let imageURL: URL?
+  let language: String
+  let organizationSlug: String
+  let slug: String
+  let title: String
+}
+
+struct CatalogSearchResults: Codable, Equatable, Sendable {
+  let chapters: [CatalogChapterSearchResult]
+  let courses: [CatalogCourseSearchResult]
+
+  var isEmpty: Bool {
+    chapters.isEmpty && courses.isEmpty
+  }
+}
+
+enum CourseCatalogFailure: Error, Codable, Equatable, Sendable {
+  case network
+  case unavailable
+  case notFound
+}
+
+enum CourseCatalogLoadState<Value: Codable & Equatable & Sendable>: Codable, Equatable, Sendable {
+  case idle
+  case loading
+  case loaded(Value)
+  case empty
+  case failed(CourseCatalogFailure)
+}
+
+struct CourseCatalogQuery: Equatable, Sendable {
+  let category: CourseCategory?
+  let cursor: String?
+  let language: String
+  let limit: Int?
+
+  init(
+    category: CourseCategory? = nil,
+    cursor: String? = nil,
+    language: String,
+    limit: Int? = nil
+  ) {
+    self.category = category
+    self.cursor = cursor
+    self.language = language
+    self.limit = limit
+  }
+}
+
+struct CatalogSearchQuery: Equatable, Sendable {
+  let language: String
+  let query: String
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogPresentation.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogPresentation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 struct CatalogSearchRequest<Item> {
   let items: [Item]
@@ -237,13 +238,30 @@ extension LessonKind {
     case .explanation: "lightbulb"
     case .grammar: "textformat"
     case .listening: "headphones"
-    case .practice: "figure.walk.motion"
+    case .practice: "pencil.and.scribble"
     case .quiz: "checkmark.circle"
     case .reading: "book.closed"
     case .review: "arrow.clockwise"
     case .translation: "character.bubble"
     case .tutorial: "list.number"
     case .vocabulary: "text.book.closed"
+    }
+  }
+
+  var symbolTint: Color {
+    switch self {
+    case .alphabet: .blue
+    case .custom: Color(uiColor: .secondaryLabel)
+    case .explanation: .blue
+    case .grammar: .purple
+    case .listening: .red
+    case .practice: .green
+    case .quiz: .yellow
+    case .reading: .yellow
+    case .review: .brown
+    case .translation: .orange
+    case .tutorial: .purple
+    case .vocabulary: .green
     }
   }
 }

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogPresentation.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogPresentation.swift
@@ -1,0 +1,305 @@
+import Foundation
+
+struct CatalogSearchRequest<Item> {
+  let items: [Item]
+  let locale: Locale
+  let query: String
+
+  init(items: [Item], query: String, locale: Locale = .current) {
+    self.items = items
+    self.locale = locale
+    self.query = query
+  }
+}
+
+func filterCourseChapters(
+  _ request: CatalogSearchRequest<CourseChapter>
+) -> [CourseChapter] {
+  let orderedChapters = request.items.sorted(by: CatalogOrder.chapters)
+  let searchTerm = CatalogSearchTerm(query: request.query, locale: request.locale)
+
+  guard !searchTerm.isEmpty else {
+    return orderedChapters
+  }
+
+  return orderedChapters.filter { searchTerm.matches($0) }
+}
+
+func filterCourseLessons(
+  _ request: CatalogSearchRequest<CourseLesson>
+) -> [CourseLesson] {
+  let orderedLessons = request.items.sorted(by: CatalogOrder.lessons)
+  let searchTerm = CatalogSearchTerm(query: request.query, locale: request.locale)
+
+  guard !searchTerm.isEmpty else {
+    return orderedLessons
+  }
+
+  return orderedLessons.filter { searchTerm.matches($0) }
+}
+
+func localizedCourseCategories(locale: Locale = .current) -> [CourseCategory] {
+  CourseCategory.allCases.sorted {
+    String(localized: $0.localizedTitle).compare(
+      String(localized: $1.localizedTitle),
+      options: [.caseInsensitive, .diacriticInsensitive],
+      range: nil,
+      locale: locale) == .orderedAscending
+  }
+}
+
+func catalogText(_ value: String?) -> String? {
+  let normalizedValue = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+  return normalizedValue?.isEmpty == false ? normalizedValue : nil
+}
+
+extension CourseCategory {
+  var localizedTitle: LocalizedStringResource {
+    switch self {
+    case .arts:
+      LocalizedStringResource("Arts", table: "Courses", comment: "Course category for the arts.")
+    case .business:
+      LocalizedStringResource(
+        "Business", table: "Courses", comment: "Course category for business.")
+    case .communication:
+      LocalizedStringResource(
+        "Communication", table: "Courses", comment: "Course category for communication.")
+    case .culture:
+      LocalizedStringResource(
+        "Culture", table: "Courses", comment: "Course category for culture.")
+    case .economics:
+      LocalizedStringResource(
+        "Economics", table: "Courses", comment: "Course category for economics.")
+    case .engineering:
+      LocalizedStringResource(
+        "Engineering", table: "Courses", comment: "Course category for engineering.")
+    case .geography:
+      LocalizedStringResource(
+        "Geography", table: "Courses", comment: "Course category for geography.")
+    case .health:
+      LocalizedStringResource(
+        "Health", table: "Courses", comment: "Course category for health.")
+    case .history:
+      LocalizedStringResource(
+        "History", table: "Courses", comment: "Course category for history.")
+    case .languages:
+      LocalizedStringResource(
+        "Languages", table: "Courses", comment: "Course category for languages.")
+    case .law:
+      LocalizedStringResource("Law", table: "Courses", comment: "Course category for law.")
+    case .math:
+      LocalizedStringResource(
+        "Math", table: "Courses", comment: "Course category for mathematics.")
+    case .science:
+      LocalizedStringResource(
+        "Science", table: "Courses", comment: "Course category for science.")
+    case .society:
+      LocalizedStringResource(
+        "Society", table: "Courses", comment: "Course category for society.")
+    case .tech:
+      LocalizedStringResource(
+        "Technology", table: "Courses", comment: "Course category for technology.")
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .arts: "paintpalette"
+    case .business: "briefcase"
+    case .communication: "bubble.left.and.bubble.right"
+    case .culture: "globe"
+    case .economics: "chart.line.uptrend.xyaxis"
+    case .engineering: "wrench.and.screwdriver"
+    case .geography: "map"
+    case .health: "heart"
+    case .history: "clock.arrow.circlepath"
+    case .languages: "character.bubble"
+    case .law: "scale.3d"
+    case .math: "function"
+    case .science: "flask"
+    case .society: "person.3"
+    case .tech: "cpu"
+    }
+  }
+}
+
+extension LessonKind {
+  var localizedTitle: LocalizedStringResource {
+    switch self {
+    case .alphabet:
+      LocalizedStringResource(
+        "Alphabet", table: "Courses", comment: "Fallback title for an alphabet lesson.")
+    case .custom:
+      LocalizedStringResource(
+        "Custom lesson", table: "Courses", comment: "Fallback title for a custom lesson.")
+    case .explanation:
+      LocalizedStringResource(
+        "Explanation", table: "Courses", comment: "Fallback title for an explanation lesson.")
+    case .grammar:
+      LocalizedStringResource(
+        "Grammar", table: "Courses", comment: "Fallback title for a grammar lesson.")
+    case .listening:
+      LocalizedStringResource(
+        "Listening", table: "Courses", comment: "Fallback title for a listening lesson.")
+    case .practice:
+      LocalizedStringResource(
+        "Practice", table: "Courses", comment: "Fallback title for a practice lesson.")
+    case .quiz:
+      LocalizedStringResource(
+        "Quiz", table: "Courses", comment: "Fallback title for a quiz lesson.")
+    case .reading:
+      LocalizedStringResource(
+        "Reading", table: "Courses", comment: "Fallback title for a reading lesson.")
+    case .review:
+      LocalizedStringResource(
+        "Review", table: "Courses", comment: "Fallback title for a review lesson.")
+    case .translation:
+      LocalizedStringResource(
+        "Translation", table: "Courses", comment: "Fallback title for a translation lesson.")
+    case .tutorial:
+      LocalizedStringResource(
+        "Tutorial", table: "Courses", comment: "Fallback title for a tutorial lesson.")
+    case .vocabulary:
+      LocalizedStringResource(
+        "Vocabulary", table: "Courses", comment: "Fallback title for a vocabulary lesson.")
+    }
+  }
+
+  var localizedDescription: LocalizedStringResource {
+    switch self {
+    case .alphabet:
+      LocalizedStringResource(
+        "Learn how letters and sounds work in this writing system.",
+        table: "Courses",
+        comment: "Fallback description for an alphabet lesson.")
+    case .custom:
+      LocalizedStringResource(
+        "Work through a lesson created for your goal.",
+        table: "Courses",
+        comment: "Fallback description for a custom lesson.")
+    case .explanation:
+      LocalizedStringResource(
+        "Understand the key ideas using everyday language and practical examples.",
+        table: "Courses",
+        comment: "Fallback description for an explanation lesson.")
+    case .grammar:
+      LocalizedStringResource(
+        "Practice grammar patterns with examples and exercises.",
+        table: "Courses",
+        comment: "Fallback description for a grammar lesson.")
+    case .listening:
+      LocalizedStringResource(
+        "Listen to sentences using words you recently learned.",
+        table: "Courses",
+        comment: "Fallback description for a listening lesson.")
+    case .practice:
+      LocalizedStringResource(
+        "Use what you learned in the previous lesson to solve real-world problems.",
+        table: "Courses",
+        comment: "Fallback description for a practice lesson.")
+    case .quiz:
+      LocalizedStringResource(
+        "Check what you understood with a short quiz.",
+        table: "Courses",
+        comment: "Fallback description for a quiz lesson.")
+    case .reading:
+      LocalizedStringResource(
+        "Read sentences using words you recently learned.",
+        table: "Courses",
+        comment: "Fallback description for a reading lesson.")
+    case .review:
+      LocalizedStringResource(
+        "Review this chapter with practice based on your mistakes.",
+        table: "Courses",
+        comment: "Fallback description for a review lesson.")
+    case .translation:
+      LocalizedStringResource(
+        "Translate words from your previous vocabulary lesson.",
+        table: "Courses",
+        comment: "Fallback description for a translation lesson.")
+    case .tutorial:
+      LocalizedStringResource(
+        "Follow a guided step-by-step tutorial.",
+        table: "Courses",
+        comment: "Fallback description for a tutorial lesson.")
+    case .vocabulary:
+      LocalizedStringResource(
+        "Learn new words and practice using them.",
+        table: "Courses",
+        comment: "Fallback description for a vocabulary lesson.")
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .alphabet: "character.book.closed"
+    case .custom: "sparkles"
+    case .explanation: "lightbulb"
+    case .grammar: "textformat"
+    case .listening: "headphones"
+    case .practice: "figure.walk.motion"
+    case .quiz: "checkmark.circle"
+    case .reading: "book.closed"
+    case .review: "arrow.clockwise"
+    case .translation: "character.bubble"
+    case .tutorial: "list.number"
+    case .vocabulary: "text.book.closed"
+    }
+  }
+}
+
+extension CourseLesson {
+  func displayTitle() -> String {
+    catalogText(title) ?? String(localized: kind.localizedTitle)
+  }
+
+  func displayDescription() -> String {
+    catalogText(description) ?? String(localized: kind.localizedDescription)
+  }
+}
+
+private struct CatalogSearchTerm {
+  let locale: Locale
+  let query: String
+
+  init(query: String, locale: Locale) {
+    self.locale = locale
+    self.query = query.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  var isEmpty: Bool {
+    query.isEmpty
+  }
+
+  func matches(_ value: String?) -> Bool {
+    guard let value = catalogText(value) else {
+      return false
+    }
+
+    return value.range(
+      of: query,
+      options: [.caseInsensitive, .diacriticInsensitive],
+      range: nil,
+      locale: locale) != nil
+  }
+
+  func matches(_ chapter: CourseChapter) -> Bool {
+    matches(chapter.title) || matches(chapter.description)
+  }
+
+  func matches(_ lesson: CourseLesson) -> Bool {
+    matches(lesson.displayTitle())
+      || matches(lesson.displayDescription())
+      || matches(String(localized: lesson.kind.localizedTitle))
+  }
+}
+
+private enum CatalogOrder {
+  static func chapters(_ left: CourseChapter, _ right: CourseChapter) -> Bool {
+    left.position == right.position ? left.id < right.id : left.position < right.position
+  }
+
+  static func lessons(_ left: CourseLesson, _ right: CourseLesson) -> Bool {
+    left.position == right.position ? left.id < right.id : left.position < right.position
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogProgressPresentation.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogProgressPresentation.swift
@@ -76,6 +76,7 @@ struct CatalogProgressLabel: View {
       case .inProgress(let completed, let total):
         HStack(spacing: 4) {
           Image(systemName: "circle.dashed")
+            .foregroundStyle(indicatorTint)
             .accessibilityHidden(true)
 
           Text(
@@ -88,6 +89,7 @@ struct CatalogProgressLabel: View {
       case .completed:
         HStack(spacing: 4) {
           Image(systemName: "checkmark.circle.fill")
+            .foregroundStyle(indicatorTint)
             .accessibilityHidden(true)
 
           Text(
@@ -98,7 +100,7 @@ struct CatalogProgressLabel: View {
       }
     }
     .font(.caption.weight(.semibold))
-    .foregroundStyle(tint)
+    .foregroundStyle(.primary)
     .padding(.horizontal, 8)
     .padding(.vertical, 4)
     .background(tint.opacity(0.12), in: Capsule())
@@ -110,5 +112,9 @@ struct CatalogProgressLabel: View {
     case .inProgress: .blue
     case .completed: .green
     }
+  }
+
+  private var indicatorTint: Color {
+    tint.mix(with: .primary, by: 0.35)
   }
 }

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogProgressPresentation.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogProgressPresentation.swift
@@ -66,24 +66,49 @@ struct CatalogProgressLabel: View {
   let progress: CatalogCurriculumProgress
 
   var body: some View {
+    Group {
+      switch progress {
+      case .notStarted:
+        Text(
+          "Not started",
+          tableName: "Courses",
+          comment: "Progress state for a chapter or lesson with no completed lessons.")
+      case .inProgress(let completed, let total):
+        HStack(spacing: 4) {
+          Image(systemName: "circle.dashed")
+            .accessibilityHidden(true)
+
+          Text(
+            "\(completed)/\(total) done",
+            tableName: "Courses",
+            comment:
+              "Chapter progress. The first value is completed lessons and the second is total lessons."
+          )
+        }
+      case .completed:
+        HStack(spacing: 4) {
+          Image(systemName: "checkmark.circle.fill")
+            .accessibilityHidden(true)
+
+          Text(
+            "Completed",
+            tableName: "Courses",
+            comment: "Progress state for a completed chapter or lesson.")
+        }
+      }
+    }
+    .font(.caption.weight(.semibold))
+    .foregroundStyle(tint)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 4)
+    .background(tint.opacity(0.12), in: Capsule())
+  }
+
+  private var tint: Color {
     switch progress {
-    case .notStarted:
-      Text(
-        "Not started",
-        tableName: "Courses",
-        comment: "Progress state for a chapter or lesson with no completed lessons.")
-    case .inProgress(let completed, let total):
-      Text(
-        "\(completed)/\(total) done",
-        tableName: "Courses",
-        comment:
-          "Chapter progress. The first value is completed lessons and the second is total lessons."
-      )
-    case .completed:
-      Text(
-        "Completed",
-        tableName: "Courses",
-        comment: "Progress state for a completed chapter or lesson.")
+    case .notStarted: Color(uiColor: .secondaryLabel)
+    case .inProgress: .blue
+    case .completed: .green
     }
   }
 }

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogProgressPresentation.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogProgressPresentation.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+enum CatalogPrimaryAction: Equatable {
+  case start
+  case continueLearning
+  case review
+}
+
+enum CatalogCurriculumProgress: Equatable {
+  case notStarted
+  case inProgress(completed: Int, total: Int)
+  case completed
+}
+
+func catalogPrimaryAction(
+  for continuation: CatalogContinuationTarget?
+) -> CatalogPrimaryAction {
+  if continuation?.completed == true {
+    return .review
+  }
+
+  return continuation?.hasStarted == true ? .continueLearning : .start
+}
+
+func catalogChapterProgress(
+  chapter: CourseChapter,
+  progress: CourseProgress?
+) -> CatalogCurriculumProgress? {
+  guard let progress else {
+    return nil
+  }
+
+  guard let chapterProgress = progress.chapters.first(where: { $0.chapterID == chapter.id }) else {
+    return .notStarted
+  }
+
+  guard chapterProgress.completedLessons > 0 else {
+    return .notStarted
+  }
+
+  guard
+    chapterProgress.totalLessons > 0,
+    chapterProgress.completedLessons >= chapterProgress.totalLessons
+  else {
+    return .inProgress(
+      completed: chapterProgress.completedLessons,
+      total: chapterProgress.totalLessons)
+  }
+
+  return .completed
+}
+
+func catalogLessonProgress(
+  lesson: CourseLesson,
+  progress: ChapterProgress?
+) -> CatalogCurriculumProgress? {
+  guard let progress else {
+    return nil
+  }
+
+  let isCompleted = progress.lessons.first(where: { $0.lessonID == lesson.id })?.isCompleted
+  return isCompleted == true ? .completed : .notStarted
+}
+
+struct CatalogProgressLabel: View {
+  let progress: CatalogCurriculumProgress
+
+  var body: some View {
+    switch progress {
+    case .notStarted:
+      Text(
+        "Not started",
+        tableName: "Courses",
+        comment: "Progress state for a chapter or lesson with no completed lessons.")
+    case .inProgress(let completed, let total):
+      Text(
+        "\(completed)/\(total) done",
+        tableName: "Courses",
+        comment:
+          "Chapter progress. The first value is completed lessons and the second is total lessons."
+      )
+    case .completed:
+      Text(
+        "Completed",
+        tableName: "Courses",
+        comment: "Progress state for a completed chapter or lesson.")
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogSearchResultsView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogSearchResultsView.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+struct CourseCatalogSearchResultsView: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @Environment(CourseCatalogStore.self) private var catalog
+
+  let query: String
+  let retry: @MainActor () async -> Void
+
+  var body: some View {
+    Group {
+      switch catalog.searchState {
+      case .idle:
+        searchPrompt
+      case .loading:
+        ProgressView()
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .accessibilityLabel(
+            Text(
+              "Searching the catalog",
+              tableName: "Courses",
+              comment: "Accessibility status while catalog search results load."))
+      case .loaded(let results):
+        resultsList(results)
+      case .empty:
+        ContentUnavailableView.search(text: query)
+      case .failed(let failure):
+        CatalogFailureRecoveryView(context: .catalog, failure: failure, retry: retry)
+      }
+    }
+    .frame(maxWidth: 900)
+    .frame(maxWidth: .infinity)
+  }
+
+  private var searchPrompt: some View {
+    ContentUnavailableView {
+      Label {
+        Text(
+          "Search the catalog",
+          tableName: "Courses",
+          comment: "Title shown before the learner enters a catalog search query.")
+      } icon: {
+        Image(systemName: "magnifyingglass")
+      }
+    } description: {
+      Text(
+        "Find a course or jump directly to a chapter.",
+        tableName: "Courses",
+        comment: "Guidance shown before the learner enters a catalog search query.")
+    }
+  }
+
+  private func resultsList(_ results: CatalogSearchResults) -> some View {
+    List {
+      if !results.courses.isEmpty {
+        Section {
+          ForEach(results.courses) { course in
+            NavigationLink(
+              value: CourseDestination.course(CourseReference(course))
+            ) {
+              CatalogSearchResultRow(
+                description: course.description,
+                imageURL: course.imageURL,
+                systemImage: "book.closed.fill",
+                title: course.title)
+            }
+          }
+        } header: {
+          Text(
+            "Courses",
+            tableName: "Courses",
+            comment: "Heading above matching course search results.")
+        }
+      }
+
+      if !results.chapters.isEmpty {
+        Section {
+          ForEach(results.chapters) { chapter in
+            NavigationLink(
+              value: CourseDestination.chapter(ChapterReference(chapter))
+            ) {
+              CatalogSearchResultRow(
+                description: chapter.courseTitle,
+                imageURL: chapter.imageURL,
+                systemImage: "rectangle.stack.fill",
+                title: chapter.title)
+            }
+          }
+        } header: {
+          Text(
+            "Chapters",
+            tableName: "Courses",
+            comment: "Heading above matching chapter search results.")
+        }
+      }
+    }
+    .listStyle(.plain)
+    .contentMargins(
+      .horizontal,
+      CatalogDetailLayout.horizontalInset(for: horizontalSizeClass),
+      for: .scrollContent
+    )
+    .scrollDismissesKeyboard(.immediately)
+  }
+}
+
+private struct CatalogSearchResultRow: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+  let description: String?
+  let imageURL: URL?
+  let systemImage: String
+  let title: String
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 12) {
+      CourseArtwork(
+        imageURL: imageURL,
+        cornerRadius: 12,
+        systemImage: systemImage
+      )
+      .frame(width: 56, height: 56)
+
+      VStack(alignment: .leading, spacing: 3) {
+        Text(title)
+          .font(.headline)
+          .foregroundStyle(.primary)
+          .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+
+        if let description = catalogText(description) {
+          Text(description)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(.vertical, 4)
+    .alignmentGuide(.listRowSeparatorLeading) { _ in
+      68
+    }
+    .accessibilityElement(children: .combine)
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogStore.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogStore.swift
@@ -1,0 +1,470 @@
+import Foundation
+import Observation
+
+private struct CourseCatalogRequest<Value: Codable & Equatable & Sendable>: Sendable {
+  let isEmpty: @Sendable (Value) -> Bool
+  let load: @Sendable (any CourseCatalogAPIClient) async throws -> Value
+}
+
+private enum CourseCatalogResource: Hashable, Sendable {
+  case chapter(String)
+  case course(String)
+  case courses
+  case search
+}
+
+private struct CourseCatalogRequestIdentity: Sendable {
+  let resource: CourseCatalogResource
+  let revision: UUID
+}
+
+@MainActor
+@Observable
+final class CourseCatalogStore {
+  private(set) var coursesState: CourseCatalogLoadState<CourseCatalogPage> = .idle
+  private(set) var searchState: CourseCatalogLoadState<CatalogSearchResults> = .idle
+  private(set) var isLoadingMore = false
+  private(set) var loadMoreFailure: CourseCatalogFailure?
+
+  private let api: any CourseCatalogAPIClient
+  private let language: String
+  private let session: SessionStore
+  private var activeCourseQuery: CourseCatalogQuery?
+  private var activeRequests: Set<CourseCatalogResource> = []
+  private var activeSearchQuery: CatalogSearchQuery?
+  private var chapterStates: [String: CourseCatalogLoadState<ChapterDetail>] = [:]
+  private var courseStates: [String: CourseCatalogLoadState<CourseDetail>] = [:]
+  private var loadMoreRevision: UUID?
+  private var requestRevisions: [CourseCatalogResource: UUID] = [:]
+  private var sessionIdentity: AuthenticatedSession?
+
+  init(
+    api: any CourseCatalogAPIClient,
+    language: String,
+    session: SessionStore
+  ) {
+    self.api = api
+    self.language = language
+    self.session = session
+    sessionIdentity = session.authenticatedSession
+  }
+
+  var isLoadingCourses: Bool {
+    activeRequests.contains(.courses)
+  }
+
+  var isSearching: Bool {
+    activeRequests.contains(.search)
+  }
+
+  func loadCourses(category: CourseCategory?, force: Bool = false) async {
+    let query = CourseCatalogQuery(category: category, language: language)
+    let queryChanged = query != activeCourseQuery
+
+    guard
+      queryChanged
+        || canBeginRequest(resource: .courses, state: coursesState, force: force)
+    else {
+      return
+    }
+
+    activeCourseQuery = query
+    isLoadingMore = false
+    loadMoreRevision = nil
+    loadMoreFailure = nil
+
+    let requestIdentity = beginRequest(for: .courses)
+    let previousState: CourseCatalogLoadState<CourseCatalogPage> =
+      queryChanged ? .idle : coursesState
+    coursesState = loadingState(from: previousState)
+    let state = await load(
+      CourseCatalogRequest(
+        isEmpty: { $0.courses.isEmpty },
+        load: { api in try await api.listCourses(query: query) }))
+
+    guard isCurrent(requestIdentity), activeCourseQuery == query else {
+      return
+    }
+
+    coursesState = stateAfterRequest(state, previousState: previousState)
+    finishRequest(requestIdentity)
+  }
+
+  func loadMoreCourses(category: CourseCategory?, force: Bool = false) async {
+    guard
+      let activeCourseQuery,
+      activeCourseQuery.category == category,
+      case .loaded(let currentPage) = coursesState,
+      currentPage.canLoadMore,
+      let cursor = currentPage.nextCursor,
+      !isLoadingCourses,
+      !isLoadingMore || force,
+      let catalogRevision = requestRevisions[.courses]
+    else {
+      return
+    }
+
+    isLoadingMore = true
+    loadMoreFailure = nil
+    let paginationRevision = UUID()
+    loadMoreRevision = paginationRevision
+    let nextQuery = CourseCatalogQuery(
+      category: category,
+      cursor: cursor,
+      language: language)
+
+    do {
+      let nextPage = try await api.listCourses(query: nextQuery)
+
+      guard
+        isCurrentPaginationRequest(
+          catalogRevision: catalogRevision,
+          paginationRevision: paginationRevision)
+      else {
+        return
+      }
+
+      coursesState = .loaded(merge(currentPage: currentPage, nextPage: nextPage))
+      isLoadingMore = false
+      loadMoreRevision = nil
+    } catch is CancellationError {
+      guard
+        isCurrentPaginationRequest(
+          catalogRevision: catalogRevision,
+          paginationRevision: paginationRevision)
+      else {
+        return
+      }
+
+      isLoadingMore = false
+      loadMoreRevision = nil
+    } catch let failure as CourseCatalogFailure {
+      guard
+        isCurrentPaginationRequest(
+          catalogRevision: catalogRevision,
+          paginationRevision: paginationRevision)
+      else {
+        return
+      }
+
+      isLoadingMore = false
+      loadMoreRevision = nil
+      loadMoreFailure = failure
+    } catch {
+      guard
+        isCurrentPaginationRequest(
+          catalogRevision: catalogRevision,
+          paginationRevision: paginationRevision)
+      else {
+        return
+      }
+
+      isLoadingMore = false
+      loadMoreRevision = nil
+      loadMoreFailure = .unavailable
+    }
+  }
+
+  func courseState(for id: String) -> CourseCatalogLoadState<CourseDetail> {
+    courseStates[id] ?? .idle
+  }
+
+  func loadCourse(id: String, force: Bool = false) async {
+    synchronizeSession()
+    let authenticatedSession = session.authenticatedSession
+    let resource = CourseCatalogResource.course(id)
+    let previousState = courseState(for: id)
+
+    guard canBeginRequest(resource: resource, state: previousState, force: force) else {
+      return
+    }
+
+    let requestIdentity = beginRequest(for: resource)
+    courseStates[id] = loadingState(from: previousState)
+    let state = await load(
+      CourseCatalogRequest(
+        isEmpty: { _ in false },
+        load: { api in
+          async let course = api.getCourse(id: id)
+          async let chapters = api.listCourseChapters(courseID: id)
+          async let continuation = loadCatalogSupplement {
+            try await api.getCourseNextLesson(
+              courseID: id,
+              token: authenticatedSession?.bearerToken)
+          }
+          async let progress = loadCatalogSupplement {
+            try await api.getCourseProgress(
+              courseID: id,
+              token: authenticatedSession?.bearerToken)
+          }
+          let (loadedCourse, loadedChapters, loadedContinuation, loadedProgress) =
+            try await (course, chapters, continuation, progress)
+          return CourseDetail(
+            continuation: loadedContinuation,
+            course: loadedCourse,
+            chapters: loadedChapters,
+            progress: loadedProgress)
+        }))
+
+    guard isCurrent(requestIdentity), session.authenticatedSession == authenticatedSession else {
+      synchronizeSession()
+      return
+    }
+
+    courseStates[id] = stateAfterRequest(state, previousState: previousState)
+    finishRequest(requestIdentity)
+  }
+
+  func chapterState(for id: String) -> CourseCatalogLoadState<ChapterDetail> {
+    chapterStates[id] ?? .idle
+  }
+
+  func loadChapter(id: String, force: Bool = false) async {
+    synchronizeSession()
+    let authenticatedSession = session.authenticatedSession
+    let resource = CourseCatalogResource.chapter(id)
+    let previousState = chapterState(for: id)
+
+    guard canBeginRequest(resource: resource, state: previousState, force: force) else {
+      return
+    }
+
+    let requestIdentity = beginRequest(for: resource)
+    chapterStates[id] = loadingState(from: previousState)
+    let state = await load(
+      CourseCatalogRequest(
+        isEmpty: { _ in false },
+        load: { api in
+          async let chapter = loadCatalogSupplement {
+            try await api.getChapter(id: id)
+          }
+          async let lessons = api.listChapterLessons(chapterID: id)
+          async let continuation = loadCatalogSupplement {
+            try await api.getChapterNextLesson(
+              chapterID: id,
+              token: authenticatedSession?.bearerToken)
+          }
+          async let progress = loadCatalogSupplement {
+            try await api.getChapterProgress(
+              chapterID: id,
+              token: authenticatedSession?.bearerToken)
+          }
+          let (loadedChapter, loadedLessons, loadedContinuation, loadedProgress) =
+            try await (chapter, lessons, continuation, progress)
+          return ChapterDetail(
+            chapter: loadedChapter,
+            continuation: loadedContinuation,
+            lessons: loadedLessons,
+            progress: loadedProgress)
+        }))
+
+    guard isCurrent(requestIdentity), session.authenticatedSession == authenticatedSession else {
+      synchronizeSession()
+      return
+    }
+
+    chapterStates[id] = stateAfterRequest(state, previousState: previousState)
+    finishRequest(requestIdentity)
+  }
+
+  func searchCatalog(query: String, force: Bool = false) async {
+    let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard !normalizedQuery.isEmpty else {
+      clearSearch()
+      return
+    }
+
+    let query = CatalogSearchQuery(language: language, query: normalizedQuery)
+    let queryChanged = query != activeSearchQuery
+
+    guard
+      queryChanged
+        || canBeginRequest(resource: .search, state: searchState, force: force)
+    else {
+      return
+    }
+
+    activeSearchQuery = query
+    let requestIdentity = beginRequest(for: .search)
+    let previousState: CourseCatalogLoadState<CatalogSearchResults> =
+      queryChanged ? .idle : searchState
+    searchState = loadingState(from: previousState)
+    let state = await load(
+      CourseCatalogRequest(
+        isEmpty: \.isEmpty,
+        load: { api in try await api.searchCatalog(query: query) }))
+
+    guard isCurrent(requestIdentity), activeSearchQuery == query else {
+      return
+    }
+
+    searchState = stateAfterRequest(state, previousState: previousState)
+    finishRequest(requestIdentity)
+  }
+
+  func clearSearch() {
+    activeSearchQuery = nil
+    activeRequests.remove(.search)
+    requestRevisions.removeValue(forKey: .search)
+    searchState = .idle
+  }
+
+  private func beginRequest(
+    for resource: CourseCatalogResource
+  ) -> CourseCatalogRequestIdentity {
+    let requestIdentity = CourseCatalogRequestIdentity(resource: resource, revision: UUID())
+    requestRevisions[resource] = requestIdentity.revision
+    activeRequests.insert(resource)
+    return requestIdentity
+  }
+
+  private func finishRequest(_ requestIdentity: CourseCatalogRequestIdentity) {
+    activeRequests.remove(requestIdentity.resource)
+  }
+
+  private func isCurrent(_ requestIdentity: CourseCatalogRequestIdentity) -> Bool {
+    isCurrent(resource: requestIdentity.resource, revision: requestIdentity.revision)
+  }
+
+  private func isCurrent(resource: CourseCatalogResource, revision: UUID) -> Bool {
+    requestRevisions[resource] == revision
+  }
+
+  private func isCurrentPaginationRequest(
+    catalogRevision: UUID,
+    paginationRevision: UUID
+  ) -> Bool {
+    isCurrent(resource: .courses, revision: catalogRevision)
+      && loadMoreRevision == paginationRevision
+  }
+
+  private func synchronizeSession() {
+    let currentSessionIdentity = session.authenticatedSession
+
+    guard currentSessionIdentity != sessionIdentity else {
+      return
+    }
+
+    sessionIdentity = currentSessionIdentity
+    requestRevisions = requestRevisions.filter { entry in
+      entry.key == .courses || entry.key == .search
+    }
+    activeRequests = Set(
+      activeRequests.filter { resource in
+        resource == .courses || resource == .search
+      })
+    chapterStates.removeAll()
+    courseStates.removeAll()
+  }
+
+  private func load<Value>(
+    _ request: CourseCatalogRequest<Value>
+  ) async -> CourseCatalogLoadState<Value>? {
+    do {
+      let value = try await request.load(api)
+      return request.isEmpty(value) ? .empty : .loaded(value)
+    } catch is CancellationError {
+      return nil
+    } catch let failure as CourseCatalogFailure {
+      return .failed(failure)
+    } catch {
+      return .failed(.unavailable)
+    }
+  }
+
+  private func canBeginRequest<Value>(
+    resource: CourseCatalogResource,
+    state: CourseCatalogLoadState<Value>,
+    force: Bool
+  ) -> Bool {
+    force || (!activeRequests.contains(resource) && state != .loading)
+  }
+
+  private func loadingState<Value>(
+    from state: CourseCatalogLoadState<Value>
+  ) -> CourseCatalogLoadState<Value> {
+    switch state {
+    case .loaded, .empty:
+      state
+    case .idle, .loading, .failed:
+      .loading
+    }
+  }
+
+  private func stateAfterCancellation<Value>(
+    from state: CourseCatalogLoadState<Value>
+  ) -> CourseCatalogLoadState<Value> {
+    switch state {
+    case .empty, .failed, .loaded:
+      state
+    case .idle, .loading:
+      .idle
+    }
+  }
+
+  private func stateAfterRequest<Value>(
+    _ requestState: CourseCatalogLoadState<Value>?,
+    previousState: CourseCatalogLoadState<Value>
+  ) -> CourseCatalogLoadState<Value> {
+    guard let requestState else {
+      return stateAfterCancellation(from: previousState)
+    }
+
+    guard case .failed(let failure) = requestState, failure != .notFound else {
+      return requestState
+    }
+
+    switch previousState {
+    case .loaded, .empty:
+      return previousState
+    case .idle, .loading, .failed:
+      return requestState
+    }
+  }
+
+  private func merge(
+    currentPage: CourseCatalogPage,
+    nextPage: CourseCatalogPage
+  ) -> CourseCatalogPage {
+    return CourseCatalogPage(
+      courses: appendingUniqueCourses(
+        currentCourses: currentPage.courses,
+        candidates: nextPage.courses),
+      hasMore: nextPage.hasMore,
+      nextCursor: nextPage.nextCursor)
+  }
+
+  private func appendingUniqueCourses(
+    currentCourses: [CourseSummary],
+    candidates: [CourseSummary]
+  ) -> [CourseSummary] {
+    guard let candidate = candidates.first else {
+      return currentCourses
+    }
+
+    let remainingCandidates = Array(candidates.dropFirst())
+
+    guard !currentCourses.contains(where: { $0.id == candidate.id }) else {
+      return appendingUniqueCourses(
+        currentCourses: currentCourses,
+        candidates: remainingCandidates)
+    }
+
+    return appendingUniqueCourses(
+      currentCourses: currentCourses + [candidate],
+      candidates: remainingCandidates)
+  }
+}
+
+private func loadCatalogSupplement<Value: Sendable>(
+  _ operation: @Sendable () async throws -> Value
+) async throws -> Value? {
+  do {
+    return try await operation()
+  } catch is CancellationError {
+    throw CancellationError()
+  } catch {
+    return nil
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogStore.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogStore.swift
@@ -57,6 +57,16 @@ final class CourseCatalogStore {
     activeRequests.contains(.search)
   }
 
+  func loadCoursesIfNeeded(category: CourseCategory?) async {
+    let query = CourseCatalogQuery(category: category, language: language)
+
+    guard query != activeCourseQuery || needsPresentationLoad(coursesState) else {
+      return
+    }
+
+    await loadCourses(category: category, force: true)
+  }
+
   func loadCourses(category: CourseCategory?, force: Bool = false) async {
     let query = CourseCatalogQuery(category: category, language: language)
     let queryChanged = query != activeCourseQuery
@@ -169,6 +179,16 @@ final class CourseCatalogStore {
     courseStates[id] ?? .idle
   }
 
+  func loadCourseIfNeeded(id: String) async {
+    synchronizeSession()
+
+    guard needsPresentationLoad(courseState(for: id)) else {
+      return
+    }
+
+    await loadCourse(id: id, force: true)
+  }
+
   func loadCourse(id: String, force: Bool = false) async {
     synchronizeSession()
     let authenticatedSession = session.authenticatedSession
@@ -217,6 +237,16 @@ final class CourseCatalogStore {
 
   func chapterState(for id: String) -> CourseCatalogLoadState<ChapterDetail> {
     chapterStates[id] ?? .idle
+  }
+
+  func loadChapterIfNeeded(id: String) async {
+    synchronizeSession()
+
+    guard needsPresentationLoad(chapterState(for: id)) else {
+      return
+    }
+
+    await loadChapter(id: id, force: true)
   }
 
   func loadChapter(id: String, force: Bool = false) async {
@@ -378,7 +408,18 @@ final class CourseCatalogStore {
     state: CourseCatalogLoadState<Value>,
     force: Bool
   ) -> Bool {
-    force || (!activeRequests.contains(resource) && state != .loading)
+    force || (!activeRequests.contains(resource) && needsPresentationLoad(state))
+  }
+
+  private func needsPresentationLoad<Value>(
+    _ state: CourseCatalogLoadState<Value>
+  ) -> Bool {
+    switch state {
+    case .idle, .loading, .failed:
+      true
+    case .loaded, .empty:
+      false
+    }
   }
 
   private func loadingState<Value>(

--- a/apps/apple/Zoonk/Features/Courses/CourseCategorySelector.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCategorySelector.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+struct CourseCategorySelector: View {
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+  @Binding var selection: CourseCategory?
+
+  var body: some View {
+    ScrollViewReader { proxy in
+      ScrollView(.horizontal) {
+        LazyHStack(spacing: 8) {
+          CourseCategoryButton(
+            category: nil,
+            isSelected: selection == nil,
+            selection: $selection
+          )
+          .id(scrollID(for: nil))
+
+          ForEach(localizedCourseCategories(), id: \.rawValue) { category in
+            CourseCategoryButton(
+              category: category,
+              isSelected: selection == category,
+              selection: $selection
+            )
+            .id(scrollID(for: category))
+          }
+        }
+        .padding(.horizontal, 16)
+      }
+      .scrollIndicators(.hidden)
+      .accessibilityElement(children: .contain)
+      .accessibilityLabel(
+        Text(
+          "Course categories",
+          tableName: "Courses",
+          comment: "Accessibility label for the horizontally scrolling course category selector.")
+      )
+      .onChange(of: selection) { _, selection in
+        if accessibilityReduceMotion {
+          proxy.scrollTo(scrollID(for: selection), anchor: .center)
+        } else {
+          withAnimation {
+            proxy.scrollTo(scrollID(for: selection), anchor: .center)
+          }
+        }
+      }
+    }
+  }
+
+  private func scrollID(for category: CourseCategory?) -> String {
+    category?.rawValue ?? "all"
+  }
+}
+
+private struct CourseCategoryButton: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+  let category: CourseCategory?
+  let isSelected: Bool
+  @Binding var selection: CourseCategory?
+
+  var body: some View {
+    Button {
+      selection = category
+    } label: {
+      Label {
+        title
+      } icon: {
+        Image(systemName: category?.systemImage ?? "square.grid.2x2")
+          .font(.system(size: 15, weight: .semibold))
+      }
+      .font(.subheadline.weight(.semibold))
+      .foregroundStyle(isSelected ? selectedForegroundStyle : Color.primary)
+      .fixedSize(horizontal: true, vertical: false)
+      .padding(.horizontal, 14)
+      .padding(.vertical, dynamicTypeSize.isAccessibilitySize ? 10 : 0)
+      .frame(height: dynamicTypeSize.isAccessibilitySize ? nil : 38)
+      .background(backgroundStyle, in: Capsule())
+    }
+    .buttonStyle(.plain)
+    .frame(minHeight: 44)
+    .accessibilityAddTraits(isSelected ? .isSelected : [])
+  }
+
+  private var backgroundStyle: Color {
+    isSelected ? .primary : Color(uiColor: .secondarySystemBackground)
+  }
+
+  private var selectedForegroundStyle: Color {
+    Color(uiColor: .systemBackground)
+  }
+
+  @ViewBuilder
+  private var title: some View {
+    if let category {
+      Text(category.localizedTitle)
+    } else {
+      Text(
+        "All",
+        tableName: "Courses",
+        comment: "Category option that shows courses from every category.")
+    }
+  }
+}
+
+#Preview {
+  @Previewable @State var selection: CourseCategory?
+
+  CourseCategorySelector(selection: $selection)
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseDestination.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseDestination.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+enum CourseDestination: Hashable {
+  case course(CourseReference)
+  case chapter(ChapterReference)
+  case lesson(LessonReference)
+
+  var title: String {
+    switch self {
+    case .course(let course): course.title
+    case .chapter(let chapter): chapter.title
+    case .lesson(let lesson): lesson.title
+    }
+  }
+
+  var showsCompactHeader: Bool {
+    switch self {
+    case .course, .chapter:
+      true
+    case .lesson:
+      false
+    }
+  }
+}
+
+struct CourseReference: Hashable {
+  let description: String?
+  let id: String
+  let imageURL: URL?
+  let organizationName: String
+  let organizationSlug: String
+  let title: String
+
+  init(_ course: CourseSummary) {
+    description = course.description
+    id = course.id
+    imageURL = course.imageURL
+    organizationName = course.organization.name
+    organizationSlug = course.organization.slug
+    title = course.title
+  }
+
+  init(_ course: Course) {
+    description = course.description
+    id = course.id
+    imageURL = course.imageURL
+    organizationName = course.organization.name
+    organizationSlug = course.organization.slug
+    title = course.title
+  }
+
+  init(_ result: CatalogCourseSearchResult) {
+    description = result.description
+    id = result.id
+    imageURL = result.imageURL
+    organizationName = ""
+    organizationSlug = result.organizationSlug
+    title = result.title
+  }
+}
+
+struct ChapterReference: Hashable {
+  let courseID: String
+  let courseTitle: String
+  let description: String
+  let id: String
+  let imageURL: URL?
+  let organizationSlug: String
+  let position: Int?
+  let title: String
+
+  init(_ source: (course: Course, chapter: CourseChapter)) {
+    courseID = source.course.id
+    courseTitle = source.course.title
+    description = source.chapter.description
+    id = source.chapter.id
+    imageURL = source.chapter.imageURL ?? source.course.imageURL
+    organizationSlug = source.course.organization.slug
+    position = source.chapter.position
+    title = source.chapter.title
+  }
+
+  init(_ result: CatalogChapterSearchResult) {
+    courseID = result.courseID
+    courseTitle = result.courseTitle
+    description = result.description
+    id = result.id
+    imageURL = result.imageURL
+    organizationSlug = result.organizationSlug
+    position = nil
+    title = result.title
+  }
+
+  init(_ source: (reference: ChapterReference, chapter: CourseChapter)) {
+    courseID = source.chapter.courseID
+    courseTitle = source.reference.courseTitle
+    description = source.chapter.description
+    id = source.chapter.id
+    imageURL = source.chapter.imageURL ?? source.reference.imageURL
+    organizationSlug = source.reference.organizationSlug
+    position = source.chapter.position
+    title = source.chapter.title
+  }
+
+  init(_ source: (course: Course, target: CatalogChapterContinuation)) {
+    courseID = source.target.courseID
+    courseTitle = source.course.title
+    description = ""
+    id = source.target.chapterID
+    imageURL = source.course.imageURL
+    organizationSlug = source.target.organizationSlug
+    position = nil
+    title = String(
+      localized: LocalizedStringResource(
+        "Chapter",
+        table: "Courses",
+        comment: "Fallback title for a chapter continuation target."))
+  }
+
+  init(_ source: (course: Course, target: CatalogLessonContinuation)) {
+    courseID = source.target.courseID
+    courseTitle = source.course.title
+    description = ""
+    id = source.target.chapterID
+    imageURL = source.course.imageURL
+    organizationSlug = source.target.organizationSlug
+    position = nil
+    title = String(
+      localized: LocalizedStringResource(
+        "Chapter",
+        table: "Courses",
+        comment: "Fallback title for the chapter containing a continuation lesson."))
+  }
+}
+
+struct LessonReference: Hashable {
+  let chapterTitle: String
+  let courseTitle: String
+  let id: String
+  let title: String
+
+  init(_ source: (chapter: ChapterReference, lesson: CourseLesson)) {
+    chapterTitle = source.chapter.title
+    courseTitle = source.chapter.courseTitle
+    id = source.lesson.id
+    title = source.lesson.displayTitle()
+  }
+
+  init(_ source: (chapter: ChapterReference, target: CatalogLessonContinuation)) {
+    chapterTitle = source.chapter.title
+    courseTitle = source.chapter.courseTitle
+    id = source.target.lessonID
+    title = String(
+      localized: LocalizedStringResource(
+        "Lesson",
+        table: "Courses",
+        comment: "Fallback title while the native lesson player is unavailable."))
+  }
+}
+
+func courseContinuationDestination(_ detail: CourseDetail) -> CourseDestination? {
+  guard let continuation = detail.continuation else {
+    return firstChapterDestination(detail)
+  }
+
+  switch continuation {
+  case .empty:
+    return firstChapterDestination(detail)
+  case .chapter(let target):
+    if let chapter = detail.chapters.first(where: { $0.id == target.chapterID }) {
+      return .chapter(ChapterReference((course: detail.course, chapter: chapter)))
+    }
+
+    return .chapter(ChapterReference((course: detail.course, target: target)))
+  case .lesson(let target):
+    let chapter = detail.chapters.first(where: { $0.id == target.chapterID })
+    let chapterReference =
+      chapter.map {
+        ChapterReference((course: detail.course, chapter: $0))
+      } ?? ChapterReference((course: detail.course, target: target))
+    return .lesson(LessonReference((chapter: chapterReference, target: target)))
+  }
+}
+
+private func firstChapterDestination(_ detail: CourseDetail) -> CourseDestination? {
+  guard let chapter = detail.chapters.first else {
+    return nil
+  }
+
+  return .chapter(ChapterReference((course: detail.course, chapter: chapter)))
+}
+
+func chapterContinuationDestination(
+  chapter: ChapterReference,
+  detail: ChapterDetail
+) -> CourseDestination? {
+  guard let continuation = detail.continuation else {
+    return firstLessonDestination((chapter: chapter, detail: detail))
+  }
+
+  switch continuation {
+  case .empty:
+    return firstLessonDestination((chapter: chapter, detail: detail))
+  case .chapter:
+    return .chapter(chapter)
+  case .lesson(let target):
+    if let lesson = detail.lessons.first(where: { $0.id == target.lessonID }) {
+      return .lesson(LessonReference((chapter: chapter, lesson: lesson)))
+    }
+
+    return .lesson(LessonReference((chapter: chapter, target: target)))
+  }
+}
+
+private func firstLessonDestination(
+  _ source: (chapter: ChapterReference, detail: ChapterDetail)
+) -> CourseDestination? {
+  guard let lesson = source.detail.lessons.first else {
+    return nil
+  }
+
+  return .lesson(LessonReference((chapter: source.chapter, lesson: lesson)))
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseView.swift
@@ -1,0 +1,353 @@
+import SwiftUI
+
+struct CourseView: View {
+  @Environment(CourseCatalogStore.self) private var catalog
+  @Environment(SessionStore.self) private var session
+  @State private var searchText = ""
+
+  let course: CourseReference
+
+  var body: some View {
+    Group {
+      switch catalog.courseState(for: course.id) {
+      case .idle, .loading:
+        CourseLoadingView(course: course)
+      case .loaded(let detail):
+        CourseDetailContent(detail: detail, searchText: $searchText)
+      case .empty:
+        CourseDetailEmptyView()
+      case .failed(let failure):
+        CatalogFailureRecoveryView(context: .course, failure: failure) {
+          await catalog.loadCourse(id: course.id, force: true)
+        }
+      }
+    }
+    .background(Color(uiColor: .systemBackground))
+    .task(
+      id: CatalogDetailTaskID(
+        resourceID: course.id,
+        session: session.authenticatedSession)
+    ) {
+      await catalog.loadCourse(id: course.id, force: true)
+    }
+    .refreshable {
+      await catalog.loadCourse(id: course.id, force: true)
+    }
+  }
+}
+
+private struct CourseDetailContent: View {
+  @Environment(SessionStore.self) private var session
+  @State private var isFeedbackPresented = false
+  @State private var isInformationPresented = false
+  @State private var isSearchPresented = false
+
+  let detail: CourseDetail
+  @Binding var searchText: String
+
+  var body: some View {
+    CourseDetailList(
+      detail: detail,
+      isInformationPresented: $isInformationPresented,
+      searchText: $searchText,
+      showFeedback: { isFeedbackPresented = true },
+      showInformation: { isInformationPresented = true }
+    )
+    .catalogDetailSearchPresentation(
+      text: $searchText,
+      isPresented: $isSearchPresented,
+      prompt: Text(
+        "Search chapters",
+        tableName: "Courses",
+        comment: "Placeholder for searching within a course's chapters.")
+    )
+    .sheet(isPresented: $isFeedbackPresented) {
+      FeedbackSheet(
+        api: FeedbackAPI.live(),
+        defaultEmail: session.account?.user.email)
+    }
+  }
+}
+
+private struct CourseDetailList: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @Environment(\.isSearching) private var isSearching
+
+  let detail: CourseDetail
+  @Binding var isInformationPresented: Bool
+  @Binding var searchText: String
+  let showFeedback: () -> Void
+  let showInformation: () -> Void
+
+  var body: some View {
+    VStack(spacing: 0) {
+      if !showsSearchResultsOnly {
+        detailHeader
+      }
+
+      List {
+        Section {
+          if filteredChapters.isEmpty {
+            emptyChaptersView
+              .listRowSeparator(.hidden)
+          } else {
+            ForEach(filteredChapters) { chapter in
+              NavigationLink(
+                value: CourseDestination.chapter(
+                  ChapterReference((course: detail.course, chapter: chapter)))
+              ) {
+                CatalogNumberedRow(
+                  description: chapter.description,
+                  imageURL: chapter.imageURL ?? detail.course.imageURL,
+                  number: chapter.position + 1,
+                  systemImage: "rectangle.stack.fill",
+                  title: chapter.title
+                ) {
+                  if let progress = catalogChapterProgress(
+                    chapter: chapter,
+                    progress: detail.progress)
+                  {
+                    CatalogProgressLabel(progress: progress)
+                  }
+                }
+              }
+              .listRowInsets(
+                EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
+            }
+          }
+        } header: {
+          Text(
+            "Chapters",
+            tableName: "Courses",
+            comment: "Heading above the ordered chapter list on a course screen."
+          )
+          .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+          .padding(
+            .leading,
+            CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
+        }
+      }
+      .listStyle(.plain)
+      .scrollContentBackground(.hidden)
+      .contentMargins(
+        .horizontal,
+        CatalogDetailLayout.horizontalInset(for: horizontalSizeClass),
+        for: .scrollContent)
+    }
+    .frame(maxWidth: 900)
+    .frame(maxWidth: .infinity)
+  }
+
+  private var detailHeader: some View {
+    let horizontalInset = CatalogDetailLayout.horizontalInset(for: horizontalSizeClass)
+
+    return VStack(alignment: .leading, spacing: 16) {
+      CatalogDetailHeader(
+        configuration: CatalogDetailHeaderConfiguration(
+          imageURL: detail.course.imageURL,
+          description: detail.course.description,
+          systemImage: "book.closed.fill",
+          title: detail.course.title),
+        showInformation: showInformation
+      )
+      .popover(isPresented: $isInformationPresented) {
+        CourseInformationView(
+          course: detail.course,
+          dismiss: { isInformationPresented = false }
+        )
+        .presentationCompactAdaptation(.sheet)
+      }
+
+      HStack(spacing: 8) {
+        if let continuationDestination {
+          CatalogContinueLink(
+            continuation: detail.continuation,
+            destination: continuationDestination,
+            percentComplete: detail.progress?.percentComplete)
+        } else {
+          Spacer(minLength: 0)
+        }
+
+        CatalogActionsMenu(showFeedback: showFeedback)
+
+        if horizontalSizeClass == .regular, continuationDestination != nil {
+          Spacer(minLength: 0)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.horizontal, horizontalInset)
+    .padding(.top, 16)
+    .padding(.bottom, 12)
+  }
+
+  private var showsSearchResultsOnly: Bool {
+    isSearching || catalogText(searchText) != nil
+  }
+
+  private var continuationDestination: CourseDestination? {
+    courseContinuationDestination(detail)
+  }
+
+  private var filteredChapters: [CourseChapter] {
+    filterCourseChapters(CatalogSearchRequest(items: detail.chapters, query: searchText))
+  }
+
+  @ViewBuilder
+  private var emptyChaptersView: some View {
+    if catalogText(searchText) != nil {
+      ContentUnavailableView.search(text: searchText)
+    } else {
+      ContentUnavailableView {
+        Label {
+          Text(
+            "No chapters yet",
+            tableName: "Courses",
+            comment: "Title when a course does not have any published chapters.")
+        } icon: {
+          Image(systemName: "rectangle.stack")
+        }
+      } description: {
+        Text(
+          "This course's chapters will appear here when they're available.",
+          tableName: "Courses",
+          comment: "Guidance when a course does not have any published chapters.")
+      }
+    }
+  }
+}
+
+private struct CourseInformationView: View {
+  let course: Course
+  let dismiss: () -> Void
+
+  var body: some View {
+    CatalogInformationView(
+      dismiss: dismiss,
+      title: LocalizedStringResource(
+        "Course information",
+        table: "Courses",
+        comment: "Title for secondary information about a course.")
+    ) {
+      VStack(alignment: .leading, spacing: 16) {
+        if let description = catalogText(course.description) {
+          Text(description)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+
+        VStack(alignment: .leading, spacing: 12) {
+          Text(course.organization.name)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+
+          if !course.categories.isEmpty {
+            Text(categoryDescription)
+              .font(.caption.weight(.medium))
+              .foregroundStyle(.secondary)
+              .padding(.horizontal, 10)
+              .padding(.vertical, 6)
+              .background(.quaternary, in: Capsule())
+          }
+
+          if course.organization.slug == "ai" {
+            Label {
+              Text(
+                "Created with AI",
+                tableName: "Courses",
+                comment: "Disclosure that a public course or chapter was created with AI.")
+            } icon: {
+              Image(systemName: "sparkles")
+            }
+            .foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+  }
+
+  private var categoryDescription: String {
+    course.categories
+      .map { String(localized: $0.localizedTitle) }
+      .formatted(.list(type: .and, width: .short))
+  }
+}
+
+private struct CourseLoadingView: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+  let course: CourseReference
+
+  var body: some View {
+    List {
+      VStack(alignment: .leading, spacing: 16) {
+        CatalogDetailHeader(
+          configuration: CatalogDetailHeaderConfiguration(
+            imageURL: course.imageURL,
+            description: course.description ?? "Course description",
+            systemImage: "book.closed.fill",
+            title: course.title))
+
+        HStack(spacing: 8) {
+          Text(verbatim: "Start")
+            .frame(maxWidth: horizontalSizeClass == .regular ? 260 : .infinity)
+            .frame(minHeight: 44)
+          Image(systemName: "ellipsis")
+            .frame(width: 44, height: 44)
+        }
+      }
+      .listRowSeparator(.hidden)
+
+      Section {
+        ForEach(0..<4, id: \.self) { index in
+          CatalogNumberedRow(
+            description: "A short chapter description",
+            imageURL: nil,
+            number: index + 1,
+            systemImage: "rectangle.stack.fill",
+            title: "Chapter title"
+          ) {
+            Text(verbatim: "Not started")
+          }
+          .listRowInsets(
+            EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
+        }
+      } header: {
+        Text(verbatim: "Chapters")
+          .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+          .padding(
+            .leading,
+            CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
+      }
+    }
+    .listStyle(.plain)
+    .frame(maxWidth: 900)
+    .frame(maxWidth: .infinity)
+    .redacted(reason: .placeholder)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(
+      Text(
+        "Loading course",
+        tableName: "Courses",
+        comment: "Accessibility status while a course loads."))
+  }
+}
+
+private struct CourseDetailEmptyView: View {
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        Text(
+          "Course unavailable",
+          tableName: "Courses",
+          comment: "Title when a course cannot be loaded.")
+      } icon: {
+        Image(systemName: "book.closed")
+      }
+    } description: {
+      Text(
+        "Please return to the catalog and choose another course.",
+        tableName: "Courses",
+        comment: "Guidance when a course request returns no content.")
+    }
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseView.swift
@@ -28,7 +28,7 @@ struct CourseView: View {
         resourceID: course.id,
         session: session.authenticatedSession)
     ) {
-      await catalog.loadCourse(id: course.id, force: true)
+      await catalog.loadCourseIfNeeded(id: course.id)
     }
     .refreshable {
       await catalog.loadCourse(id: course.id, force: true)

--- a/apps/apple/Zoonk/Features/Courses/CourseView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseView.swift
@@ -85,46 +85,46 @@ private struct CourseDetailList: View {
         detailHeader
       }
 
+      CatalogCurriculumHeader(
+        title: Text(
+          "Chapters",
+          tableName: "Courses",
+          comment: "Heading above the ordered chapter list on a course screen."))
+
       List {
-        Section {
-          if filteredChapters.isEmpty {
-            emptyChaptersView
-              .listRowSeparator(.hidden)
-          } else {
-            ForEach(filteredChapters) { chapter in
-              NavigationLink(
-                value: CourseDestination.chapter(
-                  ChapterReference((course: detail.course, chapter: chapter)))
+        if filteredChapters.isEmpty {
+          emptyChaptersView
+            .listRowSeparator(.hidden)
+        } else {
+          ForEach(filteredChapters) { chapter in
+            NavigationLink(
+              value: CourseDestination.chapter(
+                ChapterReference((course: detail.course, chapter: chapter)))
+            ) {
+              CatalogNumberedRow(
+                description: chapter.description,
+                imageURL: chapter.imageURL ?? detail.course.imageURL,
+                number: chapter.position + 1,
+                systemImage: "rectangle.stack.fill",
+                title: chapter.title
               ) {
-                CatalogNumberedRow(
-                  description: chapter.description,
-                  imageURL: chapter.imageURL ?? detail.course.imageURL,
-                  number: chapter.position + 1,
-                  systemImage: "rectangle.stack.fill",
-                  title: chapter.title
-                ) {
-                  if let progress = catalogChapterProgress(
-                    chapter: chapter,
-                    progress: detail.progress)
-                  {
-                    CatalogProgressLabel(progress: progress)
-                  }
+                if let progress = catalogChapterProgress(
+                  chapter: chapter,
+                  progress: detail.progress)
+                {
+                  CatalogProgressLabel(progress: progress)
                 }
               }
-              .listRowInsets(
-                EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
             }
+            .listRowInsets(
+              EdgeInsets(
+                top: CatalogDetailLayout.curriculumRowVerticalInset(
+                  for: horizontalSizeClass),
+                leading: 0,
+                bottom: CatalogDetailLayout.curriculumRowVerticalInset(
+                  for: horizontalSizeClass),
+                trailing: 0))
           }
-        } header: {
-          Text(
-            "Chapters",
-            tableName: "Courses",
-            comment: "Heading above the ordered chapter list on a course screen."
-          )
-          .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-          .padding(
-            .leading,
-            CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
         }
       }
       .listStyle(.plain)
@@ -158,22 +158,11 @@ private struct CourseDetailList: View {
         .presentationCompactAdaptation(.sheet)
       }
 
-      HStack(spacing: 8) {
-        if let continuationDestination {
-          CatalogContinueLink(
-            continuation: detail.continuation,
-            destination: continuationDestination,
-            percentComplete: detail.progress?.percentComplete)
-        } else {
-          Spacer(minLength: 0)
-        }
-
-        CatalogActionsMenu(showFeedback: showFeedback)
-
-        if horizontalSizeClass == .regular, continuationDestination != nil {
-          Spacer(minLength: 0)
-        }
-      }
+      CatalogDetailActions(
+        continuation: detail.continuation,
+        destination: continuationDestination,
+        percentComplete: detail.progress?.percentComplete,
+        showFeedback: showFeedback)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.horizontal, horizontalInset)
@@ -273,12 +262,13 @@ private struct CourseInformationView: View {
 }
 
 private struct CourseLoadingView: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
   let course: CourseReference
 
   var body: some View {
-    List {
+    VStack(spacing: 0) {
       VStack(alignment: .leading, spacing: 16) {
         CatalogDetailHeader(
           configuration: CatalogDetailHeaderConfiguration(
@@ -294,10 +284,19 @@ private struct CourseLoadingView: View {
           Image(systemName: "ellipsis")
             .frame(width: 44, height: 44)
         }
+        .padding(
+          .leading,
+          CatalogDetailLayout.actionLeadingInset(
+            for: horizontalSizeClass,
+            dynamicTypeSize: dynamicTypeSize))
       }
-      .listRowSeparator(.hidden)
+      .padding(.horizontal, CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
+      .padding(.top, 16)
+      .padding(.bottom, 12)
 
-      Section {
+      CatalogCurriculumHeader(title: Text(verbatim: "Chapters"))
+
+      List {
         ForEach(0..<4, id: \.self) { index in
           CatalogNumberedRow(
             description: "A short chapter description",
@@ -309,17 +308,21 @@ private struct CourseLoadingView: View {
             Text(verbatim: "Not started")
           }
           .listRowInsets(
-            EdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0))
+            EdgeInsets(
+              top: CatalogDetailLayout.curriculumRowVerticalInset(
+                for: horizontalSizeClass),
+              leading: 0,
+              bottom: CatalogDetailLayout.curriculumRowVerticalInset(
+                for: horizontalSizeClass),
+              trailing: 0))
         }
-      } header: {
-        Text(verbatim: "Chapters")
-          .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-          .padding(
-            .leading,
-            CatalogDetailLayout.horizontalInset(for: horizontalSizeClass))
       }
+      .listStyle(.plain)
+      .contentMargins(
+        .horizontal,
+        CatalogDetailLayout.horizontalInset(for: horizontalSizeClass),
+        for: .scrollContent)
     }
-    .listStyle(.plain)
     .frame(maxWidth: 900)
     .frame(maxWidth: .infinity)
     .redacted(reason: .placeholder)

--- a/apps/apple/Zoonk/Features/Courses/CoursesView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CoursesView.swift
@@ -1,7 +1,161 @@
 import SwiftUI
 
 struct CoursesView: View {
+  @Environment(CourseCatalogStore.self) private var catalog
+  @State private var isSearchPresented = false
+  @State private var searchText = ""
+  @State private var selectedCategory: CourseCategory?
+
+  let onCreateCourse: () -> Void
+
   var body: some View {
-    Color.clear
+    Group {
+      if showsSearch {
+        CourseCatalogSearchResultsView(
+          query: searchText,
+          retry: { await catalog.searchCatalog(query: searchText, force: true) })
+      } else {
+        browseCatalog
+      }
+    }
+    .background(Color(uiColor: .systemBackground))
+    .searchable(
+      text: $searchText,
+      isPresented: $isSearchPresented,
+      placement: .navigationBarDrawer(displayMode: .always),
+      prompt: Text(
+        "Search courses and chapters",
+        tableName: "Courses",
+        comment: "Placeholder for searching the public course catalog.")
+    )
+    .navigationDestination(for: CourseDestination.self) { destination in
+      destinationView(destination)
+        .navigationTitle(destination.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar(removing: destination.showsCompactHeader ? .title : nil)
+    }
+    .task(id: selectedCategory) {
+      await catalog.loadCourses(category: selectedCategory, force: true)
+    }
+    .task(id: searchText) {
+      await updateSearchResults()
+    }
+  }
+
+  private var browseCatalog: some View {
+    ScrollView {
+      VStack(spacing: 12) {
+        CourseCategorySelector(selection: $selectedCategory)
+
+        catalogContent
+          .padding(.horizontal, 16)
+      }
+      .frame(maxWidth: 1_180, alignment: .leading)
+      .padding(.top, 4)
+      .padding(.bottom, 20)
+      .frame(maxWidth: .infinity)
+    }
+    .scrollBounceBehavior(.basedOnSize)
+    .refreshable {
+      await catalog.loadCourses(category: selectedCategory, force: true)
+    }
+  }
+
+  private var showsSearch: Bool {
+    isSearchPresented || catalogText(searchText) != nil
+  }
+
+  private func updateSearchResults() async {
+    guard catalogText(searchText) != nil else {
+      catalog.clearSearch()
+      return
+    }
+
+    do {
+      try await Task.sleep(for: .milliseconds(250))
+    } catch {
+      return
+    }
+
+    guard !Task.isCancelled else {
+      return
+    }
+
+    await catalog.searchCatalog(query: searchText)
+  }
+
+  @ViewBuilder
+  private var catalogContent: some View {
+    switch catalog.coursesState {
+    case .idle, .loading:
+      CourseCatalogLoadingGrid()
+    case .loaded(let page):
+      CourseCatalogGrid(category: selectedCategory, page: page)
+    case .empty:
+      CourseCatalogEmptyView(category: selectedCategory, onCreateCourse: onCreateCourse)
+    case .failed(let failure):
+      CatalogFailureRecoveryView(context: .catalog, failure: failure) {
+        await catalog.loadCourses(category: selectedCategory, force: true)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func destinationView(_ destination: CourseDestination) -> some View {
+    switch destination {
+    case .course(let course):
+      CourseView(course: course)
+    case .chapter(let chapter):
+      ChapterView(chapter: chapter)
+    case .lesson(let lesson):
+      LessonPlaceholderView(lesson: lesson)
+    }
+  }
+}
+
+private struct CourseCatalogEmptyView: View {
+  let category: CourseCategory?
+  let onCreateCourse: () -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        if let category {
+          Text(
+            "No \(String(localized: category.localizedTitle)) courses yet",
+            tableName: "Courses",
+            comment: "Title when a selected category does not contain any courses.")
+        } else {
+          Text(
+            "No courses yet",
+            tableName: "Courses",
+            comment: "Title when the public course catalog is empty.")
+        }
+      } icon: {
+        Image(systemName: category?.systemImage ?? "books.vertical")
+      }
+    } description: {
+      Text(
+        "Courses will appear here when they're available.",
+        tableName: "Courses",
+        comment: "Guidance when no public courses are available.")
+    } actions: {
+      if let category {
+        Button(action: onCreateCourse) {
+          Label {
+            Text(
+              "Create a course about \(String(localized: category.localizedTitle))",
+              tableName: "Courses",
+              comment:
+                "Opens course creation from an empty category. The interpolated value is the category name."
+            )
+          } icon: {
+            Image(systemName: "plus")
+          }
+        }
+        .buttonStyle(.bordered)
+      }
+    }
+    .frame(maxWidth: .infinity, minHeight: 280)
   }
 }

--- a/apps/apple/Zoonk/Features/Courses/CoursesView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CoursesView.swift
@@ -36,7 +36,7 @@ struct CoursesView: View {
         .toolbar(removing: destination.showsCompactHeader ? .title : nil)
     }
     .task(id: selectedCategory) {
-      await catalog.loadCourses(category: selectedCategory, force: true)
+      await catalog.loadCoursesIfNeeded(category: selectedCategory)
     }
     .task(id: searchText) {
       await updateSearchResults()

--- a/apps/apple/Zoonk/Features/Courses/CoursesView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CoursesView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct CoursesView: View {
   @Environment(CourseCatalogStore.self) private var catalog
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @State private var isSearchPresented = false
   @State private var searchText = ""
   @State private var selectedCategory: CourseCategory?
@@ -52,7 +53,7 @@ struct CoursesView: View {
       }
       .frame(maxWidth: 1_180, alignment: .leading)
       .padding(.top, 4)
-      .padding(.bottom, 20)
+      .padding(.bottom, horizontalSizeClass == .regular ? 32 : 20)
       .frame(maxWidth: .infinity)
     }
     .scrollBounceBehavior(.basedOnSize)

--- a/apps/apple/Zoonk/Features/Courses/LessonPlaceholderView.swift
+++ b/apps/apple/Zoonk/Features/Courses/LessonPlaceholderView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct LessonPlaceholderView: View {
+  let lesson: LessonReference
+
+  var body: some View {
+    VStack(spacing: 24) {
+      VStack(spacing: 4) {
+        Text(lesson.courseTitle)
+        Text(lesson.chapterTitle)
+      }
+      .font(.subheadline)
+      .foregroundStyle(.secondary)
+      .multilineTextAlignment(.center)
+
+      Text(lesson.title)
+        .font(.title.bold())
+        .multilineTextAlignment(.center)
+        .accessibilityAddTraits(.isHeader)
+
+      ContentUnavailableView {
+        Label {
+          Text(
+            "Lesson player coming soon",
+            tableName: "Courses",
+            comment:
+              "Title on the temporary destination shown before the native lesson player is available."
+          )
+        } icon: {
+          Image(systemName: "play.rectangle.on.rectangle")
+        }
+      } description: {
+        Text(
+          "You can keep exploring this course and return when the lesson player is ready.",
+          tableName: "Courses",
+          comment: "Guidance on the temporary lesson player destination.")
+      }
+    }
+    .frame(maxWidth: 520)
+    .padding(24)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color(uiColor: .systemBackground))
+  }
+}

--- a/apps/apple/Zoonk/Features/Feedback/FeedbackAPI.swift
+++ b/apps/apple/Zoonk/Features/Feedback/FeedbackAPI.swift
@@ -1,0 +1,101 @@
+import Foundation
+import OpenAPIRuntime
+
+struct FeedbackSubmission: Equatable, Sendable {
+  let email: String
+  let message: String
+}
+
+enum FeedbackFailure: Error, Equatable, Sendable {
+  case network
+  case unavailable
+  case validation
+}
+
+protocol FeedbackAPIClient: Sendable {
+  func submit(_ submission: FeedbackSubmission) async throws
+}
+
+struct FeedbackAPI: FeedbackAPIClient, @unchecked Sendable {
+  private let clients: APIClientFactory
+
+  init(clients: APIClientFactory) {
+    self.clients = clients
+  }
+
+  static func live(configuration: AppConfiguration = .current) -> FeedbackAPI {
+    FeedbackAPI(
+      clients: APIClientFactory.live(baseURL: configuration.apiBaseURL))
+  }
+
+  func submit(_ submission: FeedbackSubmission) async throws {
+    try await perform { client in
+      let output = try await client.createFeedback(
+        .init(
+          body: .json(
+            .init(
+              email: submission.email,
+              message: submission.message))))
+
+      switch output {
+      case .ok:
+        return
+      case .badRequest:
+        throw FeedbackFailure.validation
+      case .forbidden, .internalServerError, .undocumented:
+        throw FeedbackFailure.unavailable
+      }
+    }
+  }
+
+  /// Keeps generated transport failures behind stable form recovery states while preserving task cancellation.
+  private func perform<Output: Sendable>(
+    operation: @Sendable (Client) async throws -> Output
+  ) async throws -> Output {
+    do {
+      return try await operation(clients.makeClient())
+    } catch {
+      if isRequestCancellation(error) {
+        throw CancellationError()
+      }
+
+      if let failure = error as? FeedbackFailure {
+        throw failure
+      }
+
+      if isNetworkError(error) {
+        throw FeedbackFailure.network
+      }
+
+      throw FeedbackFailure.unavailable
+    }
+  }
+
+  private func isRequestCancellation(_ error: Error) -> Bool {
+    if error is CancellationError {
+      return true
+    }
+
+    if let urlError = error as? URLError {
+      return urlError.code == .cancelled
+    }
+
+    if let clientError = error as? ClientError {
+      return isRequestCancellation(clientError.underlyingError)
+    }
+
+    return false
+  }
+
+  private func isNetworkError(_ error: Error) -> Bool {
+    if error is URLError {
+      return true
+    }
+
+    if let clientError = error as? ClientError {
+      return isNetworkError(clientError.underlyingError)
+    }
+
+    return false
+  }
+}

--- a/apps/apple/Zoonk/Features/Feedback/FeedbackFormStore.swift
+++ b/apps/apple/Zoonk/Features/Feedback/FeedbackFormStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Observation
+
+enum FeedbackFormState: Equatable, Sendable {
+  case idle
+  case submitting
+  case sent
+  case failed(FeedbackFailure)
+}
+
+@MainActor
+@Observable
+final class FeedbackFormStore {
+  var email: String
+  var message = ""
+  private(set) var state = FeedbackFormState.idle
+
+  private let api: any FeedbackAPIClient
+
+  init(api: any FeedbackAPIClient, defaultEmail: String? = nil) {
+    self.api = api
+    email = defaultEmail?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  }
+
+  var canSubmit: Bool {
+    guard state != .submitting else {
+      return false
+    }
+
+    let emailParts = normalizedEmail.split(separator: "@", omittingEmptySubsequences: false)
+    let isEmailValid =
+      emailParts.count == 2
+      && !emailParts[0].isEmpty
+      && emailParts[1].contains(".")
+
+    return isEmailValid && !normalizedMessage.isEmpty
+  }
+
+  func submit() async {
+    guard canSubmit else {
+      return
+    }
+
+    state = .submitting
+
+    do {
+      try await api.submit(
+        FeedbackSubmission(
+          email: normalizedEmail,
+          message: normalizedMessage))
+      state = .sent
+    } catch is CancellationError {
+      state = .idle
+    } catch let failure as FeedbackFailure {
+      state = .failed(failure)
+    } catch {
+      state = .failed(.unavailable)
+    }
+  }
+
+  func clearFailure() {
+    guard case .failed = state else {
+      return
+    }
+
+    state = .idle
+  }
+
+  private var normalizedEmail: String {
+    email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  }
+
+  private var normalizedMessage: String {
+    message.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}

--- a/apps/apple/Zoonk/Features/Feedback/FeedbackSheet.swift
+++ b/apps/apple/Zoonk/Features/Feedback/FeedbackSheet.swift
@@ -1,0 +1,222 @@
+import SwiftUI
+
+struct FeedbackSheet: View {
+  @Environment(\.dismiss) private var dismiss
+  @FocusState private var focusedField: FeedbackField?
+  @State private var store: FeedbackFormStore
+
+  init(api: any FeedbackAPIClient, defaultEmail: String? = nil) {
+    _store = State(
+      initialValue: FeedbackFormStore(
+        api: api,
+        defaultEmail: defaultEmail))
+  }
+
+  var body: some View {
+    NavigationStack {
+      Group {
+        if store.state == .sent {
+          confirmation
+        } else {
+          form
+        }
+      }
+      .navigationTitle(
+        Text(
+          "Feedback",
+          tableName: "Feedback",
+          comment: "Navigation title for the feedback form.")
+      )
+      .toolbarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button(action: dismiss.callAsFunction) {
+            if store.state == .sent {
+              Text(
+                "Done",
+                tableName: "Feedback",
+                comment: "Dismisses the feedback success confirmation.")
+            } else {
+              Text(
+                "Cancel",
+                tableName: "Feedback",
+                comment: "Dismisses the feedback form without sending it.")
+            }
+          }
+          .disabled(store.state == .submitting)
+        }
+
+        if store.state != .sent {
+          ToolbarItem(placement: .confirmationAction) {
+            Button(action: submit) {
+              if store.state == .submitting {
+                ProgressView()
+                  .controlSize(.small)
+                  .accessibilityLabel(
+                    Text(
+                      "Sending feedback",
+                      tableName: "Feedback",
+                      comment: "Accessibility status while feedback is being sent."))
+              } else {
+                Text(
+                  "Send",
+                  tableName: "Feedback",
+                  comment: "Submits the feedback form.")
+              }
+            }
+            .disabled(!store.canSubmit)
+          }
+        }
+      }
+    }
+    .interactiveDismissDisabled(store.state == .submitting)
+    .presentationDetents([.medium, .large])
+    .presentationDragIndicator(.visible)
+  }
+
+  private var form: some View {
+    Form {
+      Section {
+        Text(
+          "Share feedback, ask a question, or tell us what we could improve.",
+          tableName: "Feedback",
+          comment: "Introduction shown above the feedback fields."
+        )
+        .foregroundStyle(.secondary)
+      }
+
+      Section {
+        TextField(
+          text: $store.email,
+          prompt: Text(
+            "you@example.com",
+            tableName: "Feedback",
+            comment: "Example email address in the feedback form.")
+        ) {
+          Text(
+            "Email address",
+            tableName: "Feedback",
+            comment: "Email field label in the feedback form.")
+        }
+        .focused($focusedField, equals: .email)
+        .textInputAutocapitalization(.never)
+        .keyboardType(.emailAddress)
+        .autocorrectionDisabled()
+        .textContentType(.emailAddress)
+        .submitLabel(.next)
+        .onSubmit {
+          focusedField = .message
+        }
+        .accessibilityLabel(
+          Text(
+            "Email address",
+            tableName: "Feedback",
+            comment: "Email field label in the feedback form."))
+      } footer: {
+        Text(
+          "We'll use this email to contact you.",
+          tableName: "Feedback",
+          comment: "Explains why the feedback form asks for an email address.")
+      }
+
+      Section {
+        TextField(
+          text: $store.message,
+          prompt: Text(
+            "How can we help?",
+            tableName: "Feedback",
+            comment: "Placeholder in the feedback message field."),
+          axis: .vertical
+        ) {
+          Text(
+            "Message",
+            tableName: "Feedback",
+            comment: "Message field label in the feedback form.")
+        }
+        .focused($focusedField, equals: .message)
+        .lineLimit(5...10)
+        .accessibilityLabel(
+          Text(
+            "Message",
+            tableName: "Feedback",
+            comment: "Message field label in the feedback form."))
+      } footer: {
+        Text(
+          "Please provide as much detail as possible.",
+          tableName: "Feedback",
+          comment: "Guidance below the feedback message field.")
+      }
+
+      if case .failed(let failure) = store.state {
+        Section {
+          Label {
+            Text(failureMessage(failure))
+          } icon: {
+            Image(systemName: "exclamationmark.triangle")
+          }
+          .foregroundStyle(.red)
+          .accessibilityAddTraits(.isStaticText)
+        }
+      }
+    }
+    .disabled(store.state == .submitting)
+    .onChange(of: store.email) { _, _ in
+      store.clearFailure()
+    }
+    .onChange(of: store.message) { _, _ in
+      store.clearFailure()
+    }
+  }
+
+  private var confirmation: some View {
+    ContentUnavailableView {
+      Label {
+        Text(
+          "Thanks for your feedback",
+          tableName: "Feedback",
+          comment: "Confirmation title after feedback is sent.")
+      } icon: {
+        Image(systemName: "checkmark.circle.fill")
+          .foregroundStyle(.green)
+      }
+    } description: {
+      Text(
+        "Your message was sent.",
+        tableName: "Feedback",
+        comment: "Confirmation message after feedback is sent.")
+    }
+  }
+
+  private func submit() {
+    focusedField = nil
+
+    Task {
+      await store.submit()
+    }
+  }
+
+  private func failureMessage(_ failure: FeedbackFailure) -> LocalizedStringResource {
+    switch failure {
+    case .network:
+      LocalizedStringResource(
+        "You're offline. Check your connection and try again.",
+        table: "Feedback",
+        comment: "Feedback form error when the network is unavailable.")
+    case .unavailable:
+      LocalizedStringResource(
+        "Feedback couldn't be sent. Try again later.",
+        table: "Feedback",
+        comment: "Feedback form error when the service is temporarily unavailable.")
+    case .validation:
+      LocalizedStringResource(
+        "Check your email and message, then try again.",
+        table: "Feedback",
+        comment: "Feedback form error when the submitted fields are invalid.")
+    }
+  }
+}
+
+private enum FeedbackField: Hashable {
+  case email
+  case message
+}

--- a/apps/apple/Zoonk/Features/Progress/LevelProgressView.swift
+++ b/apps/apple/Zoonk/Features/Progress/LevelProgressView.swift
@@ -97,10 +97,15 @@ private struct LevelProgressContent: View {
           ProgressView(value: level.progressValue, total: level.progressTotal)
             .tint(level.belt.progressColor)
             .accessibilityLabel(
-              Text(
-                level.isMaxLevel ? "Level progress" : "Progress to the next level",
-                tableName: "Progress",
-                comment: "Accessibility label for level progress")
+              level.isMaxLevel
+                ? Text(
+                  "Level progress",
+                  tableName: "Progress",
+                  comment: "Accessibility label for progress within the maximum level")
+                : Text(
+                  "Progress to the next level",
+                  tableName: "Progress",
+                  comment: "Accessibility label for progress toward the learner's next level")
             )
             .accessibilityValue(milestoneDescription)
         }

--- a/apps/apple/Zoonk/Features/Progress/ProgressOverviewView.swift
+++ b/apps/apple/Zoonk/Features/Progress/ProgressOverviewView.swift
@@ -318,10 +318,15 @@ private struct ProgressOverviewContent: View {
         )
         .tint(level.belt.progressColor)
         .accessibilityLabel(
-          Text(
-            level.isMaxLevel ? "Level progress" : "Progress to the next level",
-            tableName: "Progress",
-            comment: "Accessibility label for level progress.")
+          level.isMaxLevel
+            ? Text(
+              "Level progress",
+              tableName: "Progress",
+              comment: "Accessibility label for progress within the maximum level.")
+            : Text(
+              "Progress to the next level",
+              tableName: "Progress",
+              comment: "Accessibility label for progress toward the learner's next level.")
         )
         .accessibilityValue(
           level.isMaxLevel

--- a/apps/apple/Zoonk/Navigation/AppSection+Tab.swift
+++ b/apps/apple/Zoonk/Navigation/AppSection+Tab.swift
@@ -1,24 +1,25 @@
 import SwiftUI
 
-extension AppSection {
-  var tabRole: TabRole? {
-    self == .search ? .search : nil
-  }
+struct AppSectionActions {
+  let presentAccount: () -> Void
+  let selectSection: (AppSection) -> Void
+}
 
+extension AppSection {
   @MainActor
   @ViewBuilder
-  func tabContent(onPresentAccount: @escaping () -> Void) -> some View {
+  func tabContent(actions: AppSectionActions) -> some View {
     switch self {
     case .home:
       HomeView()
     case .newCourse:
       NewCourseView()
     case .courses:
-      CoursesView()
+      CoursesView {
+        actions.selectSection(.newCourse)
+      }
     case .progress:
-      ProgressOverviewView(onSignIn: onPresentAccount)
-    case .search:
-      SearchView()
+      ProgressOverviewView(onSignIn: actions.presentAccount)
     }
   }
 }

--- a/apps/apple/Zoonk/Navigation/AppSection.swift
+++ b/apps/apple/Zoonk/Navigation/AppSection.swift
@@ -5,7 +5,6 @@ enum AppSection: CaseIterable, Hashable, Identifiable {
   case newCourse
   case courses
   case progress
-  case search
 
   var id: Self { self }
 
@@ -25,17 +24,12 @@ enum AppSection: CaseIterable, Hashable, Identifiable {
       LocalizedStringResource(
         "Courses",
         table: "Navigation",
-        comment: "Navigation title for the learner's courses.")
+        comment: "Navigation title for browsing the public course catalog.")
     case .progress:
       LocalizedStringResource(
         "Progress",
         table: "Navigation",
         comment: "Navigation title for the learner's progress overview.")
-    case .search:
-      LocalizedStringResource(
-        "Search",
-        table: "Navigation",
-        comment: "Navigation title for searching Zoonk.")
     }
   }
 
@@ -60,8 +54,6 @@ enum AppSection: CaseIterable, Hashable, Identifiable {
       "square.grid.2x2"
     case .progress:
       "chart.line.uptrend.xyaxis"
-    case .search:
-      "magnifyingglass"
     }
   }
 }

--- a/apps/apple/Zoonk/Resources/Localization/Courses.xcstrings
+++ b/apps/apple/Zoonk/Resources/Localization/Courses.xcstrings
@@ -1,791 +1,855 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "6-digit code" : {
-      "comment" : "Placeholder for the account deletion verification code\nPlaceholder for the email sign-in code",
+    "%lld/%lld done" : {
+      "comment" : "Chapter progress. The first value is completed lessons and the second is total lessons.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "6-stelliger Code"
+            "value" : "%1$lld/%2$lld abgeschlossen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld/%2$lld done"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Código de 6 dígitos"
+            "value" : "%1$lld/%2$lld completadas"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Code à 6 chiffres"
+            "value" : "%1$lld/%2$lld terminées"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Código de 6 dígitos"
+            "value" : "%1$lld/%2$lld concluídas"
           }
         }
       }
     },
-    "Account" : {
-      "comment" : "Accessibility label for the account button\nAccount sheet navigation title",
+    "All" : {
+      "comment" : "Category option that shows courses from every category.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Konto"
+            "value" : "Alle"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cuenta"
+            "value" : "Todos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compte"
+            "value" : "Tous"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conta"
+            "value" : "Todos"
           }
         }
       }
     },
-    "Account deleted" : {
-      "comment" : "Title shown after deletion when Apple authorization needs manual removal\nTitle shown after successful account deletion",
+    "Alphabet" : {
+      "comment" : "Fallback title for an alphabet lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Konto gelöscht"
+            "value" : "Alphabet"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cuenta eliminada"
+            "value" : "Alfabeto"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compte supprimé"
+            "value" : "Alphabet"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conta excluída"
+            "value" : "Alfabeto"
           }
         }
       }
     },
-    "Account deletion can't be undone." : {
-      "comment" : "Warns that account deletion is irreversible",
+    "Arts" : {
+      "comment" : "Course category for the arts.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Das Löschen des Kontos kann nicht rückgängig gemacht werden."
+            "value" : "Kunst"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La eliminación de la cuenta no se puede deshacer."
+            "value" : "Arte"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La suppression du compte est irréversible."
+            "value" : "Arts"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "A exclusão da conta não pode ser desfeita."
+            "value" : "Artes"
           }
         }
       }
     },
-    "Account email" : {
-      "comment" : "Section title above the read-only account email",
+    "Business" : {
+      "comment" : "Course category for business.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "E-Mail-Adresse des Kontos"
+            "value" : "Betriebswirtschaft"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Correo de la cuenta"
+            "value" : "Negocios"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Adresse e-mail du compte"
+            "value" : "Commerce"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Email da conta"
+            "value" : "Negócios"
           }
         }
       }
     },
-    "Account unavailable" : {
-      "comment" : "Title shown when the saved account cannot be loaded",
+    "Chapter" : {
+      "comment" : "Fallback title for a chapter continuation target.\nFallback title for the chapter containing a continuation lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Konto nicht verfügbar"
+            "value" : "Kapitel"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cuenta no disponible"
+            "value" : "Capítulo"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compte indisponible"
+            "value" : "Chapitre"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conta indisponível"
+            "value" : "Capítulo"
           }
         }
       }
     },
-    "Active" : {
-      "comment" : "Status for an active subscription",
+    "Chapter information" : {
+      "comment" : "Title for secondary information about a chapter.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aktiv"
+            "value" : "Kapitelinformationen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Activa"
+            "value" : "Información del capítulo"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Actif"
+            "value" : "Informations sur le chapitre"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ativa"
+            "value" : "Informações do capítulo"
           }
         }
       }
     },
-    "App Store" : {
-      "comment" : "Status shown when an active subscription is managed by the App Store",
+    "Chapter not found" : {
+      "comment" : "Title when a chapter cannot be found.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "App Store"
+            "value" : "Kapitel nicht gefunden"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "App Store"
+            "value" : "Capítulo no encontrado"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "App Store"
+            "value" : "Chapitre introuvable"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "App Store"
+            "value" : "Capítulo não encontrado"
           }
         }
       }
     },
-    "Blog" : {
-      "comment" : "Account option for the blog",
+    "Chapter unavailable" : {
+      "comment" : "Title when a chapter cannot be loaded.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blog"
+            "value" : "Kapitel nicht verfügbar"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blog"
+            "value" : "Capítulo no disponible"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blog"
+            "value" : "Chapitre indisponible"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blog"
+            "value" : "Capítulo indisponível"
           }
         }
       }
     },
-    "Browse courses" : {
-      "comment" : "Account option that opens the public course catalog",
+    "Chapters" : {
+      "comment" : "Heading above matching chapter search results.\nHeading above the ordered chapter list on a course screen.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kurse entdecken"
+            "value" : "Kapitel"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Explorar cursos"
+            "value" : "Capítulos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Parcourir les cours"
+            "value" : "Chapitres"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ver cursos"
+            "value" : "Capítulos"
           }
         }
       }
     },
-    "By continuing, you agree to the Zoonk Terms of Service and Privacy Policy." : {
-      "comment" : "Legal agreement shown below sign-in methods",
+    "Check what you understood with a short quiz." : {
+      "comment" : "Fallback description for a quiz lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wenn du fortfährst, stimmst du den Nutzungsbedingungen und der Datenschutzerklärung von Zoonk zu."
+            "value" : "Teste mit einem kurzen Quiz, was du verstanden hast."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Al continuar, aceptas los Términos del Servicio y la Política de Privacidad de Zoonk."
+            "value" : "Comprueba lo que entendiste con un breve cuestionario."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En continuant, tu acceptes les Conditions d’utilisation et la Politique de confidentialité de Zoonk."
+            "value" : "Vérifie ce que tu as compris avec un petit quiz."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ao continuar, você concorda com os Termos de Serviço e a Política de Privacidade do Zoonk."
+            "value" : "Confira o que você entendeu com um quiz rápido."
           }
         }
       }
     },
-    "Cancel" : {
-      "comment" : "Cancels permanent account deletion",
+    "Check your connection and try again." : {
+      "comment" : "Recovery guidance for an offline catalog request.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abbrechen"
+            "value" : "Prüfe deine Verbindung und versuche es erneut."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cancelar"
+            "value" : "Comprueba tu conexión e inténtalo de nuevo."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annuler"
+            "value" : "Vérifie ta connexion et réessaie."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cancelar"
+            "value" : "Confira sua conexão e tente de novo."
           }
         }
       }
     },
-    "Check the information and try again." : {
-      "comment" : "Error shown when profile information is invalid",
+    "Communication" : {
+      "comment" : "Course category for communication.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Überprüfe die Angaben und versuche es erneut."
+            "value" : "Kommunikation"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Revisa la información e inténtalo de nuevo."
+            "value" : "Comunicación"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vérifie les informations et réessaie."
+            "value" : "Communication"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Confira as informações e tente de novo."
+            "value" : "Comunicação"
           }
         }
       }
     },
-    "Check your App Store purchase history, then contact support for help." : {
-      "comment" : "Recovery guidance when Zoonk cannot accept a verified App Store purchase",
+    "Completed" : {
+      "comment" : "Progress state for a completed chapter or lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prüfe deinen Einkaufsverlauf im App Store und wende dich dann an den Support."
+            "value" : "Abgeschlossen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Revisa tu historial de compras del App Store y luego contacta con soporte para obtener ayuda."
+            "value" : "Completado"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Consulte l’historique de tes achats dans l’App Store, puis contacte l’assistance pour obtenir de l’aide."
+            "value" : "Terminé"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Confira seu histórico de compras na App Store e depois fale com o suporte para receber ajuda."
+            "value" : "Completou"
           }
         }
       }
     },
-    "Check your App Store purchase history, then contact support if you need help." : {
-      "comment" : "Recovery guidance after StoreKit transaction verification fails",
+    "Continue" : {
+      "comment" : "Continues a course or chapter from the learner's next lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prüfe deinen Einkaufsverlauf im App Store und wende dich an den Support, wenn du Hilfe brauchst."
+            "value" : "Fortsetzen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Revisa tu historial de compras del App Store y luego contacta con soporte si necesitas ayuda."
+            "value" : "Continuar"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Consulte l’historique de tes achats dans l’App Store, puis contacte l’assistance si tu as besoin d’aide."
+            "value" : "Continuer"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Confira seu histórico de compras na App Store e depois fale com o suporte se precisar de ajuda."
+            "value" : "Continuar"
           }
         }
       }
     },
-    "Check your connection and try restoring again." : {
-      "comment" : "Recovery guidance after restoring App Store purchases fails",
+    "Continue, %lld%% complete" : {
+      "comment" : "Accessible continue action followed by the course or chapter completion percent.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prüfe deine Internetverbindung und versuche erneut, deine Käufe wiederherzustellen."
+            "value" : "Fortsetzen, zu %lld %% abgeschlossen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Comprueba tu conexión e intenta restaurar las compras de nuevo."
+            "value" : "Continuar, %lld%% completado"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vérifie ta connexion, puis réessaie de restaurer tes achats."
+            "value" : "Continuer, progression à %lld %%"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Confira sua conexão e tente restaurar as compras novamente."
+            "value" : "Continuar, %lld%% concluído"
           }
         }
       }
     },
-    "Choose how your name appears before you continue." : {
-      "comment" : "Explains why first-time profile setup is required",
+    "Couldn't load more courses." : {
+      "comment" : "Message when another course page cannot be loaded.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lege fest, wie dein Name angezeigt werden soll, bevor du fortfährst."
+            "value" : "Weitere Kurse konnten nicht geladen werden."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Elige cómo aparecerá tu nombre antes de continuar."
+            "value" : "No se pudieron cargar más cursos."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Choisis comment ton nom apparaîtra avant de continuer."
+            "value" : "Impossible de charger plus de cours."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Escolha como seu nome será exibido antes de continuar."
+            "value" : "Não foi possível carregar mais cursos."
           }
         }
       }
     },
-    "Close" : {
-      "comment" : "Closes the account sheet",
+    "Couldn't load more while offline." : {
+      "comment" : "Message when another course page cannot load because the device is offline.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Schließen"
+            "value" : "Ohne Internet konnten keine weiteren Kurse geladen werden."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cerrar"
+            "value" : "No se pudieron cargar más cursos sin conexión."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fermer"
+            "value" : "Impossible de charger plus de cours sans connexion."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fechar"
+            "value" : "Não foi possível carregar mais cursos sem conexão."
           }
         }
       }
     },
-    "Continue with Apple to confirm that this account is yours before deleting it." : {
-      "comment" : "Explains why Apple reauthorization is required for deletion",
+    "Course categories" : {
+      "comment" : "Accessibility label for the horizontally scrolling course category selector.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fahre mit Apple fort, um vor dem Löschen zu bestätigen, dass dieses Konto dir gehört."
+            "value" : "Kurskategorien"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continúa con Apple para confirmar que esta cuenta es tuya antes de eliminarla."
+            "value" : "Categorías de cursos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continue avec Apple pour confirmer que ce compte t’appartient avant de le supprimer."
+            "value" : "Catégories de cours"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continue com a Apple para confirmar que esta conta é sua antes de excluí-la."
+            "value" : "Categorias de cursos"
           }
         }
       }
     },
-    "Continue with email" : {
-      "comment" : "Email sign-in button label",
+    "Course information" : {
+      "comment" : "Title for secondary information about a course.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Weiter mit E-Mail"
+            "value" : "Kursinformationen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continuar con correo electrónico"
+            "value" : "Información del curso"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continuer avec un e-mail"
+            "value" : "Informations sur le cours"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continuar com email"
+            "value" : "Informações do curso"
           }
         }
       }
     },
-    "Couldn't restore purchases" : {
-      "comment" : "Title shown when restoring App Store purchases fails",
+    "Course not found" : {
+      "comment" : "Title when a course cannot be found.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Käufe konnten nicht wiederhergestellt werden"
+            "value" : "Kurs nicht gefunden"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No se pudieron restaurar las compras"
+            "value" : "Curso no encontrado"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Impossible de restaurer les achats"
+            "value" : "Cours introuvable"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Não foi possível restaurar as compras"
+            "value" : "Curso não encontrado"
           }
         }
       }
     },
-    "Couldn't update your account" : {
-      "comment" : "Title shown when a verified App Store transaction could not reach Zoonk",
+    "Course unavailable" : {
+      "comment" : "Title when a course cannot be loaded.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dein Konto konnte nicht aktualisiert werden"
+            "value" : "Kurs nicht verfügbar"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No se pudo actualizar tu cuenta"
+            "value" : "Curso no disponible"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Impossible de mettre à jour ton compte"
+            "value" : "Cours indisponible"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Não foi possível atualizar sua conta"
+            "value" : "Curso indisponível"
           }
         }
       }
     },
-    "Course progress" : {
-      "comment" : "Learning data removed during account deletion",
+    "Courses" : {
+      "comment" : "Heading above matching course search results.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kursfortschritt"
+            "value" : "Kurse"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Progreso del curso"
+            "value" : "Cursos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Progression du cours"
+            "value" : "Cours"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Progresso do curso"
+            "value" : "Cursos"
           }
         }
       }
     },
-    "Delete account" : {
-      "comment" : "Account deletion navigation title\nAccount option that opens permanent account deletion\nConfirms permanent account deletion\nStarts permanent account deletion",
+    "Courses are unavailable" : {
+      "comment" : "Title when the public course catalog cannot be loaded.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Konto löschen"
+            "value" : "Kurse sind nicht verfügbar"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eliminar cuenta"
+            "value" : "Los cursos no están disponibles"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Supprimer le compte"
+            "value" : "Les cours sont indisponibles"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Excluir conta"
+            "value" : "Os cursos estão indisponíveis"
           }
         }
       }
     },
-    "Delete your Zoonk account?" : {
-      "comment" : "Final confirmation title before permanent account deletion",
+    "Courses will appear here when they're available." : {
+      "comment" : "Guidance when no public courses are available.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dein Zoonk-Konto löschen?"
+            "value" : "Verfügbare Kurse werden hier angezeigt."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Eliminar tu cuenta de Zoonk?"
+            "value" : "Los cursos aparecerán aquí cuando estén disponibles."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Supprimer ton compte Zoonk ?"
+            "value" : "Les cours apparaîtront ici dès qu'ils seront disponibles."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Excluir sua conta do Zoonk?"
+            "value" : "Os cursos vão aparecer aqui quando estiverem disponíveis."
           }
         }
       }
     },
-    "Deleting your Zoonk account doesn't cancel App Store billing. Cancel the subscription first if you don't want it to renew." : {
-      "comment" : "Warns that App Store billing continues independently of Zoonk account deletion",
+    "Create a course about %@" : {
+      "comment" : "Opens course creation from an empty category. The interpolated value is the category name.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durch das Löschen deines Zoonk-Kontos wird die Abrechnung im App Store nicht beendet. Kündige zuerst das Abonnement, wenn es nicht verlängert werden soll."
+            "value" : "Kurs über %@ erstellen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eliminar tu cuenta de Zoonk no cancela la facturación del App Store. Cancela primero la suscripción si no quieres que se renueve."
+            "value" : "Crear un curso sobre %@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Supprimer ton compte Zoonk n’annule pas la facturation via l’App Store. Résilie d’abord l’abonnement si tu ne veux pas qu’il soit renouvelé."
+            "value" : "Créer un cours sur %@"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Excluir sua conta do Zoonk não cancela a cobrança da App Store. Cancele primeiro a assinatura se não quiser que ela seja renovada."
+            "value" : "Crie um curso sobre %@"
           }
         }
       }
     },
-    "Deleting your Zoonk account doesn't cancel Google Play billing. Use Google Play on an Android device to cancel it first if you don't want it to renew." : {
-      "comment" : "Warns that Google Play billing continues independently of Zoonk account deletion",
+    "Created with AI" : {
+      "comment" : "Disclosure that a public course or chapter was created with AI.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wenn du dein Zoonk-Konto löschst, endet dein über Google Play abgerechnetes Abo nicht. Kündige es zuerst über Google Play auf einem Android-Gerät, wenn es sich nicht verlängern soll."
+            "value" : "Mit KI erstellt"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eliminar tu cuenta de Zoonk no cancela la facturación de Google Play. Si no quieres que se renueve, cancela primero la suscripción desde Google Play en un dispositivo Android."
+            "value" : "Creado con IA"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La suppression de ton compte Zoonk n’annule pas la facturation Google Play. Si tu ne veux pas que ton abonnement soit renouvelé, annule-le d’abord dans Google Play sur un appareil Android."
+            "value" : "Créé avec l'IA"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Excluir sua conta do Zoonk não cancela a cobrança do Google Play. Se você não quiser renovar, cancele primeiro pelo Google Play em um dispositivo Android."
+            "value" : "Criado com IA"
+          }
+        }
+      }
+    },
+    "Culture" : {
+      "comment" : "Course category for culture.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kultur"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cultura"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Culture"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cultura"
+          }
+        }
+      }
+    },
+    "Custom lesson" : {
+      "comment" : "Fallback title for a custom lesson.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eigene Lektion"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lección personalizada"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leçon personnalisée"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aula personalizada"
           }
         }
       }
     },
     "Done" : {
-      "comment" : "Closes successful account deletion\nCloses the Apple revocation outcome",
+      "comment" : "Closes catalog information presented in a popover or sheet.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -808,1434 +872,1666 @@
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Concluído"
-          }
-        }
-      }
-    },
-    "Email" : {
-      "comment" : "Email sign-in field label\nFixed account email used to reauthorize deletion\nRead-only profile email label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "E-Mail"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Correo electrónico"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "E-mail"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Email"
-          }
-        }
-      }
-    },
-    "Email sign-in" : {
-      "comment" : "Email login navigation title",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mit E-Mail anmelden"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicio de sesión con correo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connexion par e-mail"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrar com email"
-          }
-        }
-      }
-    },
-    "Enter a valid email address." : {
-      "comment" : "Error shown when an email address is invalid",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gib eine gültige E-Mail-Adresse ein."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingresa un correo electrónico válido."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saisis une adresse e-mail valide."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digite um email válido."
-          }
-        }
-      }
-    },
-    "Feedback & Support" : {
-      "comment" : "Account option for feedback and support",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Feedback & Support"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comentarios y ayuda"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avis et aide"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sugestões e Suporte"
-          }
-        }
-      }
-    },
-    "Finish setup" : {
-      "comment" : "Navigation title for required first-time profile setup",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einrichtung abschließen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizar configuración"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminer la configuration"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Concluir configuração"
-          }
-        }
-      }
-    },
-    "For your security, enter a new code sent to the email on this account." : {
-      "comment" : "Explains the email reauthentication requirement for account deletion",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gib zu deiner Sicherheit einen neuen Code ein, der an die E-Mail-Adresse dieses Kontos gesendet wurde."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por tu seguridad, introduce un nuevo código enviado al correo de esta cuenta."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour ta sécurité, saisis un nouveau code envoyé à l’adresse e-mail de ce compte."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para sua segurança, insira um novo código enviado para o email desta conta."
-          }
-        }
-      }
-    },
-    "Free" : {
-      "comment" : "Status shown when the account has no active subscription",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kostenlos"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gratis"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gratuit"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Grátis"
-          }
-        }
-      }
-    },
-    "Google Play" : {
-      "comment" : "Status shown when an active subscription is managed by Google Play",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Google Play"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Google Play"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Google Play"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Google Play"
-          }
-        }
-      }
-    },
-    "Keep your courses and progress available on all your devices." : {
-      "comment" : "Explains the benefit of signing in",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deine Kurse und dein Fortschritt sind auf allen deinen Geräten verfügbar."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accede a tus cursos y a tu progreso desde todos tus dispositivos."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retrouve tes cours et ta progression sur tous tes appareils."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acesse seus cursos e seu progresso em todos os seus dispositivos."
-          }
-        }
-      }
-    },
-    "Learn anything. It’s all included." : {
-      "comment" : "Headline on the Zoonk Plus subscription screen",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lerne, was du willst. Alles ist dabei."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aprende lo que quieras. Todo está incluido."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apprends ce que tu veux. Tout est inclus."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aprenda qualquer coisa. Está tudo incluído."
-          }
-        }
-      }
-    },
-    "Learning built around your goals" : {
-      "comment" : "Zoonk Plus benefit describing personalized learning",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lernen passend zu deinen Zielen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estudio adaptado a tus objetivos"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Un apprentissage adapté à tes objectifs"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estudo pensado para seus objetivos"
-          }
-        }
-      }
-    },
-    "Make sure you're signed in with the Apple Account used for the purchase, then try again." : {
-      "comment" : "Recovery guidance when restore finds no eligible App Store purchases",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stelle sicher, dass du mit dem Apple Account angemeldet bist, den du für den Kauf verwendet hast, und versuche es erneut."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asegúrate de haber iniciado sesión con la Cuenta de Apple que usaste para la compra e inténtalo de nuevo."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifie que tu es connecté au compte Apple utilisé pour l’achat, puis réessaie."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Confira se você entrou com a Conta Apple usada na compra e tente novamente."
-          }
-        }
-      }
-    },
-    "Manage App Store subscription" : {
-      "comment" : "Opens Apple's subscription management before account deletion",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Store-Abonnement verwalten"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gestionar suscripción del App Store"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gérer l’abonnement App Store"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gerenciar assinatura da App Store"
-          }
-        }
-      }
-    },
-    "Manage Sign in with Apple" : {
-      "comment" : "Opens Apple account authorization management after deletion",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "„Mit Apple anmelden“ verwalten"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gestionar Inicio de sesión con Apple"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gérer Connexion avec Apple"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gerenciar Iniciar Sessão com a Apple"
-          }
-        }
-      }
-    },
-    "Managed on Google Play" : {
-      "comment" : "Identifies Google Play as the owner of subscription billing\nTitle explaining where a Google-owned subscription is managed",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Über Google Play verwaltet"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gestionada en Google Play"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Géré sur Google Play"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gerenciada pelo Google Play"
-          }
-        }
-      }
-    },
-    "Name" : {
-      "comment" : "Profile name field label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Name"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nom"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome"
-          }
-        }
-      }
-    },
-    "No active subscription found" : {
-      "comment" : "Title shown when restored App Store purchases do not currently provide Plus",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein aktives Abo gefunden"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontró ninguna suscripción activa"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun abonnement actif trouvé"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhuma assinatura ativa encontrada"
-          }
-        }
-      }
-    },
-    "No purchases found" : {
-      "comment" : "Title shown when restore finds no eligible App Store purchases",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Käufe gefunden"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontraron compras"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucun achat trouvé"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhuma compra encontrada"
-          }
-        }
-      }
-    },
-    "OK" : {
-      "comment" : "Dismisses a subscription status message\nDismisses subscription management guidance",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aceptar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
             "value" : "OK"
           }
         }
       }
     },
-    "Permanently deleted" : {
-      "comment" : "Heading above the data removed during account deletion",
+    "Economics" : {
+      "comment" : "Course category for economics.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dauerhaft gelöscht"
+            "value" : "Volkswirtschaft"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eliminado permanentemente"
+            "value" : "Economía"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Supprimé définitivement"
+            "value" : "Économie"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Excluídos permanentemente"
+            "value" : "Economia"
           }
         }
       }
     },
-    "Personalized courses" : {
-      "comment" : "Personalized learning data removed during account deletion",
+    "Engineering" : {
+      "comment" : "Course category for engineering.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Personalisierte Kurse"
+            "value" : "Ingenieurwesen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cursos personalizados"
+            "value" : "Ingeniería"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cours personnalisés"
+            "value" : "Ingénierie"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cursos personalizados"
+            "value" : "Engenharia"
           }
         }
       }
     },
-    "Plus gives you unlimited courses and lessons for whatever you want to learn." : {
-      "comment" : "Summary of the Zoonk Plus subscription",
+    "Explanation" : {
+      "comment" : "Fallback title for an explanation lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mit Plus bekommst du unbegrenzt viele Kurse und Lektionen zu allem, was du lernen möchtest."
+            "value" : "Erklärung"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Plus te ofrece cursos y lecciones ilimitados sobre todo lo que quieras aprender."
+            "value" : "Explicación"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Avec Plus, suis autant de cours et de leçons que tu veux, sur tout ce que tu souhaites apprendre."
+            "value" : "Explication"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "O Plus oferece cursos e aulas ilimitados sobre o que você quiser aprender."
+            "value" : "Explicação"
           }
         }
       }
     },
-    "Privacy Policy" : {
-      "comment" : "Link to the privacy policy",
+    "Find a course or jump directly to a chapter." : {
+      "comment" : "Guidance shown before the learner enters a catalog search query.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Datenschutzerklärung"
+            "value" : "Finde einen Kurs oder springe direkt zu einem Kapitel."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Política de privacidad"
+            "value" : "Busca un curso o ve directamente a un capítulo."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Politique de confidentialité"
+            "value" : "Trouve un cours ou va directement à un chapitre."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Política de privacidade"
+            "value" : "Encontre um curso ou vá direto para um capítulo."
           }
         }
       }
     },
-    "Profile" : {
-      "comment" : "Account option for profile\nProfile editor navigation title",
+    "Follow a guided step-by-step tutorial." : {
+      "comment" : "Fallback description for a tutorial lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Profil"
+            "value" : "Folge einer Anleitung Schritt für Schritt."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perfil"
+            "value" : "Sigue un tutorial guiado paso a paso."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Profil"
+            "value" : "Suis un tutoriel guidé étape par étape."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perfil"
+            "value" : "Siga um tutorial guiado passo a passo."
           }
         }
       }
     },
-    "Profile and account information" : {
-      "comment" : "Account data removed during deletion",
+    "Geography" : {
+      "comment" : "Course category for geography.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Profil- und Kontoinformationen"
+            "value" : "Geografie"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Información del perfil y de la cuenta"
+            "value" : "Geografía"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Informations du profil et du compte"
+            "value" : "Géographie"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Informações do perfil e da conta"
+            "value" : "Geografia"
           }
         }
       }
     },
-    "Purchase couldn't be linked" : {
-      "comment" : "Title shown when Zoonk cannot accept a verified App Store purchase",
+    "Grammar" : {
+      "comment" : "Fallback title for a grammar lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kauf konnte nicht verknüpft werden"
+            "value" : "Grammatik"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No se pudo vincular la compra"
+            "value" : "Gramática"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Impossible d’associer l’achat"
+            "value" : "Grammaire"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Não foi possível vincular a compra"
+            "value" : "Gramática"
           }
         }
       }
     },
-    "Purchase couldn't be verified" : {
-      "comment" : "Title shown when StoreKit cannot verify a purchase",
+    "Health" : {
+      "comment" : "Course category for health.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kauf konnte nicht überprüft werden"
+            "value" : "Gesundheit"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No se pudo verificar la compra"
+            "value" : "Salud"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Impossible de vérifier l’achat"
+            "value" : "Santé"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Não foi possível verificar a compra"
+            "value" : "Saúde"
           }
         }
       }
     },
-    "Purchase linked to another account" : {
-      "comment" : "Title shown when an App Store purchase belongs to another Zoonk account",
+    "History" : {
+      "comment" : "Course category for history.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kauf ist mit einem anderen Konto verknüpft"
+            "value" : "Geschichte"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compra vinculada a otra cuenta"
+            "value" : "Historia"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Achat associé à un autre compte"
+            "value" : "Histoire"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compra vinculada a outra conta"
+            "value" : "História"
           }
         }
       }
     },
-    "Purchase not completed" : {
-      "comment" : "Title shown when an App Store purchase fails",
+    "Languages" : {
+      "comment" : "Course category for languages.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kauf nicht abgeschlossen"
+            "value" : "Sprachen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compra no completada"
+            "value" : "Idiomas"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Achat non finalisé"
+            "value" : "Langues"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compra não concluída"
+            "value" : "Idiomas"
           }
         }
       }
     },
-    "Purchases restored" : {
-      "comment" : "Title shown when App Store purchases were restored",
+    "Law" : {
+      "comment" : "Course category for law.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Käufe wiederhergestellt"
+            "value" : "Recht"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compras restauradas"
+            "value" : "Derecho"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Achats restaurés"
+            "value" : "Droit"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Compras restauradas"
+            "value" : "Direito"
           }
         }
       }
     },
-    "Restore Purchases" : {
-      "comment" : "Restores App Store purchases and synchronizes them with the Zoonk account",
+    "Learn how letters and sounds work in this writing system." : {
+      "comment" : "Fallback description for an alphabet lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Käufe wiederherstellen"
+            "value" : "Lerne, wie Buchstaben und Laute in diesem Schriftsystem funktionieren."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Restaurar compras"
+            "value" : "Aprende cómo funcionan las letras y los sonidos en este sistema de escritura."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Restaurer les achats"
+            "value" : "Découvre comment fonctionnent les lettres et les sons dans ce système d'écriture."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Restaurar compras"
+            "value" : "Aprenda como as letras e os sons funcionam neste sistema de escrita."
           }
         }
       }
     },
-    "Save" : {
-      "comment" : "Button that saves profile changes",
+    "Learn new words and practice using them." : {
+      "comment" : "Fallback description for a vocabulary lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Speichern"
+            "value" : "Lerne neue Wörter und übe, sie zu verwenden."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Guardar"
+            "value" : "Aprende palabras nuevas y practica cómo usarlas."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enregistrer"
+            "value" : "Apprends de nouveaux mots et entraîne-toi à les utiliser."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Salvar"
+            "value" : "Aprenda palavras novas e pratique como usar elas."
           }
         }
       }
     },
-    "Send a new code" : {
-      "comment" : "Sends a replacement account deletion verification code",
+    "Lesson" : {
+      "comment" : "Fallback title while the native lesson player is unavailable.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Neuen Code senden"
+            "value" : "Lektion"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enviar un código nuevo"
+            "value" : "Lección"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Envoyer un nouveau code"
+            "value" : "Leçon"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enviar novo código"
+            "value" : "Aula"
           }
         }
       }
     },
-    "Send code" : {
-      "comment" : "Button that sends an email sign-in code",
+    "Lesson player coming soon" : {
+      "comment" : "Title on the temporary destination shown before the native lesson player is available.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Code senden"
+            "value" : "Lektionsplayer bald verfügbar"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enviar código"
+            "value" : "El reproductor de lecciones estará disponible pronto"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Envoyer le code"
+            "value" : "Le lecteur de leçons arrive bientôt"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enviar código"
+            "value" : "O reprodutor de aulas estará disponível em breve"
           }
         }
       }
     },
-    "Send verification code" : {
-      "comment" : "Sends an email code for account deletion reauthorization",
+    "Lessons" : {
+      "comment" : "Heading above the ordered lesson list on a chapter screen.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bestätigungscode senden"
+            "value" : "Lektionen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enviar código de verificación"
+            "value" : "Lecciones"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Envoyer le code de vérification"
+            "value" : "Leçons"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Enviar código de verificação"
+            "value" : "Aulas"
           }
         }
       }
     },
-    "Sign in" : {
-      "comment" : "Button that verifies an email code",
+    "Listen to sentences using words you recently learned." : {
+      "comment" : "Fallback description for a listening lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Anmelden"
+            "value" : "Höre Sätze mit Wörtern, die du kürzlich gelernt hast."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Iniciar sesión"
+            "value" : "Escucha frases con palabras que aprendiste recientemente."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Se connecter"
+            "value" : "Écoute des phrases avec des mots que tu viens d'apprendre."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Entrar"
+            "value" : "Escute frases com palavras que você aprendeu recentemente."
           }
         }
       }
     },
-    "Sign in again" : {
-      "comment" : "Heading for email reauthentication before account deletion\nTitle shown when subscription synchronization requires authentication",
+    "Listening" : {
+      "comment" : "Fallback title for a listening lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erneut anmelden"
+            "value" : "Hören"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Volver a iniciar sesión"
+            "value" : "Escucha"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Se reconnecter"
+            "value" : "Écoute"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Entrar novamente"
+            "value" : "Escuta"
           }
         }
       }
     },
-    "Sign in to the Zoonk account that owns this App Store purchase, or contact support for help." : {
-      "comment" : "Recovery guidance when an App Store purchase belongs to another Zoonk account",
+    "Loading chapter" : {
+      "comment" : "Accessibility status while a chapter loads.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Melde dich bei dem Zoonk-Konto an, mit dem dieser Kauf im App Store verknüpft ist, oder wende dich an den Support."
+            "value" : "Kapitel wird geladen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inicia sesión en la cuenta de Zoonk vinculada a esta compra del App Store o contacta con soporte para obtener ayuda."
+            "value" : "Cargando capítulo"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Connecte-toi au compte Zoonk auquel cet achat de l’App Store est associé, ou contacte l’assistance pour obtenir de l’aide."
+            "value" : "Chargement du chapitre"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Entre na conta do Zoonk vinculada a esta compra da App Store ou fale com o suporte para receber ajuda."
+            "value" : "Carregando capítulo"
           }
         }
       }
     },
-    "Sign in to Zoonk" : {
-      "comment" : "Title above the native sign-in methods",
+    "Loading course" : {
+      "comment" : "Accessibility status while a course loads.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bei Zoonk anmelden"
+            "value" : "Kurs wird geladen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inicia sesión en Zoonk"
+            "value" : "Cargando curso"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Connecte-toi à Zoonk"
+            "value" : "Chargement du cours"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Entrar no Zoonk"
+            "value" : "Carregando curso"
           }
         }
       }
     },
-    "Sign in with Google" : {
-      "comment" : "Accessibility label for the native Google sign-in button\nVisible label on the Google sign-in button",
+    "Loading courses" : {
+      "comment" : "Accessibility status while the course catalog loads.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mit Google anmelden"
+            "value" : "Kurse werden geladen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Iniciar sesión con Google"
+            "value" : "Cargando cursos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Se connecter avec Google"
+            "value" : "Chargement des cours"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Entrar com o Google"
+            "value" : "Carregando cursos"
           }
         }
       }
     },
-    "Sign out" : {
-      "comment" : "Account sign-out action",
+    "Loading more courses" : {
+      "comment" : "Accessibility status while the next course page loads.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abmelden"
+            "value" : "Weitere Kurse werden geladen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cerrar sesión"
+            "value" : "Cargando más cursos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Se déconnecter"
+            "value" : "Chargement de cours supplémentaires"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sair"
+            "value" : "Carregando mais cursos"
           }
         }
       }
     },
-    "Subscription" : {
-      "comment" : "Account option for subscription\nHeading for mobile-store billing guidance during account deletion",
+    "Math" : {
+      "comment" : "Course category for mathematics.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abo"
+            "value" : "Mathematik"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suscripción"
+            "value" : "Matemáticas"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Abonnement"
+            "value" : "Mathématiques"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Assinatura"
+            "value" : "Matemática"
           }
         }
       }
     },
-    "Terms of Service" : {
-      "comment" : "Link to the terms of service",
+    "More options" : {
+      "comment" : "Accessibility label for secondary catalog actions.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nutzungsbedingungen"
+            "value" : "Weitere Optionen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Términos del Servicio"
+            "value" : "Más opciones"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conditions d’utilisation"
+            "value" : "Plus d’options"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Termos de Serviço"
+            "value" : "Mais opções"
           }
         }
       }
     },
-    "That code belongs to a different account. Request a new code for this account." : {
-      "comment" : "Error shown when an account deletion code belongs to a different account",
+    "No %@ courses yet" : {
+      "comment" : "Title when a selected category does not contain any courses.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dieser Code gehört zu einem anderen Konto. Fordere einen neuen Code für dieses Konto an."
+            "value" : "Noch keine Kurse in der Kategorie %@"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ese código pertenece a otra cuenta. Solicita un código nuevo para esta cuenta."
+            "value" : "Todavía no hay cursos de %@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ce code appartient à un autre compte. Demande un nouveau code pour ce compte."
+            "value" : "Aucun cours de la catégorie %@ pour le moment"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Esse código pertence a outra conta. Solicite um novo código para esta conta."
+            "value" : "Ainda não há cursos de %@"
           }
         }
       }
     },
-    "That code is invalid or expired. Request a new code and try again." : {
-      "comment" : "Error shown when an email verification code is invalid or expired",
+    "No chapters yet" : {
+      "comment" : "Title when a course does not have any published chapters.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dieser Code ist ungültig oder abgelaufen. Fordere einen neuen Code an und versuche es erneut."
+            "value" : "Noch keine Kapitel"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ese código no es válido o ha caducado. Solicita uno nuevo e inténtalo de nuevo."
+            "value" : "Todavía no hay capítulos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ce code est invalide ou a expiré. Demande un nouveau code et réessaie."
+            "value" : "Aucun chapitre pour le moment"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Esse código é inválido ou expirou. Solicite um novo código e tente novamente."
+            "value" : "Ainda não há capítulos"
           }
         }
       }
     },
-    "That username is already taken." : {
-      "comment" : "Error shown when a chosen username is unavailable",
+    "No courses yet" : {
+      "comment" : "Title when the public course catalog is empty.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dieser Benutzername ist bereits vergeben."
+            "value" : "Noch keine Kurse"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ese nombre de usuario ya está en uso."
+            "value" : "Todavía no hay cursos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ce nom d’utilisateur est déjà pris."
+            "value" : "Aucun cours pour le moment"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Esse nome de usuário já está em uso."
+            "value" : "Ainda não há cursos"
           }
         }
       }
     },
-    "The App Store couldn't complete this purchase. Check your connection and try again." : {
-      "comment" : "Recovery guidance after an App Store purchase fails",
+    "No lessons yet" : {
+      "comment" : "Title when a chapter does not have any published lessons.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Der App Store konnte diesen Kauf nicht abschließen. Prüfe deine Internetverbindung und versuche es erneut."
+            "value" : "Noch keine Lektionen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "El App Store no pudo completar esta compra. Comprueba tu conexión e inténtalo de nuevo."
+            "value" : "Todavía no hay lecciones"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L’App Store n’a pas pu finaliser cet achat. Vérifie ta connexion, puis réessaie."
+            "value" : "Aucune leçon pour le moment"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "A App Store não conseguiu concluir esta compra. Confira sua conexão e tente novamente."
+            "value" : "Ainda não há aulas"
           }
         }
       }
     },
-    "This permanently deletes your profile, progress, and personalized courses. This can't be undone." : {
-      "comment" : "Explains the consequences of confirming permanent account deletion",
+    "Not started" : {
+      "comment" : "Progress state for a chapter or lesson with no completed lessons.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dadurch werden dein Profil, dein Fortschritt und deine personalisierten Kurse dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden."
+            "value" : "Nicht begonnen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Esto elimina permanentemente tu perfil, tu progreso y tus cursos personalizados. No se puede deshacer."
+            "value" : "Sin empezar"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ton profil, ta progression et tes cours personnalisés seront supprimés définitivement. Cette action est irréversible."
+            "value" : "Pas commencé"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Isso exclui permanentemente seu perfil, seu progresso e seus cursos personalizados. Não é possível desfazer."
+            "value" : "Não começou"
           }
         }
       }
     },
-    "Too many attempts. Wait a moment, then try again." : {
-      "comment" : "Error shown when sign-in attempts are temporarily rate limited",
+    "Opens the course" : {
+      "comment" : "Accessibility hint for a course in the catalog.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zu viele Versuche. Warte einen Moment und versuche es dann erneut."
+            "value" : "Öffnet den Kurs"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Demasiados intentos. Espera un momento y vuelve a intentarlo."
+            "value" : "Abre el curso"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trop de tentatives. Attends un instant, puis réessaie."
+            "value" : "Ouvre le cours"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Muitas tentativas. Espere um pouco e tente de novo."
+            "value" : "Abre o curso"
+          }
+        }
+      }
+    },
+    "Please return to the catalog and choose another course." : {
+      "comment" : "Guidance when a course request returns no content.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kehre bitte zum Katalog zurück und wähle einen anderen Kurs."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vuelve al catálogo y elige otro curso."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retourne au catalogue et choisis un autre cours."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volte ao catálogo e escolha outro curso."
+          }
+        }
+      }
+    },
+    "Please try again in a moment." : {
+      "comment" : "Recovery guidance when catalog content is temporarily unavailable.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versuche es bitte gleich noch einmal."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inténtalo de nuevo en unos instantes."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réessaie dans un instant."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tente de novo daqui a pouco."
+          }
+        }
+      }
+    },
+    "Practice" : {
+      "comment" : "Fallback title for a practice lesson.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übung"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Práctica"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entraînement"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prática"
+          }
+        }
+      }
+    },
+    "Practice grammar patterns with examples and exercises." : {
+      "comment" : "Fallback description for a grammar lesson.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übe Grammatikmuster mit Beispielen und Aufgaben."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Practica estructuras gramaticales con ejemplos y ejercicios."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entraîne-toi aux règles de grammaire avec des exemples et des exercices."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pratique estruturas gramaticais com exemplos e exercícios."
+          }
+        }
+      }
+    },
+    "Quiz" : {
+      "comment" : "Fallback title for a quiz lesson.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quiz"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuestionario"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quiz"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quiz"
+          }
+        }
+      }
+    },
+    "Read sentences using words you recently learned." : {
+      "comment" : "Fallback description for a reading lesson.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lies Sätze mit Wörtern, die du kürzlich gelernt hast."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lee oraciones con palabras que aprendiste hace poco."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lis des phrases avec des mots que tu as appris récemment."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leia frases com palavras que você aprendeu recentemente."
+          }
+        }
+      }
+    },
+    "Reading" : {
+      "comment" : "Fallback title for a reading lesson.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lectura"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leitura"
+          }
+        }
+      }
+    },
+    "Review" : {
+      "comment" : "Fallback title for a review lesson.\nReviews a completed course or chapter.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederholung"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repaso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Révision"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisão"
+          }
+        }
+      }
+    },
+    "Review this chapter with practice based on your mistakes." : {
+      "comment" : "Fallback description for a review lesson.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederhole dieses Kapitel mit Übungen zu deinen Fehlern."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repasa este capítulo con ejercicios basados en tus errores."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Révise ce chapitre avec des exercices basés sur tes erreurs."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revise este capítulo com atividades baseadas nos seus erros."
+          }
+        }
+      }
+    },
+    "Review, %lld%% complete" : {
+      "comment" : "Accessible review action followed by the course or chapter completion percent.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederholen, zu %lld %% abgeschlossen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repasar, %lld%% completado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réviser, progression à %lld %%"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisar, %lld%% concluído"
+          }
+        }
+      }
+    },
+    "Science" : {
+      "comment" : "Course category for science.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wissenschaft"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ciencia"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sciences"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ciências"
+          }
+        }
+      }
+    },
+    "Search chapters" : {
+      "comment" : "Placeholder for searching within a course's chapters.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kapitel suchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar capítulos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des chapitres"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar capítulos"
+          }
+        }
+      }
+    },
+    "Search courses and chapters" : {
+      "comment" : "Placeholder for searching the public course catalog.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurse und Kapitel durchsuchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar cursos y capítulos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des cours et des chapitres"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar cursos e capítulos"
+          }
+        }
+      }
+    },
+    "Search lessons" : {
+      "comment" : "Placeholder for searching within a chapter's lessons.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lektionen suchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar lecciones"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher des leçons"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar aulas"
+          }
+        }
+      }
+    },
+    "Search the catalog" : {
+      "comment" : "Title shown before the learner enters a catalog search query.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Katalog durchsuchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar en el catálogo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher dans le catalogue"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar no catálogo"
+          }
+        }
+      }
+    },
+    "Searching the catalog" : {
+      "comment" : "Accessibility status while catalog search results load.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Katalog wird durchsucht"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando en el catálogo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche dans le catalogue…"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando no catálogo"
+          }
+        }
+      }
+    },
+    "Send feedback" : {
+      "comment" : "Opens a form for sending feedback about catalog content.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feedback senden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar comentarios"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer des commentaires"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar feedback"
+          }
+        }
+      }
+    },
+    "Shows more information" : {
+      "comment" : "Accessibility hint for expandable course or chapter information.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt weitere Informationen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra más información"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affiche plus d’informations"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra mais informações"
+          }
+        }
+      }
+    },
+    "Society" : {
+      "comment" : "Course category for society.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesellschaft"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sociedad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Société"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sociedade"
+          }
+        }
+      }
+    },
+    "Start" : {
+      "comment" : "Starts a course or chapter that has no learner progress.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empezar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commencer"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Começar"
+          }
+        }
+      }
+    },
+    "Start, %lld%% complete" : {
+      "comment" : "Accessible start action followed by the course or chapter completion percent.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starten, zu %lld %% abgeschlossen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empezar, %lld%% completado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commencer, progression à %lld %%"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Começar, %lld%% concluído"
+          }
+        }
+      }
+    },
+    "Technology" : {
+      "comment" : "Course category for technology.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Technologie"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tecnología"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Technologie"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tecnologia"
+          }
+        }
+      }
+    },
+    "This chapter's lessons will appear here when they're available." : {
+      "comment" : "Guidance when a chapter does not have any published lessons.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Lektionen dieses Kapitels erscheinen hier, sobald sie verfügbar sind."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las lecciones de este capítulo aparecerán aquí cuando estén disponibles."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les leçons de ce chapitre apparaîtront ici dès qu’elles seront disponibles."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "As aulas deste capítulo vão aparecer aqui quando estiverem disponíveis."
+          }
+        }
+      }
+    },
+    "This content may have moved or is no longer available." : {
+      "comment" : "Guidance when a course or chapter cannot be found.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Inhalt wurde möglicherweise verschoben oder ist nicht mehr verfügbar."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es posible que este contenido se haya movido o ya no esté disponible."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce contenu a peut-être été déplacé ou n’est plus disponible."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este conteúdo pode ter mudado de lugar ou não estar mais disponível."
+          }
+        }
+      }
+    },
+    "This course's chapters will appear here when they're available." : {
+      "comment" : "Guidance when a course does not have any published chapters.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Kapitel dieses Kurses erscheinen hier, sobald sie verfügbar sind."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los capítulos de este curso aparecerán aquí cuando estén disponibles."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les chapitres de ce cours apparaîtront ici dès qu’ils seront disponibles."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Os capítulos deste curso vão aparecer aqui quando estiverem disponíveis."
+          }
+        }
+      }
+    },
+    "Translate words from your previous vocabulary lesson." : {
+      "comment" : "Fallback description for a translation lesson.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übersetze Wörter aus deiner letzten Wortschatzlektion."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traduce palabras de tu lección de vocabulario anterior."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traduis des mots de ta leçon de vocabulaire précédente."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traduza palavras da aula de vocabulário anterior."
+          }
+        }
+      }
+    },
+    "Translation" : {
+      "comment" : "Fallback title for a translation lesson.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Übersetzung"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traducción"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traduction"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tradução"
           }
         }
       }
     },
     "Try again" : {
-      "comment" : "Retries loading the saved account",
+      "comment" : "Retries loading catalog content after a failure.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -2246,7 +2542,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inténtalo de nuevo"
+            "value" : "Volver a intentarlo"
           }
         },
         "fr" : {
@@ -2258,674 +2554,210 @@
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tentar de novo"
+            "value" : "Tentar novamente"
           }
         }
       }
     },
-    "Unlimited courses and lessons" : {
-      "comment" : "Zoonk Plus benefit describing unlimited learning content",
+    "Tutorial" : {
+      "comment" : "Fallback title for a tutorial lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unbegrenzt viele Kurse und Lektionen"
+            "value" : "Tutorial"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cursos y lecciones ilimitados"
+            "value" : "Tutorial"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cours et leçons en illimité"
+            "value" : "Tutoriel"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cursos e aulas ilimitados"
+            "value" : "Tutorial"
           }
         }
       }
     },
-    "Use 3–30 letters, numbers, or underscores." : {
-      "comment" : "Username requirements below the profile field",
+    "Understand the key ideas using everyday language and practical examples." : {
+      "comment" : "Fallback description for an explanation lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verwende 3–30 Zeichen: Buchstaben, Zahlen oder Unterstriche."
+            "value" : "Verstehe die wichtigsten Ideen mit einfacher Sprache und praktischen Beispielen."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usa entre 3 y 30 caracteres: letras, números o guiones bajos."
+            "value" : "Comprende las ideas clave con un lenguaje sencillo y ejemplos prácticos."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Utilise 3 à 30 caractères : lettres, chiffres ou tirets bas."
+            "value" : "Comprends les idées clés avec des mots simples et des exemples pratiques."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Use de 3 a 30 caracteres: letras, números ou sublinhados."
+            "value" : "Entenda as ideias principais com uma linguagem simples e exemplos práticos."
           }
         }
       }
     },
-    "Use a different email" : {
-      "comment" : "Button that returns to the email entry step",
+    "Use what you learned in the previous lesson to solve real-world problems." : {
+      "comment" : "Fallback description for a practice lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Andere E-Mail-Adresse verwenden"
+            "value" : "Nutze das Wissen aus der letzten Lektion, um Probleme aus dem Alltag zu lösen."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usar otro correo electrónico"
+            "value" : "Usa lo que aprendiste en la lección anterior para resolver problemas de la vida real."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Utiliser une autre adresse e-mail"
+            "value" : "Utilise ce que tu as appris dans la leçon précédente pour résoudre des problèmes concrets."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usar outro email"
+            "value" : "Use o que você aprendeu na aula anterior para resolver problemas do dia a dia."
           }
         }
       }
     },
-    "Use email instead" : {
-      "comment" : "Uses email OTP when Apple deletion reauthorization is unavailable",
+    "Vocabulary" : {
+      "comment" : "Fallback title for a vocabulary lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Stattdessen E-Mail verwenden"
+            "value" : "Wortschatz"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usar correo electrónico"
+            "value" : "Vocabulario"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Utiliser l’adresse e-mail"
+            "value" : "Vocabulaire"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usar email"
+            "value" : "Vocabulário"
           }
         }
       }
     },
-    "Use Google Play on an Android device to change or cancel this subscription." : {
-      "comment" : "Explains how to manage a Google-owned subscription without linking to external purchasing",
+    "Work through a lesson created for your goal." : {
+      "comment" : "Fallback description for a custom lesson.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verwende Google Play auf einem Android-Gerät, um dieses Abo zu ändern oder zu kündigen."
+            "value" : "Bearbeite eine Lektion, die auf dein Ziel zugeschnitten ist."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usa Google Play en un dispositivo Android para cambiar o cancelar esta suscripción."
+            "value" : "Completa una lección creada para tu objetivo."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Utilise Google Play sur un appareil Android pour modifier ou annuler cet abonnement."
+            "value" : "Suis une leçon créée pour ton objectif."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Use o Google Play em um dispositivo Android para alterar ou cancelar esta assinatura."
+            "value" : "Complete uma aula criada para o seu objetivo."
           }
         }
       }
     },
-    "username" : {
-      "comment" : "Placeholder for the username field",
+    "You can keep exploring this course and return when the lesson player is ready." : {
+      "comment" : "Guidance on the temporary lesson player destination.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "benutzername"
+            "value" : "Du kannst den Kurs weiter erkunden und zurückkommen, sobald die Lektionsansicht bereit ist."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "nombre de usuario"
+            "value" : "Puedes seguir explorando este curso y volver cuando el reproductor de lecciones esté listo."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "nom d’utilisateur"
+            "value" : "Tu peux continuer à explorer ce cours et revenir quand le lecteur de leçons sera prêt."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "nome de usuário"
+            "value" : "Você pode continuar explorando este curso e voltar quando a aula estiver pronta."
           }
         }
       }
     },
-    "Username" : {
-      "comment" : "Profile username field label",
+    "You're offline" : {
+      "comment" : "Title when catalog content cannot load because the device is offline.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Benutzername"
+            "value" : "Du bist offline"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nombre de usuario"
+            "value" : "No tienes conexión"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nom d’utilisateur"
+            "value" : "Tu es hors ligne"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nome de usuário"
-          }
-        }
-      }
-    },
-    "Verification code" : {
-      "comment" : "Account deletion verification code field label\nEmail sign-in code field label",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bestätigungscode"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Código de verificación"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Code de vérification"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Código de verificação"
-          }
-        }
-      }
-    },
-    "Verify and delete" : {
-      "comment" : "Verifies the email code and permanently deletes the account",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bestätigen und löschen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar y eliminar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vérifier et supprimer"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar e excluir"
-          }
-        }
-      }
-    },
-    "We sent a sign-in code to your email. It expires in 5 minutes." : {
-      "comment" : "Explains where the email code was sent and when it expires",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wir haben dir einen Anmeldecode per E-Mail gesendet. Er ist 5 Minuten lang gültig."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviamos un código de inicio de sesión a tu correo. Caduca en 5 minutos."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nous avons envoyé un code de connexion à ton adresse e-mail. Il expire dans 5 minutes."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enviamos um código de acesso para seu email. Ele expira em 5 minutos."
-          }
-        }
-      }
-    },
-    "you@example.com" : {
-      "comment" : "Example email address in the sign-in field",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "du@beispiel.de"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "tu@ejemplo.com"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "toi@exemple.fr"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "voce@exemplo.com"
-          }
-        }
-      }
-    },
-    "Your App Store purchases are now available on this Zoonk account." : {
-      "comment" : "Confirms restored purchases were synchronized with Zoonk",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deine Käufe im App Store sind jetzt für dieses Zoonk-Konto verfügbar."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus compras del App Store ya están disponibles en esta cuenta de Zoonk."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tes achats sur l’App Store sont maintenant disponibles sur ce compte Zoonk."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suas compras da App Store agora estão disponíveis nesta conta do Zoonk."
-          }
-        }
-      }
-    },
-    "Your name" : {
-      "comment" : "Placeholder for the profile name field",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dein Name"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu nombre"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ton nom"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seu nome"
-          }
-        }
-      }
-    },
-    "Your purchase is safe and hasn't been finished yet. Restore purchases when you're back online." : {
-      "comment" : "Explains that a transaction remains available after server synchronization fails",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dein Kauf geht nicht verloren und ist noch nicht abgeschlossen. Stelle deine Käufe wieder her, sobald du wieder online bist."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu compra está segura y todavía no se ha completado. Restaura las compras cuando vuelvas a tener conexión."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ton achat est bien enregistré, mais il n’est pas encore finalisé. Restaure tes achats quand tu seras de nouveau en ligne."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sua compra está segura e ainda não foi concluída. Restaure as compras quando estiver online novamente."
-          }
-        }
-      }
-    },
-    "Your purchase is safe. Sign in, then restore purchases to add Plus to your Zoonk account." : {
-      "comment" : "Explains how to recover a purchase after the Zoonk session expires",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dein Kauf geht nicht verloren. Melde dich an und stelle dann deine Käufe wieder her, um Plus für dein Zoonk-Konto zu aktivieren."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu compra está segura. Inicia sesión y restaura las compras para añadir Plus a tu cuenta de Zoonk."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ton achat est bien enregistré. Connecte-toi, puis restaure tes achats pour ajouter Plus à ton compte Zoonk."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sua compra está segura. Entre na sua conta e depois restaure as compras para ativar o Plus na sua conta do Zoonk."
-          }
-        }
-      }
-    },
-    "Your Zoonk account and personalized data were permanently deleted." : {
-      "comment" : "Confirms that account data was permanently deleted",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dein Zoonk-Konto und deine personalisierten Daten wurden dauerhaft gelöscht."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu cuenta de Zoonk y tus datos personalizados se eliminaron permanentemente."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ton compte Zoonk et tes données personnalisées ont été supprimés définitivement."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sua conta do Zoonk e seus dados personalizados foram excluídos permanentemente."
-          }
-        }
-      }
-    },
-    "Your Zoonk data was deleted, but Apple couldn't confirm that its authorization was removed. Remove Zoonk from Sign in with Apple to finish." : {
-      "comment" : "Explains that Zoonk deletion succeeded but Apple authorization needs manual removal",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deine Zoonk-Daten wurden gelöscht, aber Apple konnte nicht bestätigen, dass die Autorisierung entfernt wurde. Entferne Zoonk aus „Mit Apple anmelden“, um den Vorgang abzuschließen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tus datos de Zoonk se eliminaron, pero Apple no pudo confirmar que se retirara la autorización. Elimina Zoonk de Inicio de sesión con Apple para finalizar."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tes données Zoonk ont été supprimées, mais Apple n’a pas pu confirmer le retrait de l’autorisation. Retire Zoonk de Connexion avec Apple pour terminer."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seus dados do Zoonk foram excluídos, mas a Apple não conseguiu confirmar a remoção da autorização. Remova o Zoonk de Iniciar Sessão com a Apple para concluir."
-          }
-        }
-      }
-    },
-    "Zoonk checked your App Store purchases, but none currently provide Plus." : {
-      "comment" : "Explains that restored App Store purchases do not grant an active subscription",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk hat deine App-Store-Käufe geprüft, aber derzeit enthält keiner davon Plus."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk revisó tus compras en App Store, pero actualmente ninguna te da acceso a Plus."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk a vérifié tes achats sur l’App Store, mais aucun ne donne actuellement accès à Plus."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Zoonk verificou suas compras na App Store, mas nenhuma delas dá acesso ao Plus no momento."
-          }
-        }
-      }
-    },
-    "Zoonk couldn't connect. Check your connection and try again." : {
-      "comment" : "Error shown when an account request cannot reach the service",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk konnte keine Verbindung herstellen. Überprüfe deine Verbindung und versuche es erneut."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk no pudo conectarse. Revisa tu conexión e inténtalo de nuevo."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk n’a pas pu se connecter. Vérifie ta connexion et réessaie."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Zoonk não conseguiu se conectar. Confira sua conexão e tente de novo."
-          }
-        }
-      }
-    },
-    "Zoonk couldn't delete your account. Try again or contact hello@zoonk.com." : {
-      "comment" : "Generic account deletion failure message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk konnte dein Konto nicht löschen. Versuche es erneut oder kontaktiere hello@zoonk.com."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk no pudo eliminar tu cuenta. Inténtalo de nuevo o contacta con hello@zoonk.com."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk n’a pas pu supprimer ton compte. Réessaie ou contacte hello@zoonk.com."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Zoonk não conseguiu excluir sua conta. Tente novamente ou entre em contato pelo email hello@zoonk.com."
-          }
-        }
-      }
-    },
-    "Zoonk couldn't load your account. Your sign-in is still safely stored." : {
-      "comment" : "Explains that a temporary account load failure did not remove the session",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk konnte dein Konto nicht laden. Deine Anmeldung ist weiterhin sicher gespeichert."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk no pudo cargar tu cuenta. Tu inicio de sesión sigue guardado de forma segura."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk n’a pas pu charger ton compte. Ta connexion reste enregistrée en toute sécurité."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O Zoonk não conseguiu carregar sua conta. Seu acesso continua salvo com segurança."
-          }
-        }
-      }
-    },
-    "Zoonk couldn't sign you in. Try again or contact hello@zoonk.com." : {
-      "comment" : "Generic sign-in failure message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk konnte dich nicht anmelden. Versuche es erneut oder kontaktiere hello@zoonk.com."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk no pudo iniciar tu sesión. Inténtalo de nuevo o escribe a hello@zoonk.com."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk n’a pas pu te connecter. Réessaie ou contacte hello@zoonk.com."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível entrar no Zoonk. Tente de novo ou fale com hello@zoonk.com."
-          }
-        }
-      }
-    },
-    "Zoonk Plus" : {
-      "comment" : "Title of the native Zoonk Plus subscription screen",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk Plus"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk Plus"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk Plus"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zoonk Plus"
+            "value" : "Você está sem conexão"
           }
         }
       }

--- a/apps/apple/Zoonk/Resources/Localization/Feedback.xcstrings
+++ b/apps/apple/Zoonk/Resources/Localization/Feedback.xcstrings
@@ -1,0 +1,499 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Cancel" : {
+      "comment" : "Dismisses the feedback form without sending it.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        }
+      }
+    },
+    "Check your email and message, then try again." : {
+      "comment" : "Feedback form error when the submitted fields are invalid.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Überprüfe deine E-Mail-Adresse und deine Nachricht und versuche es dann erneut."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revisa tu correo electrónico y tu mensaje e inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifie ton adresse e-mail et ton message, puis réessaie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confira seu email e mensagem e tente de novo."
+          }
+        }
+      }
+    },
+    "Done" : {
+      "comment" : "Dismisses the feedback success confirmation.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminé"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
+    },
+    "Email address" : {
+      "comment" : "Email field label in the feedback form.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E-Mail-Adresse"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Correo electrónico"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Adresse e-mail"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Endereço de email"
+          }
+        }
+      }
+    },
+    "Feedback" : {
+      "comment" : "Navigation title for the feedback form.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feedback"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comentarios"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commentaires"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feedback"
+          }
+        }
+      }
+    },
+    "Feedback couldn't be sent. Try again later." : {
+      "comment" : "Feedback form error when the service is temporarily unavailable.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feedback konnte nicht gesendet werden. Versuche es später erneut."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No pudimos enviar tus comentarios. Inténtalo más tarde."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’envoyer ton message. Réessaie plus tard."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível enviar o feedback. Tente de novo mais tarde."
+          }
+        }
+      }
+    },
+    "How can we help?" : {
+      "comment" : "Placeholder in the feedback message field.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wie können wir dir helfen?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Cómo podemos ayudarte?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comment peut-on t’aider ?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Como a gente pode ajudar?"
+          }
+        }
+      }
+    },
+    "Message" : {
+      "comment" : "Message field label in the feedback form.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nachricht"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensaje"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Message"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensagem"
+          }
+        }
+      }
+    },
+    "Please provide as much detail as possible." : {
+      "comment" : "Guidance below the feedback message field.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bitte beschreibe dein Anliegen so genau wie möglich."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incluye todos los detalles que puedas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Donne-nous autant de détails que possible."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dê o máximo de detalhes possível."
+          }
+        }
+      }
+    },
+    "Send" : {
+      "comment" : "Submits the feedback form.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviar"
+          }
+        }
+      }
+    },
+    "Sending feedback" : {
+      "comment" : "Accessibility status while feedback is being sent.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feedback wird gesendet"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviando comentarios"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoi du message"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enviando feedback"
+          }
+        }
+      }
+    },
+    "Share feedback, ask a question, or tell us what we could improve." : {
+      "comment" : "Introduction shown above the feedback fields.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gib uns Feedback, stell eine Frage oder sag uns, was wir verbessern können."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comparte tus comentarios, haznos una pregunta o cuéntanos qué podríamos mejorar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Donne-nous ton avis, pose une question ou dis-nous ce que nous pourrions améliorer."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envie seu feedback, faça uma pergunta ou conte para a gente o que podemos melhorar."
+          }
+        }
+      }
+    },
+    "Thanks for your feedback" : {
+      "comment" : "Confirmation title after feedback is sent.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danke für dein Feedback"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gracias por tus comentarios"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Merci pour ton message"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agradecemos seu feedback"
+          }
+        }
+      }
+    },
+    "We'll use this email to contact you." : {
+      "comment" : "Explains why the feedback form asks for an email address.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wir verwenden diese E-Mail-Adresse, um dich zu kontaktieren."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usaremos este correo electrónico para contactarte."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nous utiliserons cette adresse e-mail pour te contacter."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A gente vai usar este email para falar com você."
+          }
+        }
+      }
+    },
+    "You're offline. Check your connection and try again." : {
+      "comment" : "Feedback form error when the network is unavailable.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du bist offline. Überprüfe deine Verbindung und versuche es erneut."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No tienes conexión. Comprueba tu conexión e inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu es hors ligne. Vérifie ta connexion et réessaie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Você está sem conexão. Confira sua internet e tente de novo."
+          }
+        }
+      }
+    },
+    "you@example.com" : {
+      "comment" : "Example email address in the feedback form.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "you@example.com"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "you@example.com"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "you@example.com"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "you@example.com"
+          }
+        }
+      }
+    },
+    "Your message was sent." : {
+      "comment" : "Confirmation message after feedback is sent.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Nachricht wurde gesendet."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu mensaje se ha enviado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ton message a été envoyé."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sua mensagem foi enviada."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/apps/apple/Zoonk/Resources/Localization/Navigation.xcstrings
+++ b/apps/apple/Zoonk/Resources/Localization/Navigation.xcstrings
@@ -2,7 +2,7 @@
   "sourceLanguage" : "en",
   "strings" : {
     "Courses" : {
-      "comment" : "Navigation title for the learner's courses.",
+      "comment" : "Navigation title for browsing the public course catalog.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -147,7 +147,7 @@
       }
     },
     "Search" : {
-      "comment" : "Navigation title for searching Zoonk.",
+      "comment" : "Opens search on a catalog detail screen.",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/apps/apple/Zoonk/Resources/Localization/Progress.xcstrings
+++ b/apps/apple/Zoonk/Resources/Localization/Progress.xcstrings
@@ -2137,7 +2137,7 @@
       }
     },
     "Level progress" : {
-      "comment" : "Title above progress toward the next level",
+      "comment" : "Accessibility label for progress within the maximum level\nAccessibility label for progress within the maximum level.\nTitle above progress toward the next level",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -2833,7 +2833,7 @@
       }
     },
     "Progress to the next level" : {
-      "comment" : "Accessibility label for level progress",
+      "comment" : "Accessibility label for progress toward the learner's next level\nAccessibility label for progress toward the learner's next level.",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/apps/apple/Zoonk/Testing/UITestConfiguration.swift
+++ b/apps/apple/Zoonk/Testing/UITestConfiguration.swift
@@ -3,6 +3,7 @@
 
   @MainActor
   struct UITestConfiguration {
+    let courseCatalog: CourseCatalogStore
     let initiallyPresentsAccount: Bool
     let progress: ProgressStore
     let session: SessionStore
@@ -18,6 +19,10 @@
         account: account(from: ProcessInfo.processInfo.environment))
 
       return UITestConfiguration(
+        courseCatalog: CourseCatalogStore(
+          api: courseCatalogAPI(from: ProcessInfo.processInfo.environment),
+          language: currentCourseCatalogLanguage(),
+          session: session),
         initiallyPresentsAccount: arguments.contains("--ui-testing-account-sheet"),
         progress: ProgressStore(
           api: progressAPI(from: ProcessInfo.processInfo.environment),
@@ -55,6 +60,324 @@
       } catch {
         preconditionFailure("ZOONK_UI_TEST_PROGRESS must contain a valid progress snapshot")
       }
+    }
+
+    private static func courseCatalogAPI(
+      from environment: [String: String]
+    ) -> any CourseCatalogAPIClient {
+      guard let catalogJSON = environment["ZOONK_UI_TEST_CATALOG"] else {
+        let clients = APIClientFactory.live(baseURL: AppConfiguration.current.apiBaseURL)
+        return CourseCatalogAPI(clients: clients)
+      }
+
+      do {
+        let snapshot = try JSONDecoder().decode(
+          UITestCourseCatalogSnapshot.self,
+          from: Data(catalogJSON.utf8))
+        return UITestCourseCatalogAPI(snapshot: snapshot)
+      } catch {
+        preconditionFailure("ZOONK_UI_TEST_CATALOG must contain a valid catalog snapshot")
+      }
+    }
+  }
+
+  private struct UITestCourseCatalogSnapshot: Decodable, Sendable {
+    let chapters: [CourseChapter]
+    let completedLessonIDs: Set<String>
+    let courses: [Course]
+    let lessons: [CourseLesson]
+  }
+
+  private actor UITestCourseCatalogAPI: CourseCatalogAPIClient {
+    let snapshot: UITestCourseCatalogSnapshot
+
+    init(snapshot: UITestCourseCatalogSnapshot) {
+      self.snapshot = snapshot
+    }
+
+    func listCourses(query: CourseCatalogQuery) async throws -> CourseCatalogPage {
+      let matchingCourses = snapshot.courses.filter { course in
+        course.language == query.language
+          && query.category.map(course.categories.contains) != false
+      }
+      let requestedStartIndex = query.cursor.flatMap(Int.init) ?? 0
+      let startIndex = min(max(requestedStartIndex, 0), matchingCourses.count)
+      let pageSize = max(query.limit ?? 20, 0)
+      let endIndex = min(startIndex + pageSize, matchingCourses.count)
+      let courses = matchingCourses[startIndex..<endIndex].map(makeCourseSummary)
+      let hasMore = endIndex < matchingCourses.count
+
+      return CourseCatalogPage(
+        courses: courses,
+        hasMore: hasMore,
+        nextCursor: hasMore ? String(endIndex) : nil)
+    }
+
+    func getCourse(id: String) async throws -> Course {
+      guard let course = snapshot.courses.first(where: { $0.id == id }) else {
+        throw CourseCatalogFailure.notFound
+      }
+
+      return course
+    }
+
+    func getChapter(id: String) async throws -> CourseChapter {
+      guard let chapter = snapshot.chapters.first(where: { $0.id == id }) else {
+        throw CourseCatalogFailure.notFound
+      }
+
+      return chapter
+    }
+
+    func listCourseChapters(courseID: String) async throws -> [CourseChapter] {
+      snapshot.chapters.filter { $0.courseID == courseID }
+    }
+
+    func listChapterLessons(chapterID: String) async throws -> [CourseLesson] {
+      snapshot.lessons.filter { $0.chapterID == chapterID }
+    }
+
+    func getCourseNextLesson(courseID: String, token: String?) async throws
+      -> CatalogContinuationTarget
+    {
+      guard
+        let course = snapshot.courses.first(where: { $0.id == courseID }),
+        let target = continuationTarget(
+          (lessons: lessons(inCourse: courseID), token: token)),
+        let chapter = snapshot.chapters.first(where: { $0.id == target.lesson.chapterID })
+      else {
+        return .empty(CatalogEmptyContinuation(completed: false, hasStarted: false))
+      }
+
+      return makeLessonContinuation(
+        (
+          completed: target.completed,
+          course: course,
+          chapter: chapter,
+          hasStarted: target.hasStarted,
+          lesson: target.lesson
+        ))
+    }
+
+    func getChapterNextLesson(chapterID: String, token: String?) async throws
+      -> CatalogContinuationTarget
+    {
+      guard
+        let chapter = snapshot.chapters.first(where: { $0.id == chapterID }),
+        let course = snapshot.courses.first(where: { $0.id == chapter.courseID }),
+        let target = continuationTarget(
+          (lessons: lessons(inChapter: chapterID), token: token))
+      else {
+        return .empty(CatalogEmptyContinuation(completed: false, hasStarted: false))
+      }
+
+      return makeLessonContinuation(
+        (
+          completed: target.completed,
+          course: course,
+          chapter: chapter,
+          hasStarted: target.hasStarted,
+          lesson: target.lesson
+        ))
+    }
+
+    func getCourseProgress(courseID: String, token: String?) async throws -> CourseProgress {
+      let completedLessonIDs = completedLessonIDs(token: token)
+      let courseLessons = lessons(inCourse: courseID)
+
+      return CourseProgress(
+        chapters: snapshot.chapters
+          .filter { $0.courseID == courseID }
+          .map {
+            makeCourseChapterProgress(
+              (chapter: $0, completedLessonIDs: completedLessonIDs))
+          },
+        percentComplete: completionPercent(
+          (
+            completed: courseLessons.count(where: { completedLessonIDs.contains($0.id) }),
+            total: courseLessons.count,
+            token: token
+          )))
+    }
+
+    func getChapterProgress(chapterID: String, token: String?) async throws -> ChapterProgress {
+      let completedLessonIDs = completedLessonIDs(token: token)
+      let chapterLessons = lessons(inChapter: chapterID)
+
+      return ChapterProgress(
+        lessons: chapterLessons.map {
+          ChapterLessonProgress(
+            isCompleted: completedLessonIDs.contains($0.id),
+            lessonID: $0.id)
+        },
+        percentComplete: completionPercent(
+          (
+            completed: chapterLessons.count(where: { completedLessonIDs.contains($0.id) }),
+            total: chapterLessons.count,
+            token: token
+          )))
+    }
+
+    func searchCatalog(query: CatalogSearchQuery) async throws -> CatalogSearchResults {
+      CatalogSearchResults(
+        chapters: snapshot.chapters
+          .filter {
+            matchesSearch(
+              (query: query.query, title: $0.title, description: $0.description))
+          }
+          .compactMap(makeChapterSearchResult),
+        courses: snapshot.courses
+          .filter {
+            matchesSearch(
+              (query: query.query, title: $0.title, description: $0.description))
+          }
+          .map(makeCourseSearchResult))
+    }
+
+    private func makeCourseSummary(_ course: Course) -> CourseSummary {
+      CourseSummary(
+        description: course.description,
+        id: course.id,
+        imageURL: course.imageURL,
+        language: course.language,
+        organization: course.organization,
+        slug: course.slug,
+        title: course.title)
+    }
+
+    private func completedLessonIDs(token: String?) -> Set<String> {
+      token == nil ? [] : snapshot.completedLessonIDs
+    }
+
+    private func lessons(inChapter chapterID: String) -> [CourseLesson] {
+      snapshot.lessons
+        .filter { $0.chapterID == chapterID }
+        .sorted(using: KeyPathComparator(\.position))
+    }
+
+    private func lessons(inCourse courseID: String) -> [CourseLesson] {
+      let chapterPositions = Dictionary(
+        uniqueKeysWithValues: snapshot.chapters.map { ($0.id, $0.position) })
+
+      return snapshot.lessons
+        .filter { $0.courseID == courseID }
+        .sorted { left, right in
+          courseLessonOrder((lesson: left, chapterPositions: chapterPositions))
+            < courseLessonOrder((lesson: right, chapterPositions: chapterPositions))
+        }
+    }
+
+    private func courseLessonOrder(
+      _ source: (lesson: CourseLesson, chapterPositions: [String: Int])
+    ) -> (Int, Int, String) {
+      (
+        source.chapterPositions[source.lesson.chapterID] ?? 0,
+        source.lesson.position,
+        source.lesson.id
+      )
+    }
+
+    private func continuationTarget(
+      _ source: (lessons: [CourseLesson], token: String?)
+    ) -> (completed: Bool, hasStarted: Bool, lesson: CourseLesson)? {
+      guard let firstLesson = source.lessons.first else {
+        return nil
+      }
+
+      let completedLessonIDs = completedLessonIDs(token: source.token)
+      let hasStarted = source.lessons.contains(where: { completedLessonIDs.contains($0.id) })
+
+      guard
+        let nextLesson = source.lessons.first(where: { !completedLessonIDs.contains($0.id) })
+      else {
+        return (completed: true, hasStarted: hasStarted, lesson: firstLesson)
+      }
+
+      return (completed: false, hasStarted: hasStarted, lesson: nextLesson)
+    }
+
+    private func completionPercent(
+      _ source: (completed: Int, total: Int, token: String?)
+    ) -> Int? {
+      guard source.token != nil, source.total > 0 else {
+        return nil
+      }
+
+      return source.completed * 100 / source.total
+    }
+
+    private func makeCourseChapterProgress(
+      _ source: (chapter: CourseChapter, completedLessonIDs: Set<String>)
+    ) -> CourseChapterProgress {
+      let chapterLessons = lessons(inChapter: source.chapter.id)
+      return CourseChapterProgress(
+        chapterID: source.chapter.id,
+        completedLessons: chapterLessons.count(where: {
+          source.completedLessonIDs.contains($0.id)
+        }),
+        totalLessons: chapterLessons.count)
+    }
+
+    private func makeLessonContinuation(
+      _ source: (
+        completed: Bool,
+        course: Course,
+        chapter: CourseChapter,
+        hasStarted: Bool,
+        lesson: CourseLesson
+      )
+    ) -> CatalogContinuationTarget {
+      .lesson(
+        CatalogLessonContinuation(
+          canPrefetch: true,
+          chapterID: source.chapter.id,
+          chapterSlug: source.chapter.slug,
+          completed: source.completed,
+          courseID: source.course.id,
+          courseSlug: source.course.slug,
+          hasStarted: source.hasStarted,
+          lessonID: source.lesson.id,
+          lessonPosition: source.lesson.position,
+          lessonSlug: source.lesson.slug,
+          organizationSlug: source.course.organization.slug))
+    }
+
+    private func matchesSearch(
+      _ source: (query: String, title: String, description: String?)
+    ) -> Bool {
+      source.title.localizedCaseInsensitiveContains(source.query)
+        || source.description?.localizedCaseInsensitiveContains(source.query) == true
+    }
+
+    private func makeCourseSearchResult(_ course: Course) -> CatalogCourseSearchResult {
+      CatalogCourseSearchResult(
+        description: course.description,
+        id: course.id,
+        imageURL: course.imageURL,
+        language: course.language,
+        organizationSlug: course.organization.slug,
+        slug: course.slug,
+        title: course.title)
+    }
+
+    private func makeChapterSearchResult(
+      _ chapter: CourseChapter
+    ) -> CatalogChapterSearchResult? {
+      guard let course = snapshot.courses.first(where: { $0.id == chapter.courseID }) else {
+        return nil
+      }
+
+      return CatalogChapterSearchResult(
+        courseID: course.id,
+        courseSlug: course.slug,
+        courseTitle: course.title,
+        description: chapter.description,
+        id: chapter.id,
+        imageURL: chapter.imageURL,
+        language: chapter.language,
+        organizationSlug: course.organization.slug,
+        slug: chapter.slug,
+        title: chapter.title)
     }
   }
 

--- a/apps/apple/ZoonkTests/CourseCatalogAPITests.swift
+++ b/apps/apple/ZoonkTests/CourseCatalogAPITests.swift
@@ -1,0 +1,531 @@
+import HTTPTypes
+import OpenAPIRuntime
+import XCTest
+
+@testable import Zoonk
+
+final class CourseCatalogAPITests: XCTestCase {
+  func testListCoursesUsesPublicCatalogQueryAndMapsPage() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "listCourses",
+        expectedPath: "/courses",
+        expectedQuery: [
+          "category": "science",
+          "cursor": "opaque-cursor",
+          "language": "en",
+          "limit": "24",
+        ],
+        responseBody:
+          #"""
+          {
+            "data": [
+              {
+                "description": "Understand the night sky.",
+                "id": "00000000-0000-7000-8000-000000000002",
+                "imageUrl": "https://cdn.zoonk.test/course.png",
+                "language": "en",
+                "organization": {
+                  "id": "00000000-0000-7000-8000-000000000001",
+                  "logo": "https://cdn.zoonk.test/organization.png",
+                  "name": "Zoonk",
+                  "slug": "zoonk"
+                },
+                "slug": "astronomy",
+                "title": "Astronomy"
+              }
+            ],
+            "pagination": { "hasMore": true, "nextCursor": "next-page" }
+          }
+          """#,
+        status: .ok))
+
+    let page = try await api.listCourses(
+      query: CourseCatalogQuery(
+        category: .science,
+        cursor: "opaque-cursor",
+        language: "en",
+        limit: 24))
+
+    XCTAssertEqual(page.courses, [.testFixture])
+    XCTAssertTrue(page.hasMore)
+    XCTAssertEqual(page.nextCursor, "next-page")
+  }
+
+  func testGetCourseMapsPublicCourseMetadata() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "getCourse",
+        expectedPath: "/courses/00000000-0000-7000-8000-000000000002",
+        expectedQuery: [:],
+        responseBody:
+          #"""
+          {
+            "categories": ["science"],
+            "coursePromptId": null,
+            "description": "Understand the night sky.",
+            "format": "core",
+            "generationId": null,
+            "generationStatus": "completed",
+            "id": "00000000-0000-7000-8000-000000000002",
+            "imageUrl": "https://cdn.zoonk.test/course.png",
+            "language": "en",
+            "organization": {
+              "id": "00000000-0000-7000-8000-000000000001",
+              "logo": "https://cdn.zoonk.test/organization.png",
+              "name": "Zoonk",
+              "slug": "zoonk"
+            },
+            "slug": "astronomy",
+            "targetLanguage": null,
+            "title": "Astronomy"
+          }
+          """#,
+        status: .ok))
+
+    let course = try await api.getCourse(id: Course.testFixture.id)
+
+    XCTAssertEqual(course, .testFixture)
+  }
+
+  func testGetChapterMapsCanonicalChapterMetadata() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "getChapter",
+        expectedPath: "/chapters/00000000-0000-7000-8000-000000000004",
+        expectedQuery: [:],
+        responseBody:
+          #"""
+          {
+            "courseId": "00000000-0000-7000-8000-000000000002",
+            "description": "Meet our cosmic neighborhood.",
+            "generationId": null,
+            "generationStatus": "completed",
+            "id": "00000000-0000-7000-8000-000000000004",
+            "imageUrl": null,
+            "language": "en",
+            "position": 0,
+            "slug": "solar-system",
+            "title": "The Solar System"
+          }
+          """#,
+        status: .ok))
+
+    let chapter = try await api.getChapter(id: CourseChapter.testFixture.id)
+
+    XCTAssertEqual(chapter, .resourceTestFixture)
+  }
+
+  func testListCourseChaptersMapsAuthoredOrderAndLessonCount() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "listCourseChapters",
+        expectedPath: "/courses/00000000-0000-7000-8000-000000000002/chapters",
+        expectedQuery: [:],
+        responseBody:
+          #"""
+          {
+            "data": [
+              {
+                "courseId": "00000000-0000-7000-8000-000000000002",
+                "description": "Meet our cosmic neighborhood.",
+                "generationId": null,
+                "generationStatus": "completed",
+                "id": "00000000-0000-7000-8000-000000000004",
+                "imageUrl": null,
+                "language": "en",
+                "lessonCount": 2,
+                "position": 0,
+                "slug": "solar-system",
+                "title": "The Solar System"
+              }
+            ]
+          }
+          """#,
+        status: .ok))
+
+    let chapters = try await api.listCourseChapters(courseID: Course.testFixture.id)
+
+    XCTAssertEqual(chapters, [.testFixture])
+  }
+
+  func testListChapterLessonsMapsLessonKind() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "listChapterLessons",
+        expectedPath: "/chapters/00000000-0000-7000-8000-000000000004/lessons",
+        expectedQuery: [:],
+        responseBody:
+          #"""
+          {
+            "data": [
+              {
+                "chapterId": "00000000-0000-7000-8000-000000000004",
+                "courseId": "00000000-0000-7000-8000-000000000002",
+                "description": "A first look at our star.",
+                "generationId": null,
+                "generationStatus": "completed",
+                "id": "00000000-0000-7000-8000-000000000005",
+                "imageUrl": null,
+                "kind": "explanation",
+                "language": "en",
+                "position": 0,
+                "slug": "the-sun",
+                "title": "The Sun"
+              }
+            ]
+          }
+          """#,
+        status: .ok))
+
+    let lessons = try await api.listChapterLessons(chapterID: CourseChapter.testFixture.id)
+
+    XCTAssertEqual(lessons, [.testFixture])
+  }
+
+  func testGetCourseNextLessonMapsConcreteLessonTarget() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "getCourseNextLesson",
+        expectedPath:
+          "/courses/00000000-0000-7000-8000-000000000002/next-lesson",
+        expectedQuery: [:],
+        expectedToken: "session-token",
+        responseBody:
+          #"""
+          {
+            "canPrefetch": true,
+            "chapterId": "00000000-0000-7000-8000-000000000004",
+            "chapterSlug": "solar-system",
+            "completed": false,
+            "courseId": "00000000-0000-7000-8000-000000000002",
+            "courseSlug": "astronomy",
+            "hasStarted": true,
+            "lessonId": "00000000-0000-7000-8000-000000000005",
+            "lessonPosition": 0,
+            "lessonSlug": "the-sun",
+            "organizationSlug": "zoonk",
+            "type": "lesson"
+          }
+          """#,
+        status: .ok))
+
+    let target = try await api.getCourseNextLesson(
+      courseID: Course.testFixture.id,
+      token: "session-token")
+
+    XCTAssertEqual(target, .testLessonFixture)
+  }
+
+  func testGetChapterNextLessonMapsEmptyTarget() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "getChapterNextLesson",
+        expectedPath:
+          "/chapters/00000000-0000-7000-8000-000000000004/next-lesson",
+        expectedQuery: [:],
+        expectedToken: "session-token",
+        responseBody:
+          #"""
+          { "completed": false, "hasStarted": false, "type": "empty" }
+          """#,
+        status: .ok))
+
+    let target = try await api.getChapterNextLesson(
+      chapterID: CourseChapter.testFixture.id,
+      token: "session-token")
+
+    XCTAssertEqual(
+      target,
+      .empty(CatalogEmptyContinuation(completed: false, hasStarted: false)))
+  }
+
+  func testGetCourseNextLessonMapsPendingChapterTargetWithoutAuthorization() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "getCourseNextLesson",
+        expectedPath:
+          "/courses/00000000-0000-7000-8000-000000000002/next-lesson",
+        expectedQuery: [:],
+        responseBody:
+          #"""
+          {
+            "canPrefetch": false,
+            "chapterId": "00000000-0000-7000-8000-000000000004",
+            "chapterSlug": "solar-system",
+            "completed": false,
+            "courseId": "00000000-0000-7000-8000-000000000002",
+            "courseSlug": "astronomy",
+            "hasStarted": false,
+            "organizationSlug": "zoonk",
+            "type": "chapter"
+          }
+          """#,
+        status: .ok))
+
+    let target = try await api.getCourseNextLesson(
+      courseID: Course.testFixture.id,
+      token: nil)
+
+    XCTAssertEqual(target, .testChapterFixture)
+  }
+
+  func testGetCourseProgressMapsChapterAndAggregateProgress() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "getCourseProgress",
+        expectedPath: "/courses/00000000-0000-7000-8000-000000000002/progress",
+        expectedQuery: [:],
+        expectedToken: "session-token",
+        responseBody:
+          #"""
+          {
+            "chapters": [
+              {
+                "chapterId": "00000000-0000-7000-8000-000000000004",
+                "completedLessons": 1,
+                "totalLessons": 2
+              }
+            ],
+            "percentComplete": 50
+          }
+          """#,
+        status: .ok))
+
+    let progress = try await api.getCourseProgress(
+      courseID: Course.testFixture.id,
+      token: "session-token")
+
+    XCTAssertEqual(progress, .testFixture)
+  }
+
+  func testGetChapterProgressMapsLessonAndAggregateProgress() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "getChapterProgress",
+        expectedPath: "/chapters/00000000-0000-7000-8000-000000000004/progress",
+        expectedQuery: [:],
+        expectedToken: "session-token",
+        responseBody:
+          #"""
+          {
+            "lessons": [
+              {
+                "isCompleted": true,
+                "lessonId": "00000000-0000-7000-8000-000000000005"
+              }
+            ],
+            "percentComplete": 50
+          }
+          """#,
+        status: .ok))
+
+    let progress = try await api.getChapterProgress(
+      chapterID: CourseChapter.testFixture.id,
+      token: "session-token")
+
+    XCTAssertEqual(progress, .testFixture)
+  }
+
+  func testSearchCatalogMapsCourseAndChapterResults() async throws {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "searchCatalog",
+        expectedPath: "/catalog/search",
+        expectedQuery: ["language": "en", "query": "stars"],
+        responseBody:
+          #"""
+          {
+            "chapters": [
+              {
+                "courseId": "00000000-0000-7000-8000-000000000002",
+                "courseSlug": "astronomy",
+                "courseTitle": "Astronomy",
+                "description": "Meet our cosmic neighborhood.",
+                "id": "00000000-0000-7000-8000-000000000004",
+                "imageUrl": "https://cdn.zoonk.test/chapter.png",
+                "language": "en",
+                "organizationSlug": "zoonk",
+                "slug": "solar-system",
+                "title": "The Solar System"
+              }
+            ],
+            "courses": [
+              {
+                "description": "Understand the night sky.",
+                "id": "00000000-0000-7000-8000-000000000002",
+                "imageUrl": "https://cdn.zoonk.test/course.png",
+                "language": "en",
+                "organizationSlug": "zoonk",
+                "slug": "astronomy",
+                "title": "Astronomy"
+              }
+            ]
+          }
+          """#,
+        status: .ok))
+
+    let results = try await api.searchCatalog(
+      query: CatalogSearchQuery(language: "en", query: "stars"))
+
+    XCTAssertEqual(results, .testFixture)
+  }
+
+  func testMissingCourseMapsToNotFound() async {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "getCourse",
+        expectedPath: "/courses/00000000-0000-7000-8000-000000000002",
+        expectedQuery: [:],
+        responseBody: errorResponseBody,
+        status: .notFound))
+
+    do {
+      _ = try await api.getCourse(id: Course.testFixture.id)
+      XCTFail("Expected not found")
+    } catch let error as CourseCatalogFailure {
+      XCTAssertEqual(error, .notFound)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testServerFailureMapsToUnavailable() async {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogResponseTransport(
+        expectedOperationID: "listCourses",
+        expectedPath: "/courses",
+        expectedQuery: ["language": "en"],
+        responseBody: errorResponseBody,
+        status: .internalServerError))
+
+    do {
+      _ = try await api.listCourses(query: CourseCatalogQuery(language: "en"))
+      XCTFail("Expected unavailable")
+    } catch let error as CourseCatalogFailure {
+      XCTAssertEqual(error, .unavailable)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testURLFailureMapsToNetwork() async {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogFailureTransport(failure: .network))
+
+    do {
+      _ = try await api.listCourses(query: CourseCatalogQuery(language: "en"))
+      XCTFail("Expected network failure")
+    } catch let error as CourseCatalogFailure {
+      XCTAssertEqual(error, .network)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testCancellationRemainsCancellation() async {
+    let api = makeCourseCatalogAPI(
+      transport: CourseCatalogFailureTransport(failure: .cancellation))
+
+    do {
+      _ = try await api.listCourses(query: CourseCatalogQuery(language: "en"))
+      XCTFail("Expected cancellation")
+    } catch is CancellationError {
+      return
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+}
+
+private let errorResponseBody =
+  #"{"error":{"code":"RESOURCE_NOT_FOUND","message":"Resource not found"}}"#
+
+private func makeCourseCatalogAPI(transport: any ClientTransport) -> CourseCatalogAPI {
+  CourseCatalogAPI(
+    clients: APIClientFactory(
+      baseURL: URL(string: "https://api.zoonk.test")!,
+      transport: transport))
+}
+
+/// Exercises the generated public catalog operations without depending on an external server.
+private struct CourseCatalogResponseTransport: ClientTransport {
+  let expectedOperationID: String
+  let expectedPath: String
+  let expectedQuery: [String: String]
+  let expectedToken: String?
+  let responseBody: String
+  let status: HTTPResponse.Status
+
+  init(
+    expectedOperationID: String,
+    expectedPath: String,
+    expectedQuery: [String: String],
+    expectedToken: String? = nil,
+    responseBody: String,
+    status: HTTPResponse.Status
+  ) {
+    self.expectedOperationID = expectedOperationID
+    self.expectedPath = expectedPath
+    self.expectedQuery = expectedQuery
+    self.expectedToken = expectedToken
+    self.responseBody = responseBody
+    self.status = status
+  }
+
+  func send(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    XCTAssertEqual(baseURL, URL(string: "https://api.zoonk.test/v1"))
+    XCTAssertEqual(operationID, expectedOperationID)
+    XCTAssertEqual(request.method, .get)
+    XCTAssertEqual(
+      request.headerFields[.authorization],
+      expectedToken.map { "Bearer \($0)" })
+    XCTAssertNotNil(request.headerFields[.acceptLanguage])
+
+    let components = try XCTUnwrap(
+      URLComponents(string: "https://api.zoonk.test\(request.path ?? "")"))
+    let query = Dictionary(
+      uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+        item.value.map { (item.name, $0) }
+      })
+
+    XCTAssertEqual(components.path, expectedPath)
+    XCTAssertEqual(query, expectedQuery)
+
+    var headerFields = HTTPFields()
+    headerFields[.contentType] = "application/json"
+
+    return (
+      HTTPResponse(status: status, headerFields: headerFields),
+      HTTPBody(responseBody)
+    )
+  }
+}
+
+private enum CourseCatalogTransportFailure: Sendable {
+  case cancellation
+  case network
+}
+
+private struct CourseCatalogFailureTransport: ClientTransport {
+  let failure: CourseCatalogTransportFailure
+
+  func send(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    switch failure {
+    case .cancellation:
+      throw CancellationError()
+    case .network:
+      throw URLError(.notConnectedToInternet)
+    }
+  }
+}

--- a/apps/apple/ZoonkTests/CourseCatalogLanguageTests.swift
+++ b/apps/apple/ZoonkTests/CourseCatalogLanguageTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+
+@testable import Zoonk
+
+final class CourseCatalogLanguageTests: XCTestCase {
+  func testRegionalLocalizationsUseTheirSupportedBaseLanguage() {
+    XCTAssertEqual(courseCatalogLanguage(preferredLocalizations: ["pt-BR"]), "pt")
+    XCTAssertEqual(courseCatalogLanguage(preferredLocalizations: ["de_DE"]), "de")
+    XCTAssertEqual(courseCatalogLanguage(preferredLocalizations: ["ES-mx"]), "es")
+  }
+
+  func testFirstSupportedLocalizationWins() {
+    XCTAssertEqual(
+      courseCatalogLanguage(preferredLocalizations: ["ja-JP", "fr-CA", "en-US"]),
+      "fr")
+  }
+
+  func testUnsupportedAndMissingLocalizationsFallBackToEnglish() {
+    XCTAssertEqual(courseCatalogLanguage(preferredLocalizations: ["ja-JP"]), "en")
+    XCTAssertEqual(courseCatalogLanguage(preferredLocalizations: []), "en")
+  }
+}

--- a/apps/apple/ZoonkTests/CourseCatalogModelsTests.swift
+++ b/apps/apple/ZoonkTests/CourseCatalogModelsTests.swift
@@ -1,0 +1,241 @@
+import XCTest
+
+@testable import Zoonk
+
+final class CourseCatalogModelsTests: XCTestCase {
+  func testCatalogDetailRoundTripsThroughCodable() throws {
+    let organization = CourseOrganization(
+      id: "00000000-0000-7000-8000-000000000001",
+      logoURL: URL(string: "https://cdn.zoonk.test/organization.png"),
+      name: "Zoonk",
+      slug: "zoonk")
+    let course = Course(
+      categories: [.science, .tech],
+      description: "Understand the night sky.",
+      id: "00000000-0000-7000-8000-000000000002",
+      imageURL: URL(string: "https://cdn.zoonk.test/course.png"),
+      language: "en",
+      organization: organization,
+      slug: "astronomy",
+      targetLanguage: nil,
+      title: "Astronomy")
+    let chapter = CourseChapter(
+      courseID: course.id,
+      description: "Meet our cosmic neighborhood.",
+      id: "00000000-0000-7000-8000-000000000003",
+      imageURL: nil,
+      language: "en",
+      lessonCount: 4,
+      position: 1,
+      slug: "solar-system",
+      title: "The Solar System")
+    let detail = CourseDetail(course: course, chapters: [chapter])
+
+    let encoded = try JSONEncoder().encode(detail)
+    let decoded = try JSONDecoder().decode(CourseDetail.self, from: encoded)
+
+    XCTAssertEqual(decoded, detail)
+  }
+
+  func testCatalogEnumsPreservePublicAPIRawValues() {
+    XCTAssertEqual(
+      CourseCategory.allCases.map(\.rawValue),
+      [
+        "arts", "business", "communication", "culture", "economics", "engineering",
+        "geography", "health", "history", "languages", "law", "math", "science", "society",
+        "tech",
+      ])
+    XCTAssertEqual(
+      LessonKind.allCases.map(\.rawValue),
+      [
+        "alphabet", "custom", "explanation", "grammar", "listening", "practice", "quiz",
+        "reading", "review", "translation", "tutorial", "vocabulary",
+      ])
+  }
+
+  func testCatalogPageCanLoadMoreOnlyWithAnOpaqueCursor() {
+    let course = CourseSummary.testFixture
+
+    XCTAssertTrue(
+      CourseCatalogPage(courses: [course], hasMore: true, nextCursor: "opaque-cursor")
+        .canLoadMore)
+    XCTAssertFalse(
+      CourseCatalogPage(courses: [course], hasMore: true, nextCursor: nil).canLoadMore)
+    XCTAssertFalse(
+      CourseCatalogPage(courses: [course], hasMore: false, nextCursor: "stale-cursor")
+        .canLoadMore)
+  }
+
+  func testCatalogSupplementalDetailsRoundTripThroughCodable() throws {
+    let courseDetail = CourseDetail(
+      continuation: .testLessonFixture,
+      course: .testFixture,
+      chapters: [.testFixture],
+      progress: .testFixture)
+    let chapterDetail = ChapterDetail(
+      chapter: .resourceTestFixture,
+      continuation: .testLessonFixture,
+      lessons: [.testFixture],
+      progress: .testFixture)
+
+    let courseData = try JSONEncoder().encode(courseDetail)
+    let chapterData = try JSONEncoder().encode(chapterDetail)
+
+    XCTAssertEqual(try JSONDecoder().decode(CourseDetail.self, from: courseData), courseDetail)
+    XCTAssertEqual(try JSONDecoder().decode(ChapterDetail.self, from: chapterData), chapterDetail)
+  }
+}
+
+extension CourseOrganization {
+  static let testFixture = CourseOrganization(
+    id: "00000000-0000-7000-8000-000000000001",
+    logoURL: URL(string: "https://cdn.zoonk.test/organization.png"),
+    name: "Zoonk",
+    slug: "zoonk")
+}
+
+extension CourseSummary {
+  static let testFixture = CourseSummary(
+    description: "Understand the night sky.",
+    id: "00000000-0000-7000-8000-000000000002",
+    imageURL: URL(string: "https://cdn.zoonk.test/course.png"),
+    language: "en",
+    organization: .testFixture,
+    slug: "astronomy",
+    title: "Astronomy")
+
+  static let secondTestFixture = CourseSummary(
+    description: "Learn how computers work.",
+    id: "00000000-0000-7000-8000-000000000003",
+    imageURL: nil,
+    language: "en",
+    organization: .testFixture,
+    slug: "computer-science",
+    title: "Computer Science")
+}
+
+extension Course {
+  static let testFixture = Course(
+    categories: [.science],
+    description: "Understand the night sky.",
+    id: CourseSummary.testFixture.id,
+    imageURL: CourseSummary.testFixture.imageURL,
+    language: "en",
+    organization: .testFixture,
+    slug: "astronomy",
+    targetLanguage: nil,
+    title: "Astronomy")
+}
+
+extension CourseChapter {
+  static let testFixture = CourseChapter(
+    courseID: Course.testFixture.id,
+    description: "Meet our cosmic neighborhood.",
+    id: "00000000-0000-7000-8000-000000000004",
+    imageURL: nil,
+    language: "en",
+    lessonCount: 2,
+    position: 0,
+    slug: "solar-system",
+    title: "The Solar System")
+
+  static let resourceTestFixture = CourseChapter(
+    courseID: Course.testFixture.id,
+    description: "Meet our cosmic neighborhood.",
+    id: "00000000-0000-7000-8000-000000000004",
+    imageURL: nil,
+    language: "en",
+    lessonCount: nil,
+    position: 0,
+    slug: "solar-system",
+    title: "The Solar System")
+}
+
+extension CourseLesson {
+  static let testFixture = CourseLesson(
+    chapterID: CourseChapter.testFixture.id,
+    courseID: Course.testFixture.id,
+    description: "A first look at our star.",
+    id: "00000000-0000-7000-8000-000000000005",
+    imageURL: nil,
+    kind: .explanation,
+    language: "en",
+    position: 0,
+    slug: "the-sun",
+    title: "The Sun")
+}
+
+extension CatalogContinuationTarget {
+  static let testChapterFixture = CatalogContinuationTarget.chapter(
+    CatalogChapterContinuation(
+      canPrefetch: false,
+      chapterID: CourseChapter.testFixture.id,
+      chapterSlug: CourseChapter.testFixture.slug,
+      completed: false,
+      courseID: Course.testFixture.id,
+      courseSlug: Course.testFixture.slug,
+      hasStarted: false,
+      organizationSlug: CourseOrganization.testFixture.slug))
+
+  static let testLessonFixture = CatalogContinuationTarget.lesson(
+    CatalogLessonContinuation(
+      canPrefetch: true,
+      chapterID: CourseChapter.testFixture.id,
+      chapterSlug: CourseChapter.testFixture.slug,
+      completed: false,
+      courseID: Course.testFixture.id,
+      courseSlug: Course.testFixture.slug,
+      hasStarted: true,
+      lessonID: CourseLesson.testFixture.id,
+      lessonPosition: CourseLesson.testFixture.position,
+      lessonSlug: CourseLesson.testFixture.slug,
+      organizationSlug: CourseOrganization.testFixture.slug))
+}
+
+extension CourseProgress {
+  static let testFixture = CourseProgress(
+    chapters: [
+      CourseChapterProgress(
+        chapterID: CourseChapter.testFixture.id,
+        completedLessons: 1,
+        totalLessons: 2)
+    ],
+    percentComplete: 50)
+}
+
+extension ChapterProgress {
+  static let testFixture = ChapterProgress(
+    lessons: [
+      ChapterLessonProgress(
+        isCompleted: true,
+        lessonID: CourseLesson.testFixture.id)
+    ],
+    percentComplete: 50)
+}
+
+extension CatalogSearchResults {
+  static let testFixture = CatalogSearchResults(
+    chapters: [
+      CatalogChapterSearchResult(
+        courseID: Course.testFixture.id,
+        courseSlug: Course.testFixture.slug,
+        courseTitle: Course.testFixture.title,
+        description: CourseChapter.testFixture.description,
+        id: CourseChapter.testFixture.id,
+        imageURL: URL(string: "https://cdn.zoonk.test/chapter.png"),
+        language: "en",
+        organizationSlug: CourseOrganization.testFixture.slug,
+        slug: CourseChapter.testFixture.slug,
+        title: CourseChapter.testFixture.title)
+    ],
+    courses: [
+      CatalogCourseSearchResult(
+        description: Course.testFixture.description,
+        id: Course.testFixture.id,
+        imageURL: Course.testFixture.imageURL,
+        language: Course.testFixture.language,
+        organizationSlug: CourseOrganization.testFixture.slug,
+        slug: Course.testFixture.slug,
+        title: Course.testFixture.title)
+    ])
+}

--- a/apps/apple/ZoonkTests/CourseCatalogProgressPresentationTests.swift
+++ b/apps/apple/ZoonkTests/CourseCatalogProgressPresentationTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+
+@testable import Zoonk
+
+final class CourseCatalogProgressPresentationTests: XCTestCase {
+  func testPrimaryActionMatchesMainContinuationStates() {
+    XCTAssertEqual(catalogPrimaryAction(for: nil), .start)
+    XCTAssertEqual(
+      catalogPrimaryAction(
+        for: .empty(CatalogEmptyContinuation(completed: false, hasStarted: false))),
+      .start)
+    XCTAssertEqual(
+      catalogPrimaryAction(for: continuation(hasStarted: true, completed: false)),
+      .continueLearning)
+    XCTAssertEqual(
+      catalogPrimaryAction(for: continuation(hasStarted: true, completed: true)),
+      .review)
+  }
+
+  func testChapterProgressUsesNotStartedPartialAndCompletedStates() {
+    let chapter = CourseChapter.testFixture
+
+    XCTAssertNil(catalogChapterProgress(chapter: chapter, progress: nil))
+    XCTAssertEqual(
+      catalogChapterProgress(
+        chapter: chapter,
+        progress: CourseProgress(chapters: [], percentComplete: 0)),
+      .notStarted)
+    XCTAssertEqual(
+      catalogChapterProgress(
+        chapter: chapter,
+        progress: CourseProgress(
+          chapters: [
+            CourseChapterProgress(
+              chapterID: chapter.id,
+              completedLessons: 1,
+              totalLessons: 2)
+          ],
+          percentComplete: 50)),
+      .inProgress(completed: 1, total: 2))
+    XCTAssertEqual(
+      catalogChapterProgress(
+        chapter: chapter,
+        progress: CourseProgress(
+          chapters: [
+            CourseChapterProgress(
+              chapterID: chapter.id,
+              completedLessons: 2,
+              totalLessons: 2)
+          ],
+          percentComplete: 100)),
+      .completed)
+  }
+
+  func testLessonProgressUsesCompletionByLessonID() {
+    let lesson = CourseLesson.testFixture
+
+    XCTAssertNil(catalogLessonProgress(lesson: lesson, progress: nil))
+    XCTAssertEqual(
+      catalogLessonProgress(
+        lesson: lesson,
+        progress: ChapterProgress(lessons: [], percentComplete: 0)),
+      .notStarted)
+    XCTAssertEqual(
+      catalogLessonProgress(
+        lesson: lesson,
+        progress: ChapterProgress(
+          lessons: [ChapterLessonProgress(isCompleted: true, lessonID: lesson.id)],
+          percentComplete: 100)),
+      .completed)
+  }
+
+  func testCourseContinuationFallsBackToFirstChapterWithoutSupplementalData() {
+    let detail = CourseDetail(course: .testFixture, chapters: [.testFixture])
+    let expectedDestination = CourseDestination.chapter(
+      ChapterReference((course: .testFixture, chapter: .testFixture)))
+
+    XCTAssertEqual(courseContinuationDestination(detail), expectedDestination)
+    XCTAssertEqual(
+      courseContinuationDestination(
+        CourseDetail(
+          continuation: .empty(
+            CatalogEmptyContinuation(completed: false, hasStarted: false)),
+          course: .testFixture,
+          chapters: [.testFixture])),
+      expectedDestination)
+  }
+
+  func testChapterContinuationFallsBackToFirstLessonWithoutSupplementalData() {
+    let chapter = ChapterReference((course: .testFixture, chapter: .testFixture))
+    let detail = ChapterDetail(lessons: [.testFixture])
+
+    XCTAssertEqual(
+      chapterContinuationDestination(chapter: chapter, detail: detail),
+      .lesson(LessonReference((chapter: chapter, lesson: .testFixture))))
+  }
+
+  private func continuation(
+    hasStarted: Bool,
+    completed: Bool
+  ) -> CatalogContinuationTarget {
+    .lesson(
+      CatalogLessonContinuation(
+        canPrefetch: true,
+        chapterID: CourseChapter.testFixture.id,
+        chapterSlug: CourseChapter.testFixture.slug,
+        completed: completed,
+        courseID: Course.testFixture.id,
+        courseSlug: Course.testFixture.slug,
+        hasStarted: hasStarted,
+        lessonID: CourseLesson.testFixture.id,
+        lessonPosition: CourseLesson.testFixture.position,
+        lessonSlug: CourseLesson.testFixture.slug,
+        organizationSlug: CourseOrganization.testFixture.slug))
+  }
+}

--- a/apps/apple/ZoonkTests/CourseCatalogSearchTests.swift
+++ b/apps/apple/ZoonkTests/CourseCatalogSearchTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import XCTest
+
+@testable import Zoonk
+
+final class CourseCatalogSearchTests: XCTestCase {
+  func testChapterSearchIgnoresCaseAndDiacriticsWhilePreservingCourseOrder() {
+    let chapters = [
+      makeChapter(id: "third", description: "Advanced work", position: 2, title: "Canopy"),
+      makeChapter(id: "first", description: "Meet the café garden", position: 0, title: "Roots"),
+      makeChapter(id: "second", description: "Water and light", position: 1, title: "Leaves"),
+    ]
+
+    let matches = filterCourseChapters(
+      CatalogSearchRequest(items: chapters, query: "CAFE", locale: Locale(identifier: "en_US")))
+
+    XCTAssertEqual(matches.map(\.id), ["first"])
+  }
+
+  func testBlankChapterSearchReturnsTheCurriculumInPositionOrder() {
+    let chapters = [
+      makeChapter(id: "second", description: "", position: 1, title: "Leaves"),
+      makeChapter(id: "first", description: "", position: 0, title: "Roots"),
+    ]
+
+    let matches = filterCourseChapters(
+      CatalogSearchRequest(items: chapters, query: "  \n", locale: Locale(identifier: "en_US")))
+
+    XCTAssertEqual(matches.map(\.id), ["first", "second"])
+  }
+
+  func testLessonSearchMatchesStoredDescriptionsAndPreservesLessonOrder() {
+    let lessons = [
+      makeLesson(id: "second", description: "Practice conversation", position: 1),
+      makeLesson(id: "first", description: "Listen at a café", position: 0),
+    ]
+
+    let matches = filterCourseLessons(
+      CatalogSearchRequest(items: lessons, query: "cafe", locale: Locale(identifier: "en_US")))
+
+    XCTAssertEqual(matches.map(\.id), ["first"])
+  }
+
+  func testBlankLessonContentUsesSearchableLocalizedKindFallbacks() {
+    let lesson = CourseLesson(
+      chapterID: "chapter",
+      courseID: "course",
+      description: " \n",
+      id: "listening",
+      imageURL: nil,
+      kind: .listening,
+      language: "en",
+      position: 0,
+      slug: "listening",
+      title: " ")
+    let fallbackTitle = String(localized: LessonKind.listening.localizedTitle)
+    let fallbackDescription = String(localized: LessonKind.listening.localizedDescription)
+
+    XCTAssertEqual(lesson.displayTitle(), fallbackTitle)
+    XCTAssertEqual(lesson.displayDescription(), fallbackDescription)
+
+    let matches = filterCourseLessons(
+      CatalogSearchRequest(
+        items: [lesson],
+        query: fallbackTitle,
+        locale: Locale(identifier: "en_US")))
+
+    XCTAssertEqual(matches.map(\.id), [lesson.id])
+  }
+
+  private func makeChapter(
+    id: String,
+    description: String,
+    position: Int,
+    title: String
+  ) -> CourseChapter {
+    CourseChapter(
+      courseID: "course",
+      description: description,
+      id: id,
+      imageURL: nil,
+      language: "en",
+      lessonCount: 2,
+      position: position,
+      slug: id,
+      title: title)
+  }
+
+  private func makeLesson(
+    id: String,
+    description: String,
+    position: Int
+  ) -> CourseLesson {
+    CourseLesson(
+      chapterID: "chapter",
+      courseID: "course",
+      description: description,
+      id: id,
+      imageURL: nil,
+      kind: .listening,
+      language: "en",
+      position: position,
+      slug: id,
+      title: nil)
+  }
+}

--- a/apps/apple/ZoonkTests/CourseCatalogStoreTests.swift
+++ b/apps/apple/ZoonkTests/CourseCatalogStoreTests.swift
@@ -1,0 +1,1057 @@
+import XCTest
+
+@testable import Zoonk
+
+extension CourseCatalogStore {
+  fileprivate convenience init(api: any CourseCatalogAPIClient, language: String) {
+    self.init(api: api, language: language, session: .preview())
+  }
+}
+
+@MainActor
+final class CourseCatalogStoreTests: XCTestCase {
+  func testStoreStartsIdle() {
+    let store = CourseCatalogStore(api: CourseCatalogAPIStub(), language: "en")
+
+    XCTAssertEqual(store.coursesState, .idle)
+    XCTAssertEqual(store.courseState(for: Course.testFixture.id), .idle)
+    XCTAssertEqual(store.chapterState(for: CourseChapter.testFixture.id), .idle)
+    XCTAssertFalse(store.isLoadingMore)
+    XCTAssertNil(store.loadMoreFailure)
+  }
+
+  func testInitialCourseLoadPublishesCatalogPageAndQuery() async {
+    let page = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: true,
+      nextCursor: "next-page")
+    let api = CourseCatalogAPIStub(coursePageResults: [.success(page)])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: .science)
+
+    XCTAssertEqual(store.coursesState, .loaded(page))
+    let queries = await api.courseQueries
+    XCTAssertEqual(
+      queries,
+      [CourseCatalogQuery(category: .science, language: "en")])
+  }
+
+  func testEmptyCourseLoadPublishesEmptyState() async {
+    let api = CourseCatalogAPIStub(
+      coursePageResults: [
+        .success(CourseCatalogPage(courses: [], hasMore: false, nextCursor: nil))
+      ])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: nil)
+
+    XCTAssertEqual(store.coursesState, .empty)
+  }
+
+  func testCourseLoadPublishesUsefulFailures() async {
+    let networkStore = CourseCatalogStore(
+      api: CourseCatalogAPIStub(coursePageResults: [.failure(CourseCatalogFailure.network)]),
+      language: "en")
+    let unavailableStore = CourseCatalogStore(
+      api: CourseCatalogAPIStub(coursePageResults: [.failure(CourseCatalogFailure.unavailable)]),
+      language: "en")
+
+    await networkStore.loadCourses(category: nil)
+    await unavailableStore.loadCourses(category: nil)
+
+    XCTAssertEqual(networkStore.coursesState, .failed(.network))
+    XCTAssertEqual(unavailableStore.coursesState, .failed(.unavailable))
+  }
+
+  func testChangingCategoryReplacesTheVisibleCatalog() async {
+    let sciencePage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let technologyPage = CourseCatalogPage(
+      courses: [.secondTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let api = CourseCatalogAPIStub(
+      coursePageResults: [.success(sciencePage), .success(technologyPage)])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: .science)
+    await store.loadCourses(category: .tech)
+
+    XCTAssertEqual(store.coursesState, .loaded(technologyPage))
+    let queries = await api.courseQueries
+    XCTAssertEqual(queries.map(\.category), [.science, .tech])
+  }
+
+  func testLoadMoreMergesUniqueStableCourseIDs() async {
+    let firstPage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: true,
+      nextCursor: "page-two")
+    let secondPage = CourseCatalogPage(
+      courses: [.testFixture, .secondTestFixture, .secondTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let api = CourseCatalogAPIStub(
+      coursePageResults: [.success(firstPage), .success(secondPage)])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: .science)
+    await store.loadMoreCourses(category: .science)
+
+    XCTAssertEqual(
+      store.coursesState,
+      .loaded(
+        CourseCatalogPage(
+          courses: [.testFixture, .secondTestFixture],
+          hasMore: false,
+          nextCursor: nil)))
+    XCTAssertFalse(store.isLoadingMore)
+    XCTAssertNil(store.loadMoreFailure)
+
+    let queries = await api.courseQueries
+    XCTAssertEqual(queries.last?.cursor, "page-two")
+  }
+
+  func testLoadMoreFailurePreservesLoadedCourses() async {
+    let firstPage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: true,
+      nextCursor: "page-two")
+    let api = CourseCatalogAPIStub(
+      coursePageResults: [
+        .success(firstPage),
+        .failure(CourseCatalogFailure.network),
+      ])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: nil)
+    await store.loadMoreCourses(category: nil)
+
+    XCTAssertEqual(store.coursesState, .loaded(firstPage))
+    XCTAssertEqual(store.loadMoreFailure, .network)
+    XCTAssertFalse(store.isLoadingMore)
+  }
+
+  func testCancelledLoadMorePreservesLoadedCoursesWithoutFailure() async {
+    let firstPage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: true,
+      nextCursor: "page-two")
+    let api = CourseCatalogAPIStub(
+      coursePageResults: [
+        .success(firstPage),
+        .failure(CancellationError()),
+      ])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: nil)
+    await store.loadMoreCourses(category: nil)
+
+    XCTAssertEqual(store.coursesState, .loaded(firstPage))
+    XCTAssertNil(store.loadMoreFailure)
+    XCTAssertFalse(store.isLoadingMore)
+  }
+
+  func testCancelledLoadDoesNotPublishFailure() async {
+    let api = CourseCatalogAPIStub(
+      coursePageResults: [.failure(CancellationError())])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: nil)
+
+    XCTAssertEqual(store.coursesState, .idle)
+  }
+
+  func testCancelledRefreshPreservesLoadedCourses() async {
+    let page = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let api = CourseCatalogAPIStub(
+      coursePageResults: [
+        .success(page),
+        .failure(CancellationError()),
+      ])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: nil)
+    await store.loadCourses(category: nil, force: true)
+
+    XCTAssertEqual(store.coursesState, .loaded(page))
+  }
+
+  func testFailedRefreshPreservesLoadedCourses() async {
+    let page = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let api = CourseCatalogAPIStub(
+      coursePageResults: [
+        .success(page),
+        .failure(CourseCatalogFailure.network),
+      ])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: nil)
+    await store.loadCourses(category: nil, force: true)
+
+    XCTAssertEqual(store.coursesState, .loaded(page))
+  }
+
+  func testLoadedCoursesRemainVisibleWhileRefreshing() async {
+    let firstRequestStarted = expectation(description: "Initial catalog request started")
+    let refreshStarted = expectation(description: "Catalog refresh started")
+    let api = SuspendedCourseCatalogAPI { requestCount in
+      if requestCount == 1 {
+        firstRequestStarted.fulfill()
+      } else if requestCount == 2 {
+        refreshStarted.fulfill()
+      }
+    }
+    let store = CourseCatalogStore(api: api, language: "en")
+    let initialPage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let refreshedPage = CourseCatalogPage(
+      courses: [.secondTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+
+    let initialRequest = Task { await store.loadCourses(category: .science) }
+    await fulfillment(of: [firstRequestStarted], timeout: 1)
+    await api.resolveCourseRequest(at: 0, with: initialPage)
+    await initialRequest.value
+
+    let refreshRequest = Task { await store.loadCourses(category: .science, force: true) }
+    await fulfillment(of: [refreshStarted], timeout: 1)
+
+    XCTAssertEqual(store.coursesState, .loaded(initialPage))
+
+    await api.resolveCourseRequest(at: 1, with: refreshedPage)
+    await refreshRequest.value
+    XCTAssertEqual(store.coursesState, .loaded(refreshedPage))
+  }
+
+  func testOrdinaryLoadDeduplicatesAnInFlightRefresh() async {
+    let initialRequestStarted = expectation(description: "Initial catalog request started")
+    let refreshStarted = expectation(description: "Catalog refresh started")
+    let api = SuspendedCourseCatalogAPI { requestCount in
+      if requestCount == 1 {
+        initialRequestStarted.fulfill()
+      } else if requestCount == 2 {
+        refreshStarted.fulfill()
+      }
+    }
+    let store = CourseCatalogStore(api: api, language: "en")
+    let initialPage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let refreshedPage = CourseCatalogPage(
+      courses: [.secondTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+
+    let initialRequest = Task { await store.loadCourses(category: nil) }
+    await fulfillment(of: [initialRequestStarted], timeout: 1)
+    await api.resolveCourseRequest(at: 0, with: initialPage)
+    await initialRequest.value
+
+    let refreshRequest = Task { await store.loadCourses(category: nil, force: true) }
+    await fulfillment(of: [refreshStarted], timeout: 1)
+    let duplicateRequest = Task { await store.loadCourses(category: nil) }
+    for _ in 0..<10 {
+      await Task.yield()
+    }
+
+    let requestCount = await api.courseRequestCount
+    XCTAssertEqual(requestCount, 2)
+    if requestCount == 3 {
+      await api.resolveCourseRequest(at: 2, with: refreshedPage)
+    }
+
+    await api.resolveCourseRequest(at: 1, with: refreshedPage)
+    await duplicateRequest.value
+    await refreshRequest.value
+
+    XCTAssertEqual(store.coursesState, .loaded(refreshedPage))
+  }
+
+  func testLateCatalogResponseCannotOverwriteANewerCategory() async {
+    let scienceStarted = expectation(description: "Science catalog request started")
+    let technologyStarted = expectation(description: "Technology catalog request started")
+    let api = SuspendedCourseCatalogAPI { requestCount in
+      if requestCount == 1 {
+        scienceStarted.fulfill()
+      } else if requestCount == 2 {
+        technologyStarted.fulfill()
+      }
+    }
+    let store = CourseCatalogStore(api: api, language: "en")
+    let sciencePage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let technologyPage = CourseCatalogPage(
+      courses: [.secondTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+
+    let scienceRequest = Task { await store.loadCourses(category: .science) }
+    await fulfillment(of: [scienceStarted], timeout: 1)
+
+    let technologyRequest = Task { await store.loadCourses(category: .tech) }
+    await fulfillment(of: [technologyStarted], timeout: 1)
+
+    await api.resolveCourseRequest(at: 1, with: technologyPage)
+    await technologyRequest.value
+    await api.resolveCourseRequest(at: 0, with: sciencePage)
+    await scienceRequest.value
+
+    XCTAssertEqual(store.coursesState, .loaded(technologyPage))
+  }
+
+  func testReenteringCatalogSupersedesACancellationDelayedRequest() async {
+    let firstRequestStarted = expectation(description: "Initial catalog request started")
+    let replacementRequestStarted = expectation(description: "Replacement catalog request started")
+    let api = SuspendedCourseCatalogAPI { requestCount in
+      if requestCount == 1 {
+        firstRequestStarted.fulfill()
+      } else if requestCount == 2 {
+        replacementRequestStarted.fulfill()
+      }
+    }
+    let store = CourseCatalogStore(api: api, language: "en")
+    let page = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: false,
+      nextCursor: nil)
+
+    let initialRequest = Task { await store.loadCourses(category: .science) }
+    await fulfillment(of: [firstRequestStarted], timeout: 1)
+    initialRequest.cancel()
+
+    let replacementRequest = Task {
+      await store.loadCourses(category: .science, force: true)
+    }
+    await fulfillment(of: [replacementRequestStarted], timeout: 1)
+
+    guard await api.courseRequestCount == 2 else {
+      await api.failCourseRequest(at: 0, with: CancellationError())
+      await initialRequest.value
+      await replacementRequest.value
+      return
+    }
+
+    await api.failCourseRequest(at: 0, with: CancellationError())
+    await initialRequest.value
+    await api.resolveCourseRequest(at: 1, with: page)
+    await replacementRequest.value
+
+    XCTAssertEqual(store.coursesState, .loaded(page))
+  }
+
+  func testReappearingPaginationTriggerSupersedesACancellationDelayedRequest() async {
+    let initialRequestStarted = expectation(description: "Initial catalog request started")
+    let firstPageRequestStarted = expectation(description: "First pagination request started")
+    let replacementPageRequestStarted = expectation(
+      description: "Replacement pagination request started")
+    let api = SuspendedCourseCatalogAPI { requestCount in
+      if requestCount == 1 {
+        initialRequestStarted.fulfill()
+      } else if requestCount == 2 {
+        firstPageRequestStarted.fulfill()
+      } else if requestCount == 3 {
+        replacementPageRequestStarted.fulfill()
+      }
+    }
+    let store = CourseCatalogStore(api: api, language: "en")
+    let firstPage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: true,
+      nextCursor: "next-page")
+    let finalPage = CourseCatalogPage(
+      courses: [.secondTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+
+    let initialRequest = Task { await store.loadCourses(category: nil) }
+    await fulfillment(of: [initialRequestStarted], timeout: 1)
+    await api.resolveCourseRequest(at: 0, with: firstPage)
+    await initialRequest.value
+
+    let firstPageRequest = Task { await store.loadMoreCourses(category: nil) }
+    await fulfillment(of: [firstPageRequestStarted], timeout: 1)
+    firstPageRequest.cancel()
+
+    let replacementPageRequest = Task {
+      await store.loadMoreCourses(category: nil, force: true)
+    }
+    await fulfillment(of: [replacementPageRequestStarted], timeout: 1)
+
+    guard await api.courseRequestCount == 3 else {
+      await api.failCourseRequest(at: 1, with: CancellationError())
+      await firstPageRequest.value
+      await replacementPageRequest.value
+      return
+    }
+
+    await api.failCourseRequest(at: 1, with: CancellationError())
+    await firstPageRequest.value
+    await api.resolveCourseRequest(at: 2, with: finalPage)
+    await replacementPageRequest.value
+
+    XCTAssertEqual(
+      store.coursesState,
+      .loaded(
+        CourseCatalogPage(
+          courses: [.testFixture, .secondTestFixture],
+          hasMore: false,
+          nextCursor: nil)))
+  }
+
+  func testPaginationWaitsForAFirstPageRefreshBeforeMerging() async {
+    let initialRequestStarted = expectation(description: "Initial catalog request started")
+    let refreshStarted = expectation(description: "Catalog refresh started")
+    let paginationStarted = expectation(description: "Pagination request started")
+    let api = SuspendedCourseCatalogAPI { requestCount in
+      if requestCount == 1 {
+        initialRequestStarted.fulfill()
+      } else if requestCount == 2 {
+        refreshStarted.fulfill()
+      } else if requestCount == 3 {
+        paginationStarted.fulfill()
+      }
+    }
+    let store = CourseCatalogStore(api: api, language: "en")
+    let initialPage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: true,
+      nextCursor: "next-page")
+    let refreshedPage = CourseCatalogPage(
+      courses: [.secondTestFixture],
+      hasMore: true,
+      nextCursor: "next-page")
+    let finalPage = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: false,
+      nextCursor: nil)
+
+    let initialRequest = Task { await store.loadCourses(category: nil) }
+    await fulfillment(of: [initialRequestStarted], timeout: 1)
+    await api.resolveCourseRequest(at: 0, with: initialPage)
+    await initialRequest.value
+
+    let refreshRequest = Task { await store.loadCourses(category: nil, force: true) }
+    await fulfillment(of: [refreshStarted], timeout: 1)
+
+    let paginationDuringRefresh = Task {
+      await store.loadMoreCourses(category: nil, force: true)
+    }
+    for _ in 0..<10 {
+      await Task.yield()
+    }
+    let requestCountDuringRefresh = await api.courseRequestCount
+    XCTAssertEqual(
+      requestCountDuringRefresh,
+      2,
+      "Expected pagination to wait until the first-page refresh completes")
+
+    await api.resolveCourseRequest(at: 1, with: refreshedPage)
+    await refreshRequest.value
+
+    let paginationAfterRefresh: Task<Void, Never>?
+    if requestCountDuringRefresh == 2 {
+      paginationAfterRefresh = Task {
+        await store.loadMoreCourses(category: nil, force: true)
+      }
+    } else {
+      paginationAfterRefresh = nil
+    }
+
+    await fulfillment(of: [paginationStarted], timeout: 1)
+    await api.resolveCourseRequest(at: 2, with: finalPage)
+    await paginationDuringRefresh.value
+    await paginationAfterRefresh?.value
+
+    XCTAssertEqual(
+      store.coursesState,
+      .loaded(
+        CourseCatalogPage(
+          courses: [.secondTestFixture, .testFixture],
+          hasMore: false,
+          nextCursor: nil)))
+  }
+
+  func testCourseDetailLoadsCourseAndChaptersConcurrently() async {
+    let courseStarted = expectation(description: "Course request started")
+    let chaptersStarted = expectation(description: "Chapters request started")
+    let api = SuspendedCourseDetailAPI(
+      chaptersDidStart: { chaptersStarted.fulfill() },
+      courseDidStart: { courseStarted.fulfill() })
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    let request = Task { await store.loadCourse(id: Course.testFixture.id) }
+    await fulfillment(of: [courseStarted, chaptersStarted], timeout: 1)
+    await api.resolveCourse(with: .testFixture)
+    await api.resolveChapters(with: [.testFixture])
+    await request.value
+
+    XCTAssertEqual(
+      store.courseState(for: Course.testFixture.id),
+      .loaded(CourseDetail(course: .testFixture, chapters: [.testFixture])))
+  }
+
+  func testCourseDetailLoadsContinuationAndProgressWithTheCurrentSession() async {
+    let session = SessionStore.preview(account: makeCourseCatalogTestAccount())
+    let api = CourseCatalogAPIStub(
+      chapterResults: [.success([.testFixture])],
+      courseContinuationResults: [.success(.testLessonFixture)],
+      courseProgressResults: [.success(.testFixture)],
+      courseResults: [.success(.testFixture)])
+    let store = CourseCatalogStore(api: api, language: "en", session: session)
+
+    await store.loadCourse(id: Course.testFixture.id)
+
+    XCTAssertEqual(
+      store.courseState(for: Course.testFixture.id),
+      .loaded(
+        CourseDetail(
+          continuation: .testLessonFixture,
+          course: .testFixture,
+          chapters: [.testFixture],
+          progress: .testFixture)))
+    let continuationTokens = await api.courseContinuationTokens
+    let progressTokens = await api.courseProgressTokens
+    XCTAssertEqual(continuationTokens, ["preview-session"])
+    XCTAssertEqual(progressTokens, ["preview-session"])
+  }
+
+  func testSupplementalCourseFailureDoesNotHideBaseCatalogContent() async {
+    let api = CourseCatalogAPIStub(
+      chapterResults: [.success([.testFixture])],
+      courseContinuationResults: [.failure(CourseCatalogFailure.network)],
+      courseProgressResults: [.failure(CourseCatalogFailure.unavailable)],
+      courseResults: [.success(.testFixture)])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourse(id: Course.testFixture.id)
+
+    XCTAssertEqual(
+      store.courseState(for: Course.testFixture.id),
+      .loaded(CourseDetail(course: .testFixture, chapters: [.testFixture])))
+  }
+
+  func testSupplementalCourseCancellationCancelsTheDetailLoad() async {
+    let api = CourseCatalogAPIStub(
+      chapterResults: [.success([.testFixture])],
+      courseContinuationResults: [.failure(CancellationError())],
+      courseProgressResults: [.success(.testFixture)],
+      courseResults: [.success(.testFixture)])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourse(id: Course.testFixture.id)
+
+    XCTAssertEqual(store.courseState(for: Course.testFixture.id), .idle)
+  }
+
+  func testSessionChangeReloadsCourseSupplementalDataWithTheNewIdentity() async throws {
+    let session = SessionStore.preview(account: makeCourseCatalogTestAccount())
+    let api = CourseCatalogAPIStub(
+      chapterResults: [.success([.testFixture]), .success([.testFixture])],
+      courseContinuationResults: [
+        .success(.testLessonFixture),
+        .success(.testLessonFixture),
+      ],
+      courseProgressResults: [
+        .success(.testFixture),
+        .success(.testFixture),
+      ],
+      courseResults: [.success(.testFixture), .success(.testFixture)])
+    let store = CourseCatalogStore(api: api, language: "en", session: session)
+
+    await store.loadCourse(id: Course.testFixture.id)
+    await session.expire(try XCTUnwrap(session.authenticatedSession))
+    await store.loadCourse(id: Course.testFixture.id)
+
+    let continuationTokens = await api.courseContinuationTokens
+    let progressTokens = await api.courseProgressTokens
+    XCTAssertEqual(continuationTokens, ["preview-session", nil])
+    XCTAssertEqual(progressTokens, ["preview-session", nil])
+    XCTAssertEqual(
+      store.courseState(for: Course.testFixture.id),
+      .loaded(
+        CourseDetail(
+          continuation: .testLessonFixture,
+          course: .testFixture,
+          chapters: [.testFixture],
+          progress: .testFixture)))
+  }
+
+  func testMissingCoursePublishesNotFound() async {
+    let api = CourseCatalogAPIStub(
+      courseResults: [.failure(CourseCatalogFailure.notFound)])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourse(id: Course.testFixture.id)
+
+    XCTAssertEqual(store.courseState(for: Course.testFixture.id), .failed(.notFound))
+  }
+
+  func testFailedCourseRefreshPreservesLoadedDetail() async {
+    let detail = CourseDetail(course: .testFixture, chapters: [.testFixture])
+    let api = CourseCatalogAPIStub(
+      chapterResults: [
+        .success([.testFixture]),
+        .failure(CourseCatalogFailure.network),
+      ],
+      courseResults: [
+        .success(.testFixture),
+        .failure(CourseCatalogFailure.network),
+      ])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourse(id: Course.testFixture.id)
+    await store.loadCourse(id: Course.testFixture.id, force: true)
+
+    XCTAssertEqual(store.courseState(for: Course.testFixture.id), .loaded(detail))
+  }
+
+  func testNotFoundCourseRefreshReplacesStaleDetail() async {
+    let api = CourseCatalogAPIStub(
+      chapterResults: [
+        .success([.testFixture]),
+        .success([.testFixture]),
+      ],
+      courseResults: [
+        .success(.testFixture),
+        .failure(CourseCatalogFailure.notFound),
+      ])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourse(id: Course.testFixture.id)
+    await store.loadCourse(id: Course.testFixture.id, force: true)
+
+    XCTAssertEqual(store.courseState(for: Course.testFixture.id), .failed(.notFound))
+  }
+
+  func testChapterDetailLoadsLessons() async {
+    let api = CourseCatalogAPIStub(
+      lessonResults: [.success([.testFixture])])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadChapter(id: CourseChapter.testFixture.id)
+
+    XCTAssertEqual(
+      store.chapterState(for: CourseChapter.testFixture.id),
+      .loaded(ChapterDetail(chapter: .resourceTestFixture, lessons: [.testFixture])))
+  }
+
+  func testChapterDetailLoadsContinuationAndProgressWithTheCurrentSession() async {
+    let session = SessionStore.preview(account: makeCourseCatalogTestAccount())
+    let api = CourseCatalogAPIStub(
+      chapterContinuationResults: [.success(.testLessonFixture)],
+      chapterProgressResults: [.success(.testFixture)],
+      lessonResults: [.success([.testFixture])])
+    let store = CourseCatalogStore(api: api, language: "en", session: session)
+
+    await store.loadChapter(id: CourseChapter.testFixture.id)
+
+    XCTAssertEqual(
+      store.chapterState(for: CourseChapter.testFixture.id),
+      .loaded(
+        ChapterDetail(
+          chapter: .resourceTestFixture,
+          continuation: .testLessonFixture,
+          lessons: [.testFixture],
+          progress: .testFixture)))
+    let continuationTokens = await api.chapterContinuationTokens
+    let progressTokens = await api.chapterProgressTokens
+    XCTAssertEqual(continuationTokens, ["preview-session"])
+    XCTAssertEqual(progressTokens, ["preview-session"])
+  }
+
+  func testChapterMetadataFailureDoesNotHideLoadedLessons() async {
+    let api = CourseCatalogAPIStub(
+      chapterDetailResults: [.failure(CourseCatalogFailure.network)],
+      lessonResults: [.success([.testFixture])])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadChapter(id: CourseChapter.testFixture.id)
+
+    XCTAssertEqual(
+      store.chapterState(for: CourseChapter.testFixture.id),
+      .loaded(ChapterDetail(lessons: [.testFixture])))
+  }
+
+  func testChapterWithoutLessonsPreservesCanonicalDetail() async {
+    let api = CourseCatalogAPIStub(lessonResults: [.success([])])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadChapter(id: CourseChapter.testFixture.id)
+
+    XCTAssertEqual(
+      store.chapterState(for: CourseChapter.testFixture.id),
+      .loaded(ChapterDetail(chapter: .resourceTestFixture, lessons: [])))
+  }
+
+  func testFailedChapterRefreshPreservesLoadedLessons() async {
+    let detail = ChapterDetail(chapter: .resourceTestFixture, lessons: [.testFixture])
+    let api = CourseCatalogAPIStub(
+      lessonResults: [
+        .success([.testFixture]),
+        .failure(CourseCatalogFailure.network),
+      ])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadChapter(id: CourseChapter.testFixture.id)
+    await store.loadChapter(id: CourseChapter.testFixture.id, force: true)
+
+    XCTAssertEqual(store.chapterState(for: CourseChapter.testFixture.id), .loaded(detail))
+  }
+
+  func testCatalogSearchPublishesGroupedResultsWithAnAnonymousRequest() async {
+    let api = CourseCatalogAPIStub(searchResults: [.success(.testFixture)])
+    let store = CourseCatalogStore(
+      api: api,
+      language: "en",
+      session: .preview(account: makeCourseCatalogTestAccount()))
+
+    await store.searchCatalog(query: "  stars  ")
+
+    XCTAssertEqual(store.searchState, .loaded(.testFixture))
+    let searchQueries = await api.searchQueries
+    XCTAssertEqual(
+      searchQueries,
+      [CatalogSearchQuery(language: "en", query: "stars")])
+  }
+
+  func testBlankCatalogSearchReturnsToIdleWithoutRequestingTheAPI() async {
+    let api = CourseCatalogAPIStub(searchResults: [.success(.testFixture)])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.searchCatalog(query: "  \n")
+
+    XCTAssertEqual(store.searchState, .idle)
+    let searchQueries = await api.searchQueries
+    XCTAssertEqual(searchQueries, [])
+  }
+
+  func testLateCatalogSearchCannotReplaceANewerQuery() async {
+    let firstSearchStarted = expectation(description: "First catalog search started")
+    let secondSearchStarted = expectation(description: "Second catalog search started")
+    let api = SuspendedCourseCatalogAPI(
+      { _ in },
+      searchDidStart: { requestCount in
+        if requestCount == 1 {
+          firstSearchStarted.fulfill()
+        } else if requestCount == 2 {
+          secondSearchStarted.fulfill()
+        }
+      })
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    let firstSearch = Task { await store.searchCatalog(query: "stars") }
+    await fulfillment(of: [firstSearchStarted], timeout: 1)
+
+    let secondSearch = Task { await store.searchCatalog(query: "planets") }
+    await fulfillment(of: [secondSearchStarted], timeout: 1)
+
+    await api.resolveSearchRequest(at: 1, with: .testFixture)
+    await secondSearch.value
+    await api.resolveSearchRequest(
+      at: 0,
+      with: CatalogSearchResults(chapters: [], courses: []))
+    await firstSearch.value
+
+    XCTAssertEqual(store.searchState, .loaded(.testFixture))
+  }
+}
+
+private actor CourseCatalogAPIStub: CourseCatalogAPIClient {
+  private var chapterDetailResults: [Result<CourseChapter, Error>]
+  private var chapterContinuationResults: [Result<CatalogContinuationTarget, Error>]
+  private var chapterProgressResults: [Result<ChapterProgress, Error>]
+  private var chapterResults: [Result<[CourseChapter], Error>]
+  private var courseContinuationResults: [Result<CatalogContinuationTarget, Error>]
+  private var coursePageResults: [Result<CourseCatalogPage, Error>]
+  private var courseProgressResults: [Result<CourseProgress, Error>]
+  private var courseResults: [Result<Course, Error>]
+  private var lessonResults: [Result<[CourseLesson], Error>]
+  private var searchResults: [Result<CatalogSearchResults, Error>]
+  private(set) var chapterContinuationTokens: [String?] = []
+  private(set) var chapterProgressTokens: [String?] = []
+  private(set) var courseContinuationTokens: [String?] = []
+  private(set) var courseProgressTokens: [String?] = []
+  private(set) var courseQueries: [CourseCatalogQuery] = []
+  private(set) var searchQueries: [CatalogSearchQuery] = []
+
+  init(
+    chapterDetailResults: [Result<CourseChapter, Error>] = [.success(.resourceTestFixture)],
+    chapterContinuationResults: [Result<CatalogContinuationTarget, Error>] = [],
+    chapterProgressResults: [Result<ChapterProgress, Error>] = [],
+    chapterResults: [Result<[CourseChapter], Error>] = [],
+    courseContinuationResults: [Result<CatalogContinuationTarget, Error>] = [],
+    coursePageResults: [Result<CourseCatalogPage, Error>] = [],
+    courseProgressResults: [Result<CourseProgress, Error>] = [],
+    courseResults: [Result<Course, Error>] = [],
+    lessonResults: [Result<[CourseLesson], Error>] = [],
+    searchResults: [Result<CatalogSearchResults, Error>] = []
+  ) {
+    self.chapterDetailResults = chapterDetailResults
+    self.chapterContinuationResults = chapterContinuationResults
+    self.chapterProgressResults = chapterProgressResults
+    self.chapterResults = chapterResults
+    self.courseContinuationResults = courseContinuationResults
+    self.coursePageResults = coursePageResults
+    self.courseProgressResults = courseProgressResults
+    self.courseResults = courseResults
+    self.lessonResults = lessonResults
+    self.searchResults = searchResults
+  }
+
+  func listCourses(query: CourseCatalogQuery) async throws -> CourseCatalogPage {
+    courseQueries.append(query)
+    return try takeFirstResult(from: &coursePageResults).get()
+  }
+
+  func getCourse(id: String) async throws -> Course {
+    try takeFirstResult(from: &courseResults).get()
+  }
+
+  func getChapter(id: String) async throws -> CourseChapter {
+    try takeFirstResult(from: &chapterDetailResults).get()
+  }
+
+  func listCourseChapters(courseID: String) async throws -> [CourseChapter] {
+    try takeFirstResult(from: &chapterResults).get()
+  }
+
+  func listChapterLessons(chapterID: String) async throws -> [CourseLesson] {
+    try takeFirstResult(from: &lessonResults).get()
+  }
+
+  func getCourseNextLesson(courseID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  {
+    courseContinuationTokens.append(token)
+    return try takeFirstResult(from: &courseContinuationResults).get()
+  }
+
+  func getChapterNextLesson(chapterID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  {
+    chapterContinuationTokens.append(token)
+    return try takeFirstResult(from: &chapterContinuationResults).get()
+  }
+
+  func getCourseProgress(courseID: String, token: String?) async throws -> CourseProgress {
+    courseProgressTokens.append(token)
+    return try takeFirstResult(from: &courseProgressResults).get()
+  }
+
+  func getChapterProgress(chapterID: String, token: String?) async throws -> ChapterProgress {
+    chapterProgressTokens.append(token)
+    return try takeFirstResult(from: &chapterProgressResults).get()
+  }
+
+  func searchCatalog(query: CatalogSearchQuery) async throws -> CatalogSearchResults {
+    searchQueries.append(query)
+    return try takeFirstResult(from: &searchResults).get()
+  }
+
+  private func takeFirstResult<Value>(
+    from results: inout [Result<Value, Error>]
+  ) -> Result<Value, Error> {
+    guard !results.isEmpty else {
+      return .failure(CourseCatalogFailure.unavailable)
+    }
+
+    return results.removeFirst()
+  }
+}
+
+private actor SuspendedCourseCatalogAPI: CourseCatalogAPIClient {
+  private struct CourseRequest {
+    let continuation: CheckedContinuation<CourseCatalogPage, any Error>
+  }
+
+  private struct SearchRequest {
+    let continuation: CheckedContinuation<CatalogSearchResults, any Error>
+  }
+
+  private let requestDidStart: @Sendable (Int) -> Void
+  private let searchDidStart: @Sendable (Int) -> Void
+  private var requests: [CourseRequest?] = []
+  private var searchRequests: [SearchRequest?] = []
+
+  var courseRequestCount: Int {
+    requests.count
+  }
+
+  init(
+    _ requestDidStart: @escaping @Sendable (Int) -> Void,
+    searchDidStart: @escaping @Sendable (Int) -> Void = { _ in }
+  ) {
+    self.requestDidStart = requestDidStart
+    self.searchDidStart = searchDidStart
+  }
+
+  func resolveCourseRequest(at index: Int, with page: CourseCatalogPage) {
+    requests[index]?.continuation.resume(returning: page)
+    requests[index] = nil
+  }
+
+  func failCourseRequest(at index: Int, with error: any Error) {
+    requests[index]?.continuation.resume(throwing: error)
+    requests[index] = nil
+  }
+
+  func resolveSearchRequest(at index: Int, with results: CatalogSearchResults) {
+    searchRequests[index]?.continuation.resume(returning: results)
+    searchRequests[index] = nil
+  }
+
+  func listCourses(query: CourseCatalogQuery) async throws -> CourseCatalogPage {
+    try await withCheckedThrowingContinuation { continuation in
+      requests.append(CourseRequest(continuation: continuation))
+      requestDidStart(requests.count)
+    }
+  }
+
+  func getCourse(id: String) async throws -> Course {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getChapter(id: String) async throws -> CourseChapter {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func listCourseChapters(courseID: String) async throws -> [CourseChapter] {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func listChapterLessons(chapterID: String) async throws -> [CourseLesson] {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getCourseNextLesson(courseID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getChapterNextLesson(chapterID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getCourseProgress(courseID: String, token: String?) async throws -> CourseProgress {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getChapterProgress(chapterID: String, token: String?) async throws -> ChapterProgress {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func searchCatalog(query: CatalogSearchQuery) async throws -> CatalogSearchResults {
+    try await withCheckedThrowingContinuation { continuation in
+      searchRequests.append(SearchRequest(continuation: continuation))
+      searchDidStart(searchRequests.count)
+    }
+  }
+}
+
+private actor SuspendedCourseDetailAPI: CourseCatalogAPIClient {
+  private let chaptersDidStart: @Sendable () -> Void
+  private let courseDidStart: @Sendable () -> Void
+  private var chaptersContinuation: CheckedContinuation<[CourseChapter], any Error>?
+  private var courseContinuation: CheckedContinuation<Course, any Error>?
+
+  init(
+    chaptersDidStart: @escaping @Sendable () -> Void,
+    courseDidStart: @escaping @Sendable () -> Void
+  ) {
+    self.chaptersDidStart = chaptersDidStart
+    self.courseDidStart = courseDidStart
+  }
+
+  func resolveCourse(with course: Course) {
+    courseContinuation?.resume(returning: course)
+    courseContinuation = nil
+  }
+
+  func resolveChapters(with chapters: [CourseChapter]) {
+    chaptersContinuation?.resume(returning: chapters)
+    chaptersContinuation = nil
+  }
+
+  func listCourses(query: CourseCatalogQuery) async throws -> CourseCatalogPage {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getCourse(id: String) async throws -> Course {
+    try await withCheckedThrowingContinuation { continuation in
+      courseContinuation = continuation
+      courseDidStart()
+    }
+  }
+
+  func getChapter(id: String) async throws -> CourseChapter {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func listCourseChapters(courseID: String) async throws -> [CourseChapter] {
+    try await withCheckedThrowingContinuation { continuation in
+      chaptersContinuation = continuation
+      chaptersDidStart()
+    }
+  }
+
+  func listChapterLessons(chapterID: String) async throws -> [CourseLesson] {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getCourseNextLesson(courseID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getChapterNextLesson(chapterID: String, token: String?) async throws
+    -> CatalogContinuationTarget
+  {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getCourseProgress(courseID: String, token: String?) async throws -> CourseProgress {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func getChapterProgress(chapterID: String, token: String?) async throws -> ChapterProgress {
+    throw CourseCatalogFailure.unavailable
+  }
+
+  func searchCatalog(query: CatalogSearchQuery) async throws -> CatalogSearchResults {
+    throw CourseCatalogFailure.unavailable
+  }
+}
+
+private func makeCourseCatalogTestAccount() -> CurrentAccount {
+  CurrentAccount(
+    account: AccountAccess(
+      deletion: AccountDeletionRequirements(hasAppleAccount: false),
+      subscription: nil),
+    user: AccountUser(
+      displayUsername: "learner",
+      email: "learner@zoonk.test",
+      id: "course-catalog-test-user",
+      image: nil,
+      name: "Learner",
+      username: "learner"))
+}

--- a/apps/apple/ZoonkTests/CourseCatalogStoreTests.swift
+++ b/apps/apple/ZoonkTests/CourseCatalogStoreTests.swift
@@ -37,6 +37,21 @@ final class CourseCatalogStoreTests: XCTestCase {
       [CourseCatalogQuery(category: .science, language: "en")])
   }
 
+  func testLoadedCatalogIsReusedByAPresentationLoad() async {
+    let page = CourseCatalogPage(
+      courses: [.testFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let api = CourseCatalogAPIStub(coursePageResults: [.success(page)])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourses(category: .science)
+    await store.loadCoursesIfNeeded(category: .science)
+
+    let queries = await api.courseQueries
+    XCTAssertEqual(queries, [CourseCatalogQuery(category: .science, language: "en")])
+  }
+
   func testEmptyCourseLoadPublishesEmptyState() async {
     let api = CourseCatalogAPIStub(
       coursePageResults: [
@@ -336,7 +351,7 @@ final class CourseCatalogStoreTests: XCTestCase {
     initialRequest.cancel()
 
     let replacementRequest = Task {
-      await store.loadCourses(category: .science, force: true)
+      await store.loadCoursesIfNeeded(category: .science)
     }
     await fulfillment(of: [replacementRequestStarted], timeout: 1)
 
@@ -506,6 +521,21 @@ final class CourseCatalogStoreTests: XCTestCase {
       .loaded(CourseDetail(course: .testFixture, chapters: [.testFixture])))
   }
 
+  func testLoadedCourseDetailIsReusedByAPresentationLoad() async {
+    let api = CourseCatalogAPIStub(
+      chapterResults: [.success([.testFixture])],
+      courseResults: [.success(.testFixture)])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadCourse(id: Course.testFixture.id)
+    await store.loadCourseIfNeeded(id: Course.testFixture.id)
+
+    let courseRequestCount = await api.courseRequestCount
+    let chapterListRequestCount = await api.chapterListRequestCount
+    XCTAssertEqual(courseRequestCount, 1)
+    XCTAssertEqual(chapterListRequestCount, 1)
+  }
+
   func testCourseDetailLoadsContinuationAndProgressWithTheCurrentSession() async {
     let session = SessionStore.preview(account: makeCourseCatalogTestAccount())
     let api = CourseCatalogAPIStub(
@@ -651,6 +681,19 @@ final class CourseCatalogStoreTests: XCTestCase {
       .loaded(ChapterDetail(chapter: .resourceTestFixture, lessons: [.testFixture])))
   }
 
+  func testLoadedChapterDetailIsReusedByAPresentationLoad() async {
+    let api = CourseCatalogAPIStub(lessonResults: [.success([.testFixture])])
+    let store = CourseCatalogStore(api: api, language: "en")
+
+    await store.loadChapter(id: CourseChapter.testFixture.id)
+    await store.loadChapterIfNeeded(id: CourseChapter.testFixture.id)
+
+    let chapterRequestCount = await api.chapterRequestCount
+    let lessonListRequestCount = await api.lessonListRequestCount
+    XCTAssertEqual(chapterRequestCount, 1)
+    XCTAssertEqual(lessonListRequestCount, 1)
+  }
+
   func testChapterDetailLoadsContinuationAndProgressWithTheCurrentSession() async {
     let session = SessionStore.preview(account: makeCourseCatalogTestAccount())
     let api = CourseCatalogAPIStub(
@@ -788,6 +831,10 @@ private actor CourseCatalogAPIStub: CourseCatalogAPIClient {
   private(set) var courseContinuationTokens: [String?] = []
   private(set) var courseProgressTokens: [String?] = []
   private(set) var courseQueries: [CourseCatalogQuery] = []
+  private(set) var chapterListRequestCount = 0
+  private(set) var chapterRequestCount = 0
+  private(set) var courseRequestCount = 0
+  private(set) var lessonListRequestCount = 0
   private(set) var searchQueries: [CatalogSearchQuery] = []
 
   init(
@@ -820,19 +867,23 @@ private actor CourseCatalogAPIStub: CourseCatalogAPIClient {
   }
 
   func getCourse(id: String) async throws -> Course {
-    try takeFirstResult(from: &courseResults).get()
+    courseRequestCount += 1
+    return try takeFirstResult(from: &courseResults).get()
   }
 
   func getChapter(id: String) async throws -> CourseChapter {
-    try takeFirstResult(from: &chapterDetailResults).get()
+    chapterRequestCount += 1
+    return try takeFirstResult(from: &chapterDetailResults).get()
   }
 
   func listCourseChapters(courseID: String) async throws -> [CourseChapter] {
-    try takeFirstResult(from: &chapterResults).get()
+    chapterListRequestCount += 1
+    return try takeFirstResult(from: &chapterResults).get()
   }
 
   func listChapterLessons(chapterID: String) async throws -> [CourseLesson] {
-    try takeFirstResult(from: &lessonResults).get()
+    lessonListRequestCount += 1
+    return try takeFirstResult(from: &lessonResults).get()
   }
 
   func getCourseNextLesson(courseID: String, token: String?) async throws

--- a/apps/apple/ZoonkTests/FeedbackAPITests.swift
+++ b/apps/apple/ZoonkTests/FeedbackAPITests.swift
@@ -1,0 +1,162 @@
+import HTTPTypes
+import OpenAPIRuntime
+import XCTest
+
+@testable import Zoonk
+
+final class FeedbackAPITests: XCTestCase {
+  func testSubmitFeedbackUsesPublicEndpoint() async throws {
+    let api = makeFeedbackAPI(
+      transport: FeedbackResponseTransport(
+        expectedSubmission: FeedbackSubmission(
+          email: "learner@zoonk.test",
+          message: "The chapter explanation could be clearer."),
+        responseBody: #"{"message":"Feedback received"}"#,
+        status: .ok))
+
+    try await api.submit(
+      FeedbackSubmission(
+        email: "learner@zoonk.test",
+        message: "The chapter explanation could be clearer."))
+  }
+
+  func testValidationResponseRemainsActionable() async {
+    let api = makeFeedbackAPI(
+      transport: FeedbackResponseTransport(
+        expectedSubmission: FeedbackSubmission(
+          email: "invalid-email",
+          message: "Please help."),
+        responseBody: feedbackErrorResponseBody,
+        status: .badRequest))
+
+    await assertFailure(.validation) {
+      try await api.submit(
+        FeedbackSubmission(email: "invalid-email", message: "Please help."))
+    }
+  }
+
+  func testServerFailureMapsToUnavailable() async {
+    let api = makeFeedbackAPI(
+      transport: FeedbackResponseTransport(
+        expectedSubmission: FeedbackSubmission(
+          email: "learner@zoonk.test",
+          message: "Please help."),
+        responseBody: feedbackErrorResponseBody,
+        status: .internalServerError))
+
+    await assertFailure(.unavailable) {
+      try await api.submit(
+        FeedbackSubmission(email: "learner@zoonk.test", message: "Please help."))
+    }
+  }
+
+  func testURLFailureMapsToNetwork() async {
+    let api = makeFeedbackAPI(transport: FeedbackFailureTransport(failure: .network))
+
+    await assertFailure(.network) {
+      try await api.submit(
+        FeedbackSubmission(email: "learner@zoonk.test", message: "Please help."))
+    }
+  }
+
+  func testCancellationRemainsCancellation() async {
+    let api = makeFeedbackAPI(transport: FeedbackFailureTransport(failure: .cancellation))
+
+    do {
+      try await api.submit(
+        FeedbackSubmission(email: "learner@zoonk.test", message: "Please help."))
+      XCTFail("Expected cancellation")
+    } catch is CancellationError {
+      return
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  private func assertFailure(
+    _ expectedFailure: FeedbackFailure,
+    operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+      XCTFail("Expected \(expectedFailure)")
+    } catch let failure as FeedbackFailure {
+      XCTAssertEqual(failure, expectedFailure)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+}
+
+private let feedbackErrorResponseBody =
+  #"{"error":{"code":"INVALID_FEEDBACK","message":"Invalid feedback"}}"#
+
+private func makeFeedbackAPI(transport: any ClientTransport) -> FeedbackAPI {
+  FeedbackAPI(
+    clients: APIClientFactory(
+      baseURL: URL(string: "https://api.zoonk.test")!,
+      transport: transport))
+}
+
+/// Exercises the generated public feedback operation without sending a real message.
+private struct FeedbackResponseTransport: ClientTransport {
+  let expectedSubmission: FeedbackSubmission
+  let responseBody: String
+  let status: HTTPResponse.Status
+
+  func send(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    XCTAssertEqual(baseURL, URL(string: "https://api.zoonk.test/v1"))
+    XCTAssertEqual(operationID, "createFeedback")
+    XCTAssertEqual(request.method, .post)
+    XCTAssertEqual(request.path, "/feedback")
+    XCTAssertNil(request.headerFields[.authorization])
+
+    let requestBody = try await String(
+      collecting: XCTUnwrap(body),
+      upTo: 4_096)
+    let requestPayload = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: Data(requestBody.utf8)) as? [String: String])
+    XCTAssertEqual(
+      requestPayload,
+      [
+        "email": expectedSubmission.email,
+        "message": expectedSubmission.message,
+      ])
+
+    var headerFields = HTTPFields()
+    headerFields[.contentType] = "application/json"
+
+    return (
+      HTTPResponse(status: status, headerFields: headerFields),
+      HTTPBody(responseBody)
+    )
+  }
+}
+
+private enum FeedbackTransportFailure: Sendable {
+  case cancellation
+  case network
+}
+
+private struct FeedbackFailureTransport: ClientTransport {
+  let failure: FeedbackTransportFailure
+
+  func send(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    switch failure {
+    case .cancellation:
+      throw CancellationError()
+    case .network:
+      throw URLError(.notConnectedToInternet)
+    }
+  }
+}

--- a/apps/apple/ZoonkTests/FeedbackFormStoreTests.swift
+++ b/apps/apple/ZoonkTests/FeedbackFormStoreTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+@testable import Zoonk
+
+@MainActor
+final class FeedbackFormStoreTests: XCTestCase {
+  func testSubmitNormalizesFieldsAndPublishesSuccess() async {
+    let api = FeedbackAPISpy(result: .success(()))
+    let store = FeedbackFormStore(
+      api: api,
+      defaultEmail: "  LEARNER@zoonk.test ")
+    store.message = "  Please clarify the first chapter. \n"
+
+    await store.submit()
+
+    let submissions = await api.submissions()
+
+    XCTAssertEqual(store.state, .sent)
+    XCTAssertEqual(
+      submissions,
+      [
+        FeedbackSubmission(
+          email: "learner@zoonk.test",
+          message: "Please clarify the first chapter.")
+      ])
+  }
+
+  func testFailurePublishesRecoverableState() async {
+    let api = FeedbackAPISpy(result: .failure(FeedbackFailure.network))
+    let store = FeedbackFormStore(api: api, defaultEmail: "learner@zoonk.test")
+    store.message = "Please clarify the first chapter."
+
+    await store.submit()
+
+    XCTAssertEqual(store.state, .failed(.network))
+  }
+
+  func testBlankFieldsDoNotSubmit() async {
+    let api = FeedbackAPISpy(result: .success(()))
+    let store = FeedbackFormStore(api: api, defaultEmail: "learner@zoonk.test")
+    store.message = "   \n"
+
+    await store.submit()
+
+    let submissions = await api.submissions()
+
+    XCTAssertEqual(store.state, .idle)
+    XCTAssertTrue(submissions.isEmpty)
+  }
+
+  func testCancellationReturnsToIdle() async {
+    let api = FeedbackAPISpy(result: .failure(CancellationError()))
+    let store = FeedbackFormStore(api: api, defaultEmail: "learner@zoonk.test")
+    store.message = "Please clarify the first chapter."
+
+    await store.submit()
+
+    XCTAssertEqual(store.state, .idle)
+  }
+}
+
+private actor FeedbackAPISpy: FeedbackAPIClient {
+  private var recordedSubmissions = [FeedbackSubmission]()
+  private let result: Result<Void, Error>
+
+  init(result: Result<Void, Error>) {
+    self.result = result
+  }
+
+  func submit(_ submission: FeedbackSubmission) async throws {
+    recordedSubmissions.append(submission)
+    try result.get()
+  }
+
+  func submissions() -> [FeedbackSubmission] {
+    recordedSubmissions
+  }
+}

--- a/apps/apple/ZoonkUITests/CourseCatalogUITestFixture.swift
+++ b/apps/apple/ZoonkUITests/CourseCatalogUITestFixture.swift
@@ -95,7 +95,7 @@ let courseCatalogUITestSnapshotJSON =
         "description": "Trace water as it moves from the soil through a plant.",
         "id": "lesson-follow-water",
         "imageURL": null,
-        "kind": "explanation",
+        "kind": "practice",
         "language": "en",
         "position": 1,
         "slug": "follow-the-water",

--- a/apps/apple/ZoonkUITests/CourseCatalogUITestFixture.swift
+++ b/apps/apple/ZoonkUITests/CourseCatalogUITestFixture.swift
@@ -1,0 +1,118 @@
+let courseCatalogUITestSnapshotJSON =
+  #"""
+  {
+    "completedLessonIDs": ["lesson-meet-roots"],
+    "courses": [
+      {
+        "categories": ["science"],
+        "description": "Discover how roots, stems, and leaves work together to help a plant thrive.",
+        "id": "course-plants",
+        "imageURL": null,
+        "language": "en",
+        "organization": {
+          "id": "organization-ai",
+          "logoURL": null,
+          "name": "Zoonk AI",
+          "slug": "ai"
+        },
+        "slug": "how-plants-grow",
+        "targetLanguage": null,
+        "title": "How Plants Grow"
+      },
+      {
+        "categories": ["science"],
+        "description": "Explore ocean habitats from sunlit shores to the deep sea.",
+        "id": "course-oceans",
+        "imageURL": null,
+        "language": "en",
+        "organization": {
+          "id": "organization-zoonk",
+          "logoURL": null,
+          "name": "Zoonk",
+          "slug": "zoonk"
+        },
+        "slug": "ocean-worlds",
+        "targetLanguage": null,
+        "title": "Ocean Worlds"
+      },
+      {
+        "categories": ["math"],
+        "description": "Build confidence with the numbers and patterns you meet every day.",
+        "id": "course-numbers",
+        "imageURL": null,
+        "language": "en",
+        "organization": {
+          "id": "organization-zoonk",
+          "logoURL": null,
+          "name": "Zoonk",
+          "slug": "zoonk"
+        },
+        "slug": "everyday-numbers",
+        "targetLanguage": null,
+        "title": "Everyday Numbers"
+      }
+    ],
+    "chapters": [
+      {
+        "courseID": "course-plants",
+        "description": "See how plants anchor themselves and carry water from the soil.",
+        "id": "chapter-roots",
+        "imageURL": null,
+        "language": "en",
+        "lessonCount": 2,
+        "position": 0,
+        "slug": "roots-and-water",
+        "title": "Roots and Water"
+      },
+      {
+        "courseID": "course-plants",
+        "description": "Learn how leaves turn light into the energy a plant needs.",
+        "id": "chapter-leaves",
+        "imageURL": null,
+        "language": "en",
+        "lessonCount": 1,
+        "position": 1,
+        "slug": "leaves-and-light",
+        "title": "Leaves and Light"
+      }
+    ],
+    "lessons": [
+      {
+        "chapterID": "chapter-roots",
+        "courseID": "course-plants",
+        "description": "Meet the root structures that hold a plant in place.",
+        "id": "lesson-meet-roots",
+        "imageURL": null,
+        "kind": "explanation",
+        "language": "en",
+        "position": 0,
+        "slug": "meet-the-roots",
+        "title": "Meet the Roots"
+      },
+      {
+        "chapterID": "chapter-roots",
+        "courseID": "course-plants",
+        "description": "Trace water as it moves from the soil through a plant.",
+        "id": "lesson-follow-water",
+        "imageURL": null,
+        "kind": "explanation",
+        "language": "en",
+        "position": 1,
+        "slug": "follow-the-water",
+        "title": "Follow the Water"
+      },
+      {
+        "chapterID": "chapter-leaves",
+        "courseID": "course-plants",
+        "description": "Explore how leaves capture sunlight.",
+        "id": "lesson-capture-light",
+        "imageURL": null,
+        "kind": "explanation",
+        "language": "en",
+        "position": 0,
+        "slug": "capture-the-light",
+        "title": "Capture the Light"
+      }
+    ]
+  }
+  """#

--- a/apps/apple/ZoonkUITests/ZoonkUITests.swift
+++ b/apps/apple/ZoonkUITests/ZoonkUITests.swift
@@ -523,6 +523,16 @@ final class ZoonkUITests: XCTestCase {
     XCTAssertTrue(
       courseContinue.waitForExistence(timeout: 2),
       "Expected the course action to use Main's continuation label and progress")
+
+    if app.frame.width > 600 {
+      let courseTitle = app.staticTexts["How Plants Grow"].firstMatch
+      XCTAssertEqual(
+        courseContinue.frame.minX,
+        courseTitle.frame.minX,
+        accuracy: 1,
+        "Expected the primary course action to align with the hero text on iPad")
+    }
+
     courseContinue.tap()
 
     XCTAssertTrue(
@@ -536,6 +546,9 @@ final class ZoonkUITests: XCTestCase {
     XCTAssertTrue(
       chapter.waitForExistence(timeout: 5),
       "Expected the course to expose its first chapter")
+    XCTAssertTrue(
+      app.staticTexts["1. Roots and Water"].exists,
+      "Expected the chapter number to be part of the title instead of a separate leading column")
     XCTAssertTrue(
       chapter.label.contains("1/2 done"),
       "Expected the chapter row to expose learner progress instead of a lesson count")
@@ -575,9 +588,21 @@ final class ZoonkUITests: XCTestCase {
       chapterContinue.waitForExistence(timeout: 2),
       "Expected the chapter action to use Main's continuation label and progress")
 
+    if app.frame.width > 600 {
+      let chapterTitle = app.staticTexts["1. Roots and Water"].firstMatch
+      XCTAssertEqual(
+        chapterContinue.frame.minX,
+        chapterTitle.frame.minX,
+        accuracy: 1,
+        "Expected the primary chapter action to align with the hero text on iPad")
+    }
+
     let completedLesson = app.buttons.matching(
       NSPredicate(format: "label CONTAINS %@", "Meet the Roots")
     ).firstMatch
+    XCTAssertTrue(
+      app.staticTexts["1. Meet the Roots"].exists,
+      "Expected the lesson number to be part of the title instead of a separate leading column")
     XCTAssertTrue(completedLesson.label.contains("Completed"))
 
     let nextLesson = app.buttons.matching(
@@ -598,7 +623,7 @@ final class ZoonkUITests: XCTestCase {
     chapterBackButton.tap()
 
     XCTAssertTrue(
-      app.staticTexts["Follow the Water"].waitForExistence(timeout: 5),
+      app.staticTexts["2. Follow the Water"].waitForExistence(timeout: 5),
       "Expected Back to return to the chapter's lesson list")
   }
 
@@ -685,17 +710,23 @@ final class ZoonkUITests: XCTestCase {
     searchField.tap()
     searchField.typeText("leaves")
 
-    XCTAssertFalse(
-      app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Continue")).firstMatch
-        .exists,
+    let courseContinue = app.buttons.matching(
+      NSPredicate(format: "label BEGINSWITH %@", "Continue")
+    ).firstMatch
+    let hiddenCourseHeader = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"),
+      object: courseContinue)
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [hiddenCourseHeader], timeout: 5),
+      .completed,
       "Expected active search to remove the detail header between search and results")
     XCTAssertTrue(
-      app.staticTexts["Leaves and Light"].waitForExistence(timeout: 5),
+      app.staticTexts["2. Leaves and Light"].waitForExistence(timeout: 5),
       "Expected the matching chapter to remain visible above the keyboard")
     XCTAssertTrue(
-      app.staticTexts["Leaves and Light"].isHittable,
+      app.staticTexts["2. Leaves and Light"].isHittable,
       "Expected the filtered chapter to remain directly interactive during search")
-    XCTAssertFalse(app.staticTexts["Roots and Water"].exists)
+    XCTAssertFalse(app.staticTexts["1. Roots and Water"].exists)
   }
 
   /// Proves lesson filtering uses the same compact search hierarchy as chapter filtering.
@@ -706,7 +737,7 @@ final class ZoonkUITests: XCTestCase {
     let app = makeApp(for: .catalog)
     app.launch()
     openPlantsCourse(in: app)
-    app.staticTexts["Roots and Water"].firstMatch.tap()
+    app.staticTexts["1. Roots and Water"].firstMatch.tap()
 
     XCTAssertFalse(app.searchFields["Search lessons"].exists)
     app.buttons["Search"].tap()
@@ -715,17 +746,23 @@ final class ZoonkUITests: XCTestCase {
     searchField.tap()
     searchField.typeText("water")
 
-    XCTAssertFalse(
-      app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Continue")).firstMatch
-        .exists,
+    let chapterContinue = app.buttons.matching(
+      NSPredicate(format: "label BEGINSWITH %@", "Continue")
+    ).firstMatch
+    let hiddenChapterHeader = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"),
+      object: chapterContinue)
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [hiddenChapterHeader], timeout: 5),
+      .completed,
       "Expected active search to remove the detail header between search and results")
     XCTAssertTrue(
-      app.staticTexts["Follow the Water"].waitForExistence(timeout: 5),
+      app.staticTexts["2. Follow the Water"].waitForExistence(timeout: 5),
       "Expected the matching lesson to remain visible above the keyboard")
     XCTAssertTrue(
-      app.staticTexts["Follow the Water"].isHittable,
+      app.staticTexts["2. Follow the Water"].isHittable,
       "Expected the filtered lesson to remain directly interactive during search")
-    XCTAssertFalse(app.staticTexts["Meet the Roots"].exists)
+    XCTAssertFalse(app.staticTexts["1. Meet the Roots"].exists)
   }
 
   @MainActor

--- a/apps/apple/ZoonkUITests/ZoonkUITests.swift
+++ b/apps/apple/ZoonkUITests/ZoonkUITests.swift
@@ -6,6 +6,7 @@ private enum UITestScenario: Equatable {
   case appleSubscription
   case freeSubscription
   case googleSubscription
+  case catalog
   case progress
   case progressActivityUnauthorized
   case progressDaypartOnly
@@ -24,7 +25,7 @@ private enum UITestScenario: Equatable {
       accountJSON(provider: nil)
     case .googleSubscription:
       accountJSON(provider: "google")
-    case .progress, .progressActivityUnauthorized, .progressDaypartOnly, .progressEmpty,
+    case .catalog, .progress, .progressActivityUnauthorized, .progressDaypartOnly, .progressEmpty,
       .progressOverviewFailure:
       accountJSON(provider: nil)
     case .signedOut:
@@ -45,7 +46,8 @@ private enum UITestScenario: Equatable {
       progressDaypartOnlyUITestSnapshotJSON
     case .progressEmpty:
       progressEmptyUITestSnapshotJSON
-    case .appleSubscription, .freeSubscription, .googleSubscription, .requiredSetup, .signedOut:
+    case .appleSubscription, .catalog, .freeSubscription, .googleSubscription, .requiredSetup,
+      .signedOut:
       nil
     }
   }
@@ -56,7 +58,7 @@ private enum UITestScenario: Equatable {
       "activity-unauthorized"
     case .progressOverviewFailure:
       "overview-network"
-    case .appleSubscription, .freeSubscription, .googleSubscription, .progress,
+    case .appleSubscription, .catalog, .freeSubscription, .googleSubscription, .progress,
       .progressDaypartOnly, .progressEmpty, .requiredSetup, .signedOut:
       nil
     }
@@ -318,6 +320,26 @@ final class ZoonkUITests: XCTestCase {
       "Expected guidance without an external Google Play purchase link")
   }
 
+  /// Proves the account shortcut names the public destination it opens instead of promising an unimplemented learner library.
+  @MainActor
+  func testBrowseCoursesAccountActionOpensThePublicCatalog() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .freeSubscription)
+    app.launch()
+    openAccount(in: app)
+
+    let browseCourses = app.buttons["Browse courses"]
+    XCTAssertTrue(
+      browseCourses.waitForExistence(timeout: 5),
+      "Expected the account sheet to describe the public catalog destination")
+    browseCourses.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["How Plants Grow"].firstMatch.waitForExistence(timeout: 5),
+      "Expected the account shortcut to open the deterministic public catalog")
+  }
+
   /// Proves that account deletion is a deliberate native flow: the account option opens a dedicated screen and the irreversible request still requires confirmation.
   @MainActor
   func testAccountDeletionRequiresConfirmation() {
@@ -394,7 +416,6 @@ final class ZoonkUITests: XCTestCase {
       (tabTitle: "New", screenTitle: "New course"),
       (tabTitle: "Courses", screenTitle: "Courses"),
       (tabTitle: "Progress", screenTitle: "Progress"),
-      (tabTitle: "Search", screenTitle: "Search"),
     ]
 
     for destination in destinations {
@@ -416,6 +437,295 @@ final class ZoonkUITests: XCTestCase {
         app.navigationBars[destination.screenTitle].firstMatch.waitForExistence(timeout: 5),
         "Expected the \(destination.screenTitle) screen heading to exist")
     }
+
+    XCTAssertFalse(app.buttons["Search"].exists, "Expected search to no longer be a primary tab")
+  }
+
+  /// Proves the public catalog filters by category and keeps course, chapter, and lesson navigation inside the native Courses stack.
+  @MainActor
+  func testCourseCatalogNavigatesToLessonPlaceholderAndBack() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .catalog)
+    app.launch()
+
+    let coursesTab = app.buttons["Courses"].firstMatch
+    XCTAssertTrue(coursesTab.waitForExistence(timeout: 5))
+    coursesTab.tap()
+
+    let categorySelector = app.scrollViews["Course categories"]
+    XCTAssertTrue(
+      categorySelector.waitForExistence(timeout: 5),
+      "Expected the catalog to expose its category selector")
+
+    let scienceCategory = app.buttons["Science"]
+    categorySelector.scrollToReveal(scienceCategory)
+
+    XCTAssertTrue(
+      scienceCategory.waitForExistence(timeout: 2),
+      "Expected the App Store-style category selector to expose Science")
+    XCTAssertTrue(
+      categorySelector.frame.contains(
+        CGPoint(x: scienceCategory.frame.midX, y: scienceCategory.frame.midY)),
+      "Expected Science to be fully reachable inside the category selector")
+    scienceCategory.tap()
+
+    let nonScienceCourse = app.staticTexts["Everyday Numbers"].firstMatch
+    let filteredCatalog = XCTNSPredicateExpectation(
+      predicate: NSPredicate(format: "exists == false"),
+      object: nonScienceCourse)
+    XCTAssertEqual(
+      XCTWaiter.wait(for: [filteredCatalog], timeout: 5),
+      .completed,
+      "Expected Science to remove courses from other categories")
+
+    let course = app.staticTexts["How Plants Grow"].firstMatch
+    XCTAssertTrue(
+      course.waitForExistence(timeout: 5),
+      "Expected Science to load its deterministic fixture course")
+    course.tap()
+
+    XCTAssertFalse(
+      app.staticTexts["Zoonk AI"].exists,
+      "Expected course authorship to stay inside progressive disclosure")
+    XCTAssertFalse(
+      app.staticTexts["Created with AI"].exists,
+      "Expected the AI disclosure to stay inside progressive disclosure")
+
+    let courseDescription = app.buttons.matching(
+      NSPredicate(format: "label CONTAINS %@", "Discover how roots")
+    ).firstMatch
+    XCTAssertTrue(
+      courseDescription.waitForExistence(timeout: 2),
+      "Expected the course description to reveal expanded information")
+    courseDescription.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["Zoonk AI"].waitForExistence(timeout: 2),
+      "Expected the course information popover to identify its author")
+    XCTAssertTrue(
+      app.staticTexts["Created with AI"].exists,
+      "Expected the course information popover to disclose AI authorship")
+    XCTAssertFalse(app.staticTexts["Organization"].exists)
+    XCTAssertFalse(app.staticTexts["Categories"].exists)
+    app.buttons["Done"].tap()
+
+    app.buttons["More options"].tap()
+    XCTAssertFalse(
+      app.buttons["Course information"].exists,
+      "Expected information to be attached to the course description instead of duplicated")
+    XCTAssertTrue(
+      app.buttons["Send feedback"].waitForExistence(timeout: 2),
+      "Expected the course action menu to expose feedback")
+    app.tap()
+
+    let courseContinue = app.buttons["Continue, 33% complete"]
+    XCTAssertTrue(
+      courseContinue.waitForExistence(timeout: 2),
+      "Expected the course action to use Main's continuation label and progress")
+    courseContinue.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["Lesson player coming soon"].waitForExistence(timeout: 5),
+      "Expected the course continuation action to open the next lesson directly")
+    app.navigationBars.firstMatch.buttons["How Plants Grow"].tap()
+
+    let chapter = app.buttons.matching(
+      NSPredicate(format: "label CONTAINS %@", "Roots and Water")
+    ).firstMatch
+    XCTAssertTrue(
+      chapter.waitForExistence(timeout: 5),
+      "Expected the course to expose its first chapter")
+    XCTAssertTrue(
+      chapter.label.contains("1/2 done"),
+      "Expected the chapter row to expose learner progress instead of a lesson count")
+    XCTAssertFalse(chapter.label.contains("2 lessons"))
+    chapter.tap()
+
+    XCTAssertFalse(
+      app.staticTexts["Created with AI"].exists,
+      "Expected the chapter AI disclosure to stay inside progressive disclosure")
+
+    let chapterDescription = app.buttons.matching(
+      NSPredicate(format: "label CONTAINS %@", "See how plants anchor")
+    ).firstMatch
+    XCTAssertTrue(
+      chapterDescription.waitForExistence(timeout: 2),
+      "Expected the chapter description to reveal expanded information")
+    chapterDescription.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["Created with AI"].waitForExistence(timeout: 2),
+      "Expected the chapter information popover to disclose AI authorship")
+    XCTAssertFalse(app.staticTexts["Organization"].exists)
+    XCTAssertFalse(app.staticTexts["Categories"].exists)
+    app.buttons["Done"].tap()
+
+    app.buttons["More options"].tap()
+    XCTAssertFalse(
+      app.buttons["Chapter information"].exists,
+      "Expected information to be attached to the chapter description instead of duplicated")
+    XCTAssertTrue(
+      app.buttons["Send feedback"].waitForExistence(timeout: 2),
+      "Expected the chapter action menu to expose feedback")
+    app.tap()
+
+    let chapterContinue = app.buttons["Continue, 50% complete"]
+    XCTAssertTrue(
+      chapterContinue.waitForExistence(timeout: 2),
+      "Expected the chapter action to use Main's continuation label and progress")
+
+    let completedLesson = app.buttons.matching(
+      NSPredicate(format: "label CONTAINS %@", "Meet the Roots")
+    ).firstMatch
+    XCTAssertTrue(completedLesson.label.contains("Completed"))
+
+    let nextLesson = app.buttons.matching(
+      NSPredicate(format: "label CONTAINS %@", "Follow the Water")
+    ).firstMatch
+    XCTAssertTrue(nextLesson.label.contains("Not started"))
+    chapterContinue.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["Lesson player coming soon"].waitForExistence(timeout: 5),
+      "Expected the chapter continuation action to open the next lesson directly")
+    XCTAssertTrue(app.navigationBars["Follow the Water"].exists)
+
+    let chapterBackButton = app.navigationBars.firstMatch.buttons["Roots and Water"]
+    XCTAssertTrue(
+      chapterBackButton.waitForExistence(timeout: 5),
+      "Expected the lesson placeholder to retain the native chapter back action")
+    chapterBackButton.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["Follow the Water"].waitForExistence(timeout: 5),
+      "Expected Back to return to the chapter's lesson list")
+  }
+
+  /// Proves catalog search replaces the removed Search tab and searches beyond the selected category.
+  @MainActor
+  func testCoursesSearchFindsCoursesAndChapters() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .catalog)
+    app.launch()
+    app.buttons["Courses"].firstMatch.tap()
+
+    let searchField = app.searchFields["Search courses and chapters"]
+    XCTAssertTrue(searchField.waitForExistence(timeout: 5))
+    searchField.tap()
+    searchField.typeText("water")
+
+    XCTAssertFalse(
+      app.scrollViews["Course categories"].exists,
+      "Expected active catalog search to put results directly below the search field")
+    XCTAssertTrue(
+      app.staticTexts["Chapters"].waitForExistence(timeout: 5),
+      "Expected catalog search to group chapter matches")
+    XCTAssertTrue(app.staticTexts["Roots and Water"].exists)
+    XCTAssertTrue(app.staticTexts["How Plants Grow"].exists)
+
+    app.staticTexts["Roots and Water"].firstMatch.tap()
+    XCTAssertTrue(
+      app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "1. Roots and Water"))
+        .firstMatch.waitForExistence(timeout: 10),
+      "Expected a chapter search result to load its canonical position and metadata")
+  }
+
+  /// Proves an empty category turns unmet demand into the existing course-creation flow.
+  @MainActor
+  func testEmptyCategoryOffersCourseCreation() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .catalog)
+    app.launch()
+    app.buttons["Courses"].firstMatch.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["How Plants Grow"].firstMatch.waitForExistence(timeout: 10),
+      "Expected the catalog to finish loading before changing categories")
+
+    let categorySelector = app.scrollViews["Course categories"]
+    XCTAssertTrue(categorySelector.waitForExistence(timeout: 5))
+
+    let technologyCategory = app.buttons["Technology"]
+    categorySelector.scrollToReveal(technologyCategory)
+    XCTAssertTrue(
+      categorySelector.frame.contains(
+        CGPoint(x: technologyCategory.frame.midX, y: technologyCategory.frame.midY)),
+      "Expected the far-right Technology category to be reachable")
+    technologyCategory.tap()
+
+    XCTAssertTrue(
+      app.staticTexts["No Technology courses yet"].waitForExistence(timeout: 5),
+      "Expected the empty category to offer recovery")
+    app.buttons["Create a course about Technology"].tap()
+
+    XCTAssertTrue(
+      app.navigationBars["New course"].waitForExistence(timeout: 5),
+      "Expected the empty category action to open the existing New course screen")
+    XCTAssertTrue(
+      app.buttons["New"].firstMatch.isSelected,
+      "Expected New to become the selected primary tab")
+  }
+
+  /// Proves searching chapters replaces the detail header so filtered content remains visible while the keyboard is open.
+  @MainActor
+  func testCourseSearchKeepsFilteredChaptersVisible() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .catalog)
+    app.launch()
+    openPlantsCourse(in: app)
+
+    XCTAssertFalse(app.searchFields["Search chapters"].exists)
+    app.buttons["Search"].tap()
+    let searchField = app.searchFields["Search chapters"]
+    XCTAssertTrue(searchField.waitForExistence(timeout: 5))
+    searchField.tap()
+    searchField.typeText("leaves")
+
+    XCTAssertFalse(
+      app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Continue")).firstMatch
+        .exists,
+      "Expected active search to remove the detail header between search and results")
+    XCTAssertTrue(
+      app.staticTexts["Leaves and Light"].waitForExistence(timeout: 5),
+      "Expected the matching chapter to remain visible above the keyboard")
+    XCTAssertTrue(
+      app.staticTexts["Leaves and Light"].isHittable,
+      "Expected the filtered chapter to remain directly interactive during search")
+    XCTAssertFalse(app.staticTexts["Roots and Water"].exists)
+  }
+
+  /// Proves lesson filtering uses the same compact search hierarchy as chapter filtering.
+  @MainActor
+  func testChapterSearchKeepsFilteredLessonsVisible() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .catalog)
+    app.launch()
+    openPlantsCourse(in: app)
+    app.staticTexts["Roots and Water"].firstMatch.tap()
+
+    XCTAssertFalse(app.searchFields["Search lessons"].exists)
+    app.buttons["Search"].tap()
+    let searchField = app.searchFields["Search lessons"]
+    XCTAssertTrue(searchField.waitForExistence(timeout: 5))
+    searchField.tap()
+    searchField.typeText("water")
+
+    XCTAssertFalse(
+      app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Continue")).firstMatch
+        .exists,
+      "Expected active search to remove the detail header between search and results")
+    XCTAssertTrue(
+      app.staticTexts["Follow the Water"].waitForExistence(timeout: 5),
+      "Expected the matching lesson to remain visible above the keyboard")
+    XCTAssertTrue(
+      app.staticTexts["Follow the Water"].isHittable,
+      "Expected the filtered lesson to remain directly interactive during search")
+    XCTAssertFalse(app.staticTexts["Meet the Roots"].exists)
   }
 
   @MainActor
@@ -566,6 +876,7 @@ final class ZoonkUITests: XCTestCase {
   private func makeApp(for scenario: UITestScenario = .signedOut) -> XCUIApplication {
     let app = XCUIApplication()
     app.launchArguments += scenario.launchArguments
+    app.launchEnvironment["ZOONK_UI_TEST_CATALOG"] = courseCatalogUITestSnapshotJSON
 
     if let accountJSON = scenario.accountJSON {
       app.launchEnvironment["ZOONK_UI_TEST_ACCOUNT"] = accountJSON
@@ -607,6 +918,17 @@ final class ZoonkUITests: XCTestCase {
   }
 
   @MainActor
+  private func openPlantsCourse(in app: XCUIApplication) {
+    let coursesTab = app.buttons["Courses"].firstMatch
+    XCTAssertTrue(coursesTab.waitForExistence(timeout: 5))
+    coursesTab.tap()
+
+    let course = app.staticTexts["How Plants Grow"].firstMatch
+    XCTAssertTrue(course.waitForExistence(timeout: 10))
+    course.tap()
+  }
+
+  @MainActor
   private func openAccount(in app: XCUIApplication) {
     let accountButton = app.buttons["Account"]
     XCTAssertTrue(
@@ -624,5 +946,20 @@ final class ZoonkUITests: XCTestCase {
     session.clearTransactions()
     session.disableDialogs = true
     return session
+  }
+}
+
+extension XCUIElement {
+  @MainActor
+  fileprivate func scrollToReveal(_ element: XCUIElement) {
+    for _ in 0..<8 {
+      if element.exists,
+        frame.contains(CGPoint(x: element.frame.midX, y: element.frame.midY))
+      {
+        return
+      }
+
+      swipeLeft(velocity: .fast)
+    }
   }
 }

--- a/apps/apple/ZoonkUITests/ZoonkUITests.swift
+++ b/apps/apple/ZoonkUITests/ZoonkUITests.swift
@@ -604,11 +604,19 @@ final class ZoonkUITests: XCTestCase {
       app.staticTexts["1. Meet the Roots"].exists,
       "Expected the lesson number to be part of the title instead of a separate leading column")
     XCTAssertTrue(completedLesson.label.contains("Completed"))
+    XCTAssertEqual(
+      completedLesson.value as? String,
+      "Explanation",
+      "Expected VoiceOver to identify the lesson kind independently from its title")
 
     let nextLesson = app.buttons.matching(
       NSPredicate(format: "label CONTAINS %@", "Follow the Water")
     ).firstMatch
     XCTAssertTrue(nextLesson.label.contains("Not started"))
+    XCTAssertEqual(
+      nextLesson.value as? String,
+      "Practice",
+      "Expected VoiceOver to identify the lesson kind independently from its title")
     chapterContinue.tap()
 
     XCTAssertTrue(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a browsable course catalog with search, categories, course/chapter details, progress tracking, and a feedback form to the Apple app.

The Courses tab now shows the public catalog instead of the learner's own courses, and the separate Search tab is gone; search now lives inside the catalog. Content is localized based on device language. Course and chapter screens include lesson lists, search, progress states, and continue/start actions; loaded details are reused when screens reopen. A new feedback sheet is accessible from catalog screens and the account menu. The lesson player is a placeholder for now, with a message that it is coming soon. The catalog grid adapts across device and dynamic type sizes, including iPad. Unit and UI tests cover the new API client, store, search, models, progress presentation, and catalog UI scenarios.

<sup>Written for commit d752cb87f7f01482d93b5c49ce69a28c7e47374f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

