### PR TITLE
chore(ui): replace class merging dependencies with cn

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,10 +31,9 @@
     "@shadcn/react": "0.3.1",
     "@zoonk/utils": "workspace:*",
     "class-variance-authority": "0.7.1",
-    "clsx": "2.1.1",
+    "cn": "0.2.6",
     "input-otp": "1.5.0",
-    "react-infinite-scroll-hook": "6.0.1",
-    "tailwind-merge": "3.6.0"
+    "react-infinite-scroll-hook": "6.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "catalog:",

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,6 +1,1 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from "cn";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1203,9 +1203,9 @@ importers:
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
-      clsx:
-        specifier: 2.1.1
-        version: 2.1.1
+      cn:
+        specifier: 0.2.6
+        version: 0.2.6
       input-otp:
         specifier: 1.5.0
         version: 1.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1221,9 +1221,6 @@ importers:
       react-infinite-scroll-hook:
         specifier: 6.0.1
         version: 6.0.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      tailwind-merge:
-        specifier: 3.6.0
-        version: 3.6.0
     devDependencies:
       '@tailwindcss/postcss':
         specifier: 'catalog:'
@@ -5130,6 +5127,11 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cn@0.2.6:
+    resolution: {integrity: sha512-+i4L0zUGgRcEnhsxueVrP7iBGxBx5iD0WOTYg1MwFEu2ZyCmH5Ov2V1cul2Ht5UchRQQgftCf4be/RxspuW6QQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -12285,6 +12287,8 @@ snapshots:
     optional: true
 
   clsx@2.1.1: {}
+
+  cn@0.2.6: {}
 
   collapse-white-space@2.1.0: {}
 


### PR DESCRIPTION
Replace the shared `twMerge(clsx(...))` helper with `cn@0.2.6`, consolidating the UI package's class-merging dependencies while preserving existing imports. Update the lockfile and remove the direct `clsx` and `tailwind-merge` dependencies.
