### PR TITLE
fix(player): count match columns answers individually

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## Scope and completion
 
-- Carry the requested work through implementation and relevant verification before returning it for local review. Resolve routine implementation choices from repository context; ask only when missing information materially changes the product, architecture, or authorization.
+- Own the user’s intended outcome through implementation and verification. Use the request, examples, and surrounding context to establish what successful completion requires. Evaluate the solution in the context of the surrounding system. Before handing work back, challenge the assumptions behind your approach and investigate evidence that the solution is incomplete or introduces regressions. Complete the supporting work necessary for the authorized goal. Apply simplicity and scope constraints to achieve the smallest complete solution.
 - Keep changes within the requested scope. Refactor supporting code when needed for a complete solution, and remove code, tests, types, and layout left over from superseded requirements.
 - Treat review comments and specs as hypotheses. Verify the actual path, product assumptions, and impact. In review/assessment work, fix confirmed bugs unless the user asks for findings only or the fix requires a meaningful product or architecture decision. Explain unsupported claims without changing code to satisfy them.
 - Read task-relevant files and documentation. Skills provide conditional guidance; an explicit user request takes precedence. If an instruction blocks authorized work, identify the file and rule and explain the concrete conflict.
@@ -24,7 +24,7 @@
 
 ## Verification
 
-- Choose checks that prove the changed behavior and cover affected consumers. For behavior changes, prefer a failing regression test before implementation when practical. For documentation, copy, styling, or other low-impact edits, use relevant validation without adding tests that mirror the edit.
+- Choose verification that could expose mistakes in your understanding or implementation. Judge completion against the intended behavior and available evidence; passing checks alone do not establish that the task is complete. For behavior changes, prefer a failing regression test before implementation when practical. For documentation, copy, styling, or other low-impact edits, use relevant validation without adding tests that mirror the edit.
 - Use [zoonk-testing](.agents/skills/zoonk-testing/SKILL.md) when writing or changing tests: E2E for user flows, real-database integration tests for persistence and business logic, and unit tests for non-trivial pure helpers. Do not write React component unit tests. Do not add tests for `admin`, `evals`, or `blog`.
 - Run relevant local checks and fix failures caused by the requested change without pausing for review after each step. Investigate failures, including intermittent ones; do not rerun until green and dismiss them. Fix failures in the affected scope, and report unrelated failures with evidence instead of silently expanding the task.
 - Once affected checks pass, broaden or repeat them only for new changes, failures, unresolved risks, or an explicit request. For timing, concurrency, or fixture-isolation changes, repeat the focused affected coverage to establish stability.

--- a/apps/api/e2e/lesson-resources.test.ts
+++ b/apps/api/e2e/lesson-resources.test.ts
@@ -997,6 +997,41 @@ test.describe("Lesson resources API", () => {
     await apiContext.dispose();
   });
 
+  test("rejects oversized matching mistake counts before saving progress", async () => {
+    const { lesson } = await createPublishedLesson({});
+
+    const pairs = [
+      { left: "A", right: "1" },
+      { left: "B", right: "2" },
+    ];
+
+    const step = await stepFixture({
+      content: { pairs },
+      isPublished: true,
+      kind: "matchColumns",
+      lessonId: lesson.id,
+    });
+
+    const { apiContext, user } = await createBearerApiContext({
+      baseURL,
+      prefix: "matching-mistake-limit",
+    });
+
+    const response = await apiContext.post(`/v1/lessons/${lesson.id}/completions`, {
+      data: {
+        answers: { [step.id]: { kind: "matchColumns", mistakes: 2 ** 31, userPairs: pairs } },
+        startedAt: Date.now() - 10_000,
+        stepTimings: {},
+        timeZone: "UTC",
+      },
+    });
+
+    expect(response.status()).toBe(400);
+    await expect(prisma.dailyProgress.count({ where: { userId: user.id } })).resolves.toBe(0);
+    await expect(prisma.stepAttempt.count({ where: { userId: user.id } })).resolves.toBe(0);
+    await apiContext.dispose();
+  });
+
   test("completes a lesson and returns the authoritative rewards", async () => {
     const { lesson } = await createPublishedLesson({});
 

--- a/apps/apple/Zoonk/openapi.json
+++ b/apps/apple/Zoonk/openapi.json
@@ -4189,7 +4189,9 @@
                       ]
                     },
                     "mistakes": {
-                      "type": "number"
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 10000
                     },
                     "userPairs": {
                       "type": "array",

--- a/packages/core/src/player/commands/create-lesson-completion.test.ts
+++ b/packages/core/src/player/commands/create-lesson-completion.test.ts
@@ -590,6 +590,71 @@ describe(completeLesson, () => {
     });
   });
 
+  it("persists every successful match and wrong attempt in the lesson score", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, step } = await createMultipleChoiceLesson({
+      chapterId: chapter.id,
+      organizationId: organization.id,
+    });
+
+    const pairs = [
+      { left: "A", right: "1" },
+      { left: "B", right: "2" },
+    ];
+
+    const [otherSteps, matchStep] = await Promise.all([
+      Promise.all(
+        Array.from({ length: 8 }, (_, index) =>
+          stepFixture({
+            content: buildMultipleChoiceContent(),
+            isPublished: true,
+            kind: "multipleChoice",
+            lessonId: lesson.id,
+            position: index + 1,
+          }),
+        ),
+      ),
+      stepFixture({
+        content: { pairs },
+        isPublished: true,
+        kind: "matchColumns",
+        lessonId: lesson.id,
+        position: 9,
+      }),
+    ]);
+
+    const input = buildCompletionInputForSteps({
+      lessonId: lesson.id,
+      stepIds: [step.id, ...otherSteps.map((item) => item.id)],
+    });
+
+    const completion = await submitCompletionForUser({
+      input: {
+        ...input,
+        answers: {
+          ...input.answers,
+          [matchStep.id]: { kind: "matchColumns", mistakes: 2, userPairs: pairs },
+        },
+      },
+      userId: user.id,
+    });
+
+    expect(completion).toMatchObject({
+      result: { correctCount: 11, energyDelta: 2, incorrectCount: 2 },
+      status: "completed",
+    });
+
+    await expect(
+      prisma.dailyProgress.findMany({ where: { userId: user.id } }),
+    ).resolves.toStrictEqual([
+      expect.objectContaining({ correctAnswers: 11, incorrectAnswers: 2 }),
+    ]);
+  });
+
   it("does not write completion progress for a guest", async () => {
     const { chapter, organization } = await createChapterContext();
 

--- a/packages/core/src/player/commands/create-lesson-completion.test.ts
+++ b/packages/core/src/player/commands/create-lesson-completion.test.ts
@@ -11,10 +11,16 @@ import { revalidateTag } from "next/cache";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockSession } from "../../_test-utils/mock-session";
 import { getUserProgressCacheTag } from "../../cache/tags";
+import { getRequestProgressDateContext } from "../../progress/get-request-date-context";
+import { getScorePatterns } from "../../progress/get-score-patterns";
 import { type CompletionInput } from "../contracts/completion-input-schema";
 import { completeLesson } from "./create-lesson-completion";
 
 vi.mock("../../users/get-session", () => ({ getSession: vi.fn() }));
+
+vi.mock("../../progress/get-request-date-context", () => ({
+  getRequestProgressDateContext: vi.fn(),
+}));
 
 const TEST_SECONDS_PER_MINUTE = 60;
 const TEST_COMPLETION_CAP_MINUTES = 30;
@@ -591,6 +597,14 @@ describe(completeLesson, () => {
   });
 
   it("persists every successful match and wrong attempt in the lesson score", async () => {
+    const now = new Date();
+
+    vi.mocked(getRequestProgressDateContext).mockResolvedValue({
+      currentDate: now,
+      currentInstant: now,
+      timeZone: "UTC",
+    });
+
     const [user, { chapter, organization }] = await Promise.all([
       userFixture(),
       createChapterContext(),
@@ -639,6 +653,7 @@ describe(completeLesson, () => {
           ...input.answers,
           [matchStep.id]: { kind: "matchColumns", mistakes: 2, userPairs: pairs },
         },
+        stepTimings: { ...input.stepTimings, [matchStep.id]: input.stepTimings[step.id]! },
       },
       userId: user.id,
     });
@@ -653,6 +668,57 @@ describe(completeLesson, () => {
     ).resolves.toStrictEqual([
       expect.objectContaining({ correctAnswers: 11, incorrectAnswers: 2 }),
     ]);
+
+    const patterns = await getScorePatterns();
+
+    expect(patterns?.times).toStrictEqual([
+      {
+        correctAnswers: 11,
+        incorrectAnswers: 2,
+        period: 2,
+        score: (11 / 13) * 100,
+        totalAnswers: 13,
+      },
+    ]);
+
+    expect(patterns?.weekdays).toStrictEqual([
+      expect.objectContaining({ correctAnswers: 11, incorrectAnswers: 2, totalAnswers: 13 }),
+    ]);
+  });
+
+  it("does not overflow progress counters for an oversized match mistake count", async () => {
+    const [user, { chapter, organization }] = await Promise.all([
+      userFixture(),
+      createChapterContext(),
+    ]);
+
+    const { lesson, step } = await createMultipleChoiceLesson({
+      chapterId: chapter.id,
+      organizationId: organization.id,
+    });
+
+    const pairs = [
+      { left: "A", right: "1" },
+      { left: "B", right: "2" },
+    ];
+
+    await prisma.step.update({
+      data: { content: { pairs }, kind: "matchColumns" },
+      where: { id: step.id },
+    });
+
+    const completion = await submitCompletionForUser({
+      input: {
+        ...buildCompletionInput({ lessonId: lesson.id, stepId: step.id }),
+        answers: { [step.id]: { kind: "matchColumns", mistakes: 2 ** 31, userPairs: pairs } },
+      },
+      userId: user.id,
+    });
+
+    expect(completion).toMatchObject({
+      result: { correctCount: 0, incorrectCount: 1 },
+      status: "completed",
+    });
   });
 
   it("does not write completion progress for a guest", async () => {

--- a/packages/core/src/player/commands/create-lesson-completion.ts
+++ b/packages/core/src/player/commands/create-lesson-completion.ts
@@ -231,6 +231,7 @@ export async function completeLesson(input: CompletionInput) {
 
     return {
       answer: validated.answer,
+      answerCounts: validated.answerCounts,
       answeredAt: timing ? new Date(timing.answeredAt) : new Date(),
       dayOfWeek: timing?.dayOfWeek ?? new Date().getDay(),
       durationSeconds: getCappedStepAttemptDurationSeconds({

--- a/packages/core/src/player/commands/submit-lesson-completion.ts
+++ b/packages/core/src/player/commands/submit-lesson-completion.ts
@@ -2,6 +2,8 @@ import "server-only";
 import { prisma } from "@zoonk/db";
 import { type BeltLevelResult, calculateBeltLevel } from "@zoonk/utils/belt-level";
 import { clampEnergy } from "../../progress/energy";
+import { getStepAnswerCounts } from "../contracts/answer-counts";
+import { type AnswerResult } from "../contracts/check-answer";
 import { type ScoreResult } from "../contracts/compute-score";
 import { getCompletionEnergyContext } from "./_utils/completion-energy";
 import { getCompletionField, upsertDailyProgress } from "./_utils/daily-progress";
@@ -19,6 +21,7 @@ export async function submitLessonCompletion(input: {
   startedAt: Date;
   stepResults: {
     answer: object;
+    answerCounts?: AnswerResult["answerCounts"];
     answeredAt: Date;
     dayOfWeek: number;
     durationSeconds: number;
@@ -47,9 +50,11 @@ export async function submitLessonCompletion(input: {
         data: input.stepResults.map((step) => ({
           answer: step.answer,
           answeredAt: step.answeredAt,
+          correctAnswers: getStepAnswerCounts(step).correct,
           dayOfWeek: step.dayOfWeek,
           durationSeconds: step.durationSeconds,
           hourOfDay: step.hourOfDay,
+          incorrectAnswers: getStepAnswerCounts(step).incorrect,
           isCorrect: step.isCorrect,
           stepId: step.stepId,
           userId: input.userId,

--- a/packages/core/src/player/contracts/_utils/match-columns-limits.ts
+++ b/packages/core/src/player/contracts/_utils/match-columns-limits.ts
@@ -1,0 +1,5 @@
+/**
+ * A generous per-step limit keeps client-supplied mistake counts well below
+ * PostgreSQL's signed 32-bit progress counters, with room for daily aggregation.
+ */
+export const MAX_MATCH_COLUMNS_MISTAKES = 10_000;

--- a/packages/core/src/player/contracts/_utils/selected-answer-schema.ts
+++ b/packages/core/src/player/contracts/_utils/selected-answer-schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MAX_MATCH_COLUMNS_MISTAKES } from "./match-columns-limits";
 
 type SelectedAnswerSchemaLimits = {
   maxItems?: number;
@@ -30,18 +31,10 @@ function getAnswerItemsSchema<T extends z.ZodType>({
   return itemsSchema.max(maxItems);
 }
 
-function getMistakesSchema(maxMistakes: number | undefined) {
-  if (maxMistakes === undefined) {
-    return z.number();
-  }
-
-  return z.number().int().min(0).max(maxMistakes);
-}
-
 /** Keeps completion answers and stricter derived boundaries on one discriminated data contract. */
 export function createSelectedAnswerSchema({
   maxItems,
-  maxMistakes,
+  maxMistakes = MAX_MATCH_COLUMNS_MISTAKES,
   maxTextLength,
 }: SelectedAnswerSchemaLimits = {}) {
   const answerTextSchema = getAnswerTextSchema(maxTextLength);
@@ -53,7 +46,7 @@ export function createSelectedAnswerSchema({
     z.object({ arrangedWords: answerItemsSchema, kind: z.literal("listening") }),
     z.object({
       kind: z.literal("matchColumns"),
-      mistakes: getMistakesSchema(maxMistakes),
+      mistakes: z.number().int().min(0).max(maxMistakes),
       userPairs: getAnswerItemsSchema({ itemSchema: matchPairSchema, maxItems }),
     }),
     z.object({ kind: z.literal("multipleChoice"), selectedOptionId: answerTextSchema }),

--- a/packages/core/src/player/contracts/answer-counts.ts
+++ b/packages/core/src/player/contracts/answer-counts.ts
@@ -1,0 +1,11 @@
+import { type AnswerResult } from "./check-answer";
+
+/** Keeps saved attempts and completion totals on the same scoring units. */
+export function getStepAnswerCounts(result: Pick<AnswerResult, "answerCounts" | "isCorrect">) {
+  return (
+    result.answerCounts ?? {
+      correct: Number(result.isCorrect),
+      incorrect: Number(!result.isCorrect),
+    }
+  );
+}

--- a/packages/core/src/player/contracts/check-answer.test.ts
+++ b/packages/core/src/player/contracts/check-answer.test.ts
@@ -170,16 +170,30 @@ describe(checkMatchColumnsAnswer, () => {
     });
   });
 
-  it.each([-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY])(
-    "does not award matching credit for invalid mistake count %s",
-    (mistakes) => {
-      expect(checkMatchColumnsAnswer(content, content.pairs, mistakes)).toStrictEqual({
-        correctAnswer: null,
-        feedback: null,
-        isCorrect: false,
-      });
-    },
-  );
+  it("counts mistakes up to the supported per-step limit", () => {
+    expect(checkMatchColumnsAnswer(content, content.pairs, 10_000)).toStrictEqual({
+      answerCounts: { correct: 2, incorrect: 10_000 },
+      correctAnswer: null,
+      feedback: null,
+      isCorrect: false,
+    });
+  });
+
+  it.each([
+    -1,
+    0.5,
+    10_001,
+    2 ** 31,
+    Number.MAX_SAFE_INTEGER + 1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])("does not award matching credit for invalid mistake count %s", (mistakes) => {
+    expect(checkMatchColumnsAnswer(content, content.pairs, mistakes)).toStrictEqual({
+      correctAnswer: null,
+      feedback: null,
+      isCorrect: false,
+    });
+  });
 
   it("returns incorrect when a pair is wrong", () => {
     const userPairs = [

--- a/packages/core/src/player/contracts/check-answer.test.ts
+++ b/packages/core/src/player/contracts/check-answer.test.ts
@@ -135,6 +135,7 @@ describe(checkMatchColumnsAnswer, () => {
     ];
 
     expect(checkMatchColumnsAnswer(content, userPairs, 0)).toStrictEqual({
+      answerCounts: { correct: 2, incorrect: 0 },
       correctAnswer: null,
       feedback: null,
       isCorrect: true,
@@ -148,6 +149,7 @@ describe(checkMatchColumnsAnswer, () => {
     ];
 
     expect(checkMatchColumnsAnswer(content, userPairs, 0)).toStrictEqual({
+      answerCounts: { correct: 2, incorrect: 0 },
       correctAnswer: null,
       feedback: null,
       isCorrect: true,
@@ -161,11 +163,23 @@ describe(checkMatchColumnsAnswer, () => {
     ];
 
     expect(checkMatchColumnsAnswer(content, userPairs, 1)).toStrictEqual({
+      answerCounts: { correct: 2, incorrect: 1 },
       correctAnswer: null,
       feedback: null,
       isCorrect: false,
     });
   });
+
+  it.each([-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "does not award matching credit for invalid mistake count %s",
+    (mistakes) => {
+      expect(checkMatchColumnsAnswer(content, content.pairs, mistakes)).toStrictEqual({
+        correctAnswer: null,
+        feedback: null,
+        isCorrect: false,
+      });
+    },
+  );
 
   it("returns incorrect when a pair is wrong", () => {
     const userPairs = [

--- a/packages/core/src/player/contracts/check-answer.ts
+++ b/packages/core/src/player/contracts/check-answer.ts
@@ -5,6 +5,7 @@ import {
   type SelectImageStepContent,
   type SortOrderStepContent,
 } from "@zoonk/core/steps/contract/content";
+import { MAX_MATCH_COLUMNS_MISTAKES } from "./_utils/match-columns-limits";
 import { matchesAcceptedArrangeWords } from "./arrange-words-answers";
 
 export type AnswerResult = {
@@ -100,7 +101,12 @@ export function checkMatchColumnsAnswer(
 ): AnswerResult {
   const allPairsCorrect = hasSameMatchPairCounts({ correctPairs: content.pairs, userPairs });
 
-  if (!allPairsCorrect || !Number.isInteger(mistakes) || mistakes < 0) {
+  if (
+    !allPairsCorrect ||
+    !Number.isSafeInteger(mistakes) ||
+    mistakes < 0 ||
+    mistakes > MAX_MATCH_COLUMNS_MISTAKES
+  ) {
     return { correctAnswer: null, feedback: null, isCorrect: false };
   }
 

--- a/packages/core/src/player/contracts/check-answer.ts
+++ b/packages/core/src/player/contracts/check-answer.ts
@@ -8,6 +8,7 @@ import {
 import { matchesAcceptedArrangeWords } from "./arrange-words-answers";
 
 export type AnswerResult = {
+  answerCounts?: { correct: number; incorrect: number };
   correctAnswer: string | null;
   isCorrect: boolean;
   feedback: string | null;
@@ -99,7 +100,17 @@ export function checkMatchColumnsAnswer(
 ): AnswerResult {
   const allPairsCorrect = hasSameMatchPairCounts({ correctPairs: content.pairs, userPairs });
 
-  return { correctAnswer: null, feedback: null, isCorrect: allPairsCorrect && mistakes === 0 };
+  if (!allPairsCorrect || !Number.isInteger(mistakes) || mistakes < 0) {
+    return { correctAnswer: null, feedback: null, isCorrect: false };
+  }
+
+  /** The player requires every pair to be solved and records wrong attempts separately. */
+  return {
+    answerCounts: { correct: content.pairs.length, incorrect: mistakes },
+    correctAnswer: null,
+    feedback: null,
+    isCorrect: mistakes === 0,
+  };
 }
 
 export function checkSortOrderAnswer(

--- a/packages/core/src/player/contracts/compute-score.test.ts
+++ b/packages/core/src/player/contracts/compute-score.test.ts
@@ -1,7 +1,29 @@
 import { describe, expect, it } from "vitest";
+import { checkMatchColumnsAnswer } from "./check-answer";
 import { computeLessonScore } from "./compute-score";
 
 describe("computeLessonScore (generic)", () => {
+  it.each([0, 2, 5])("counts each successful match and %i wrong attempts", (mistakes) => {
+    const pairs = [
+      { left: "A", right: "1" },
+      { left: "B", right: "2" },
+    ];
+
+    const result = computeLessonScore({
+      results: [
+        ...Array.from({ length: 9 }, () => ({ isCorrect: true })),
+        checkMatchColumnsAnswer({ pairs }, pairs, mistakes),
+      ],
+    });
+
+    expect(result).toStrictEqual({
+      brainPower: 10,
+      correctCount: 11,
+      energyDelta: (22 - mistakes) / 10,
+      incorrectCount: mistakes,
+    });
+  });
+
   it("all correct (5): BP=10, energyDelta=1.0", () => {
     const result = computeLessonScore({
       results: [

--- a/packages/core/src/player/contracts/compute-score.ts
+++ b/packages/core/src/player/contracts/compute-score.ts
@@ -1,5 +1,6 @@
 import { BRAIN_POWER_PER_LESSON } from "@zoonk/utils/brain-power";
 import { ENERGY_PER_CORRECT, ENERGY_PER_INCORRECT, ENERGY_PER_STATIC } from "../../progress/energy";
+import { getStepAnswerCounts } from "./answer-counts";
 import { type AnswerResult } from "./check-answer";
 
 export type ScoreResult = {
@@ -20,15 +21,10 @@ type ScoredStepResult = Pick<AnswerResult, "answerCounts" | "isCorrect">;
  * static reading steps count as completing useful lesson work.
  */
 export function computeLessonScore({ results }: { results: ScoredStepResult[] }): ScoreResult {
-  const correctCount = results.reduce(
-    (total, result) => total + (result.answerCounts?.correct ?? Number(result.isCorrect)),
-    0,
-  );
+  const counts = results.map((result) => getStepAnswerCounts(result));
+  const correctCount = counts.reduce((total, count) => total + count.correct, 0);
 
-  const incorrectCount = results.reduce(
-    (total, result) => total + (result.answerCounts?.incorrect ?? Number(!result.isCorrect)),
-    0,
-  );
+  const incorrectCount = counts.reduce((total, count) => total + count.incorrect, 0);
 
   const energyDelta =
     results.length === 0

--- a/packages/core/src/player/contracts/compute-score.ts
+++ b/packages/core/src/player/contracts/compute-score.ts
@@ -1,5 +1,6 @@
 import { BRAIN_POWER_PER_LESSON } from "@zoonk/utils/brain-power";
 import { ENERGY_PER_CORRECT, ENERGY_PER_INCORRECT, ENERGY_PER_STATIC } from "../../progress/energy";
+import { type AnswerResult } from "./check-answer";
 
 export type ScoreResult = {
   brainPower: number;
@@ -8,7 +9,7 @@ export type ScoreResult = {
   incorrectCount: number;
 };
 
-type ScoredStepResult = { isCorrect: boolean };
+type ScoredStepResult = Pick<AnswerResult, "answerCounts" | "isCorrect">;
 
 /**
  * Computes completion rewards from checked step results.
@@ -19,8 +20,15 @@ type ScoredStepResult = { isCorrect: boolean };
  * static reading steps count as completing useful lesson work.
  */
 export function computeLessonScore({ results }: { results: ScoredStepResult[] }): ScoreResult {
-  const correctCount = results.filter((result) => result.isCorrect).length;
-  const incorrectCount = results.length - correctCount;
+  const correctCount = results.reduce(
+    (total, result) => total + (result.answerCounts?.correct ?? Number(result.isCorrect)),
+    0,
+  );
+
+  const incorrectCount = results.reduce(
+    (total, result) => total + (result.answerCounts?.incorrect ?? Number(!result.isCorrect)),
+    0,
+  );
 
   const energyDelta =
     results.length === 0

--- a/packages/core/src/player/contracts/validate-answers.ts
+++ b/packages/core/src/player/contracts/validate-answers.ts
@@ -1,10 +1,14 @@
 import { type StepKind } from "@zoonk/db";
+import { type AnswerResult } from "./check-answer";
 import { type CheckableStep, checkStepAnswer } from "./check-step-answer";
 import { type SelectedAnswer } from "./completion-input-schema";
 
 export type StepData = CheckableStep & { id: string };
 
-type ValidatedStepResult = { answer: object; isCorrect: boolean; stepId: string };
+type ValidatedStepResult = Pick<AnswerResult, "answerCounts" | "isCorrect"> & {
+  answer: object;
+  stepId: string;
+};
 
 export const ANSWERABLE_STEP_KINDS = [
   "fillBlank",
@@ -40,6 +44,15 @@ export function validateAnswers(
 
     const result = checkStepAnswer(step, answer);
 
-    return result ? [{ answer, isCorrect: result.isCorrect, stepId: step.id }] : [];
+    return result
+      ? [
+          {
+            answer,
+            answerCounts: result.answerCounts,
+            isCorrect: result.isCorrect,
+            stepId: step.id,
+          },
+        ]
+      : [];
   });
 }

--- a/packages/core/src/progress/get-score-patterns.ts
+++ b/packages/core/src/progress/get-score-patterns.ts
@@ -86,6 +86,7 @@ function getAnsweredAtRangeFilter({ endDate, startDate }: { endDate: Date; start
 /**
  * Loads weekday and time-of-day aggregates in parallel so the Patterns page
  * gets one coherent window without creating a database waterfall.
+ * Attempts without saved answer totals retain their original boolean score.
  */
 async function queryScorePatterns({
   dailyProgress,
@@ -109,8 +110,8 @@ async function queryScorePatterns({
           WHEN hour_of_day BETWEEN 12 AND 17 THEN 2
           ELSE 3
         END AS "period",
-        COUNT(*) FILTER (WHERE is_correct = true)::int AS "correctAnswers",
-        COUNT(*) FILTER (WHERE is_correct = false)::int AS "incorrectAnswers"
+        SUM(COALESCE(correct_answers, is_correct::int))::int AS "correctAnswers",
+        SUM(COALESCE(incorrect_answers, (NOT is_correct)::int))::int AS "incorrectAnswers"
       FROM step_attempts
       WHERE user_id = ${userId} AND ${answeredAtRangeFilter}
       GROUP BY 1

--- a/packages/db/src/prisma/_sync-content/preserve.ts
+++ b/packages/db/src/prisma/_sync-content/preserve.ts
@@ -178,9 +178,10 @@ export async function restoreDestinationReferences({
   const stepAttempts = await destination.query(
     `INSERT INTO step_attempts
            (id, user_id, step_id, is_correct, answer, effects, duration_seconds, answered_at,
-            hour_of_day, day_of_week)
+            hour_of_day, day_of_week, correct_answers, incorrect_answers)
          SELECT local.id, local.user_id, steps.id, local.is_correct, local.answer, local.effects,
-                local.duration_seconds, local.answered_at, local.hour_of_day, local.day_of_week
+                local.duration_seconds, local.answered_at, local.hour_of_day, local.day_of_week,
+                local.correct_answers, local.incorrect_answers
            FROM local_step_attempts local
            JOIN courses ON courses.organization_id = $1 AND courses.slug = local.course_slug
            JOIN chapters ON chapters.course_id = courses.id AND chapters.slug = local.chapter_slug

--- a/packages/db/src/prisma/migrations/20260910201440_add_step_attempt_answer_counts/migration.sql
+++ b/packages/db/src/prisma/migrations/20260910201440_add_step_attempt_answer_counts/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "step_attempts" ADD COLUMN     "correct_answers" INTEGER,
+ADD COLUMN     "incorrect_answers" INTEGER;

--- a/packages/db/src/prisma/models/progress.prisma
+++ b/packages/db/src/prisma/models/progress.prisma
@@ -46,18 +46,20 @@ model CourseCompletion {
 }
 
 model StepAttempt {
-  id              String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
-  userId          String   @map("user_id") @db.Uuid
-  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  stepId          String   @map("step_id") @db.Uuid
-  step            Step     @relation(fields: [stepId], references: [id], onDelete: Cascade)
-  isCorrect       Boolean  @map("is_correct")
-  answer          Json
-  effects         Json?
-  durationSeconds Int      @map("duration_seconds")
-  answeredAt      DateTime @default(now()) @map("answered_at")
-  hourOfDay       Int      @map("hour_of_day") @db.SmallInt
-  dayOfWeek       Int      @map("day_of_week") @db.SmallInt
+  id               String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  userId           String   @map("user_id") @db.Uuid
+  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  stepId           String   @map("step_id") @db.Uuid
+  step             Step     @relation(fields: [stepId], references: [id], onDelete: Cascade)
+  isCorrect        Boolean  @map("is_correct")
+  correctAnswers   Int?     @map("correct_answers")
+  incorrectAnswers Int?     @map("incorrect_answers")
+  answer           Json
+  effects          Json?
+  durationSeconds  Int      @map("duration_seconds")
+  answeredAt       DateTime @default(now()) @map("answered_at")
+  hourOfDay        Int      @map("hour_of_day") @db.SmallInt
+  dayOfWeek        Int      @map("day_of_week") @db.SmallInt
 
   @@index([userId, answeredAt])
   @@index([stepId])

--- a/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
+++ b/packages/player/src/_browser-tests/player-arrangement.browser.test.tsx
@@ -247,7 +247,7 @@ describe("player browser integration: arrangement steps", () => {
       .toBeInTheDocument();
   });
 
-  it("keeps match-columns mistakes in the completion result even after correction", async () => {
+  it("counts successful matches and mistakes separately in the completion result", async () => {
     renderPlayer({
       lesson: buildSerializedLesson({
         steps: [
@@ -281,7 +281,7 @@ describe("player browser integration: arrangement steps", () => {
     await page.getByRole("button", { name: /check/iu }).click();
 
     await expect.element(page.getByRole("status")).toBeInTheDocument();
-    await expect.element(page.getByText("0%")).toBeInTheDocument();
+    await expect.element(page.getByText("67%")).toBeInTheDocument();
   });
 
   it("shows the correct order when the shared sort-order answer is wrong", async () => {

--- a/packages/player/src/player-completion.test.ts
+++ b/packages/player/src/player-completion.test.ts
@@ -1,5 +1,6 @@
 import { type SerializedStep } from "@zoonk/core/player/contracts/prepare-lesson-data";
 import { describe, expect, it } from "vitest";
+import { checkStep } from "./check-step";
 import { computeLocalCompletion } from "./player-completion";
 import { type PlayerState, type StepResult } from "./player-reducer";
 
@@ -45,6 +46,40 @@ function buildState(overrides: Partial<PlayerState> = {}): PlayerState {
 }
 
 describe(computeLocalCompletion, () => {
+  it("previews 11 correct and 2 wrong answers for nine correct steps and two matches", () => {
+    const pairs = [
+      { left: "A", right: "1" },
+      { left: "B", right: "2" },
+    ];
+
+    const step = buildStep({ content: { pairs }, id: "match", kind: "matchColumns" });
+    const answer = { kind: "matchColumns" as const, mistakes: 2, userPairs: pairs };
+
+    const results: Record<string, StepResult> = Object.fromEntries(
+      Array.from({ length: 9 }, (_, index) => [
+        `mc-${index}`,
+        { result: { correctAnswer: null, feedback: null, isCorrect: true }, stepId: `mc-${index}` },
+      ]),
+    );
+
+    const completion = computeLocalCompletion(
+      buildState({
+        results: {
+          ...results,
+          [step.id]: { answer, result: checkStep(step, answer).result, stepId: step.id },
+        },
+      }),
+    );
+
+    expect(completion).toMatchObject({ correctCount: 11, energyDelta: 2, incorrectCount: 2 });
+
+    expect(
+      Math.round(
+        (completion.correctCount / (completion.correctCount + completion.incorrectCount)) * 100,
+      ),
+    ).toBe(85);
+  });
+
   it("uses standard scoring for checked steps", () => {
     const steps = [
       buildStep({


### PR DESCRIPTION
Count each successful match and wrong attempt separately in lesson completion previews and saved scores, preserving credit for correct matches after a mistake. Nine correct answers plus two successful matches and two wrong attempts now yield 11 correct and 2 wrong answers, rounded to 85%.
