### PR TITLE
fix(oxlint-plugin): allow supported promise.all translation bindings

### DIFF
--- a/packages/oxlint-plugin/AGENTS.md
+++ b/packages/oxlint-plugin/AGENTS.md
@@ -1,0 +1,3 @@
+# Oxlint plugin
+
+Do not add automated test files, test dependencies, or test infrastructure for lint rules in this package. Lint rule changes are low-risk and easy to verify manually: run Oxlint against small valid and invalid code examples instead.

--- a/packages/oxlint-plugin/rules/no-dynamic-translation-key.js
+++ b/packages/oxlint-plugin/rules/no-dynamic-translation-key.js
@@ -1,44 +1,5 @@
 import { defineRule } from "@oxlint/plugins";
-
-function isGetExtractedCall(node) {
-  if (!node) {
-    return false;
-  }
-
-  if (node.type === "AwaitExpression") {
-    return isGetExtractedCall(node.argument);
-  }
-
-  if (node.type !== "CallExpression") {
-    return false;
-  }
-
-  if (node.callee.type === "Identifier" && node.callee.name === "getExtracted") {
-    return true;
-  }
-
-  return false;
-}
-
-function isUseExtractedCall(node) {
-  if (!node) {
-    return false;
-  }
-
-  if (node.type !== "CallExpression") {
-    return false;
-  }
-
-  if (node.callee.type === "Identifier" && node.callee.name === "useExtracted") {
-    return true;
-  }
-
-  return false;
-}
-
-function isTVariable(node) {
-  return isGetExtractedCall(node) || isUseExtractedCall(node);
-}
+import { getTranslationVariableNames } from "../utils/translation-bindings.js";
 
 function isStringLiteral(node) {
   if (!node) {
@@ -116,12 +77,8 @@ export default defineRule({
       },
 
       VariableDeclarator(node) {
-        if (!node.id || node.id.type !== "Identifier") {
-          return;
-        }
-
-        if (isTVariable(node.init)) {
-          tVariableNames.add(node.id.name);
+        for (const name of getTranslationVariableNames({ node, sourceCode: context.sourceCode })) {
+          tVariableNames.add(name);
         }
       },
 

--- a/packages/oxlint-plugin/rules/no-dynamic-translation-key.js
+++ b/packages/oxlint-plugin/rules/no-dynamic-translation-key.js
@@ -1,5 +1,5 @@
 import { defineRule } from "@oxlint/plugins";
-import { getTranslationVariableNames } from "../utils/translation-bindings.js";
+import { isTranslationIdentifier } from "../utils/translation-bindings.js";
 
 function isStringLiteral(node) {
   if (!node) {
@@ -69,39 +69,11 @@ function isStaticTranslationArgument(node) {
 
 export default defineRule({
   createOnce(context) {
-    let tVariableNames;
-
     return {
-      before() {
-        tVariableNames = new Set();
-      },
-
-      VariableDeclarator(node) {
-        for (const name of getTranslationVariableNames({ node, sourceCode: context.sourceCode })) {
-          tVariableNames.add(name);
-        }
-      },
-
       CallExpression(node) {
-        if (tVariableNames.size === 0) {
-          return;
-        }
+        const callee = node.callee.type === "MemberExpression" ? node.callee.object : node.callee;
 
-        // Get the callee name
-        let calleeName = null;
-
-        // Direct call: t("key")
-        if (node.callee.type === "Identifier") {
-          calleeName = node.callee.name;
-        }
-
-        // Method call: t.rich("key"), t.raw("key"), t.markup("key")
-        if (node.callee.type === "MemberExpression" && node.callee.object.type === "Identifier") {
-          calleeName = node.callee.object.name;
-        }
-
-        // Skip if not a t function call
-        if (!calleeName || !tVariableNames.has(calleeName)) {
+        if (!isTranslationIdentifier({ node: callee, sourceCode: context.sourceCode })) {
           return;
         }
 

--- a/packages/oxlint-plugin/rules/no-get-extracted-in-promise.js
+++ b/packages/oxlint-plugin/rules/no-get-extracted-in-promise.js
@@ -39,7 +39,7 @@ function containsGetExtractedCall(node, supportedCalls) {
     return node.body.some((statement) => containsGetExtractedCall(statement, supportedCalls));
   }
 
-  if (node.type === "ExpressionStatement") {
+  if (node.type === "ExpressionStatement" || node.type === "ChainExpression") {
     return containsGetExtractedCall(node.expression, supportedCalls);
   }
 

--- a/packages/oxlint-plugin/rules/no-get-extracted-in-promise.js
+++ b/packages/oxlint-plugin/rules/no-get-extracted-in-promise.js
@@ -1,49 +1,54 @@
 import { defineRule } from "@oxlint/plugins";
+import { getPromiseAllTranslationBindings } from "../utils/translation-bindings.js";
 
 const PROMISE_METHODS = new Set(["all", "allSettled", "race", "any"]);
 
-function containsGetExtractedCall(node) {
+function containsGetExtractedCall(node, supportedCalls) {
   if (!node) {
     return false;
   }
 
   if (node.type === "CallExpression") {
     if (node.callee.type === "Identifier" && node.callee.name === "getExtracted") {
-      return true;
+      return !supportedCalls.has(node);
     }
 
     return (
-      node.arguments.some((arg) => containsGetExtractedCall(arg)) ||
-      containsGetExtractedCall(node.callee)
+      node.arguments.some((arg) => containsGetExtractedCall(arg, supportedCalls)) ||
+      containsGetExtractedCall(node.callee, supportedCalls)
     );
   }
 
-  if (node.type === "AwaitExpression") {
-    return containsGetExtractedCall(node.argument);
+  if (
+    node.type === "AwaitExpression" ||
+    node.type === "SpreadElement" ||
+    node.type === "ReturnStatement"
+  ) {
+    return containsGetExtractedCall(node.argument, supportedCalls);
   }
 
   if (node.type === "ArrayExpression") {
-    return node.elements.some((element) => containsGetExtractedCall(element));
+    return node.elements.some((element) => containsGetExtractedCall(element, supportedCalls));
   }
 
   if (node.type === "ArrowFunctionExpression" || node.type === "FunctionExpression") {
-    return containsGetExtractedCall(node.body);
+    return containsGetExtractedCall(node.body, supportedCalls);
   }
 
   if (node.type === "BlockStatement") {
-    return node.body.some((statement) => containsGetExtractedCall(statement));
+    return node.body.some((statement) => containsGetExtractedCall(statement, supportedCalls));
   }
 
-  if (node.type === "ReturnStatement" || node.type === "ExpressionStatement") {
-    return containsGetExtractedCall(node.expression);
+  if (node.type === "ExpressionStatement") {
+    return containsGetExtractedCall(node.expression, supportedCalls);
   }
 
   if (node.type === "VariableDeclaration") {
-    return node.declarations.some((decl) => containsGetExtractedCall(decl));
+    return node.declarations.some((decl) => containsGetExtractedCall(decl, supportedCalls));
   }
 
   if (node.type === "VariableDeclarator") {
-    return containsGetExtractedCall(node.init);
+    return containsGetExtractedCall(node.init, supportedCalls);
   }
 
   return false;
@@ -63,7 +68,22 @@ function isPromiseCombinator(node) {
 
 export default defineRule({
   createOnce(context) {
+    let supportedCalls;
+
     return {
+      before() {
+        supportedCalls = new WeakSet();
+      },
+
+      VariableDeclarator(node) {
+        for (const { call } of getPromiseAllTranslationBindings({
+          node,
+          sourceCode: context.sourceCode,
+        })) {
+          supportedCalls.add(call);
+        }
+      },
+
       CallExpression(node) {
         if (!isPromiseCombinator(node)) {
           return;
@@ -72,7 +92,7 @@ export default defineRule({
         const methodName = node.callee.property.name;
 
         for (const arg of node.arguments) {
-          if (containsGetExtractedCall(arg)) {
+          if (containsGetExtractedCall(arg, supportedCalls)) {
             context.report({
               loc: arg.loc,
               messageId: "noGetExtractedInPromise",
@@ -87,10 +107,11 @@ export default defineRule({
   meta: {
     docs: {
       description:
-        "Disallow getExtracted() inside Promise.all, Promise.allSettled, Promise.race, or Promise.any",
+        "Disallow getExtracted() in Promise combinators unless next-intl can extract its translator binding",
     },
     messages: {
-      noGetExtractedInPromise: "getExtracted() cannot be used inside Promise.{{method}}().",
+      noGetExtractedInPromise:
+        "next-intl cannot extract this getExtracted() usage inside Promise.{{method}}(). Await it directly or use const [t, data] = await Promise.all([getExtracted(), fetchData()]) with an inline array without spreads and an identifier binding for each translator.",
     },
     schema: [],
     type: "problem",

--- a/packages/oxlint-plugin/rules/no-t-function-as-argument.js
+++ b/packages/oxlint-plugin/rules/no-t-function-as-argument.js
@@ -1,44 +1,5 @@
 import { defineRule } from "@oxlint/plugins";
-
-function isGetExtractedCall(node) {
-  if (!node) {
-    return false;
-  }
-
-  if (node.type === "AwaitExpression") {
-    return isGetExtractedCall(node.argument);
-  }
-
-  if (node.type !== "CallExpression") {
-    return false;
-  }
-
-  if (node.callee.type === "Identifier" && node.callee.name === "getExtracted") {
-    return true;
-  }
-
-  return false;
-}
-
-function isUseExtractedCall(node) {
-  if (!node) {
-    return false;
-  }
-
-  if (node.type !== "CallExpression") {
-    return false;
-  }
-
-  if (node.callee.type === "Identifier" && node.callee.name === "useExtracted") {
-    return true;
-  }
-
-  return false;
-}
-
-function isTVariable(node) {
-  return isGetExtractedCall(node) || isUseExtractedCall(node);
-}
+import { getTranslationVariableNames } from "../utils/translation-bindings.js";
 
 function checkObjectProperty(prop, tVariableNames, context) {
   if (prop.type !== "Property") {
@@ -76,12 +37,8 @@ export default defineRule({
       },
 
       VariableDeclarator(node) {
-        if (!node.id || node.id.type !== "Identifier") {
-          return;
-        }
-
-        if (isTVariable(node.init)) {
-          tVariableNames.add(node.id.name);
+        for (const name of getTranslationVariableNames({ node, sourceCode: context.sourceCode })) {
+          tVariableNames.add(name);
         }
       },
 

--- a/packages/oxlint-plugin/rules/no-t-function-as-argument.js
+++ b/packages/oxlint-plugin/rules/no-t-function-as-argument.js
@@ -1,24 +1,12 @@
 import { defineRule } from "@oxlint/plugins";
-import { getTranslationVariableNames } from "../utils/translation-bindings.js";
+import { isTranslationIdentifier } from "../utils/translation-bindings.js";
 
-function checkObjectProperty(prop, tVariableNames, context) {
+function checkObjectProperty(prop, context) {
   if (prop.type !== "Property") {
     return;
   }
 
-  // Check shorthand first: { t } - use key since it's the visible identifier
-  if (prop.shorthand && prop.key.type === "Identifier" && tVariableNames.has(prop.key.name)) {
-    context.report({
-      data: { name: prop.key.name },
-      loc: prop.key.loc,
-      messageId: "noTFunctionAsArgument",
-    });
-
-    return;
-  }
-
-  // Non-shorthand: { translate: t }
-  if (prop.value.type === "Identifier" && tVariableNames.has(prop.value.name)) {
+  if (isTranslationIdentifier({ node: prop.value, sourceCode: context.sourceCode })) {
     context.report({
       data: { name: prop.value.name },
       loc: prop.value.loc,
@@ -29,44 +17,18 @@ function checkObjectProperty(prop, tVariableNames, context) {
 
 export default defineRule({
   createOnce(context) {
-    let tVariableNames;
-
     return {
-      before() {
-        tVariableNames = new Set();
-      },
-
-      VariableDeclarator(node) {
-        for (const name of getTranslationVariableNames({ node, sourceCode: context.sourceCode })) {
-          tVariableNames.add(name);
-        }
-      },
-
       CallExpression(node) {
-        if (tVariableNames.size === 0) {
-          return;
-        }
-
-        // Get the callee name for checking if this is a direct t() call
-        let calleeName = null;
-
-        if (node.callee.type === "Identifier") {
-          calleeName = node.callee.name;
-        } else if (
-          node.callee.type === "MemberExpression" &&
-          node.callee.object.type === "Identifier"
-        ) {
-          calleeName = node.callee.object.name;
-        }
+        const callee = node.callee.type === "MemberExpression" ? node.callee.object : node.callee;
 
         // Skip if this is calling t itself (t("key") or t.rich("key"))
-        if (calleeName && tVariableNames.has(calleeName)) {
+        if (isTranslationIdentifier({ node: callee, sourceCode: context.sourceCode })) {
           return;
         }
 
         // Check if any argument is the t variable
         for (const arg of node.arguments) {
-          if (arg.type === "Identifier" && tVariableNames.has(arg.name)) {
+          if (isTranslationIdentifier({ node: arg, sourceCode: context.sourceCode })) {
             context.report({
               data: { name: arg.name },
               loc: arg.loc,
@@ -77,7 +39,7 @@ export default defineRule({
           // Also check object properties: someHelper({ translate: t }) or { t }
           if (arg.type === "ObjectExpression") {
             for (const prop of arg.properties) {
-              checkObjectProperty(prop, tVariableNames, context);
+              checkObjectProperty(prop, context);
             }
           }
         }

--- a/packages/oxlint-plugin/utils/translation-bindings.js
+++ b/packages/oxlint-plugin/utils/translation-bindings.js
@@ -1,0 +1,78 @@
+function isNamedCall(node, name) {
+  return (
+    node?.type === "CallExpression" &&
+    node.callee.type === "Identifier" &&
+    node.callee.name === name
+  );
+}
+
+function getTranslationBinding({ call, binding, sourceCode }) {
+  if (
+    binding?.type !== "Identifier" ||
+    !isNamedCall(call, "getExtracted") ||
+    !["[", ","].includes(sourceCode.getTokenBefore(call).value)
+  ) {
+    return [];
+  }
+
+  return [{ call, name: binding.name }];
+}
+
+/** next-intl maps inline Promise.all elements to identifier bindings by position. */
+export function getPromiseAllTranslationBindings({ node, sourceCode }) {
+  if (node.id?.type !== "ArrayPattern" || node.init?.type !== "AwaitExpression") {
+    return [];
+  }
+
+  const call = node.init.argument;
+
+  if (
+    call.type !== "CallExpression" ||
+    call.optional ||
+    call.callee.type !== "MemberExpression" ||
+    call.callee.computed ||
+    call.callee.optional ||
+    call.callee.object.type !== "Identifier" ||
+    call.callee.object.name !== "Promise" ||
+    call.callee.property.name !== "all"
+  ) {
+    return [];
+  }
+
+  const array = call.arguments[0];
+
+  if (
+    array?.type !== "ArrayExpression" ||
+    array.elements.some((element) => element?.type === "SpreadElement")
+  ) {
+    return [];
+  }
+
+  /** ESTree omits parentheses that still prevent next-intl's SWC pattern matching. */
+  if (
+    sourceCode.getTokenBefore(node.init).value !== "=" ||
+    sourceCode.getTokenAfter(sourceCode.getFirstToken(node.init)).range[0] !== call.range[0] ||
+    sourceCode.getFirstToken(call).range[0] !== call.callee.range[0] ||
+    sourceCode.getTokenAfter(sourceCode.getTokenAfter(call.callee)).range[0] !== array.range[0]
+  ) {
+    return [];
+  }
+
+  return array.elements.flatMap((element, index) =>
+    getTranslationBinding({ call: element, binding: node.id.elements[index], sourceCode }),
+  );
+}
+
+export function getTranslationVariableNames({ node, sourceCode }) {
+  if (node.id?.type !== "Identifier") {
+    return getPromiseAllTranslationBindings({ node, sourceCode }).map((binding) => binding.name);
+  }
+
+  const call = node.init?.type === "AwaitExpression" ? node.init.argument : node.init;
+
+  if (isNamedCall(call, "getExtracted") || isNamedCall(node.init, "useExtracted")) {
+    return [node.id.name];
+  }
+
+  return [];
+}

--- a/packages/oxlint-plugin/utils/translation-bindings.js
+++ b/packages/oxlint-plugin/utils/translation-bindings.js
@@ -1,6 +1,7 @@
 function isNamedCall(node, name) {
   return (
     node?.type === "CallExpression" &&
+    !node.optional &&
     node.callee.type === "Identifier" &&
     node.callee.name === name
   );
@@ -63,7 +64,7 @@ export function getPromiseAllTranslationBindings({ node, sourceCode }) {
   );
 }
 
-export function getTranslationVariableNames({ node, sourceCode }) {
+function getTranslationVariableNames({ node, sourceCode }) {
   if (node.id?.type !== "Identifier") {
     return getPromiseAllTranslationBindings({ node, sourceCode }).map((binding) => binding.name);
   }
@@ -75,4 +76,23 @@ export function getTranslationVariableNames({ node, sourceCode }) {
   }
 
   return [];
+}
+
+/** Resolve the nearest declaration so shadowed names never inherit translator behavior. */
+export function isTranslationIdentifier({ node, sourceCode }) {
+  if (node.type !== "Identifier") {
+    return false;
+  }
+
+  for (let scope = sourceCode.getScope(node); scope; scope = scope.upper) {
+    const variable = scope.set.get(node.name);
+
+    if (variable) {
+      return variable.defs.some((definition) =>
+        getTranslationVariableNames({ node: definition.node, sourceCode }).includes(node.name),
+      );
+    }
+  }
+
+  return false;
 }


### PR DESCRIPTION
Allow next-intl's supported `const [t, data] = await Promise.all([getExtracted(), fetchData()])` pattern while retaining guards for unsupported Promise usages. Share translator-binding detection so dynamic-message and translator-argument checks also cover destructured translators.

Add package guidance to verify lint rules manually instead of adding automated test files or test infrastructure.
