### PR TITLE
chore(ai): use gpt-image-2.5-flare

### DIFF
--- a/packages/ai/src/tasks/_utils/generate-image-with-safety-retry.test.ts
+++ b/packages/ai/src/tasks/_utils/generate-image-with-safety-retry.test.ts
@@ -90,7 +90,7 @@ describe(generateImageWithSafetyRetry, () => {
       buildPrompt: ({ input }) => `Create a course thumbnail for ${input}.`,
       input: originalInput,
       maxImagesPerCall: 1,
-      model: "openai/gpt-image-2",
+      model: "openai/gpt-image-2.5-flare",
       size: "1024x1024",
     });
 
@@ -118,7 +118,7 @@ describe(generateImageWithSafetyRetry, () => {
         buildPrompt: ({ input }) => `Create a course thumbnail for ${input}.`,
         input: "safe course",
         maxImagesPerCall: 1,
-        model: "openai/gpt-image-2",
+        model: "openai/gpt-image-2.5-flare",
         size: "1024x1024",
       }),
     ).rejects.toThrow("Model timed out");

--- a/packages/ai/src/tasks/content/content-thumbnail.ts
+++ b/packages/ai/src/tasks/content/content-thumbnail.ts
@@ -5,7 +5,7 @@ import { type ImageGenerationQuality, buildImageProviderOptions } from "../../pr
 import { generateImageWithSafetyRetry } from "../_utils/generate-image-with-safety-retry";
 import promptTemplate from "./content-thumbnail.prompt.md";
 
-const defaultModel = "openai/gpt-image-2";
+const defaultModel = "openai/gpt-image-2.5-flare";
 const DEFAULT_QUALITY = "low";
 
 const fallbackModels = [

--- a/packages/ai/src/tasks/steps/step-content-image.ts
+++ b/packages/ai/src/tasks/steps/step-content-image.ts
@@ -7,7 +7,7 @@ import { getPromptLanguageName } from "../_utils/prompt-language";
 import illustrationPromptTemplate from "./step-content-image.prompt.md";
 import practicePromptTemplate from "./step-content-practice-image.prompt.md";
 
-const defaultModel = "openai/gpt-image-2";
+const defaultModel = "openai/gpt-image-2.5-flare";
 const DEFAULT_QUALITY = "low";
 
 const fallbackModels = [

--- a/packages/ai/src/tasks/steps/step-select-image.ts
+++ b/packages/ai/src/tasks/steps/step-select-image.ts
@@ -6,7 +6,7 @@ import { generateImageWithSafetyRetry } from "../_utils/generate-image-with-safe
 import { getPromptLanguageName } from "../_utils/prompt-language";
 import promptTemplate from "./step-select-image.prompt.md";
 
-const defaultModel = "openai/gpt-image-2";
+const defaultModel = "openai/gpt-image-2.5-flare";
 const DEFAULT_QUALITY = "low";
 
 const fallbackModels = [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the default image generation model from `openai/gpt-image-2` to `openai/gpt-image-2.5-flare` across thumbnail and step image tasks, and updates the corresponding tests to match.

<sup>Written for commit 05cc5df6a598361d6f5b13328cdde71468e3d4ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

