### PR TITLE
feat(apple): add my courses with scoped search

### DIFF
--- a/apps/api/e2e/current-learning.test.ts
+++ b/apps/api/e2e/current-learning.test.ts
@@ -78,6 +78,78 @@ test.describe("Current learner catalog API", () => {
     await Promise.all([apiContext.dispose(), otherUser.apiContext.dispose()]);
   });
 
+  test("searches enrolled course titles and descriptions before paginating", async () => {
+    const baseURL = process.env.E2E_BASE_URL ?? "";
+
+    const [{ apiContext, user }, organization] = await Promise.all([
+      createAuthenticatedApiContext({ baseURL, prefix: "search-my-courses" }),
+      organizationFixture({ kind: "brand" }),
+    ]);
+
+    const [titleMatch, descriptionMatch, unrelated, unenrolled] = await Promise.all([
+      courseFixture({ organizationId: organization.id, title: "Ocean habitats" }),
+      courseFixture({
+        description: "Explore ocean ecosystems",
+        organizationId: null,
+        title: "Marine science",
+        userId: user.id,
+      }),
+      courseFixture({
+        description: "Numbers and patterns",
+        organizationId: organization.id,
+        title: "Math",
+      }),
+      courseFixture({ organizationId: organization.id, title: "Ocean navigation" }),
+    ]);
+
+    await Promise.all([
+      courseUserFixture({ courseId: titleMatch.id, userId: user.id }),
+      courseUserFixture({ courseId: descriptionMatch.id, userId: user.id }),
+      courseUserFixture({ courseId: unrelated.id, userId: user.id }),
+    ]);
+
+    const firstResponse = await apiContext.get("/v1/me/courses", {
+      params: { limit: 1, query: "  OCEAN  " },
+    });
+
+    expect(firstResponse.status()).toBe(200);
+    const firstPage = await firstResponse.json();
+    expect(firstPage.data).toHaveLength(1);
+    expect(firstPage.pagination.hasMore).toBe(true);
+
+    const secondResponse = await apiContext.get("/v1/me/courses", {
+      params: { cursor: firstPage.pagination.nextCursor, limit: 1, query: "ocean" },
+    });
+
+    expect(secondResponse.status()).toBe(200);
+    const secondPage = await secondResponse.json();
+
+    const courseIds = [...firstPage.data, ...secondPage.data].map(
+      (course: { id: string }) => course.id,
+    );
+
+    expect(new Set(courseIds)).toEqual(new Set([titleMatch.id, descriptionMatch.id]));
+    expect(courseIds).not.toContain(unenrolled.id);
+    expect(secondPage.pagination).toEqual({ hasMore: false, nextCursor: null });
+
+    const emptyResponse = await apiContext.get("/v1/me/courses", {
+      params: { query: "no-matching-course" },
+    });
+
+    expect(emptyResponse.status()).toBe(200);
+
+    expect(await emptyResponse.json()).toEqual({
+      data: [],
+      pagination: { hasMore: false, nextCursor: null },
+    });
+
+    const allResponse = await apiContext.get("/v1/me/courses", { params: { query: "   " } });
+    expect(allResponse.status()).toBe(200);
+    const allPage = await allResponse.json();
+    expect(allPage.data).toHaveLength(3);
+    await apiContext.dispose();
+  });
+
   test("removes a course from the learner's library without clearing progress", async () => {
     const baseURL = process.env.E2E_BASE_URL ?? "";
 

--- a/apps/api/src/app/v1/me/courses/route.ts
+++ b/apps/api/src/app/v1/me/courses/route.ts
@@ -1,7 +1,7 @@
 import { errors } from "@/lib/api-errors";
 import { withApiErrorBoundary } from "@/lib/api-handler";
 import { toCurrentUserCourse } from "@/lib/current-learning-responses";
-import { resourcePageQuerySchema } from "@/lib/openapi/schemas/catalog-resources";
+import { currentUserCoursesQuerySchema } from "@/lib/openapi/schemas/current-learning";
 import { createPaginatedResponse, decodeCursor } from "@/lib/pagination";
 import { parseQueryParams } from "@/lib/query-params";
 import { listCurrentUserCoursesPage } from "@zoonk/core/courses/list-current-user";
@@ -12,7 +12,7 @@ import { NextResponse } from "next/server";
  * order without accepting a caller-selected user identity.
  */
 async function listCurrentUserCourses(request: Request) {
-  const parsed = parseQueryParams(new URL(request.url).searchParams, resourcePageQuerySchema);
+  const parsed = parseQueryParams(new URL(request.url).searchParams, currentUserCoursesQuerySchema);
 
   if (!parsed.success) {
     return errors.validation(parsed.error);
@@ -24,7 +24,11 @@ async function listCurrentUserCourses(request: Request) {
     return errors.badRequest("Invalid pagination cursor");
   }
 
-  const page = await listCurrentUserCoursesPage({ limit: parsed.data.limit, offset });
+  const page = await listCurrentUserCoursesPage({
+    limit: parsed.data.limit,
+    offset,
+    query: parsed.data.query,
+  });
 
   if (!page) {
     return errors.unauthorized();

--- a/apps/api/src/lib/openapi/paths/current-learning.ts
+++ b/apps/api/src/lib/openapi/paths/current-learning.ts
@@ -1,7 +1,7 @@
-import { resourcePageQuerySchema } from "../schemas/catalog-resources";
 import {
   courseContinuationListResponseSchema,
   currentUserCourseListResponseSchema,
+  currentUserCoursesQuerySchema,
   lessonVisibilitySchema,
   lessonVisibilityUpdateSchema,
 } from "../schemas/current-learning";
@@ -28,7 +28,7 @@ export const currentLearningPaths = {
   "/me/courses": {
     get: {
       operationId: "listCurrentUserCourses",
-      requestParams: { query: resourcePageQuerySchema },
+      requestParams: { query: currentUserCoursesQuerySchema },
       responses: {
         "200": {
           content: { "application/json": { schema: currentUserCourseListResponseSchema } },

--- a/apps/api/src/lib/openapi/schemas/current-learning.ts
+++ b/apps/api/src/lib/openapi/schemas/current-learning.ts
@@ -1,10 +1,20 @@
 import { MAX_CONTINUE_LEARNING_ITEMS } from "@zoonk/core/courses/continue-learning-contract";
 import { z } from "zod";
-import { organizationSummarySchema } from "./catalog-resources";
+import { organizationSummarySchema, resourcePageQuerySchema } from "./catalog-resources";
 import { paginationSchema } from "./common";
 import { lessonKindSchema } from "./curriculum";
 
 const nullableOrganizationSummarySchema = organizationSummarySchema.nullable();
+
+export const currentUserCoursesQuerySchema = resourcePageQuerySchema
+  .extend({
+    query: z
+      .string()
+      .trim()
+      .optional()
+      .meta({ description: "Filter enrolled courses by title or description, ignoring case" }),
+  })
+  .meta({ id: "CurrentUserCoursesQuery" });
 
 const currentUserCourseSchema = z
   .object({

--- a/apps/apple/Zoonk/App/AppDependencies.swift
+++ b/apps/apple/Zoonk/App/AppDependencies.swift
@@ -1,6 +1,7 @@
 @MainActor
 struct AppDependencies {
   let courseCatalogStore: CourseCatalogStore
+  let myCoursesStore: MyCoursesStore
   let progressStore: ProgressStore
   let sessionStore: SessionStore
   let subscriptionStore: AppStoreSubscriptionStore
@@ -17,6 +18,9 @@ struct AppDependencies {
       courseCatalogStore: CourseCatalogStore(
         api: CourseCatalogAPI(clients: clients),
         language: currentCourseCatalogLanguage(),
+        session: sessionStore),
+      myCoursesStore: MyCoursesStore(
+        api: MyCoursesAPI(clients: clients),
         session: sessionStore),
       progressStore: ProgressStore(
         api: ProgressAPI(clients: clients),

--- a/apps/apple/Zoonk/App/AppView.swift
+++ b/apps/apple/Zoonk/App/AppView.swift
@@ -4,6 +4,7 @@ struct AppView: View {
   @Environment(\.scenePhase) private var scenePhase
   @Environment(SessionStore.self) private var session
   @Environment(AppStoreSubscriptionStore.self) private var subscriptions
+  @State private var coursesScope = CoursesScope.all
   @State private var isAccountPresented: Bool
   @State private var navigationPaths: [AppSection: NavigationPath] = [:]
   @State private var selectedSection = AppSection.home
@@ -19,6 +20,7 @@ struct AppView: View {
           NavigationStack(path: navigationPath(for: section)) {
             section.tabContent(
               actions: AppSectionActions(
+                coursesScope: $coursesScope,
                 presentAccount: { isAccountPresented = true },
                 selectSection: { selectedSection = $0 })
             )
@@ -40,9 +42,7 @@ struct AppView: View {
     }
     .tabViewStyle(.sidebarAdaptable)
     .sheet(isPresented: $isAccountPresented) {
-      AccountSheet {
-        selectedSection = .courses
-      }
+      AccountSheet(openMyCourses: showMyCourses)
     }
     .task {
       await session.restore()
@@ -107,6 +107,12 @@ struct AppView: View {
       set: { navigationPaths[section] = $0 })
   }
 
+  private func showMyCourses() {
+    navigationPaths[.courses] = NavigationPath()
+    coursesScope = .mine
+    selectedSection = .courses
+  }
+
   /// Rechecks iCloud Keychain whenever the app returns to the foreground so a login or logout from another Apple device updates this UI without a process restart.
   private func reconcileSessionWhenActive(_ scenePhase: ScenePhase) {
     guard scenePhase == .active else {
@@ -138,6 +144,7 @@ private struct AdaptiveNavigationTitle: ViewModifier {
         language: currentCourseCatalogLanguage(),
         session: session)
     )
+    .environment(MyCoursesStore(api: MyCoursesAPI(clients: clients), session: session))
     .environment(ProgressStore(api: ProgressAPI(clients: clients), session: session))
     .environment(session)
     .environment(AppStoreSubscriptionStore.live())

--- a/apps/apple/Zoonk/App/ZoonkApp.swift
+++ b/apps/apple/Zoonk/App/ZoonkApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct ZoonkApp: App {
   @State private var courseCatalog: CourseCatalogStore
+  @State private var myCourses: MyCoursesStore
   @State private var progress: ProgressStore
   @State private var session: SessionStore
   @State private var subscriptions: AppStoreSubscriptionStore
@@ -12,6 +13,7 @@ struct ZoonkApp: App {
     #if DEBUG
       if let configuration = UITestConfiguration.current {
         _courseCatalog = State(initialValue: configuration.courseCatalog)
+        _myCourses = State(initialValue: configuration.myCourses)
         _progress = State(initialValue: configuration.progress)
         _session = State(initialValue: configuration.session)
         _subscriptions = State(initialValue: .live())
@@ -22,6 +24,7 @@ struct ZoonkApp: App {
 
     let dependencies = AppDependencies.live()
     _courseCatalog = State(initialValue: dependencies.courseCatalogStore)
+    _myCourses = State(initialValue: dependencies.myCoursesStore)
     _progress = State(initialValue: dependencies.progressStore)
     _session = State(initialValue: dependencies.sessionStore)
     _subscriptions = State(initialValue: dependencies.subscriptionStore)
@@ -32,6 +35,7 @@ struct ZoonkApp: App {
     WindowGroup {
       AppView(initiallyPresentsAccount: initiallyPresentsAccount)
         .environment(courseCatalog)
+        .environment(myCourses)
         .environment(progress)
         .environment(session)
         .environment(subscriptions)

--- a/apps/apple/Zoonk/Features/Account/AccountSheet.swift
+++ b/apps/apple/Zoonk/Features/Account/AccountSheet.swift
@@ -20,7 +20,7 @@ struct AccountSheet: View {
   @State private var isGooglePlayManagementPresented = false
   @State private var path = [AccountDestination]()
 
-  let openCatalog: () -> Void
+  let openMyCourses: () -> Void
 
   var body: some View {
     NavigationStack(path: $path) {
@@ -115,7 +115,7 @@ struct AccountSheet: View {
           deleteAccount: { path.append(.deleteAccount(makeDeletionDestination(account))) },
           editProfile: { path.append(.profile) },
           manageAppStoreSubscription: { isAppStoreSubscriptionManagementPresented = true },
-          openCatalog: showCatalog,
+          openMyCourses: showMyCourses,
           openSubscription: { showSubscription(for: account) },
           showGooglePlayManagement: { isGooglePlayManagementPresented = true }
         )
@@ -174,10 +174,10 @@ struct AccountSheet: View {
     }
   }
 
-  /// Closes the modal before moving to the app's native public catalog without opening a duplicate web surface.
-  private func showCatalog() {
+  /// Closes the modal before returning to the root of the learner's course library.
+  private func showMyCourses() {
     dismiss()
-    openCatalog()
+    openMyCourses()
   }
 
   private func showSubscription(for account: CurrentAccount) {
@@ -197,7 +197,7 @@ private struct SignedInAccountView: View {
   let deleteAccount: () -> Void
   let editProfile: () -> Void
   let manageAppStoreSubscription: () -> Void
-  let openCatalog: () -> Void
+  let openMyCourses: () -> Void
   let openSubscription: () -> Void
   let showGooglePlayManagement: () -> Void
 
@@ -221,13 +221,13 @@ private struct SignedInAccountView: View {
       }
 
       Section {
-        Button(action: openCatalog) {
+        Button(action: openMyCourses) {
           AccountRowLabel(
             title: Text(
-              "Browse courses",
+              "My courses",
               tableName: "Account",
-              comment: "Account option that opens the public course catalog"),
-            systemImage: "square.grid.2x2")
+              comment: "Account option that opens the learner's enrolled courses"),
+            systemImage: "books.vertical")
         }
       }
 

--- a/apps/apple/Zoonk/Features/Courses/AllCoursesView.swift
+++ b/apps/apple/Zoonk/Features/Courses/AllCoursesView.swift
@@ -54,6 +54,8 @@ struct AllCoursesView: View {
       return
     }
 
+    catalog.prepareSearch(query: searchText)
+
     do {
       try await Task.sleep(for: .milliseconds(250))
     } catch {

--- a/apps/apple/Zoonk/Features/Courses/AllCoursesView.swift
+++ b/apps/apple/Zoonk/Features/Courses/AllCoursesView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+struct AllCoursesView: View {
+  @Environment(CourseCatalogStore.self) private var catalog
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @State private var selectedCategory: CourseCategory?
+
+  let isSelected: Bool
+  let searchText: String
+  let onCreateCourse: () -> Void
+
+  var body: some View {
+    Group {
+      if catalogText(searchText) != nil {
+        CourseCatalogSearchResultsView(
+          query: searchText,
+          retry: { await catalog.searchCatalog(query: searchText, force: true) })
+      } else {
+        browseCatalog
+      }
+    }
+    .task(id: isSelected ? selectedCategory?.rawValue ?? "" : nil) {
+      guard isSelected else { return }
+      await catalog.loadCoursesIfNeeded(category: selectedCategory)
+    }
+    .task(id: isSelected ? searchText : nil) {
+      guard isSelected else { return }
+      await updateSearchResults()
+    }
+  }
+
+  private var browseCatalog: some View {
+    ScrollView {
+      VStack(spacing: 12) {
+        CourseCategorySelector(selection: $selectedCategory)
+
+        catalogContent
+          .padding(.horizontal, 16)
+      }
+      .frame(maxWidth: 1_180, alignment: .leading)
+      .padding(.top, 4)
+      .padding(.bottom, horizontalSizeClass == .regular ? 32 : 20)
+      .frame(maxWidth: .infinity)
+    }
+    .scrollBounceBehavior(.basedOnSize)
+    .refreshable {
+      await catalog.loadCourses(category: selectedCategory, force: true)
+    }
+  }
+
+  private func updateSearchResults() async {
+    guard catalogText(searchText) != nil else {
+      catalog.clearSearch()
+      return
+    }
+
+    do {
+      try await Task.sleep(for: .milliseconds(250))
+    } catch {
+      return
+    }
+
+    guard !Task.isCancelled else {
+      return
+    }
+
+    await catalog.searchCatalog(query: searchText)
+  }
+
+  @ViewBuilder
+  private var catalogContent: some View {
+    switch catalog.coursesState {
+    case .idle, .loading:
+      CourseCatalogLoadingGrid()
+    case .loaded(let page):
+      CourseCatalogGrid(category: selectedCategory, page: page)
+    case .empty:
+      CourseCatalogEmptyView(category: selectedCategory, onCreateCourse: onCreateCourse)
+    case .failed(let failure):
+      CatalogFailureRecoveryView(context: .catalog, failure: failure) {
+        await catalog.loadCourses(category: selectedCategory, force: true)
+      }
+    }
+  }
+}
+
+private struct CourseCatalogEmptyView: View {
+  let category: CourseCategory?
+  let onCreateCourse: () -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        if let category {
+          Text(
+            "No \(String(localized: category.localizedTitle)) courses yet",
+            tableName: "Courses",
+            comment: "Title when a selected category does not contain any courses.")
+        } else {
+          Text(
+            "No courses yet",
+            tableName: "Courses",
+            comment: "Title when the public course catalog is empty.")
+        }
+      } icon: {
+        Image(systemName: category?.systemImage ?? "books.vertical")
+      }
+    } description: {
+      Text(
+        "Courses will appear here when they're available.",
+        tableName: "Courses",
+        comment: "Guidance when no public courses are available.")
+    } actions: {
+      if let category {
+        Button(action: onCreateCourse) {
+          Label {
+            Text(
+              "Create a course about \(String(localized: category.localizedTitle))",
+              tableName: "Courses",
+              comment:
+                "Opens course creation from an empty category. The interpolated value is the category name."
+            )
+          } icon: {
+            Image(systemName: "plus")
+          }
+        }
+        .buttonStyle(.bordered)
+      }
+    }
+    .frame(maxWidth: .infinity, minHeight: 280)
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogAPI.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogAPI.swift
@@ -308,7 +308,7 @@ private func makeCourseCategory(
   return category
 }
 
-private func makeCourseOrganization(
+func makeCourseOrganization(
   _ payload: Components.Schemas.OrganizationSummary
 ) -> CourseOrganization {
   CourseOrganization(

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogGrid.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogGrid.swift
@@ -16,15 +16,17 @@ struct CourseCatalogGrid: View {
     }
 
     if page.canLoadMore {
-      CourseCatalogLoadMoreView(
-        category: category,
-        failure: catalog.loadMoreFailure,
-        isLoading: catalog.isLoadingMore)
+      CourseGridLoadMoreView(
+        failure: courseGridLoadMoreFailure(catalog.loadMoreFailure),
+        isLoading: catalog.isLoadingMore
+      ) {
+        await catalog.loadMoreCourses(category: category)
+      }
     }
   }
 
-  private var layout: CourseCatalogLayout {
-    CourseCatalogLayout(
+  private var layout: CourseGridLayout {
+    CourseGridLayout(
       dynamicTypeSize: dynamicTypeSize,
       horizontalSizeClass: horizontalSizeClass)
   }
@@ -32,20 +34,31 @@ struct CourseCatalogGrid: View {
   @ViewBuilder
   private func courseItem(_ course: CourseSummary) -> some View {
     if page.canLoadMore, course.id == page.courses.last?.id {
-      CourseCatalogItem(course: course, artworkSize: layout.artworkSize)
-        .task(
-          id: CourseCatalogPaginationTaskID(
-            cursor: page.nextCursor,
-            isLoadingCourses: catalog.isLoadingCourses)
-        ) {
-          guard !catalog.isLoadingCourses else {
-            return
-          }
-
-          await catalog.loadMoreCourses(category: category, force: true)
+      CourseGridItem(
+        artworkSize: layout.artworkSize,
+        description: course.description,
+        destination: .course(CourseReference(course)),
+        imageURL: course.imageURL,
+        title: course.title
+      )
+      .task(
+        id: CourseCatalogPaginationTaskID(
+          cursor: page.nextCursor,
+          isLoadingCourses: catalog.isLoadingCourses)
+      ) {
+        guard !catalog.isLoadingCourses else {
+          return
         }
+
+        await catalog.loadMoreCourses(category: category, force: true)
+      }
     } else {
-      CourseCatalogItem(course: course, artworkSize: layout.artworkSize)
+      CourseGridItem(
+        artworkSize: layout.artworkSize,
+        description: course.description,
+        destination: .course(CourseReference(course)),
+        imageURL: course.imageURL,
+        title: course.title)
     }
   }
 }
@@ -73,8 +86,8 @@ struct CourseCatalogLoadingGrid: View {
         comment: "Accessibility status while the course catalog loads."))
   }
 
-  private var layout: CourseCatalogLayout {
-    CourseCatalogLayout(
+  private var layout: CourseGridLayout {
+    CourseGridLayout(
       dynamicTypeSize: dynamicTypeSize,
       horizontalSizeClass: horizontalSizeClass)
   }
@@ -84,7 +97,7 @@ private struct CourseCatalogLoadingItem: View {
   let artworkSize: CGFloat
 
   var body: some View {
-    CourseCatalogRow(imageURL: nil, artworkSize: artworkSize) {
+    CourseGridRow(imageURL: nil, artworkSize: artworkSize) {
       textContent
     }
     .redacted(reason: .placeholder)
@@ -100,35 +113,48 @@ private struct CourseCatalogLoadingItem: View {
   }
 }
 
-private struct CourseCatalogItem: View {
+struct CourseGridItem: View {
   @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
-  let course: CourseSummary
   let artworkSize: CGFloat
+  let description: String?
+  let destination: CourseDestination?
+  let imageURL: URL?
+  let title: String
 
+  @ViewBuilder
   var body: some View {
-    NavigationLink(value: CourseDestination.course(CourseReference(course))) {
-      CourseCatalogRow(imageURL: course.imageURL, artworkSize: artworkSize) {
-        textContent
+    if let destination {
+      NavigationLink(value: destination) {
+        row
+          .contentShape(Rectangle())
       }
-      .contentShape(Rectangle())
+      .buttonStyle(.plain)
+      .accessibilityHint(
+        Text(
+          "Opens the course",
+          tableName: "Courses",
+          comment: "Accessibility hint for a course in the catalog."))
+    } else {
+      row
+        .accessibilityElement(children: .combine)
     }
-    .buttonStyle(.plain)
-    .accessibilityHint(
-      Text(
-        "Opens the course",
-        tableName: "Courses",
-        comment: "Accessibility hint for a course in the catalog."))
+  }
+
+  private var row: some View {
+    CourseGridRow(imageURL: imageURL, artworkSize: artworkSize) {
+      textContent
+    }
   }
 
   private var textContent: some View {
     VStack(alignment: .leading, spacing: 3) {
-      Text(course.title)
+      Text(title)
         .font(.headline)
         .foregroundStyle(.primary)
         .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
 
-      if let description = catalogText(course.description) {
+      if let description = catalogText(description) {
         Text(description)
           .font(.subheadline)
           .foregroundStyle(.secondary)
@@ -138,7 +164,7 @@ private struct CourseCatalogItem: View {
   }
 }
 
-private struct CourseCatalogRow<Content: View>: View {
+struct CourseGridRow<Content: View>: View {
   @Environment(\.dynamicTypeSize) private var dynamicTypeSize
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -147,7 +173,7 @@ private struct CourseCatalogRow<Content: View>: View {
   @ViewBuilder let content: Content
 
   var body: some View {
-    HStack(alignment: usesBalancedRegularLayout ? .center : .top, spacing: 12) {
+    HStack(alignment: dynamicTypeSize.isAccessibilitySize ? .top : .center, spacing: 12) {
       CourseArtwork(imageURL: imageURL)
         .frame(width: artworkSize, height: artworkSize)
 
@@ -168,12 +194,12 @@ private struct CourseCatalogRow<Content: View>: View {
   }
 }
 
-private struct CourseCatalogLayout {
+struct CourseGridLayout {
   let dynamicTypeSize: DynamicTypeSize
   let horizontalSizeClass: UserInterfaceSizeClass?
 
   var artworkSize: CGFloat {
-    horizontalSizeClass == .regular && !dynamicTypeSize.isAccessibilitySize ? 88 : 80
+    horizontalSizeClass == .regular && !dynamicTypeSize.isAccessibilitySize ? 88 : 64
   }
 
   var columns: [GridItem] {
@@ -185,12 +211,15 @@ private struct CourseCatalogLayout {
   }
 }
 
-private struct CourseCatalogLoadMoreView: View {
-  @Environment(CourseCatalogStore.self) private var catalog
+enum CourseGridLoadMoreFailure: Equatable {
+  case network
+  case unavailable
+}
 
-  let category: CourseCategory?
-  let failure: CourseCatalogFailure?
+struct CourseGridLoadMoreView: View {
+  let failure: CourseGridLoadMoreFailure?
   let isLoading: Bool
+  let retry: @MainActor () async -> Void
 
   var body: some View {
     Group {
@@ -208,7 +237,7 @@ private struct CourseCatalogLoadMoreView: View {
 
           Button {
             Task {
-              await catalog.loadMoreCourses(category: category)
+              await retry()
             }
           } label: {
             Text(
@@ -232,18 +261,28 @@ private struct CourseCatalogLoadMoreView: View {
   }
 
   @ViewBuilder
-  private func failureDescription(_ failure: CourseCatalogFailure) -> some View {
+  private func failureDescription(_ failure: CourseGridLoadMoreFailure) -> some View {
     switch failure {
     case .network:
       Text(
         "Couldn't load more while offline.",
         tableName: "Courses",
         comment: "Message when another course page cannot load because the device is offline.")
-    case .notFound, .unavailable:
+    case .unavailable:
       Text(
         "Couldn't load more courses.",
         tableName: "Courses",
         comment: "Message when another course page cannot be loaded.")
     }
   }
+}
+
+private func courseGridLoadMoreFailure(
+  _ failure: CourseCatalogFailure?
+) -> CourseGridLoadMoreFailure? {
+  guard let failure else {
+    return nil
+  }
+
+  return failure == .network ? .network : .unavailable
 }

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogSearchResultsView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogSearchResultsView.swift
@@ -10,9 +10,7 @@ struct CourseCatalogSearchResultsView: View {
   var body: some View {
     Group {
       switch catalog.searchState {
-      case .idle:
-        searchPrompt
-      case .loading:
+      case .idle, .loading:
         ProgressView()
           .frame(maxWidth: .infinity, maxHeight: .infinity)
           .accessibilityLabel(
@@ -30,24 +28,6 @@ struct CourseCatalogSearchResultsView: View {
     }
     .frame(maxWidth: 900)
     .frame(maxWidth: .infinity)
-  }
-
-  private var searchPrompt: some View {
-    ContentUnavailableView {
-      Label {
-        Text(
-          "Search the catalog",
-          tableName: "Courses",
-          comment: "Title shown before the learner enters a catalog search query.")
-      } icon: {
-        Image(systemName: "magnifyingglass")
-      }
-    } description: {
-      Text(
-        "Find a course or jump directly to a chapter.",
-        tableName: "Courses",
-        comment: "Guidance shown before the learner enters a catalog search query.")
-    }
   }
 
   private func resultsList(_ results: CatalogSearchResults) -> some View {

--- a/apps/apple/Zoonk/Features/Courses/CourseCatalogStore.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseCatalogStore.swift
@@ -297,6 +297,15 @@ final class CourseCatalogStore {
     finishRequest(requestIdentity)
   }
 
+  /// Invalidates the previous query before a debounced request starts, without discarding an unchanged search.
+  func prepareSearch(query: String) {
+    guard catalogText(query) != activeSearchQuery?.query else {
+      return
+    }
+
+    clearSearch()
+  }
+
   func searchCatalog(query: String, force: Bool = false) async {
     let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
 

--- a/apps/apple/Zoonk/Features/Courses/CourseDestination.swift
+++ b/apps/apple/Zoonk/Features/Courses/CourseDestination.swift
@@ -40,6 +40,19 @@ struct CourseReference: Hashable {
     title = course.title
   }
 
+  init?(_ course: UserCourseSummary) {
+    guard let organization = course.organization else {
+      return nil
+    }
+
+    description = course.description
+    id = course.id
+    imageURL = course.imageURL
+    organizationName = organization.name
+    organizationSlug = organization.slug
+    title = course.title
+  }
+
   init(_ course: Course) {
     description = course.description
     id = course.id

--- a/apps/apple/Zoonk/Features/Courses/CoursesView.swift
+++ b/apps/apple/Zoonk/Features/Courses/CoursesView.swift
@@ -1,33 +1,54 @@
 import SwiftUI
 
+enum CoursesScope: Hashable {
+  case all
+  case mine
+}
+
 struct CoursesView: View {
-  @Environment(CourseCatalogStore.self) private var catalog
-  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-  @State private var isSearchPresented = false
-  @State private var searchText = ""
-  @State private var selectedCategory: CourseCategory?
+  @Binding var scope: CoursesScope
+  @State private var allCoursesSearch = ""
+  @State private var myCoursesSearch = ""
 
   let onCreateCourse: () -> Void
+  let onSignIn: () -> Void
 
   var body: some View {
-    Group {
-      if showsSearch {
-        CourseCatalogSearchResultsView(
-          query: searchText,
-          retry: { await catalog.searchCatalog(query: searchText, force: true) })
-      } else {
-        browseCatalog
+    VStack(spacing: 0) {
+      Picker(
+        selection: $scope,
+        label: Text(
+          "Course collection",
+          tableName: "Courses",
+          comment: "Accessibility label for switching between all courses and My Courses.")
+      ) {
+        Text(
+          "All Courses",
+          tableName: "Courses",
+          comment: "Segment that shows the public course catalog."
+        )
+        .tag(CoursesScope.all)
+
+        Text(
+          "My Courses",
+          tableName: "Courses",
+          comment: "Segment that shows the signed-in learner's enrolled courses."
+        )
+        .tag(CoursesScope.mine)
       }
+      .pickerStyle(.segmented)
+      .frame(maxWidth: 420)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 8)
+
+      selectedCourses
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .background(Color(uiColor: .systemBackground))
     .searchable(
-      text: $searchText,
-      isPresented: $isSearchPresented,
+      text: searchText,
       placement: .navigationBarDrawer(displayMode: .always),
-      prompt: Text(
-        "Search courses and chapters",
-        tableName: "Courses",
-        comment: "Placeholder for searching the public course catalog.")
+      prompt: searchPrompt
     )
     .navigationDestination(for: CourseDestination.self) { destination in
       destinationView(destination)
@@ -35,69 +56,42 @@ struct CoursesView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(removing: destination.showsCompactHeader ? .title : nil)
     }
-    .task(id: selectedCategory) {
-      await catalog.loadCoursesIfNeeded(category: selectedCategory)
-    }
-    .task(id: searchText) {
-      await updateSearchResults()
-    }
   }
 
-  private var browseCatalog: some View {
-    ScrollView {
-      VStack(spacing: 12) {
-        CourseCategorySelector(selection: $selectedCategory)
+  private var selectedCourses: some View {
+    TabView(selection: $scope) {
+      AllCoursesView(
+        isSelected: scope == .all,
+        searchText: allCoursesSearch,
+        onCreateCourse: onCreateCourse
+      )
+      .tag(CoursesScope.all)
 
-        catalogContent
-          .padding(.horizontal, 16)
-      }
-      .frame(maxWidth: 1_180, alignment: .leading)
-      .padding(.top, 4)
-      .padding(.bottom, horizontalSizeClass == .regular ? 32 : 20)
-      .frame(maxWidth: .infinity)
+      MyCoursesView(
+        isSelected: scope == .mine,
+        query: myCoursesSearch,
+        onCreateCourse: onCreateCourse,
+        onSignIn: onSignIn
+      )
+      .tag(CoursesScope.mine)
     }
-    .scrollBounceBehavior(.basedOnSize)
-    .refreshable {
-      await catalog.loadCourses(category: selectedCategory, force: true)
-    }
+    .tabViewStyle(.page(indexDisplayMode: .never))
   }
 
-  private var showsSearch: Bool {
-    isSearchPresented || catalogText(searchText) != nil
+  private var searchText: Binding<String> {
+    scope == .all ? $allCoursesSearch : $myCoursesSearch
   }
 
-  private func updateSearchResults() async {
-    guard catalogText(searchText) != nil else {
-      catalog.clearSearch()
-      return
-    }
-
-    do {
-      try await Task.sleep(for: .milliseconds(250))
-    } catch {
-      return
-    }
-
-    guard !Task.isCancelled else {
-      return
-    }
-
-    await catalog.searchCatalog(query: searchText)
-  }
-
-  @ViewBuilder
-  private var catalogContent: some View {
-    switch catalog.coursesState {
-    case .idle, .loading:
-      CourseCatalogLoadingGrid()
-    case .loaded(let page):
-      CourseCatalogGrid(category: selectedCategory, page: page)
-    case .empty:
-      CourseCatalogEmptyView(category: selectedCategory, onCreateCourse: onCreateCourse)
-    case .failed(let failure):
-      CatalogFailureRecoveryView(context: .catalog, failure: failure) {
-        await catalog.loadCourses(category: selectedCategory, force: true)
-      }
+  private var searchPrompt: Text {
+    switch scope {
+    case .all:
+      Text(
+        "Search all courses", tableName: "Courses",
+        comment: "Searches the public catalog, including chapters.")
+    case .mine:
+      Text(
+        "Search my courses", tableName: "Courses",
+        comment: "Searches only the learner's enrolled courses.")
     }
   }
 
@@ -111,52 +105,5 @@ struct CoursesView: View {
     case .lesson(let lesson):
       LessonPlaceholderView(lesson: lesson)
     }
-  }
-}
-
-private struct CourseCatalogEmptyView: View {
-  let category: CourseCategory?
-  let onCreateCourse: () -> Void
-
-  var body: some View {
-    ContentUnavailableView {
-      Label {
-        if let category {
-          Text(
-            "No \(String(localized: category.localizedTitle)) courses yet",
-            tableName: "Courses",
-            comment: "Title when a selected category does not contain any courses.")
-        } else {
-          Text(
-            "No courses yet",
-            tableName: "Courses",
-            comment: "Title when the public course catalog is empty.")
-        }
-      } icon: {
-        Image(systemName: category?.systemImage ?? "books.vertical")
-      }
-    } description: {
-      Text(
-        "Courses will appear here when they're available.",
-        tableName: "Courses",
-        comment: "Guidance when no public courses are available.")
-    } actions: {
-      if let category {
-        Button(action: onCreateCourse) {
-          Label {
-            Text(
-              "Create a course about \(String(localized: category.localizedTitle))",
-              tableName: "Courses",
-              comment:
-                "Opens course creation from an empty category. The interpolated value is the category name."
-            )
-          } icon: {
-            Image(systemName: "plus")
-          }
-        }
-        .buttonStyle(.bordered)
-      }
-    }
-    .frame(maxWidth: .infinity, minHeight: 280)
   }
 }

--- a/apps/apple/Zoonk/Features/Courses/MyCoursesAPI.swift
+++ b/apps/apple/Zoonk/Features/Courses/MyCoursesAPI.swift
@@ -1,0 +1,119 @@
+import Foundation
+import OpenAPIRuntime
+
+enum MyCoursesAPIError: Error, Equatable, Sendable {
+  case network
+  case unauthorized
+  case unavailable
+}
+
+protocol MyCoursesAPIClient: Sendable {
+  func listCourses(request: MyCoursesRequest) async throws -> MyCoursesPage
+}
+
+struct MyCoursesAPI: MyCoursesAPIClient, @unchecked Sendable {
+  private let clients: APIClientFactory
+
+  init(clients: APIClientFactory) {
+    self.clients = clients
+  }
+
+  func listCourses(request: MyCoursesRequest) async throws -> MyCoursesPage {
+    try await perform(
+      (
+        token: request.token,
+        operation: { client in
+          let output = try await client.listCurrentUserCourses(
+            .init(
+              query: .init(
+                cursor: request.query.cursor, limit: request.query.limit, query: request.query.query
+              )))
+
+          switch output {
+          case .ok(let response):
+            return makeMyCoursesPage(try response.body.json)
+          case .unauthorized:
+            throw MyCoursesAPIError.unauthorized
+          case .badRequest, .internalServerError, .undocumented:
+            throw MyCoursesAPIError.unavailable
+          }
+        }
+      ))
+  }
+
+  /// Keeps generated transport failures behind stable feature errors while preserving task cancellation.
+  private func perform<Output: Sendable>(
+    _ request: (
+      token: String,
+      operation: @Sendable (Client) async throws -> Output
+    )
+  ) async throws -> Output {
+    do {
+      return try await request.operation(clients.makeClient(token: request.token))
+    } catch {
+      if isRequestCancellation(error) {
+        throw CancellationError()
+      }
+
+      if let error = error as? MyCoursesAPIError {
+        throw error
+      }
+
+      if isNetworkError(error) {
+        throw MyCoursesAPIError.network
+      }
+
+      throw MyCoursesAPIError.unavailable
+    }
+  }
+
+  private func isRequestCancellation(_ error: Error) -> Bool {
+    if error is CancellationError {
+      return true
+    }
+
+    if let urlError = error as? URLError {
+      return urlError.code == .cancelled
+    }
+
+    if let clientError = error as? ClientError {
+      return isRequestCancellation(clientError.underlyingError)
+    }
+
+    return false
+  }
+
+  private func isNetworkError(_ error: Error) -> Bool {
+    if error is URLError {
+      return true
+    }
+
+    if let clientError = error as? ClientError {
+      return isNetworkError(clientError.underlyingError)
+    }
+
+    return false
+  }
+}
+
+private func makeMyCoursesPage(
+  _ payload: Components.Schemas.CurrentUserCourseListResponse
+) -> MyCoursesPage {
+  MyCoursesPage(
+    courses: payload.data.map(makeUserCourseSummary),
+    hasMore: payload.pagination.hasMore,
+    nextCursor: payload.pagination.nextCursor)
+}
+
+private func makeUserCourseSummary(
+  _ payload: Components.Schemas.CurrentUserCourse
+) -> UserCourseSummary {
+  UserCourseSummary(
+    description: payload.description,
+    id: payload.id,
+    imageURL: payload.imageUrl.flatMap(URL.init(string:)),
+    language: payload.language,
+    organization: payload.organization.map { makeCourseOrganization($0.value1) },
+    slug: payload.slug,
+    title: payload.title)
+}

--- a/apps/apple/Zoonk/Features/Courses/MyCoursesGrid.swift
+++ b/apps/apple/Zoonk/Features/Courses/MyCoursesGrid.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct MyCoursesGrid: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @Environment(MyCoursesStore.self) private var myCourses
+
+  let page: MyCoursesPage
+
+  var body: some View {
+    LazyVGrid(columns: layout.columns, alignment: .leading, spacing: 14) {
+      ForEach(page.courses) { course in
+        courseItem(course)
+      }
+    }
+
+    if page.canLoadMore {
+      CourseGridLoadMoreView(
+        failure: courseGridLoadMoreFailure(myCourses.loadMoreFailure),
+        isLoading: myCourses.isLoadingMore
+      ) {
+        await myCourses.loadMoreCourses()
+      }
+    }
+  }
+
+  private var layout: CourseGridLayout {
+    CourseGridLayout(
+      dynamicTypeSize: dynamicTypeSize,
+      horizontalSizeClass: horizontalSizeClass)
+  }
+
+  @ViewBuilder
+  private func courseItem(_ course: UserCourseSummary) -> some View {
+    if page.canLoadMore, course.id == page.courses.last?.id {
+      gridItem(course)
+        .task(
+          id: MyCoursesPaginationTaskID(
+            cursor: page.nextCursor,
+            revision: myCourses.coursesRevision,
+            isLoadingCourses: myCourses.isLoadingCourses)
+        ) {
+          await myCourses.loadMoreCourses(force: true)
+        }
+    } else {
+      gridItem(course)
+    }
+  }
+
+  private func gridItem(_ course: UserCourseSummary) -> CourseGridItem {
+    CourseGridItem(
+      artworkSize: layout.artworkSize,
+      description: course.description,
+      destination: courseDestination(course),
+      imageURL: course.imageURL,
+      title: course.title)
+  }
+}
+
+/// Request identity also restarts pagination after a fast refresh that keeps the same cursor.
+private struct MyCoursesPaginationTaskID: Equatable {
+  let cursor: String?
+  let revision: UUID?
+  let isLoadingCourses: Bool
+}
+
+/// Personal courses remain visible in the learner's library, but only branded courses can use the public native detail route without producing a known not-found state.
+private func courseDestination(_ course: UserCourseSummary) -> CourseDestination? {
+  CourseReference(course).map(CourseDestination.course)
+}
+
+private func courseGridLoadMoreFailure(
+  _ failure: MyCoursesFailure?
+) -> CourseGridLoadMoreFailure? {
+  guard let failure else {
+    return nil
+  }
+
+  switch failure {
+  case .network:
+    return .network
+  case .unavailable:
+    return .unavailable
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/MyCoursesModels.swift
+++ b/apps/apple/Zoonk/Features/Courses/MyCoursesModels.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+struct UserCourseSummary: Codable, Equatable, Identifiable, Sendable {
+  let description: String?
+  let id: String
+  let imageURL: URL?
+  let language: String
+  let organization: CourseOrganization?
+  let slug: String
+  let title: String
+}
+
+struct MyCoursesPage: Codable, Equatable, Sendable {
+  let courses: [UserCourseSummary]
+  let hasMore: Bool
+  let nextCursor: String?
+
+  var canLoadMore: Bool {
+    hasMore && nextCursor != nil
+  }
+}
+
+struct MyCoursesQuery: Equatable, Sendable {
+  let cursor: String?
+  let limit: Int?
+  let query: String?
+
+  init(cursor: String? = nil, limit: Int? = nil, query: String? = nil) {
+    self.cursor = cursor
+    self.limit = limit
+    self.query = query
+  }
+}
+
+struct MyCoursesRequest: Equatable, Sendable {
+  let query: MyCoursesQuery
+  let token: String
+}
+
+enum MyCoursesFailure: Error, Codable, Equatable, Sendable {
+  case network
+  case unavailable
+}
+
+enum MyCoursesLoadState<Value: Codable & Equatable & Sendable>: Codable, Equatable, Sendable {
+  case idle
+  case loading
+  case loaded(Value)
+  case empty
+  case failed(MyCoursesFailure)
+}

--- a/apps/apple/Zoonk/Features/Courses/MyCoursesStore.swift
+++ b/apps/apple/Zoonk/Features/Courses/MyCoursesStore.swift
@@ -1,0 +1,341 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class MyCoursesStore {
+  private(set) var coursesState: MyCoursesLoadState<MyCoursesPage> = .idle
+  private(set) var coursesRevision: UUID?
+  private(set) var isLoadingCourses = false
+  private(set) var isLoadingMore = false
+  private(set) var loadMoreFailure: MyCoursesFailure?
+
+  private let api: any MyCoursesAPIClient
+  private let session: SessionStore
+  private var activeQuery: String?
+  private var loadMoreRevision: UUID?
+  private var sessionIdentity: AuthenticatedSession?
+
+  init(api: any MyCoursesAPIClient, session: SessionStore) {
+    self.api = api
+    self.session = session
+    sessionIdentity = session.authenticatedSession
+  }
+
+  func loadCoursesIfNeeded(query: String = "") async {
+    synchronizeSession()
+
+    guard catalogText(query) != activeQuery || canBeginCoursesRequest(force: false) else {
+      return
+    }
+
+    await loadCourses(query: query)
+  }
+
+  func loadCourses(query: String = "", force: Bool = false) async {
+    synchronizeSession()
+    let normalizedQuery = catalogText(query)
+    let queryChanged = normalizedQuery != activeQuery
+
+    guard let authenticatedSession = session.authenticatedSession,
+      queryChanged || canBeginCoursesRequest(force: force)
+    else {
+      return
+    }
+
+    let previousState: MyCoursesLoadState<MyCoursesPage> = queryChanged ? .idle : coursesState
+    activeQuery = normalizedQuery
+    let requestRevision = UUID()
+    coursesRevision = requestRevision
+    isLoadingCourses = true
+    cancelPagination()
+    coursesState = loadingState(from: previousState)
+
+    defer {
+      finishCoursesRequest(requestRevision)
+    }
+
+    do {
+      let page = try await api.listCourses(
+        request: MyCoursesRequest(
+          query: MyCoursesQuery(query: normalizedQuery),
+          token: authenticatedSession.bearerToken))
+
+      guard
+        isCurrentRequest((revision: requestRevision, session: authenticatedSession))
+      else {
+        synchronizeSession()
+        return
+      }
+
+      coursesState = page.courses.isEmpty ? .empty : .loaded(page)
+    } catch is CancellationError {
+      guard
+        isCurrentRequest((revision: requestRevision, session: authenticatedSession))
+      else {
+        synchronizeSession()
+        return
+      }
+
+      coursesState = stateAfterCancellation(from: previousState)
+    } catch MyCoursesAPIError.unauthorized {
+      guard
+        isCurrentRequest((revision: requestRevision, session: authenticatedSession))
+      else {
+        synchronizeSession()
+        return
+      }
+
+      await session.expire(authenticatedSession)
+      synchronizeSession()
+    } catch MyCoursesAPIError.network {
+      guard
+        isCurrentRequest((revision: requestRevision, session: authenticatedSession))
+      else {
+        synchronizeSession()
+        return
+      }
+
+      coursesState = stateAfterFailure((failure: .network, previousState: previousState))
+    } catch {
+      guard
+        isCurrentRequest((revision: requestRevision, session: authenticatedSession))
+      else {
+        synchronizeSession()
+        return
+      }
+
+      coursesState = stateAfterFailure((failure: .unavailable, previousState: previousState))
+    }
+  }
+
+  func loadMoreCourses(force: Bool = false) async {
+    synchronizeSession()
+
+    guard
+      let authenticatedSession = session.authenticatedSession,
+      case .loaded(let currentPage) = coursesState,
+      currentPage.canLoadMore,
+      let cursor = currentPage.nextCursor,
+      let coursesRevision,
+      !isLoadingCourses,
+      !isLoadingMore || force
+    else {
+      return
+    }
+
+    let paginationRevision = UUID()
+    loadMoreRevision = paginationRevision
+    isLoadingMore = true
+    loadMoreFailure = nil
+
+    defer {
+      finishPaginationRequest(paginationRevision)
+    }
+
+    do {
+      let nextPage = try await api.listCourses(
+        request: MyCoursesRequest(
+          query: MyCoursesQuery(cursor: cursor, query: activeQuery),
+          token: authenticatedSession.bearerToken))
+
+      guard
+        isCurrentPaginationRequest(
+          (
+            coursesRevision: coursesRevision,
+            paginationRevision: paginationRevision,
+            session: authenticatedSession
+          ))
+      else {
+        synchronizeSession()
+        return
+      }
+
+      coursesState = .loaded(merge((currentPage: currentPage, nextPage: nextPage)))
+    } catch is CancellationError {
+      guard
+        isCurrentPaginationRequest(
+          (
+            coursesRevision: coursesRevision,
+            paginationRevision: paginationRevision,
+            session: authenticatedSession
+          ))
+      else {
+        synchronizeSession()
+        return
+      }
+    } catch MyCoursesAPIError.unauthorized {
+      guard
+        isCurrentPaginationRequest(
+          (
+            coursesRevision: coursesRevision,
+            paginationRevision: paginationRevision,
+            session: authenticatedSession
+          ))
+      else {
+        synchronizeSession()
+        return
+      }
+
+      await session.expire(authenticatedSession)
+      synchronizeSession()
+    } catch MyCoursesAPIError.network {
+      guard
+        isCurrentPaginationRequest(
+          (
+            coursesRevision: coursesRevision,
+            paginationRevision: paginationRevision,
+            session: authenticatedSession
+          ))
+      else {
+        synchronizeSession()
+        return
+      }
+
+      loadMoreFailure = .network
+    } catch {
+      guard
+        isCurrentPaginationRequest(
+          (
+            coursesRevision: coursesRevision,
+            paginationRevision: paginationRevision,
+            session: authenticatedSession
+          ))
+      else {
+        synchronizeSession()
+        return
+      }
+
+      loadMoreFailure = .unavailable
+    }
+  }
+
+  private func canBeginCoursesRequest(force: Bool) -> Bool {
+    force || (!isLoadingCourses && needsPresentationLoad(coursesState))
+  }
+
+  private func needsPresentationLoad(_ state: MyCoursesLoadState<MyCoursesPage>) -> Bool {
+    switch state {
+    case .idle, .loading, .failed:
+      true
+    case .loaded, .empty:
+      false
+    }
+  }
+
+  private func loadingState(
+    from state: MyCoursesLoadState<MyCoursesPage>
+  ) -> MyCoursesLoadState<MyCoursesPage> {
+    switch state {
+    case .loaded, .empty:
+      state
+    case .idle, .loading, .failed:
+      .loading
+    }
+  }
+
+  private func stateAfterCancellation(
+    from state: MyCoursesLoadState<MyCoursesPage>
+  ) -> MyCoursesLoadState<MyCoursesPage> {
+    switch state {
+    case .empty, .failed, .loaded:
+      state
+    case .idle, .loading:
+      .idle
+    }
+  }
+
+  private func stateAfterFailure(
+    _ source: (
+      failure: MyCoursesFailure,
+      previousState: MyCoursesLoadState<MyCoursesPage>
+    )
+  ) -> MyCoursesLoadState<MyCoursesPage> {
+    switch source.previousState {
+    case .loaded, .empty:
+      source.previousState
+    case .idle, .loading, .failed:
+      .failed(source.failure)
+    }
+  }
+
+  private func isCurrentRequest(
+    _ source: (revision: UUID, session: AuthenticatedSession)
+  ) -> Bool {
+    coursesRevision == source.revision && session.authenticatedSession == source.session
+  }
+
+  private func isCurrentPaginationRequest(
+    _ source: (
+      coursesRevision: UUID,
+      paginationRevision: UUID,
+      session: AuthenticatedSession
+    )
+  ) -> Bool {
+    coursesRevision == source.coursesRevision
+      && loadMoreRevision == source.paginationRevision
+      && session.authenticatedSession == source.session
+  }
+
+  private func finishCoursesRequest(_ revision: UUID) {
+    guard coursesRevision == revision else {
+      return
+    }
+
+    isLoadingCourses = false
+  }
+
+  private func finishPaginationRequest(_ revision: UUID) {
+    guard loadMoreRevision == revision else {
+      return
+    }
+
+    isLoadingMore = false
+    loadMoreRevision = nil
+  }
+
+  private func cancelPagination() {
+    isLoadingMore = false
+    loadMoreRevision = nil
+    loadMoreFailure = nil
+  }
+
+  private func synchronizeSession() {
+    let currentSessionIdentity = session.authenticatedSession
+
+    guard currentSessionIdentity != sessionIdentity else {
+      return
+    }
+
+    sessionIdentity = currentSessionIdentity
+    activeQuery = nil
+    coursesRevision = nil
+    isLoadingCourses = false
+    cancelPagination()
+    coursesState = .idle
+  }
+
+  private func merge(
+    _ source: (currentPage: MyCoursesPage, nextPage: MyCoursesPage)
+  ) -> MyCoursesPage {
+    MyCoursesPage(
+      courses: appendingUniqueCourses(
+        (
+          currentCourses: source.currentPage.courses,
+          candidates: source.nextPage.courses
+        )),
+      hasMore: source.nextPage.hasMore,
+      nextCursor: source.nextPage.nextCursor)
+  }
+
+  private func appendingUniqueCourses(
+    _ source: (
+      currentCourses: [UserCourseSummary],
+      candidates: [UserCourseSummary]
+    )
+  ) -> [UserCourseSummary] {
+    let existingCourseIDs = Set(source.currentCourses.map(\.id))
+    let uniqueCandidates = source.candidates.filter { !existingCourseIDs.contains($0.id) }
+    return source.currentCourses + uniqueCandidates
+  }
+}

--- a/apps/apple/Zoonk/Features/Courses/MyCoursesView.swift
+++ b/apps/apple/Zoonk/Features/Courses/MyCoursesView.swift
@@ -1,0 +1,236 @@
+import SwiftUI
+
+struct MyCoursesView: View {
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  @Environment(MyCoursesStore.self) private var myCourses
+  @Environment(SessionStore.self) private var session
+
+  var isSelected = true
+  var query = ""
+  let onCreateCourse: () -> Void
+  let onSignIn: () -> Void
+
+  var body: some View {
+    Group {
+      switch session.state {
+      case .restoring:
+        loadingCourses
+      case .signedOut:
+        MyCoursesSignInView(onSignIn: onSignIn)
+      case .signedIn:
+        signedInCourses
+      case .unavailable:
+        MyCoursesAccountUnavailableView()
+      }
+    }
+    .contentMargins(.top, 16, for: .scrollContent)
+    .task(id: session.authenticatedSession) {
+      guard isSelected else { return }
+      await myCourses.loadCoursesIfNeeded(query: query)
+    }
+    .task(id: isSelected ? query : nil) {
+      guard isSelected else { return }
+      if catalogText(query) != nil {
+        do {
+          try await Task.sleep(for: .milliseconds(250))
+        } catch {
+          return
+        }
+      }
+      guard !Task.isCancelled else { return }
+      await myCourses.loadCoursesIfNeeded(query: query)
+    }
+  }
+
+  private var loadingCourses: some View {
+    ScrollView {
+      CourseCatalogLoadingGrid()
+        .frame(maxWidth: 1_180, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.bottom, horizontalSizeClass == .regular ? 32 : 20)
+        .frame(maxWidth: .infinity)
+    }
+    .scrollBounceBehavior(.basedOnSize)
+  }
+
+  private var signedInCourses: some View {
+    ScrollView {
+      signedInContent
+        .frame(maxWidth: 1_180, alignment: .leading)
+        .padding(.horizontal, 16)
+        .padding(.bottom, horizontalSizeClass == .regular ? 32 : 20)
+        .frame(maxWidth: .infinity)
+    }
+    .scrollBounceBehavior(.basedOnSize)
+    .refreshable {
+      await myCourses.loadCourses(query: query, force: true)
+    }
+  }
+
+  @ViewBuilder
+  private var signedInContent: some View {
+    switch myCourses.coursesState {
+    case .idle, .loading:
+      CourseCatalogLoadingGrid()
+    case .loaded(let page):
+      MyCoursesGrid(page: page)
+    case .empty:
+      if let query = catalogText(query) {
+        ContentUnavailableView.search(text: query)
+      } else {
+        MyCoursesEmptyView(onCreateCourse: onCreateCourse)
+      }
+    case .failed(let failure):
+      MyCoursesFailureRecoveryView(failure: failure) {
+        await myCourses.loadCourses(query: query, force: true)
+      }
+    }
+  }
+}
+
+private struct MyCoursesSignInView: View {
+  let onSignIn: () -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        Text(
+          "Log in to track your courses",
+          tableName: "Courses",
+          comment: "Title inviting signed-out learners to log in to use My Courses.")
+      } icon: {
+        Image(systemName: "person.crop.circle.badge.checkmark")
+      }
+    } description: {
+      Text(
+        "Keep your courses and progress in one place by logging in to your account.",
+        tableName: "Courses",
+        comment: "Explains why signing in is useful on the My Courses screen.")
+    } actions: {
+      Button(action: onSignIn) {
+        Text(
+          "Log in",
+          tableName: "Courses",
+          comment: "Opens the native account sheet from My Courses.")
+      }
+      .buttonStyle(.bordered)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+private struct MyCoursesAccountUnavailableView: View {
+  @Environment(SessionStore.self) private var session
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        Text(
+          "Account unavailable",
+          tableName: "Courses",
+          comment: "Title when My Courses cannot determine the signed-in account.")
+      } icon: {
+        Image(systemName: "wifi.exclamationmark")
+      }
+    } description: {
+      Text(
+        "Zoonk couldn't load your account. Check your connection and try again.",
+        tableName: "Courses",
+        comment: "Guidance when account restoration fails on My Courses.")
+    } actions: {
+      Button {
+        Task {
+          await session.retryRestore()
+        }
+      } label: {
+        Text(
+          "Try again",
+          tableName: "Courses",
+          comment: "Retries account restoration from My Courses.")
+      }
+      .buttonStyle(.bordered)
+      .disabled(session.isWorking)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+}
+
+private struct MyCoursesEmptyView: View {
+  let onCreateCourse: () -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        Text(
+          "No courses yet",
+          tableName: "Courses",
+          comment: "Title when the signed-in learner has not enrolled in any courses.")
+      } icon: {
+        Image(systemName: "books.vertical")
+      }
+    } description: {
+      Text(
+        "Start learning something new today.",
+        tableName: "Courses",
+        comment: "Guidance when the signed-in learner has no courses.")
+    } actions: {
+      Button(action: onCreateCourse) {
+        Text(
+          "Start a course",
+          tableName: "Courses",
+          comment: "Opens course creation from an empty My Courses list.")
+      }
+      .buttonStyle(.bordered)
+    }
+    .frame(maxWidth: .infinity, minHeight: 280)
+  }
+}
+
+private struct MyCoursesFailureRecoveryView: View {
+  let failure: MyCoursesFailure
+  let retry: () async -> Void
+
+  var body: some View {
+    ContentUnavailableView {
+      Label {
+        failureTitle
+      } icon: {
+        Image(systemName: failure == .network ? "wifi.exclamationmark" : "exclamationmark.triangle")
+      }
+    } description: {
+      Text(
+        "Your courses are safe. Try loading them again.",
+        tableName: "Courses",
+        comment: "Reassures learners after My Courses fails to load.")
+    } actions: {
+      Button {
+        Task {
+          await retry()
+        }
+      } label: {
+        Text(
+          "Try again",
+          tableName: "Courses",
+          comment: "Retries loading My Courses after a failure.")
+      }
+      .buttonStyle(.bordered)
+    }
+    .frame(maxWidth: .infinity, minHeight: 280)
+  }
+
+  @ViewBuilder
+  private var failureTitle: some View {
+    switch failure {
+    case .network:
+      Text(
+        "You're offline",
+        tableName: "Courses",
+        comment: "Title when My Courses cannot load without a network connection.")
+    case .unavailable:
+      Text(
+        "Courses are unavailable",
+        tableName: "Courses",
+        comment: "Title when My Courses cannot be loaded from the service.")
+    }
+  }
+}

--- a/apps/apple/Zoonk/Navigation/AppSection+Tab.swift
+++ b/apps/apple/Zoonk/Navigation/AppSection+Tab.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct AppSectionActions {
+  let coursesScope: Binding<CoursesScope>
   let presentAccount: () -> Void
   let selectSection: (AppSection) -> Void
 }
@@ -15,9 +16,10 @@ extension AppSection {
     case .newCourse:
       NewCourseView()
     case .courses:
-      CoursesView {
-        actions.selectSection(.newCourse)
-      }
+      CoursesView(
+        scope: actions.coursesScope,
+        onCreateCourse: { actions.selectSection(.newCourse) },
+        onSignIn: actions.presentAccount)
     case .progress:
       ProgressOverviewView(onSignIn: actions.presentAccount)
     }

--- a/apps/apple/Zoonk/Resources/Localization/Account.xcstrings
+++ b/apps/apple/Zoonk/Resources/Localization/Account.xcstrings
@@ -262,35 +262,6 @@
         }
       }
     },
-    "Browse courses" : {
-      "comment" : "Account option that opens the public course catalog",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kurse entdecken"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Explorar cursos"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parcourir les cours"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ver cursos"
-          }
-        }
-      }
-    },
     "By continuing, you agree to the Zoonk Terms of Service and Privacy Policy." : {
       "comment" : "Legal agreement shown below sign-in methods",
       "localizations" : {
@@ -1244,6 +1215,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gerenciada pelo Google Play"
+          }
+        }
+      }
+    },
+    "My courses" : {
+      "comment" : "Account option that opens the learner's enrolled courses",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meine Kurse"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mis cursos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mes cours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meus cursos"
           }
         }
       }

--- a/apps/apple/Zoonk/Resources/Localization/Courses.xcstrings
+++ b/apps/apple/Zoonk/Resources/Localization/Courses.xcstrings
@@ -36,6 +36,35 @@
         }
       }
     },
+    "Account unavailable" : {
+      "comment" : "Title when My Courses cannot determine the signed-in account.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konto nicht verfügbar"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuenta no disponible"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compte indisponible"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conta indisponível"
+          }
+        }
+      }
+    },
     "All" : {
       "comment" : "Category option that shows courses from every category.",
       "localizations" : {
@@ -61,6 +90,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Todos"
+          }
+        }
+      }
+    },
+    "All Courses" : {
+      "comment" : "Segment that shows the public course catalog.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Kurse"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los cursos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les cours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos os cursos"
           }
         }
       }
@@ -558,6 +616,35 @@
         }
       }
     },
+    "Course collection" : {
+      "comment" : "Accessibility label for switching between all courses and My Courses.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kursübersicht"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colección de cursos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélection de cours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coleção de cursos"
+          }
+        }
+      }
+    },
     "Course information" : {
       "comment" : "Title for secondary information about a course.",
       "localizations" : {
@@ -675,7 +762,7 @@
       }
     },
     "Courses are unavailable" : {
-      "comment" : "Title when the public course catalog cannot be loaded.",
+      "comment" : "Title when My Courses cannot be loaded from the service.\nTitle when the public course catalog cannot be loaded.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -964,35 +1051,6 @@
         }
       }
     },
-    "Find a course or jump directly to a chapter." : {
-      "comment" : "Guidance shown before the learner enters a catalog search query.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finde einen Kurs oder springe direkt zu einem Kapitel."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Busca un curso o ve directamente a un capítulo."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trouve un cours ou va directement à un chapitre."
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Encontre um curso ou vá direto para um capítulo."
-          }
-        }
-      }
-    },
     "Follow a guided step-by-step tutorial." : {
       "comment" : "Fallback description for a tutorial lesson.",
       "localizations" : {
@@ -1134,6 +1192,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "História"
+          }
+        }
+      }
+    },
+    "Keep your courses and progress in one place by logging in to your account." : {
+      "comment" : "Explains why signing in is useful on the My Courses screen.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melde dich in deinem Konto an, damit deine Kurse und dein Fortschritt an einem Ort bleiben."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicia sesión en tu cuenta para tener tus cursos y tu progreso en un solo lugar."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecte-toi à ton compte pour retrouver tes cours et ta progression au même endroit."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entre na sua conta para manter seus cursos e progresso em um só lugar."
           }
         }
       }
@@ -1515,6 +1602,64 @@
         }
       }
     },
+    "Log in" : {
+      "comment" : "Opens the native account sheet from My Courses.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anmelden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar sesión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrar"
+          }
+        }
+      }
+    },
+    "Log in to track your courses" : {
+      "comment" : "Title inviting signed-out learners to log in to use My Courses.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melde dich an, um deine Kurse im Blick zu behalten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicia sesión para llevar el control de tus cursos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecte-toi pour suivre tes cours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entre para acompanhar seus cursos"
+          }
+        }
+      }
+    },
     "Math" : {
       "comment" : "Course category for mathematics.",
       "localizations" : {
@@ -1569,6 +1714,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mais opções"
+          }
+        }
+      }
+    },
+    "My Courses" : {
+      "comment" : "Segment that shows the signed-in learner's enrolled courses.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meine Kurse"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mis cursos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mes cours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meus cursos"
           }
         }
       }
@@ -1632,7 +1806,7 @@
       }
     },
     "No courses yet" : {
-      "comment" : "Title when the public course catalog is empty.",
+      "comment" : "Title when the public course catalog is empty.\nTitle when the signed-in learner has not enrolled in any courses.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -2066,6 +2240,35 @@
         }
       }
     },
+    "Search all courses" : {
+      "comment" : "Searches the public catalog, including chapters.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle Kurse durchsuchen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar en todos los cursos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher dans tous les cours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar em todos os cursos"
+          }
+        }
+      }
+    },
     "Search chapters" : {
       "comment" : "Placeholder for searching within a course's chapters.",
       "localizations" : {
@@ -2091,35 +2294,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Buscar capítulos"
-          }
-        }
-      }
-    },
-    "Search courses and chapters" : {
-      "comment" : "Placeholder for searching the public course catalog.",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kurse und Kapitel durchsuchen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar cursos y capítulos"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des cours et des chapitres"
-          }
-        },
-        "pt" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar cursos e capítulos"
           }
         }
       }
@@ -2153,31 +2327,31 @@
         }
       }
     },
-    "Search the catalog" : {
-      "comment" : "Title shown before the learner enters a catalog search query.",
+    "Search my courses" : {
+      "comment" : "Searches only the learner's enrolled courses.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Katalog durchsuchen"
+            "value" : "Meine Kurse durchsuchen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Buscar en el catálogo"
+            "value" : "Buscar en mis cursos"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rechercher dans le catalogue"
+            "value" : "Rechercher dans mes cours"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Buscar no catálogo"
+            "value" : "Buscar nos meus cursos"
           }
         }
       }
@@ -2323,6 +2497,64 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Começar"
+          }
+        }
+      }
+    },
+    "Start a course" : {
+      "comment" : "Opens course creation from an empty My Courses list.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einen Kurs starten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empezar un curso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commencer un cours"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Começar um curso"
+          }
+        }
+      }
+    },
+    "Start learning something new today." : {
+      "comment" : "Guidance when the signed-in learner has no courses.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lerne noch heute etwas Neues."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empieza a aprender algo nuevo hoy."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commence à apprendre quelque chose de nouveau dès aujourd’hui."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comece a aprender algo novo hoje."
           }
         }
       }
@@ -2531,7 +2763,7 @@
       }
     },
     "Try again" : {
-      "comment" : "Retries loading catalog content after a failure.",
+      "comment" : "Retries account restoration from My Courses.\nRetries loading My Courses after a failure.\nRetries loading catalog content after a failure.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -2734,7 +2966,7 @@
       }
     },
     "You're offline" : {
-      "comment" : "Title when catalog content cannot load because the device is offline.",
+      "comment" : "Title when My Courses cannot load without a network connection.\nTitle when catalog content cannot load because the device is offline.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -2758,6 +2990,64 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Você está sem conexão"
+          }
+        }
+      }
+    },
+    "Your courses are safe. Try loading them again." : {
+      "comment" : "Reassures learners after My Courses fails to load.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deine Kurse sind sicher. Versuch, sie noch einmal zu laden."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tus cursos siguen ahí. Intenta cargarlos de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tes cours sont toujours là. Essaie de les charger à nouveau."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seus cursos continuam salvos. Tente carregar de novo."
+          }
+        }
+      }
+    },
+    "Zoonk couldn't load your account. Check your connection and try again." : {
+      "comment" : "Guidance when account restoration fails on My Courses.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoonk konnte dein Konto nicht laden. Prüfe deine Verbindung und versuche es noch einmal."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoonk no pudo cargar tu cuenta. Revisa tu conexión y vuelve a intentarlo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoonk n’a pas pu charger ton compte. Vérifie ta connexion et réessaie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O Zoonk não conseguiu carregar sua conta. Confira sua conexão e tente de novo."
           }
         }
       }

--- a/apps/apple/Zoonk/Testing/UITestConfiguration.swift
+++ b/apps/apple/Zoonk/Testing/UITestConfiguration.swift
@@ -5,6 +5,7 @@
   struct UITestConfiguration {
     let courseCatalog: CourseCatalogStore
     let initiallyPresentsAccount: Bool
+    let myCourses: MyCoursesStore
     let progress: ProgressStore
     let session: SessionStore
 
@@ -15,17 +16,22 @@
         return nil
       }
 
+      let environment = ProcessInfo.processInfo.environment
+      let catalogSnapshot = courseCatalogSnapshot(from: environment)
       let session = SessionStore.preview(
-        account: account(from: ProcessInfo.processInfo.environment))
+        account: account(from: environment))
 
       return UITestConfiguration(
         courseCatalog: CourseCatalogStore(
-          api: courseCatalogAPI(from: ProcessInfo.processInfo.environment),
+          api: courseCatalogAPI(snapshot: catalogSnapshot),
           language: currentCourseCatalogLanguage(),
           session: session),
         initiallyPresentsAccount: arguments.contains("--ui-testing-account-sheet"),
+        myCourses: MyCoursesStore(
+          api: myCoursesAPI(snapshot: catalogSnapshot),
+          session: session),
         progress: ProgressStore(
-          api: progressAPI(from: ProcessInfo.processInfo.environment),
+          api: progressAPI(from: environment),
           session: session),
         session: session)
     }
@@ -63,18 +69,38 @@
     }
 
     private static func courseCatalogAPI(
-      from environment: [String: String]
+      snapshot: UITestCourseCatalogSnapshot?
     ) -> any CourseCatalogAPIClient {
+      guard let snapshot else {
+        return CourseCatalogAPI(
+          clients: APIClientFactory.live(baseURL: AppConfiguration.current.apiBaseURL))
+      }
+
+      return UITestCourseCatalogAPI(snapshot: snapshot)
+    }
+
+    private static func myCoursesAPI(
+      snapshot: UITestCourseCatalogSnapshot?
+    ) -> any MyCoursesAPIClient {
+      guard let snapshot else {
+        return MyCoursesAPI(
+          clients: APIClientFactory.live(baseURL: AppConfiguration.current.apiBaseURL))
+      }
+
+      return UITestMyCoursesAPI(snapshot: snapshot)
+    }
+
+    private static func courseCatalogSnapshot(
+      from environment: [String: String]
+    ) -> UITestCourseCatalogSnapshot? {
       guard let catalogJSON = environment["ZOONK_UI_TEST_CATALOG"] else {
-        let clients = APIClientFactory.live(baseURL: AppConfiguration.current.apiBaseURL)
-        return CourseCatalogAPI(clients: clients)
+        return nil
       }
 
       do {
-        let snapshot = try JSONDecoder().decode(
+        return try JSONDecoder().decode(
           UITestCourseCatalogSnapshot.self,
           from: Data(catalogJSON.utf8))
-        return UITestCourseCatalogAPI(snapshot: snapshot)
       } catch {
         preconditionFailure("ZOONK_UI_TEST_CATALOG must contain a valid catalog snapshot")
       }
@@ -85,7 +111,79 @@
     let chapters: [CourseChapter]
     let completedLessonIDs: Set<String>
     let courses: [Course]
+    let enrolledCourseIDs: Set<String>
+    let holdsFirstMyCoursesPagination: Bool?
     let lessons: [CourseLesson]
+    let myCoursesPageSize: Int?
+    let personalCourses: [UserCourseSummary]
+  }
+
+  private actor UITestMyCoursesAPI: MyCoursesAPIClient {
+    let snapshot: UITestCourseCatalogSnapshot
+    private var didHoldPagination = false
+    private var paginationContinuation: CheckedContinuation<Void, Never>?
+
+    init(snapshot: UITestCourseCatalogSnapshot) {
+      self.snapshot = snapshot
+    }
+
+    /// Uses one-item pages by default so My Courses UI scenarios exercise automatic pagination.
+    func listCourses(request: MyCoursesRequest) async throws -> MyCoursesPage {
+      guard !request.token.isEmpty else {
+        throw MyCoursesAPIError.unauthorized
+      }
+
+      // Holds a network page until refresh replaces it, making request ordering deterministic.
+      if request.query.cursor != nil, snapshot.holdsFirstMyCoursesPagination == true,
+        !didHoldPagination
+      {
+        didHoldPagination = true
+        await withCheckedContinuation { continuation in
+          paginationContinuation = continuation
+        }
+      } else if request.query.cursor == nil {
+        paginationContinuation?.resume()
+        paginationContinuation = nil
+      }
+
+      let enrolledCourses =
+        snapshot.courses
+        .filter { course in
+          snapshot.enrolledCourseIDs.contains(course.id)
+        }
+        .map(makeUserCourseSummary) + snapshot.personalCourses
+      let matchingCourses = enrolledCourses.filter {
+        matchesQuery((course: $0, query: request.query.query))
+      }
+      let requestedStartIndex = request.query.cursor.flatMap(Int.init) ?? 0
+      let startIndex = min(max(requestedStartIndex, 0), matchingCourses.count)
+      let pageSize = max(request.query.limit ?? snapshot.myCoursesPageSize ?? 1, 0)
+      let endIndex = min(startIndex + pageSize, matchingCourses.count)
+      let courses = Array(matchingCourses[startIndex..<endIndex])
+      let hasMore = endIndex < matchingCourses.count
+
+      return MyCoursesPage(
+        courses: courses,
+        hasMore: hasMore,
+        nextCursor: hasMore ? String(endIndex) : nil)
+    }
+
+    private func matchesQuery(_ source: (course: UserCourseSummary, query: String?)) -> Bool {
+      guard let query = catalogText(source.query) else { return true }
+      return source.course.title.localizedCaseInsensitiveContains(query)
+        || source.course.description?.localizedCaseInsensitiveContains(query) == true
+    }
+
+    private func makeUserCourseSummary(_ course: Course) -> UserCourseSummary {
+      UserCourseSummary(
+        description: course.description,
+        id: course.id,
+        imageURL: course.imageURL,
+        language: course.language,
+        organization: course.organization,
+        slug: course.slug,
+        title: course.title)
+    }
   }
 
   private actor UITestCourseCatalogAPI: CourseCatalogAPIClient {

--- a/apps/apple/Zoonk/openapi.json
+++ b/apps/apple/Zoonk/openapi.json
@@ -1063,6 +1063,15 @@
               "maximum": 100
             },
             "description": "Results per page"
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "description": "Filter enrolled courses by title or description, ignoring case",
+              "type": "string"
+            },
+            "description": "Filter enrolled courses by title or description, ignoring case"
           }
         ],
         "responses": {

--- a/apps/apple/ZoonkTests/CourseCatalogStoreTests.swift
+++ b/apps/apple/ZoonkTests/CourseCatalogStoreTests.swift
@@ -784,6 +784,61 @@ final class CourseCatalogStoreTests: XCTestCase {
     XCTAssertEqual(searchQueries, [])
   }
 
+  func testPreparingANewQueryClearsPreviousSearchFeedbackBeforeRequesting() async {
+    let responses: [Result<CatalogSearchResults, Error>] = [
+      .success(.testFixture),
+      .success(CatalogSearchResults(chapters: [], courses: [])),
+      .failure(CourseCatalogFailure.network),
+    ]
+
+    for response in responses {
+      let api = CourseCatalogAPIStub(searchResults: [response, .success(.testFixture)])
+      let store = CourseCatalogStore(api: api, language: "en")
+      await store.searchCatalog(query: "stars")
+      XCTAssertNotEqual(store.searchState, .idle)
+
+      store.prepareSearch(query: "planets")
+
+      XCTAssertEqual(store.searchState, .idle)
+      XCTAssertFalse(store.isSearching)
+      let queriesBeforeDebounce = await api.searchQueries
+      XCTAssertEqual(queriesBeforeDebounce, [CatalogSearchQuery(language: "en", query: "stars")])
+
+      await store.searchCatalog(query: "planets")
+      XCTAssertEqual(store.searchState, .loaded(.testFixture))
+      let queriesAfterDebounce = await api.searchQueries
+      XCTAssertEqual(queriesAfterDebounce.map(\.query), ["stars", "planets"])
+    }
+  }
+
+  func testPreparingTheSameNormalizedQueryPreservesSearchResults() async {
+    let api = CourseCatalogAPIStub(searchResults: [.success(.testFixture)])
+    let store = CourseCatalogStore(api: api, language: "en")
+    await store.searchCatalog(query: "stars")
+
+    store.prepareSearch(query: "  stars\n")
+    await store.searchCatalog(query: "stars")
+
+    XCTAssertEqual(store.searchState, .loaded(.testFixture))
+    let queries = await api.searchQueries
+    XCTAssertEqual(queries, [CatalogSearchQuery(language: "en", query: "stars")])
+  }
+
+  func testPreviousSearchCannotPublishWhileANewQueryIsDebouncing() async {
+    let searchStarted = expectation(description: "Original search started")
+    let api = SuspendedCourseCatalogAPI({ _ in }, searchDidStart: { _ in searchStarted.fulfill() })
+    let store = CourseCatalogStore(api: api, language: "en")
+    let originalSearch = Task { await store.searchCatalog(query: "stars") }
+    await fulfillment(of: [searchStarted], timeout: 1)
+
+    store.prepareSearch(query: "planets")
+    await api.resolveSearchRequest(at: 0, with: .testFixture)
+    await originalSearch.value
+
+    XCTAssertEqual(store.searchState, .idle)
+    XCTAssertFalse(store.isSearching)
+  }
+
   func testLateCatalogSearchCannotReplaceANewerQuery() async {
     let firstSearchStarted = expectation(description: "First catalog search started")
     let secondSearchStarted = expectation(description: "Second catalog search started")

--- a/apps/apple/ZoonkTests/MyCoursesAPITests.swift
+++ b/apps/apple/ZoonkTests/MyCoursesAPITests.swift
@@ -1,0 +1,218 @@
+import HTTPTypes
+import OpenAPIRuntime
+import XCTest
+
+@testable import Zoonk
+
+final class MyCoursesAPITests: XCTestCase {
+  func testListCoursesUsesAuthenticatedPaginationAndMapsNullableOrganization() async throws {
+    let api = makeMyCoursesAPI(
+      transport: MyCoursesResponseTransport(
+        expectedOperationID: "listCurrentUserCourses",
+        expectedPath: "/me/courses",
+        expectedQuery: [
+          "cursor": "opaque-cursor",
+          "limit": "24",
+          "query": "night sky",
+        ],
+        expectedToken: "session-token",
+        responseBody:
+          #"""
+          {
+            "data": [
+              {
+                "description": "Understand the night sky.",
+                "id": "00000000-0000-7000-8000-000000000002",
+                "imageUrl": "https://cdn.zoonk.test/course.png",
+                "language": "en",
+                "organization": {
+                  "id": "00000000-0000-7000-8000-000000000001",
+                  "logo": "https://cdn.zoonk.test/organization.png",
+                  "name": "Zoonk",
+                  "slug": "zoonk"
+                },
+                "slug": "astronomy",
+                "title": "Astronomy"
+              },
+              {
+                "description": null,
+                "id": "00000000-0000-7000-8000-000000000003",
+                "imageUrl": null,
+                "language": "pt",
+                "organization": null,
+                "slug": "personal-course",
+                "title": "Personal Course"
+              }
+            ],
+            "pagination": { "hasMore": true, "nextCursor": "next-page" }
+          }
+          """#,
+        status: .ok))
+
+    let page = try await api.listCourses(
+      request: MyCoursesRequest(
+        query: MyCoursesQuery(cursor: "opaque-cursor", limit: 24, query: "night sky"),
+        token: "session-token"))
+
+    XCTAssertEqual(
+      page,
+      MyCoursesPage(
+        courses: [.myCoursesTestFixture, .personalMyCoursesTestFixture],
+        hasMore: true,
+        nextCursor: "next-page"))
+    XCTAssertNil(page.courses.last?.organization)
+  }
+
+  func testUnauthorizedResponseMapsToUnauthorized() async {
+    let api = makeMyCoursesAPI(
+      transport: MyCoursesResponseTransport(
+        expectedOperationID: "listCurrentUserCourses",
+        expectedPath: "/me/courses",
+        expectedQuery: [:],
+        expectedToken: "expired-session",
+        responseBody:
+          #"{"error":{"code":"UNAUTHORIZED","message":"Sign in to continue"}}"#,
+        status: .unauthorized))
+
+    do {
+      _ = try await api.listCourses(
+        request: MyCoursesRequest(
+          query: MyCoursesQuery(),
+          token: "expired-session"))
+      XCTFail("Expected an unauthorized error")
+    } catch let error as MyCoursesAPIError {
+      XCTAssertEqual(error, .unauthorized)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testNetworkFailureMapsToNetwork() async {
+    let api = makeMyCoursesAPI(
+      transport: MyCoursesFailureTransport(failure: .network))
+
+    do {
+      _ = try await api.listCourses(
+        request: MyCoursesRequest(query: MyCoursesQuery(), token: "session-token"))
+      XCTFail("Expected a network error")
+    } catch let error as MyCoursesAPIError {
+      XCTAssertEqual(error, .network)
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+
+  func testCancellationIsPreserved() async {
+    let api = makeMyCoursesAPI(
+      transport: MyCoursesFailureTransport(failure: .cancellation))
+
+    do {
+      _ = try await api.listCourses(
+        request: MyCoursesRequest(query: MyCoursesQuery(), token: "session-token"))
+      XCTFail("Expected cancellation")
+    } catch is CancellationError {
+      return
+    } catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+}
+
+extension CourseOrganization {
+  static let myCoursesTestFixture = CourseOrganization(
+    id: "00000000-0000-7000-8000-000000000001",
+    logoURL: URL(string: "https://cdn.zoonk.test/organization.png"),
+    name: "Zoonk",
+    slug: "zoonk")
+}
+
+extension UserCourseSummary {
+  static let myCoursesTestFixture = UserCourseSummary(
+    description: "Understand the night sky.",
+    id: "00000000-0000-7000-8000-000000000002",
+    imageURL: URL(string: "https://cdn.zoonk.test/course.png"),
+    language: "en",
+    organization: .myCoursesTestFixture,
+    slug: "astronomy",
+    title: "Astronomy")
+
+  static let personalMyCoursesTestFixture = UserCourseSummary(
+    description: nil,
+    id: "00000000-0000-7000-8000-000000000003",
+    imageURL: nil,
+    language: "pt",
+    organization: nil,
+    slug: "personal-course",
+    title: "Personal Course")
+}
+
+private func makeMyCoursesAPI(transport: any ClientTransport) -> MyCoursesAPI {
+  MyCoursesAPI(
+    clients: APIClientFactory(
+      baseURL: URL(string: "https://api.zoonk.test")!,
+      transport: transport))
+}
+
+/// Exercises the generated learner-library operation without depending on an external server.
+private struct MyCoursesResponseTransport: ClientTransport {
+  let expectedOperationID: String
+  let expectedPath: String
+  let expectedQuery: [String: String]
+  let expectedToken: String
+  let responseBody: String
+  let status: HTTPResponse.Status
+
+  func send(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    XCTAssertEqual(baseURL, URL(string: "https://api.zoonk.test/v1"))
+    XCTAssertEqual(operationID, expectedOperationID)
+    XCTAssertEqual(request.method, .get)
+    XCTAssertEqual(request.headerFields[.authorization], "Bearer \(expectedToken)")
+    XCTAssertNotNil(request.headerFields[.acceptLanguage])
+
+    let components = try XCTUnwrap(
+      URLComponents(string: "https://api.zoonk.test\(request.path ?? "")"))
+    let query = Dictionary(
+      uniqueKeysWithValues: (components.queryItems ?? []).compactMap { item in
+        item.value.map { (item.name, $0) }
+      })
+
+    XCTAssertEqual(components.path, expectedPath)
+    XCTAssertEqual(query, expectedQuery)
+
+    var headerFields = HTTPFields()
+    headerFields[.contentType] = "application/json"
+
+    return (
+      HTTPResponse(status: status, headerFields: headerFields),
+      HTTPBody(responseBody)
+    )
+  }
+}
+
+private enum MyCoursesTransportFailure: Sendable {
+  case cancellation
+  case network
+}
+
+private struct MyCoursesFailureTransport: ClientTransport {
+  let failure: MyCoursesTransportFailure
+
+  func send(
+    _ request: HTTPRequest,
+    body: HTTPBody?,
+    baseURL: URL,
+    operationID: String
+  ) async throws -> (HTTPResponse, HTTPBody?) {
+    switch failure {
+    case .cancellation:
+      throw CancellationError()
+    case .network:
+      throw URLError(.notConnectedToInternet)
+    }
+  }
+}

--- a/apps/apple/ZoonkTests/MyCoursesStoreTests.swift
+++ b/apps/apple/ZoonkTests/MyCoursesStoreTests.swift
@@ -1,0 +1,291 @@
+import XCTest
+
+@testable import Zoonk
+
+@MainActor
+final class MyCoursesStoreTests: XCTestCase {
+  func testInitialLoadPublishesCoursesAndUsesCurrentSession() async {
+    let page = MyCoursesPage(
+      courses: [.myCoursesTestFixture],
+      hasMore: true,
+      nextCursor: "next-page")
+    let api = MyCoursesAPIStub(results: [.success(page)])
+    let store = makeStore(api: api)
+
+    await store.loadCourses()
+
+    XCTAssertEqual(store.coursesState, .loaded(page))
+    let requests = await api.requests
+    XCTAssertEqual(
+      requests,
+      [MyCoursesRequest(query: MyCoursesQuery(), token: "preview-session")])
+  }
+
+  func testPresentationLoadReusesLoadedCourses() async {
+    let page = MyCoursesPage(
+      courses: [.myCoursesTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let api = MyCoursesAPIStub(results: [.success(page)])
+    let store = makeStore(api: api)
+
+    await store.loadCourses()
+    await store.loadCoursesIfNeeded()
+
+    let requests = await api.requests
+    XCTAssertEqual(requests.count, 1)
+  }
+
+  func testEmptyLoadPublishesEmptyState() async {
+    let api = MyCoursesAPIStub(
+      results: [
+        .success(MyCoursesPage(courses: [], hasMore: false, nextCursor: nil))
+      ])
+    let store = makeStore(api: api)
+
+    await store.loadCourses()
+
+    XCTAssertEqual(store.coursesState, .empty)
+  }
+
+  func testNetworkFailureCanBeRetried() async {
+    let page = MyCoursesPage(
+      courses: [.myCoursesTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let store = makeStore(
+      api: MyCoursesAPIStub(
+        results: [
+          .failure(MyCoursesAPIError.network),
+          .success(page),
+        ]))
+
+    await store.loadCourses()
+    XCTAssertEqual(store.coursesState, .failed(.network))
+
+    await store.loadCourses(force: true)
+    XCTAssertEqual(store.coursesState, .loaded(page))
+  }
+
+  func testLoadMoreAppendsUniqueCourses() async {
+    let initialPage = MyCoursesPage(
+      courses: [.myCoursesTestFixture],
+      hasMore: true,
+      nextCursor: "next-page")
+    let nextPage = MyCoursesPage(
+      courses: [.myCoursesTestFixture, .personalMyCoursesTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let api = MyCoursesAPIStub(results: [.success(initialPage), .success(nextPage)])
+    let store = makeStore(api: api)
+
+    await store.loadCourses()
+    await store.loadMoreCourses()
+
+    XCTAssertEqual(
+      store.coursesState,
+      .loaded(
+        MyCoursesPage(
+          courses: [.myCoursesTestFixture, .personalMyCoursesTestFixture],
+          hasMore: false,
+          nextCursor: nil)))
+    let requests = await api.requests
+    XCTAssertEqual(
+      requests.map(\.query),
+      [MyCoursesQuery(), MyCoursesQuery(cursor: "next-page")])
+  }
+
+  func testSearchPaginatesWithTheSameNormalizedQuery() async {
+    let api = MyCoursesAPIStub(results: [
+      .success(
+        MyCoursesPage(courses: [.myCoursesTestFixture], hasMore: true, nextCursor: "search-page")),
+      .success(
+        MyCoursesPage(courses: [.personalMyCoursesTestFixture], hasMore: false, nextCursor: nil)),
+    ])
+    let store = makeStore(api: api)
+
+    await store.loadCourses(query: "  sky  ")
+    await store.loadCoursesIfNeeded(query: "sky")
+    await store.loadMoreCourses()
+
+    let queries = await api.requests.map(\.query)
+    XCTAssertEqual(
+      queries, [MyCoursesQuery(query: "sky"), MyCoursesQuery(cursor: "search-page", query: "sky")])
+    XCTAssertEqual(
+      store.coursesState,
+      .loaded(
+        MyCoursesPage(
+          courses: [.myCoursesTestFixture, .personalMyCoursesTestFixture], hasMore: false,
+          nextCursor: nil)))
+  }
+
+  func testClearingSearchRestoresTheUnfilteredLibrary() async {
+    let page = MyCoursesPage(courses: [.myCoursesTestFixture], hasMore: false, nextCursor: nil)
+    let api = MyCoursesAPIStub(results: [
+      .success(MyCoursesPage(courses: [], hasMore: false, nextCursor: nil)), .success(page),
+    ])
+    let store = makeStore(api: api)
+
+    await store.loadCourses(query: "missing")
+    XCTAssertEqual(store.coursesState, .empty)
+    await store.loadCoursesIfNeeded(query: "")
+
+    XCTAssertEqual(store.coursesState, .loaded(page))
+    let queries = await api.requests.map(\.query)
+    XCTAssertEqual(queries, [MyCoursesQuery(query: "missing"), MyCoursesQuery()])
+  }
+
+  func testLateSearchResponseCannotReplaceANewerQuery() async {
+    let started = expectation(description: "First search started")
+    let latestPage = MyCoursesPage(
+      courses: [.personalMyCoursesTestFixture], hasMore: false, nextCursor: nil)
+    let api = SupersededMyCoursesSearchAPI(latestPage: latestPage, requestDidStart: started.fulfill)
+    let store = makeStore(api: api)
+    let firstRequest = Task { await store.loadCourses(query: "sky") }
+    await fulfillment(of: [started], timeout: 1)
+
+    await store.loadCourses(query: "personal")
+    await api.resolveFirstSearch()
+    await firstRequest.value
+
+    XCTAssertEqual(store.coursesState, .loaded(latestPage))
+  }
+
+  func testLosingTheSessionClearsLoadedCourses() async throws {
+    let page = MyCoursesPage(
+      courses: [.myCoursesTestFixture],
+      hasMore: false,
+      nextCursor: nil)
+    let api = MyCoursesAPIStub(results: [.success(page)])
+    let session = SessionStore.preview(account: makeMyCoursesTestAccount())
+    let store = MyCoursesStore(api: api, session: session)
+    let authenticatedSession = try XCTUnwrap(session.authenticatedSession)
+
+    await store.loadCourses()
+    await session.expire(authenticatedSession)
+    await store.loadCoursesIfNeeded()
+
+    XCTAssertEqual(store.coursesState, .idle)
+    let requests = await api.requests
+    XCTAssertEqual(requests.count, 1)
+  }
+
+  func testLateResponseDoesNotRestoreCoursesAfterTheSessionExpires() async throws {
+    let requestStarted = expectation(description: "My Courses request started")
+    let api = SuspendedMyCoursesAPIStub(requestDidStart: requestStarted.fulfill)
+    let session = SessionStore.preview(account: makeMyCoursesTestAccount())
+    let store = MyCoursesStore(api: api, session: session)
+    let authenticatedSession = try XCTUnwrap(session.authenticatedSession)
+    let request = Task { await store.loadCourses() }
+    await fulfillment(of: [requestStarted], timeout: 1)
+
+    await session.expire(authenticatedSession)
+    await store.loadCoursesIfNeeded()
+    await api.resolve(
+      with: MyCoursesPage(
+        courses: [.myCoursesTestFixture],
+        hasMore: false,
+        nextCursor: nil))
+    await request.value
+
+    XCTAssertEqual(store.coursesState, .idle)
+  }
+
+  func testUnauthorizedLoadExpiresTheMatchingSession() async {
+    let session = SessionStore.preview(account: makeMyCoursesTestAccount())
+    let store = MyCoursesStore(
+      api: MyCoursesAPIStub(results: [.failure(MyCoursesAPIError.unauthorized)]),
+      session: session)
+
+    await store.loadCourses()
+
+    XCTAssertNil(session.account)
+    XCTAssertEqual(store.coursesState, .idle)
+  }
+
+  private func makeStore(api: any MyCoursesAPIClient) -> MyCoursesStore {
+    MyCoursesStore(
+      api: api,
+      session: .preview(account: makeMyCoursesTestAccount()))
+  }
+}
+
+/// Delays an older network response to verify that a newer search owns the visible result.
+private actor SupersededMyCoursesSearchAPI: MyCoursesAPIClient {
+  let latestPage: MyCoursesPage
+  let requestDidStart: @Sendable () -> Void
+  private var continuation: CheckedContinuation<MyCoursesPage, Never>?
+
+  init(latestPage: MyCoursesPage, requestDidStart: @escaping @Sendable () -> Void) {
+    self.latestPage = latestPage
+    self.requestDidStart = requestDidStart
+  }
+
+  func listCourses(request: MyCoursesRequest) async throws -> MyCoursesPage {
+    guard request.query.query == "sky" else { return latestPage }
+    return await withCheckedContinuation { continuation in
+      self.continuation = continuation
+      requestDidStart()
+    }
+  }
+
+  func resolveFirstSearch() {
+    continuation?.resume(
+      returning: MyCoursesPage(courses: [.myCoursesTestFixture], hasMore: false, nextCursor: nil))
+    continuation = nil
+  }
+}
+
+private func makeMyCoursesTestAccount() -> CurrentAccount {
+  CurrentAccount(
+    account: AccountAccess(
+      deletion: AccountDeletionRequirements(hasAppleAccount: false),
+      subscription: nil),
+    user: AccountUser(
+      displayUsername: "learner",
+      email: "learner@zoonk.test",
+      id: "my-courses-test-user",
+      image: nil,
+      name: "Learner",
+      username: "learner"))
+}
+
+private actor MyCoursesAPIStub: MyCoursesAPIClient {
+  private var results: [Result<MyCoursesPage, Error>]
+  private(set) var requests: [MyCoursesRequest] = []
+
+  init(results: [Result<MyCoursesPage, Error>]) {
+    self.results = results
+  }
+
+  func listCourses(request: MyCoursesRequest) async throws -> MyCoursesPage {
+    requests.append(request)
+
+    guard !results.isEmpty else {
+      throw MyCoursesAPIError.unavailable
+    }
+
+    return try results.removeFirst().get()
+  }
+}
+
+private actor SuspendedMyCoursesAPIStub: MyCoursesAPIClient {
+  private let requestDidStart: @Sendable () -> Void
+  private var continuation: CheckedContinuation<MyCoursesPage, any Error>?
+
+  init(requestDidStart: @escaping @Sendable () -> Void) {
+    self.requestDidStart = requestDidStart
+  }
+
+  func listCourses(request: MyCoursesRequest) async throws -> MyCoursesPage {
+    try await withCheckedThrowingContinuation { continuation in
+      self.continuation = continuation
+      requestDidStart()
+    }
+  }
+
+  func resolve(with page: MyCoursesPage) {
+    continuation?.resume(returning: page)
+    continuation = nil
+  }
+}

--- a/apps/apple/ZoonkUITests/CourseCatalogUITestFixture.swift
+++ b/apps/apple/ZoonkUITests/CourseCatalogUITestFixture.swift
@@ -1,7 +1,44 @@
+import Foundation
+import XCTest
+
+/// Keeps a pending page visible during pull-to-refresh, including a production-sized page on iPad.
+func courseCatalogPaginationUITestSnapshotJSON(pageSize: Int) throws -> String {
+  var snapshot = try XCTUnwrap(
+    try JSONSerialization.jsonObject(with: Data(courseCatalogUITestSnapshotJSON.utf8))
+      as? [String: Any])
+  let templates = try XCTUnwrap(snapshot["courses"] as? [[String: Any]])
+  let template = try XCTUnwrap(templates.first)
+  let courses = (1...pageSize).map { index in
+    var course = template
+    course["id"] = "enrolled-course-\(index)"
+    course["slug"] = "enrolled-course-\(index)"
+    course["title"] = String(format: "Enrolled Course %02d", index)
+    return course
+  }
+  snapshot["courses"] = courses
+  snapshot["enrolledCourseIDs"] = courses.compactMap { $0["id"] as? String }
+  snapshot["holdsFirstMyCoursesPagination"] = true
+  snapshot["myCoursesPageSize"] = pageSize
+  let data = try JSONSerialization.data(withJSONObject: snapshot)
+  return String(decoding: data, as: UTF8.self)
+}
+
 let courseCatalogUITestSnapshotJSON =
   #"""
   {
     "completedLessonIDs": ["lesson-meet-roots"],
+    "enrolledCourseIDs": ["course-plants", "course-oceans"],
+    "personalCourses": [
+      {
+        "description": "Keep private observations and experiments together.",
+        "id": "course-field-notes",
+        "imageURL": null,
+        "language": "en",
+        "organization": null,
+        "slug": "my-backyard-field-notes",
+        "title": "My Backyard Field Notes"
+      }
+    ],
     "courses": [
       {
         "categories": ["science"],

--- a/apps/apple/ZoonkUITests/ZoonkUITests.swift
+++ b/apps/apple/ZoonkUITests/ZoonkUITests.swift
@@ -320,24 +320,171 @@ final class ZoonkUITests: XCTestCase {
       "Expected guidance without an external Google Play purchase link")
   }
 
-  /// Proves the account shortcut names the public destination it opens instead of promising an unimplemented learner library.
+  /// Proves the account shortcut leaves a course detail and opens the signed-in learner's library at its root.
   @MainActor
-  func testBrowseCoursesAccountActionOpensThePublicCatalog() {
+  func testMyCoursesAccountActionOpensTheEnrolledCourseList() {
     continueAfterFailure = false
 
-    let app = makeApp(for: .freeSubscription)
+    let app = makeApp(for: .catalog)
     app.launch()
+
+    openPlantsCourse(in: app)
+    app.buttons["Home"].firstMatch.tap()
     openAccount(in: app)
 
-    let browseCourses = app.buttons["Browse courses"]
+    let myCourses = app.buttons["My courses"]
     XCTAssertTrue(
-      browseCourses.waitForExistence(timeout: 5),
-      "Expected the account sheet to describe the public catalog destination")
-    browseCourses.tap()
+      myCourses.waitForExistence(timeout: 5), "Expected the account sheet to offer My courses")
+    myCourses.tap()
 
     XCTAssertTrue(
       app.staticTexts["How Plants Grow"].firstMatch.waitForExistence(timeout: 5),
-      "Expected the account shortcut to open the deterministic public catalog")
+      "Expected the account shortcut to open the enrolled course list")
+    XCTAssertTrue(
+      app.staticTexts["My Backyard Field Notes"].firstMatch.waitForExistence(timeout: 5),
+      "Expected pagination to retain a personal course in the learner's library")
+    XCTAssertEqual(
+      app.buttons.matching(NSPredicate(format: "label CONTAINS %@", "My Backyard Field Notes"))
+        .count, 0,
+      "Expected a personal course without a public route to remain noninteractive")
+    XCTAssertEqual(
+      app.links.matching(NSPredicate(format: "label CONTAINS %@", "My Backyard Field Notes"))
+        .count, 0,
+      "Expected a personal course without a public route to avoid a broken link")
+    XCTAssertTrue(app.buttons["My Courses"].isSelected, "Expected My Courses to be selected")
+    XCTAssertFalse(
+      app.staticTexts["Everyday Numbers"].exists,
+      "Expected the account shortcut to exclude courses outside the learner's library")
+  }
+
+  /// Proves signed-in learners can switch between the public catalog and their enrolled courses without leaving the Courses tab.
+  @MainActor
+  func testCoursesToggleSwitchesBetweenAllAndMyCourses() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .catalog)
+    app.launch()
+    app.buttons["Courses"].firstMatch.tap()
+
+    let allCourses = app.buttons["All Courses"]
+    let myCourses = app.buttons["My Courses"]
+    XCTAssertTrue(allCourses.waitForExistence(timeout: 5))
+    XCTAssertTrue(myCourses.exists)
+    XCTAssertTrue(allCourses.isSelected)
+    XCTAssertTrue(app.staticTexts["Everyday Numbers"].firstMatch.waitForExistence(timeout: 5))
+    XCTAssertTrue(app.searchFields["Search all courses"].exists)
+    let selectorPosition = myCourses.frame.minY
+
+    myCourses.tap()
+
+    XCTAssertTrue(myCourses.isSelected)
+    XCTAssertTrue(app.searchFields["Search my courses"].waitForExistence(timeout: 5))
+    XCTAssertEqual(myCourses.frame.minY, selectorPosition, accuracy: 1)
+    XCTAssertTrue(app.staticTexts["How Plants Grow"].firstMatch.waitForExistence(timeout: 5))
+    XCTAssertTrue(app.staticTexts["Ocean Worlds"].firstMatch.waitForExistence(timeout: 5))
+    XCTAssertFalse(app.staticTexts["Everyday Numbers"].exists)
+
+    allCourses.tap()
+
+    XCTAssertTrue(allCourses.isSelected)
+    XCTAssertTrue(app.staticTexts["Everyday Numbers"].firstMatch.waitForExistence(timeout: 5))
+  }
+
+  /// Refresh must resume pagination even when it returns the same first page and cursor.
+  @MainActor
+  func testMyCoursesRefreshResumesPendingPagination() throws {
+    continueAfterFailure = false
+    let isPad = UIDevice.current.userInterfaceIdiom == .pad
+    let pageSize = isPad ? 20 : 6
+    XCUIDevice.shared.orientation = isPad ? .landscapeLeft : .portrait
+    defer { XCUIDevice.shared.orientation = .portrait }
+
+    let app = makeApp(for: .catalog)
+    app.launchEnvironment["ZOONK_UI_TEST_CATALOG"] = try courseCatalogPaginationUITestSnapshotJSON(
+      pageSize: pageSize)
+    app.launch()
+    app.buttons["Courses"].firstMatch.tap()
+    app.buttons["My Courses"].tap()
+
+    let lastCourse = app.staticTexts[String(format: "Enrolled Course %02d", pageSize)].firstMatch
+    let list = app.scrollViews.containing(.staticText, identifier: "Enrolled Course 01").firstMatch
+    XCTAssertTrue(list.waitForExistence(timeout: 5))
+    list.swipeUp()
+    XCTAssertTrue(lastCourse.waitForExistence(timeout: 5))
+    XCTAssertFalse(app.staticTexts["My Backyard Field Notes"].exists)
+
+    list.swipeDown()
+    let refreshStart = list.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.15))
+    let refreshEnd = list.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8))
+    refreshStart.press(forDuration: 0.1, thenDragTo: refreshEnd)
+
+    XCTAssertTrue(
+      app.staticTexts["My Backyard Field Notes"].firstMatch.waitForExistence(timeout: 5),
+      "Expected refresh to resume pagination and show the remaining enrollment")
+  }
+
+  /// Keeps library search scoped to enrollments while preserving the catalog filter across collection changes.
+  @MainActor
+  func testMyCoursesSearchPreservesCollectionState() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .catalog)
+    app.launch()
+    app.buttons["Courses"].firstMatch.tap()
+
+    let categorySelector = app.scrollViews["Course categories"]
+    XCTAssertTrue(categorySelector.waitForExistence(timeout: 5))
+    let science = categorySelector.buttons["Science"]
+    categorySelector.scrollToReveal(science)
+    science.tap()
+    XCTAssertTrue(app.staticTexts["How Plants Grow"].firstMatch.waitForExistence(timeout: 5))
+
+    app.buttons["My Courses"].tap()
+    let searchField = app.searchFields["Search my courses"]
+    XCTAssertTrue(searchField.waitForExistence(timeout: 5))
+    searchField.tap()
+    searchField.typeText("field notes")
+    XCTAssertTrue(
+      app.staticTexts["My Backyard Field Notes"].firstMatch.waitForExistence(timeout: 5))
+    XCTAssertTrue(app.staticTexts["How Plants Grow"].firstMatch.waitForNonExistence(timeout: 5))
+
+    app.buttons["All Courses"].tap()
+    XCTAssertTrue(science.waitForExistence(timeout: 5))
+    XCTAssertTrue(science.isSelected)
+    XCTAssertFalse(app.staticTexts["Everyday Numbers"].exists)
+
+    app.buttons["My Courses"].tap()
+    XCTAssertEqual(searchField.value as? String, "field notes")
+    XCTAssertTrue(
+      app.staticTexts["My Backyard Field Notes"].firstMatch.waitForExistence(timeout: 5))
+  }
+
+  /// Proves the learner sees the value of signing in before the native account flow opens.
+  @MainActor
+  func testSignedOutMyCoursesExplainsLoginAndOpensAccountSheet() {
+    continueAfterFailure = false
+
+    let app = makeApp()
+    app.launch()
+    app.buttons["Courses"].firstMatch.tap()
+
+    let myCourses = app.buttons["My Courses"]
+    XCTAssertTrue(myCourses.waitForExistence(timeout: 5))
+    myCourses.tap()
+
+    XCTAssertTrue(app.staticTexts["Log in to track your courses"].waitForExistence(timeout: 5))
+    XCTAssertTrue(
+      app.staticTexts[
+        "Keep your courses and progress in one place by logging in to your account."
+      ].exists)
+
+    let logIn = app.buttons["Log in"]
+    XCTAssertTrue(logIn.exists)
+    logIn.tap()
+
+    XCTAssertTrue(
+      app.buttons["Continue with Apple"].waitForExistence(timeout: 5),
+      "Expected the My Courses login action to open the native account sheet")
   }
 
   /// Proves that account deletion is a deliberate native flow: the account option opens a dedicated screen and the irreversible request still requires confirmation.
@@ -644,7 +791,7 @@ final class ZoonkUITests: XCTestCase {
     app.launch()
     app.buttons["Courses"].firstMatch.tap()
 
-    let searchField = app.searchFields["Search courses and chapters"]
+    let searchField = app.searchFields["Search all courses"]
     XCTAssertTrue(searchField.waitForExistence(timeout: 5))
     searchField.tap()
     searchField.typeText("water")

--- a/apps/apple/ZoonkUITests/ZoonkUITests.swift
+++ b/apps/apple/ZoonkUITests/ZoonkUITests.swift
@@ -782,6 +782,38 @@ final class ZoonkUITests: XCTestCase {
       "Expected Back to return to the chapter's lesson list")
   }
 
+  /// Editing a search moves between matching and empty results without retaining the previous query's feedback.
+  @MainActor
+  func testCatalogSearchUpdatesWhenTheQueryChanges() {
+    continueAfterFailure = false
+
+    let app = makeApp(for: .catalog)
+    app.launch()
+    app.buttons["Courses"].firstMatch.tap()
+    let searchField = app.searchFields["Search all courses"]
+    XCTAssertTrue(searchField.waitForExistence(timeout: 5))
+    searchField.tap()
+    searchField.typeText("water")
+    XCTAssertTrue(app.staticTexts["Roots and Water"].waitForExistence(timeout: 5))
+
+    let suffix = "zznomatch"
+    searchField.typeText(suffix)
+    let emptyDescription = app.staticTexts.matching(
+      NSPredicate(format: "label CONTAINS %@", "water" + suffix)
+    ).firstMatch
+    XCTAssertTrue(emptyDescription.waitForExistence(timeout: 5))
+    XCTAssertFalse(app.staticTexts["Roots and Water"].exists)
+
+    searchField.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: suffix.count))
+    XCTAssertTrue(app.staticTexts["Roots and Water"].waitForExistence(timeout: 5))
+    XCTAssertFalse(emptyDescription.exists)
+    XCTAssertEqual(searchField.value as? String, "water")
+
+    let screenshot = XCTAttachment(screenshot: app.screenshot())
+    screenshot.lifetime = .keepAlways
+    add(screenshot)
+  }
+
   /// Proves catalog search replaces the removed Search tab and searches beyond the selected category.
   @MainActor
   func testCoursesSearchFindsCoursesAndChapters() {

--- a/packages/core/src/courses/list-current-user-courses.ts
+++ b/packages/core/src/courses/list-current-user-courses.ts
@@ -11,10 +11,12 @@ import { getSession } from "../users/get-session";
  */
 async function findCurrentUserCourses({
   offset,
+  query,
   take,
   userId,
 }: {
   offset?: number;
+  query?: string;
   take?: number;
   userId: string;
 }) {
@@ -24,7 +26,19 @@ async function findCurrentUserCourses({
     ...(take !== undefined && { take }),
     ...(offset !== undefined && { skip: Math.max(Math.trunc(offset), 0) }),
     where: {
-      course: { OR: [{ organization: { kind: "brand" } }, { organizationId: null }] },
+      course: {
+        OR: [{ organization: { kind: "brand" } }, { organizationId: null }],
+        ...(query && {
+          AND: [
+            {
+              OR: [
+                { title: { contains: query, mode: "insensitive" as const } },
+                { description: { contains: query, mode: "insensitive" as const } },
+              ],
+            },
+          ],
+        }),
+      },
       userId,
     },
   });
@@ -59,9 +73,11 @@ export async function listCurrentUserCourses() {
 export async function listCurrentUserCoursesPage({
   limit,
   offset = 0,
+  query,
 }: {
   limit: number;
   offset?: number;
+  query?: string;
 }) {
   const session = await getSession();
 
@@ -73,6 +89,7 @@ export async function listCurrentUserCoursesPage({
 
   const courses = await findCurrentUserCourses({
     offset,
+    query: query?.trim(),
     take: pageSize + 1,
     userId: session.user.id,
   });


### PR DESCRIPTION
Add All Courses and My Courses to the Apple app with a stable layout and independent search state. My Courses lists enrolled public and personal courses, explains tracking benefits when signed out, and opens directly from the account menu.

Add authenticated enrollment search to the API, refine shared course rows, and cover pagination recovery during refresh and search behavior across iPhone and iPad.