### PR TITLE
fix(main): use max energy wording consistently

### DIFF
--- a/apps/apple/Zoonk/Features/Progress/EnergyProgressView.swift
+++ b/apps/apple/Zoonk/Features/Progress/EnergyProgressView.swift
@@ -111,7 +111,7 @@ private struct EnergyProgressContent: View {
 
           ProgressDetailMetric(
             label: Text(
-              "Days at 100% Energy",
+              "Days at Max Energy",
               tableName: "Progress",
               comment: "Label for the number of days the learner reached full Energy"),
             value: Text(insights.fullEnergyDays, format: .number),
@@ -161,7 +161,7 @@ private struct EnergyProgressContent: View {
     }
 
     return Text(
-      "Keep learning to reach 100%.",
+      "Keep learning to reach Max Energy.",
       tableName: "Progress",
       comment: "Encouragement shown while the learner builds Energy.")
   }
@@ -172,6 +172,13 @@ private struct EnergyProgressContent: View {
         "No Energy recorded",
         tableName: "Progress",
         comment: "Accessible value for a day without recorded Energy")
+    }
+
+    if energy >= 100 {
+      return Text(
+        "Max Energy",
+        tableName: "Progress",
+        comment: "Accessible daily value for maximum Energy in the contribution calendar")
     }
 
     return Text(

--- a/apps/apple/Zoonk/Resources/Localization/Progress.xcstrings
+++ b/apps/apple/Zoonk/Resources/Localization/Progress.xcstrings
@@ -1353,31 +1353,31 @@
         }
       }
     },
-    "Days at 100% Energy" : {
+    "Days at Max Energy" : {
       "comment" : "Label for the number of days the learner reached full Energy",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tage mit 100 % Energie"
+            "value" : "Tage mit maximaler Energie"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Días con Energía al 100 %"
+            "value" : "Días con Energía máxima"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Jours à 100 % d’Énergie"
+            "value" : "Jours à Énergie maximale"
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dias com 100% de Energia"
+            "value" : "Dias com Energia Máxima"
           }
         }
       }
@@ -1817,31 +1817,31 @@
         }
       }
     },
-    "Keep learning to reach 100%." : {
+    "Keep learning to reach Max Energy." : {
       "comment" : "Encouragement shown while the learner builds Energy.",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lerne weiter, um 100 % zu erreichen."
+            "value" : "Lerne weiter, um maximale Energie zu erreichen."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sigue estudiando para llegar al 100 %."
+            "value" : "Sigue estudiando para alcanzar la Energía máxima."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continue à apprendre pour atteindre 100 %."
+            "value" : "Continue d’apprendre pour atteindre l’Énergie maximale."
           }
         },
         "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continue estudando para chegar a 100%."
+            "value" : "Continue estudando para chegar à Energia Máxima."
           }
         }
       }
@@ -2219,6 +2219,35 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Baixa"
+          }
+        }
+      }
+    },
+    "Max Energy" : {
+      "comment" : "Accessible daily value for maximum Energy in the contribution calendar",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximale Energie"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energía máxima"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Énergie maximale"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Energia Máxima"
           }
         }
       }

--- a/apps/main/e2e/energy.test.ts
+++ b/apps/main/e2e/energy.test.ts
@@ -192,7 +192,7 @@ test.describe("Energy Page", () => {
 
         const averageEnergyCard = page.getByRole("article", { name: /average energy/iu });
         const energyBattery = page.getByRole("progressbar", { name: /your energy/iu });
-        const fullEnergyCard = page.getByRole("article", { name: /days at 100% energy/iu });
+        const fullEnergyCard = page.getByRole("article", { name: /days at max energy/iu });
         const energyChart = page.getByRole("figure", { name: /energy history/iu });
 
         const recordedEnergyDay = energyChart.getByRole("button", {
@@ -210,9 +210,7 @@ test.describe("Energy Page", () => {
         await expect(energyChart).toBeVisible();
         await expect(recordedEnergyDay).toBeVisible();
 
-        await expect(energyChart.getByRole("button", { name: /^100% energy on /iu })).toHaveCount(
-          0,
-        );
+        await expect(energyChart.getByRole("button", { name: /^max energy on /iu })).toHaveCount(0);
 
         await expect(page.getByRole("navigation", { name: /period selection/iu })).toHaveCount(0);
 

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -246,14 +246,14 @@ msgid "Continue learning"
 msgstr "Weiterlernen"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "S5vNR_"
-msgid "Reach 100%"
-msgstr "Erreiche 100 %"
+msgctxt "0Bz4ZD"
+msgid "Reach Max Energy"
+msgstr "Erreiche maximale Energie"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "j-gOkC"
-msgid "Stay at 100%"
-msgstr "Bleib bei 100 %"
+msgctxt "MlOidD"
+msgid "Stay at Max Energy"
+msgstr "Bleib bei maximaler Energie"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
 #: src/app/[lang]/(progress)/_components/metric-pills.tsx
@@ -1065,6 +1065,11 @@ msgid "No Energy recorded on {date}"
 msgstr "Keine Energie für {date} erfasst"
 
 #: src/app/[lang]/(progress)/energy/energy-chart.tsx
+msgctxt "FpslmD"
+msgid "Max Energy on {date}"
+msgstr "Maximale Energie am {date}"
+
+#: src/app/[lang]/(progress)/energy/energy-chart.tsx
 msgctxt "GThwd0"
 msgid "{percentage} Energy on {date}"
 msgstr "{percentage} Energie am {date}"
@@ -1120,9 +1125,9 @@ msgid "Energy rewards consistency. Learning regularly helps reinforce what you l
 msgstr "Energie belohnt dich fürs Dranbleiben. Regelmäßiges Lernen hilft dir, das Gelernte zu festigen."
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
-msgctxt "qm9EdM"
-msgid "Days at 100% Energy"
-msgstr "Tage mit 100 % Energie"
+msgctxt "-1YhhW"
+msgid "Days at Max Energy"
+msgstr "Tage mit maximaler Energie"
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
 msgctxt "F9mA1x"
@@ -1135,9 +1140,9 @@ msgid "Your Energy"
 msgstr "Deine Energie"
 
 #: src/app/[lang]/(progress)/energy/page.tsx
-msgctxt "aHGjLP"
-msgid "Keep your Energy at 100% by studying every day."
-msgstr "Lerne jeden Tag, um deine Energie bei 100 % zu halten."
+msgctxt "ajjT8S"
+msgid "Stay at Max Energy by studying every day."
+msgstr "Lerne jeden Tag, um bei maximaler Energie zu bleiben."
 
 #: src/app/[lang]/(progress)/level/level-explanation.tsx
 msgctxt "gaXaWV"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -246,14 +246,14 @@ msgid "Continue learning"
 msgstr "Continue learning"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "S5vNR_"
-msgid "Reach 100%"
-msgstr "Reach 100%"
+msgctxt "0Bz4ZD"
+msgid "Reach Max Energy"
+msgstr "Reach Max Energy"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "j-gOkC"
-msgid "Stay at 100%"
-msgstr "Stay at 100%"
+msgctxt "MlOidD"
+msgid "Stay at Max Energy"
+msgstr "Stay at Max Energy"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
 #: src/app/[lang]/(progress)/_components/metric-pills.tsx
@@ -1065,6 +1065,11 @@ msgid "No Energy recorded on {date}"
 msgstr "No Energy recorded on {date}"
 
 #: src/app/[lang]/(progress)/energy/energy-chart.tsx
+msgctxt "FpslmD"
+msgid "Max Energy on {date}"
+msgstr "Max Energy on {date}"
+
+#: src/app/[lang]/(progress)/energy/energy-chart.tsx
 msgctxt "GThwd0"
 msgid "{percentage} Energy on {date}"
 msgstr "{percentage} Energy on {date}"
@@ -1120,9 +1125,9 @@ msgid "Energy rewards consistency. Learning regularly helps reinforce what you l
 msgstr "Energy rewards consistency. Learning regularly helps reinforce what you learn."
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
-msgctxt "qm9EdM"
-msgid "Days at 100% Energy"
-msgstr "Days at 100% Energy"
+msgctxt "-1YhhW"
+msgid "Days at Max Energy"
+msgstr "Days at Max Energy"
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
 msgctxt "F9mA1x"
@@ -1135,9 +1140,9 @@ msgid "Your Energy"
 msgstr "Your Energy"
 
 #: src/app/[lang]/(progress)/energy/page.tsx
-msgctxt "aHGjLP"
-msgid "Keep your Energy at 100% by studying every day."
-msgstr "Keep your Energy at 100% by studying every day."
+msgctxt "ajjT8S"
+msgid "Stay at Max Energy by studying every day."
+msgstr "Stay at Max Energy by studying every day."
 
 #: src/app/[lang]/(progress)/level/level-explanation.tsx
 msgctxt "gaXaWV"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -246,14 +246,14 @@ msgid "Continue learning"
 msgstr "Seguir estudiando"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "S5vNR_"
-msgid "Reach 100%"
-msgstr "Alcanza el 100 %"
+msgctxt "0Bz4ZD"
+msgid "Reach Max Energy"
+msgstr "Alcanza la Energía máxima"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "j-gOkC"
-msgid "Stay at 100%"
-msgstr "Mantente al 100 %"
+msgctxt "MlOidD"
+msgid "Stay at Max Energy"
+msgstr "Mantén la Energía al máximo"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
 #: src/app/[lang]/(progress)/_components/metric-pills.tsx
@@ -1065,6 +1065,11 @@ msgid "No Energy recorded on {date}"
 msgstr "No se registró Energía el {date}"
 
 #: src/app/[lang]/(progress)/energy/energy-chart.tsx
+msgctxt "FpslmD"
+msgid "Max Energy on {date}"
+msgstr "Energía máxima el {date}"
+
+#: src/app/[lang]/(progress)/energy/energy-chart.tsx
 msgctxt "GThwd0"
 msgid "{percentage} Energy on {date}"
 msgstr "{percentage} de Energía el {date}"
@@ -1120,9 +1125,9 @@ msgid "Energy rewards consistency. Learning regularly helps reinforce what you l
 msgstr "La Energía premia la constancia. Estudiar con regularidad te ayuda a reforzar lo que aprendes."
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
-msgctxt "qm9EdM"
-msgid "Days at 100% Energy"
-msgstr "Días con Energía al 100 %"
+msgctxt "-1YhhW"
+msgid "Days at Max Energy"
+msgstr "Días con la Energía al máximo"
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
 msgctxt "F9mA1x"
@@ -1135,9 +1140,9 @@ msgid "Your Energy"
 msgstr "Tu Energía"
 
 #: src/app/[lang]/(progress)/energy/page.tsx
-msgctxt "aHGjLP"
-msgid "Keep your Energy at 100% by studying every day."
-msgstr "Mantén tu Energía al 100 % estudiando todos los días."
+msgctxt "ajjT8S"
+msgid "Stay at Max Energy by studying every day."
+msgstr "Mantén la Energía al máximo estudiando todos los días."
 
 #: src/app/[lang]/(progress)/level/level-explanation.tsx
 msgctxt "gaXaWV"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -246,14 +246,14 @@ msgid "Continue learning"
 msgstr "Continuer à apprendre"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "S5vNR_"
-msgid "Reach 100%"
-msgstr "Atteins 100 %"
+msgctxt "0Bz4ZD"
+msgid "Reach Max Energy"
+msgstr "Atteins l’Énergie maximale"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "j-gOkC"
-msgid "Stay at 100%"
-msgstr "Reste à 100 %"
+msgctxt "MlOidD"
+msgid "Stay at Max Energy"
+msgstr "Reste à l’Énergie maximale"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
 #: src/app/[lang]/(progress)/_components/metric-pills.tsx
@@ -1065,6 +1065,11 @@ msgid "No Energy recorded on {date}"
 msgstr "Aucune Énergie enregistrée le {date}"
 
 #: src/app/[lang]/(progress)/energy/energy-chart.tsx
+msgctxt "FpslmD"
+msgid "Max Energy on {date}"
+msgstr "Énergie maximale le {date}"
+
+#: src/app/[lang]/(progress)/energy/energy-chart.tsx
 msgctxt "GThwd0"
 msgid "{percentage} Energy on {date}"
 msgstr "Énergie à {percentage} le {date}"
@@ -1120,9 +1125,9 @@ msgid "Energy rewards consistency. Learning regularly helps reinforce what you l
 msgstr "L’Énergie récompense ta régularité. Apprendre régulièrement t’aide à mieux retenir ce que tu apprends."
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
-msgctxt "qm9EdM"
-msgid "Days at 100% Energy"
-msgstr "Jours à 100 % d’Énergie"
+msgctxt "-1YhhW"
+msgid "Days at Max Energy"
+msgstr "Jours à l’Énergie maximale"
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
 msgctxt "F9mA1x"
@@ -1135,9 +1140,9 @@ msgid "Your Energy"
 msgstr "Ton Énergie"
 
 #: src/app/[lang]/(progress)/energy/page.tsx
-msgctxt "aHGjLP"
-msgid "Keep your Energy at 100% by studying every day."
-msgstr "Garde ton Énergie à 100 % en étudiant tous les jours."
+msgctxt "ajjT8S"
+msgid "Stay at Max Energy by studying every day."
+msgstr "Reste à l’Énergie maximale en étudiant chaque jour."
 
 #: src/app/[lang]/(progress)/level/level-explanation.tsx
 msgctxt "gaXaWV"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -246,14 +246,14 @@ msgid "Continue learning"
 msgstr "Continuar estudando"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "S5vNR_"
-msgid "Reach 100%"
-msgstr "Chegue a 100%"
+msgctxt "0Bz4ZD"
+msgid "Reach Max Energy"
+msgstr "Alcance a Energia Máxima"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
-msgctxt "j-gOkC"
-msgid "Stay at 100%"
-msgstr "Continue em 100%"
+msgctxt "MlOidD"
+msgid "Stay at Max Energy"
+msgstr "Mantenha a Energia Máxima"
 
 #: src/app/[lang]/(catalog)/(home)/energy.tsx
 #: src/app/[lang]/(progress)/_components/metric-pills.tsx
@@ -1065,6 +1065,11 @@ msgid "No Energy recorded on {date}"
 msgstr "Nenhuma Energia registrada em {date}"
 
 #: src/app/[lang]/(progress)/energy/energy-chart.tsx
+msgctxt "FpslmD"
+msgid "Max Energy on {date}"
+msgstr "Energia Máxima em {date}"
+
+#: src/app/[lang]/(progress)/energy/energy-chart.tsx
 msgctxt "GThwd0"
 msgid "{percentage} Energy on {date}"
 msgstr "{percentage} de Energia em {date}"
@@ -1120,9 +1125,9 @@ msgid "Energy rewards consistency. Learning regularly helps reinforce what you l
 msgstr "A Energia recompensa a constância. Estudar com frequência ajuda a fixar o que você aprende."
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
-msgctxt "qm9EdM"
-msgid "Days at 100% Energy"
-msgstr "Dias com 100% de Energia"
+msgctxt "-1YhhW"
+msgid "Days at Max Energy"
+msgstr "Dias com Energia Máxima"
 
 #: src/app/[lang]/(progress)/energy/energy-insights.tsx
 msgctxt "F9mA1x"
@@ -1135,9 +1140,9 @@ msgid "Your Energy"
 msgstr "Sua Energia"
 
 #: src/app/[lang]/(progress)/energy/page.tsx
-msgctxt "aHGjLP"
-msgid "Keep your Energy at 100% by studying every day."
-msgstr "Mantenha sua Energia em 100% estudando todos os dias."
+msgctxt "ajjT8S"
+msgid "Stay at Max Energy by studying every day."
+msgstr "Mantenha a Energia Máxima estudando todos os dias."
 
 #: src/app/[lang]/(progress)/level/level-explanation.tsx
 msgctxt "gaXaWV"

--- a/apps/main/src/app/[lang]/(catalog)/(home)/energy.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/(home)/energy.tsx
@@ -25,7 +25,7 @@ export async function Energy({ energy }: { energy: number }) {
   const energyMenu = getMenu("energy");
   const formattedEnergy = formatMetricPercent({ format, value: energy });
 
-  const description = energy < MAX_ENERGY ? t("Reach 100%") : t("Stay at 100%");
+  const description = energy < MAX_ENERGY ? t("Reach Max Energy") : t("Stay at Max Energy");
 
   return (
     <FeatureCardLink render={<Link href={energyMenu.url} prefetch />}>

--- a/apps/main/src/app/[lang]/(progress)/energy/energy-chart.tsx
+++ b/apps/main/src/app/[lang]/(progress)/energy/energy-chart.tsx
@@ -1,4 +1,4 @@
-import { type EnergyDay } from "@zoonk/core/progress/energy";
+import { type EnergyDay, MAX_ENERGY } from "@zoonk/core/progress/energy";
 import {
   ContributionCalendar,
   ContributionCalendarCaption,
@@ -138,19 +138,26 @@ export async function EnergyChart({ days }: { days: EnergyDay[] }) {
   const monthFormatter = new Intl.DateTimeFormat(locale, { month: "short", timeZone: "UTC" });
   const shortDateFormatter = getProgressInsightDateFormatter(locale);
 
-  const calendarDays = days.map((day) => {
+  function getAccessibleLabel(day: EnergyDay) {
     const date = shortDateFormatter.format(day.date);
 
-    const accessibleLabel =
-      day.energy === null
-        ? t("No Energy recorded on {date}", { date })
-        : t("{percentage} Energy on {date}", {
-            date,
-            percentage: formatMetricPercent({ format, value: day.energy }),
-          });
+    if (day.energy === null) {
+      return t("No Energy recorded on {date}", { date });
+    }
 
-    return getEnergyCalendarDay({ accessibleLabel, day, keyboardStartDate });
-  });
+    if (day.energy >= MAX_ENERGY) {
+      return t("Max Energy on {date}", { date });
+    }
+
+    return t("{percentage} Energy on {date}", {
+      date,
+      percentage: formatMetricPercent({ format, value: day.energy }),
+    });
+  }
+
+  const calendarDays = days.map((day) =>
+    getEnergyCalendarDay({ accessibleLabel: getAccessibleLabel(day), day, keyboardStartDate }),
+  );
 
   const weeks = groupContributionCalendarDaysByWeek(calendarDays).map((week) =>
     getEnergyCalendarWeek({ monthFormatter, week }),

--- a/apps/main/src/app/[lang]/(progress)/energy/energy-insights.tsx
+++ b/apps/main/src/app/[lang]/(progress)/energy/energy-insights.tsx
@@ -47,7 +47,7 @@ async function FullEnergyCard({ count }: { count: number }) {
         <ZapIcon />
       </ProgressMetricCardIcon>
       <ProgressMetricCardLabel id={DAYS_AT_FULL_ENERGY_LABEL_ID}>
-        {t("Days at 100% Energy")}
+        {t("Days at Max Energy")}
       </ProgressMetricCardLabel>
       <ProgressMetricCardValue>{countLabel}</ProgressMetricCardValue>
     </ProgressMetricCard>

--- a/apps/main/src/app/[lang]/(progress)/energy/page.tsx
+++ b/apps/main/src/app/[lang]/(progress)/energy/page.tsx
@@ -14,7 +14,7 @@ import { EnergyContent, EnergyContentSkeleton } from "./energy-content";
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted();
 
-  return { description: t("Keep your Energy at 100% by studying every day."), title: t("Energy") };
+  return { description: t("Stay at Max Energy by studying every day."), title: t("Energy") };
 }
 
 export default async function EnergyPage() {
@@ -26,7 +26,7 @@ export default async function EnergyPage() {
         <ContainerHeaderGroup>
           <ContainerTitle>{t("Energy")}</ContainerTitle>
           <ContainerDescription>
-            {t("Keep your Energy at 100% by studying every day.")}
+            {t("Stay at Max Energy by studying every day.")}
           </ContainerDescription>
         </ContainerHeaderGroup>
       </ContainerHeader>

--- a/packages/player/messages/de.po
+++ b/packages/player/messages/de.po
@@ -97,19 +97,19 @@ msgid "{percentage} Energy"
 msgstr "{percentage} Energie"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "AW9QoT"
-msgid "Complete lessons every day and answer correctly to reach 100%."
-msgstr "Schließe jeden Tag Lektionen ab und antworte richtig, um 100 % zu erreichen."
+msgctxt "4ZXR7W"
+msgid "Complete lessons every day and answer correctly to reach Max Energy."
+msgstr "Schließe jeden Tag Lektionen ab und antworte richtig, um Max Energy zu erreichen."
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "5YVYKd"
-msgid "1 year of max Energy"
-msgstr "1 Jahr lang maximale Energie"
+msgctxt "xCyvpN"
+msgid "1 year of Max Energy"
+msgstr "1 Jahr Max Energy"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "zcc-w4"
-msgid "{days} days at 100% Energy"
-msgstr "{days} Tage mit 100 % Energie"
+msgctxt "-kk9tg"
+msgid "{days} days at Max Energy"
+msgstr "{days} Tage Max Energy"
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "JEEeYJ"

--- a/packages/player/messages/en.po
+++ b/packages/player/messages/en.po
@@ -97,19 +97,19 @@ msgid "{percentage} Energy"
 msgstr "{percentage} Energy"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "AW9QoT"
-msgid "Complete lessons every day and answer correctly to reach 100%."
-msgstr "Complete lessons every day and answer correctly to reach 100%."
+msgctxt "4ZXR7W"
+msgid "Complete lessons every day and answer correctly to reach Max Energy."
+msgstr "Complete lessons every day and answer correctly to reach Max Energy."
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "5YVYKd"
-msgid "1 year of max Energy"
-msgstr "1 year of max Energy"
+msgctxt "xCyvpN"
+msgid "1 year of Max Energy"
+msgstr "1 year of Max Energy"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "zcc-w4"
-msgid "{days} days at 100% Energy"
-msgstr "{days} days at 100% Energy"
+msgctxt "-kk9tg"
+msgid "{days} days at Max Energy"
+msgstr "{days} days at Max Energy"
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "JEEeYJ"

--- a/packages/player/messages/es.po
+++ b/packages/player/messages/es.po
@@ -97,19 +97,19 @@ msgid "{percentage} Energy"
 msgstr "{percentage} de Energía"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "AW9QoT"
-msgid "Complete lessons every day and answer correctly to reach 100%."
-msgstr "Completa lecciones todos los días y responde correctamente para llegar al 100 %."
+msgctxt "4ZXR7W"
+msgid "Complete lessons every day and answer correctly to reach Max Energy."
+msgstr "Completa lecciones todos los días y responde correctamente para alcanzar la Energía máxima."
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "5YVYKd"
-msgid "1 year of max Energy"
+msgctxt "xCyvpN"
+msgid "1 year of Max Energy"
 msgstr "1 año con la Energía al máximo"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "zcc-w4"
-msgid "{days} days at 100% Energy"
-msgstr "{days} días con la Energía al 100 %"
+msgctxt "-kk9tg"
+msgid "{days} days at Max Energy"
+msgstr "{days} días con la Energía al máximo"
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "JEEeYJ"

--- a/packages/player/messages/fr.po
+++ b/packages/player/messages/fr.po
@@ -97,19 +97,19 @@ msgid "{percentage} Energy"
 msgstr "{percentage} Énergie"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "AW9QoT"
-msgid "Complete lessons every day and answer correctly to reach 100%."
-msgstr "Termine des leçons chaque jour et réponds correctement pour atteindre 100 %."
+msgctxt "4ZXR7W"
+msgid "Complete lessons every day and answer correctly to reach Max Energy."
+msgstr "Termine des leçons chaque jour et réponds correctement pour atteindre l’Énergie maximale."
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "5YVYKd"
-msgid "1 year of max Energy"
-msgstr "1 an d’Énergie au maximum"
+msgctxt "xCyvpN"
+msgid "1 year of Max Energy"
+msgstr "1 an à l’Énergie maximale"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "zcc-w4"
-msgid "{days} days at 100% Energy"
-msgstr "Énergie à 100 % pendant {days} jours"
+msgctxt "-kk9tg"
+msgid "{days} days at Max Energy"
+msgstr "{days} jours à l’Énergie maximale"
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "JEEeYJ"

--- a/packages/player/messages/pt.po
+++ b/packages/player/messages/pt.po
@@ -97,19 +97,19 @@ msgid "{percentage} Energy"
 msgstr "{percentage} de Energia"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "AW9QoT"
-msgid "Complete lessons every day and answer correctly to reach 100%."
-msgstr "Complete aulas todos os dias e responda corretamente para chegar a 100%."
+msgctxt "4ZXR7W"
+msgid "Complete lessons every day and answer correctly to reach Max Energy."
+msgstr "Complete aulas todos os dias e responda corretamente para chegar à Energia Máxima."
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "5YVYKd"
-msgid "1 year of max Energy"
-msgstr "1 ano com Energia máxima"
+msgctxt "xCyvpN"
+msgid "1 year of Max Energy"
+msgstr "1 ano de Energia Máxima"
 
 #: src/components/completion-energy-milestone.tsx
-msgctxt "zcc-w4"
-msgid "{days} days at 100% Energy"
-msgstr "{days} dias com 100% de Energia"
+msgctxt "-kk9tg"
+msgid "{days} days at Max Energy"
+msgstr "{days} dias com Energia Máxima"
 
 #: src/components/completion-energy-milestone.tsx
 msgctxt "JEEeYJ"

--- a/packages/player/src/components/completion-energy-milestone.tsx
+++ b/packages/player/src/components/completion-energy-milestone.tsx
@@ -21,7 +21,7 @@ export function EnergyMilestoneIndicator() {
   );
 }
 
-/** Keeps every threshold celebration pointed at the single 100% Energy goal. */
+/** Keeps every threshold celebration pointed at the Max Energy goal. */
 function EnergyThresholdCopy({
   milestone,
 }: {
@@ -49,25 +49,25 @@ function EnergyThresholdCopy({
         })}
       </CompletionMilestoneTitle>
       <PlayerSupportingText>
-        {t("Complete lessons every day and answer correctly to reach 100%.")}
+        {t("Complete lessons every day and answer correctly to reach Max Energy.")}
       </PlayerSupportingText>
     </>
   );
 }
 
-/** Preserves the one-year celebration while naming other milestones by the familiar 100% goal. */
+/** Preserves the one-year celebration while naming other milestones by the Max Energy goal. */
 function FullEnergyDaysTitle({ days }: { days: number }) {
   const t = useExtracted();
   const format = useFormatter();
   const formattedDays = formatWholeNumber({ format, value: days });
 
   if (days === 365) {
-    return <CompletionMilestoneTitle>{t("1 year of max Energy")}</CompletionMilestoneTitle>;
+    return <CompletionMilestoneTitle>{t("1 year of Max Energy")}</CompletionMilestoneTitle>;
   }
 
   return (
     <CompletionMilestoneTitle>
-      {t("{days} days at 100% Energy", { days: formattedDays })}
+      {t("{days} days at Max Energy", { days: formattedDays })}
     </CompletionMilestoneTitle>
   );
 }


### PR DESCRIPTION
Use “Max Energy” consistently for maximum-energy goals, milestones, and calendar labels across the web and Apple apps. Update translations and the existing Energy test assertions to match.
