### PR TITLE
feat(main): add localized course editions

### DIFF
--- a/.agents/skills/zoonk-code-review/SKILL.md
+++ b/.agents/skills/zoonk-code-review/SKILL.md
@@ -17,7 +17,9 @@ Determine the requested comparison: index, unstaged changes, working tree, commi
 
 Follow the root instructions for fixing confirmed bugs during reviews. An explicitly findings-only or read-only review stays read-only. For authorized fixes, preserve the user's index and complete relevant verification before local review; the skill does not authorize commits or external publication.
 
-Treat each claim, including your own, as a hypothesis. Trace the reachable code path and its product assumptions, and seek evidence that could disprove it. A constructed reproduction proves that case occurs under its supplied conditions; verify that those conditions are possible in this product.
+Reconstruct the intended behavior independently of the implementation’s explanation. Identify the assumptions required for the design to work, then investigate reachable conditions that could invalidate them. Trace those assumptions across callers, shared state, and component boundaries; individually correct parts do not establish correct composition. A constructed reproduction proves that case occurs under its supplied conditions; verify that those conditions are possible in this product.
+
+A follow-up review must reassess the assumptions and coverage supporting the earlier conclusion. Reuse valid evidence, but investigate what the earlier review did not establish. Review fixes with the same scrutiny as the original change, including their effects on surrounding behavior.
 
 Classify concerns before reporting:
 
@@ -30,7 +32,7 @@ Classify concerns before reporting:
 Choose the relevant areas below rather than running a fixed audit of every subsystem:
 
 - **Product and correctness:** Trace input through validation, persistence, side effects, caching, and output. Examine retries, cancellation, concurrency, stale state, and partial failure where the changed path permits them. Preserve the product contract and remove leftovers from superseded requirements.
-- **Architecture and simplicity:** Check the core/app boundary, API parity, ownership of shared rules, and whether the added abstraction solves an actual need. Reject competing sources of truth and unnecessary compatibility layers. Check consumers when moving symbols or changing contracts.
+- **Architecture and simplicity:** Check the core/app boundary, API parity, ownership of shared rules, and whether the added abstraction solves an actual need. Evaluate reused abstractions against the guarantees their callers require. Establish those guarantees from their implementations and actual usage, rather than their names, proximity, or existing adoption. Reject competing sources of truth and unnecessary compatibility layers. Check consumers when moving symbols or changing contracts.
 - **Permissions and privacy:** Check authorization beside protected reads/writes, including resource ownership and publication state. Review cache scope, input handling, and exposure of private data through responses, logs, analytics, or client bundles. UI visibility is not authorization.
 - **Performance:** Preserve independent async work; examine added queries, model calls, unbounded results, or client payloads. Repeated cheap translation calls are expected. Require evidence before proposing performance machinery.
 - **Data and workflows:** Check uniqueness, transactions, retry safety, freshness, and invalidation. Public API changes must preserve the OpenAPI contract; distinguish public product endpoints from the same-origin transport exception in [API guidance](../../../apps/api/AGENTS.md).

--- a/.agents/skills/zoonk-testing/SKILL.md
+++ b/.agents/skills/zoonk-testing/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 # Zoonk testing
 
-Choose the smallest test boundary that proves the changed product behavior. Follow the root verification policy for scope, completion, and reruns; do not turn every edit into a full-suite exercise.
+Choose a test boundary capable of exercising the behavior under investigation. Choose the overall set of checks from the affected behavior and consumers. A small regression test may demonstrate one property while broader existing coverage remains necessary for the change. Follow the root verification policy for scope, completion, and reruns.
 
 For behavior changes, prefer a failing regression test before implementation when practical. Confirm it fails for the expected reason. If it already passes, investigate whether the defect is reproduced and whether the assertion distinguishes the intended outcome; do not weaken assertions or manufacture a failure.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@
 
 ## Scope and completion
 
-- Own the user’s intended outcome through implementation and verification. Use the request, examples, and surrounding context to establish what successful completion requires. Evaluate the solution in the context of the surrounding system. Before handing work back, challenge the assumptions behind your approach and investigate evidence that the solution is incomplete or introduces regressions. Complete the supporting work necessary for the authorized goal. Apply simplicity and scope constraints to achieve the smallest complete solution.
+- Own the user’s intended outcome through implementation and verification. Before declaring completion, reconcile the intended outcome, the resulting implementation, and the evidence collected. Close material gaps that can be investigated within the authorized task. Passing selected checks establishes only what those checks exercise. Carry earlier evidence forward only while subsequent changes leave it applicable.
 - Keep changes within the requested scope. Refactor supporting code when needed for a complete solution, and remove code, tests, types, and layout left over from superseded requirements.
 - Treat review comments and specs as hypotheses. Verify the actual path, product assumptions, and impact. In review/assessment work, fix confirmed bugs unless the user asks for findings only or the fix requires a meaningful product or architecture decision. Explain unsupported claims without changing code to satisfy them.
 - Read task-relevant files and documentation. Skills provide conditional guidance; an explicit user request takes precedence. If an instruction blocks authorized work, identify the file and rule and explain the concrete conflict.
-- Report the outcome, relevant verification, and material limitations in plain language. Distinguish observed behavior, static review, passed checks, and anything unverified.
+- Report the outcome and verification in plain language, distinguishing observed behavior, static review, and passed checks. Base progress and completion claims on observed results, accounting for failures across the relevant run. Identify running, blocked, or unrun checks and material verification limits.
 
 ## Architecture shared by all workspaces
 
@@ -24,10 +24,10 @@
 
 ## Verification
 
-- Choose verification that could expose mistakes in your understanding or implementation. Judge completion against the intended behavior and available evidence; passing checks alone do not establish that the task is complete. For behavior changes, prefer a failing regression test before implementation when practical. For documentation, copy, styling, or other low-impact edits, use relevant validation without adding tests that mirror the edit.
+- Derive verification scope from the behavior and contracts being changed, including affected consumers and tests in unchanged files. Use focused checks when that scope is demonstrably bounded. When the impact is broad or uncertain, run the relevant containing suites. For behavior changes, prefer a failing regression test before implementation when practical. For documentation, copy, styling, or other low-impact edits, use relevant validation without adding tests that mirror the edit.
 - Use [zoonk-testing](.agents/skills/zoonk-testing/SKILL.md) when writing or changing tests: E2E for user flows, real-database integration tests for persistence and business logic, and unit tests for non-trivial pure helpers. Do not write React component unit tests. Do not add tests for `admin`, `evals`, or `blog`.
 - Run relevant local checks and fix failures caused by the requested change without pausing for review after each step. Investigate failures, including intermittent ones; do not rerun until green and dismiss them. Fix failures in the affected scope, and report unrelated failures with evidence instead of silently expanding the task.
-- Once affected checks pass, broaden or repeat them only for new changes, failures, unresolved risks, or an explicit request. For timing, concurrency, or fixture-isolation changes, repeat the focused affected coverage to establish stability.
+- Once the affected scope has been verified, broaden or repeat checks only for new changes, failures, unresolved risks, or an explicit request. For timing, concurrency, or fixture-isolation changes, repeat the focused affected coverage to establish stability.
 
 ## Task-specific guidance
 

--- a/apps/api/e2e/course-editions.test.ts
+++ b/apps/api/e2e/course-editions.test.ts
@@ -1,0 +1,244 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { expect, test } from "@zoonk/e2e/fixtures";
+import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { normalizeString } from "@zoonk/utils/string";
+import { getCourseEditionPrompt } from "../../../packages/core/src/courses/_utils/edition-prompt";
+
+async function sourceCourseFixture(attrs: Parameters<typeof courseFixture>[0] = {}) {
+  const organization = await getAiOrganization();
+  const title = attrs.title ?? `Edition source ${randomUUID()}`;
+
+  return courseFixture({
+    isPublished: true,
+    language: "en",
+    normalizedTitle: normalizeString(title),
+    organizationId: organization.id,
+    title,
+    ...attrs,
+  });
+}
+
+test.describe("Course language editions API", () => {
+  test("reads and reuses an existing edition without changing its localized slug", async ({
+    request,
+  }) => {
+    const family = await prisma.courseFamily.create({ data: {} });
+    const source = await sourceCourseFixture({ familyId: family.id });
+
+    const edition = await courseFixture({
+      familyId: family.id,
+      isPublished: true,
+      language: "pt-BR",
+      organizationId: source.organizationId,
+      slug: `ciencia-da-computacao-pt-${randomUUID()}`,
+    });
+
+    const path = `/v1/courses/${source.id}/editions`;
+    const read = await request.get(`${path}?language=pt`);
+
+    expect(read.status()).toBe(200);
+    await expect(read.json()).resolves.toStrictEqual({ courseId: edition.id, kind: "course" });
+
+    const resolved = await request.post(path, { data: { language: "pt" } });
+
+    expect(resolved.status()).toBe(200);
+
+    await expect(resolved.json()).resolves.toStrictEqual({ courseId: edition.id, kind: "course" });
+
+    const course = await request.get(`/v1/courses/${edition.id}`);
+
+    expect(course.status()).toBe(200);
+    await expect(course.json()).resolves.toMatchObject({ id: edition.id, slug: edition.slug });
+  });
+
+  test("reports a missing edition without preparing generation", async ({ request }) => {
+    const source = await sourceCourseFixture();
+    const response = await request.get(`/v1/courses/${source.id}/editions?language=pt`);
+
+    expect(response.status()).toBe(200);
+    await expect(response.json()).resolves.toStrictEqual({ kind: "missing" });
+
+    const [prompt, editionRequest, storedSource] = await Promise.all([
+      prisma.coursePrompt.findUnique({
+        where: {
+          languageNormalizedPrompt: {
+            language: "pt",
+            normalizedPrompt: normalizeString(getCourseEditionPrompt(source)),
+          },
+        },
+      }),
+      prisma.courseEditionRequest.findUnique({
+        where: { sourceLanguage: { language: "pt", sourceCourseId: source.id } },
+      }),
+      prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+    ]);
+
+    expect(prompt).toBeNull();
+    expect(editionRequest).toBeNull();
+    expect(storedSource.familyId).toBeNull();
+  });
+
+  test("stops offering generation destinations after an edition is unpublished", async ({
+    request,
+  }) => {
+    const family = await prisma.courseFamily.create({ data: {} });
+
+    const [source, target] = await Promise.all([
+      sourceCourseFixture({ familyId: family.id }),
+      sourceCourseFixture({ familyId: family.id, language: "pt" }),
+    ]);
+
+    const prompt = await coursePromptFixture({
+      courseId: target.id,
+      generationStatus: "completed",
+      language: "pt",
+    });
+
+    await prisma.courseEditionRequest.create({
+      data: { coursePromptId: prompt.id, language: "pt", sourceCourseId: source.id },
+    });
+
+    const path = `/v1/courses/${source.id}/editions`;
+    const available = await request.get(`${path}?language=pt`);
+
+    expect(available.status()).toBe(200);
+    await expect(available.json()).resolves.toStrictEqual({ courseId: target.id, kind: "course" });
+
+    await prisma.course.update({ data: { isPublished: false }, where: { id: target.id } });
+
+    const [read, resolved, generation] = await Promise.all([
+      request.get(`${path}?language=pt`),
+      request.post(path, { data: { language: "pt" } }),
+      request.get(`/v1/course-prompts/${prompt.id}`),
+    ]);
+
+    expect([read.status(), resolved.status(), generation.status()]).toStrictEqual([200, 200, 404]);
+
+    await expect(read.json()).resolves.toStrictEqual({
+      kind: "unsupported",
+      reason: "unavailable",
+    });
+
+    await expect(resolved.json()).resolves.toStrictEqual({
+      kind: "unsupported",
+      reason: "unavailable",
+    });
+
+    await expect(generation.json()).resolves.toMatchObject({ error: { code: "NOT_FOUND" } });
+  });
+
+  test("requires authentication before resolving a missing edition", async ({ request }) => {
+    const source = await sourceCourseFixture();
+
+    const response = await request.post(`/v1/courses/${source.id}/editions`, {
+      data: { language: "pt" },
+    });
+
+    expect(response.status()).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "UNAUTHORIZED" } });
+
+    await expect(
+      prisma.courseEditionRequest.findUnique({
+        where: { sourceLanguage: { language: "pt", sourceCourseId: source.id } },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  test("reuses an existing generation request without requiring another sign-in", async ({
+    request,
+  }) => {
+    const source = await sourceCourseFixture();
+
+    const prompt = await coursePromptFixture({
+      generationStatus: "running",
+      language: "pt",
+      prompt: source.title,
+    });
+
+    await prisma.courseEditionRequest.create({
+      data: { coursePromptId: prompt.id, language: "pt", sourceCourseId: source.id },
+    });
+
+    const path = `/v1/courses/${source.id}/editions`;
+
+    const responses = await Promise.all([
+      request.get(`${path}?language=pt`),
+      request.post(path, { data: { language: "pt" } }),
+    ]);
+
+    expect(responses.map((response) => response.status())).toStrictEqual([200, 200]);
+
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+
+    const expected = { coursePromptId: prompt.id, generationStatus: "running", kind: "generation" };
+
+    expect(bodies).toStrictEqual([expected, expected]);
+  });
+
+  test("suppresses editions taught in the language being learned", async ({ request }) => {
+    const source = await sourceCourseFixture({ format: "language", targetLanguage: "pt" });
+    const path = `/v1/courses/${source.id}/editions`;
+
+    const responses = await Promise.all([
+      request.get(`${path}?language=pt`),
+      request.post(path, { data: { language: "pt" } }),
+    ]);
+
+    expect(responses.map((response) => response.status())).toStrictEqual([200, 200]);
+
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+
+    expect(bodies).toStrictEqual([
+      { kind: "unsupported", reason: "sameLanguage" },
+      { kind: "unsupported", reason: "sameLanguage" },
+    ]);
+
+    await expect(
+      prisma.courseEditionRequest.findUnique({
+        where: { sourceLanguage: { language: "pt", sourceCourseId: source.id } },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  test("returns not found for an unpublished source course", async ({ request }) => {
+    const source = await sourceCourseFixture({ isPublished: false });
+    const path = `/v1/courses/${source.id}/editions`;
+
+    const responses = await Promise.all([
+      request.get(`${path}?language=pt`),
+      request.post(path, { data: { language: "pt" } }),
+    ]);
+
+    expect(responses.map((response) => response.status())).toStrictEqual([404, 404]);
+
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+
+    expect(bodies).toStrictEqual([
+      { error: { code: "NOT_FOUND", message: "Course not found" } },
+      { error: { code: "NOT_FOUND", message: "Course not found" } },
+    ]);
+  });
+
+  for (const language of ["it", "pt-BR", ""]) {
+    test(`rejects an invalid requested locale: ${language || "empty"}`, async ({ request }) => {
+      const path = `/v1/courses/${randomUUID()}/editions`;
+
+      const responses = await Promise.all([
+        request.get(`${path}?${new URLSearchParams({ language })}`),
+        request.post(path, { data: { language } }),
+      ]);
+
+      expect(responses.map((response) => response.status())).toStrictEqual([400, 400]);
+
+      const bodies = await Promise.all(responses.map((response) => response.json()));
+
+      expect(bodies).toMatchObject([
+        { error: { code: "VALIDATION_ERROR" } },
+        { error: { code: "VALIDATION_ERROR" } },
+      ]);
+    });
+  }
+});

--- a/apps/api/e2e/workflows-course-generation.test.ts
+++ b/apps/api/e2e/workflows-course-generation.test.ts
@@ -55,35 +55,45 @@ test.describe("Course Generation Workflow API", () => {
     await apiContext.dispose();
   });
 
-  test("rejects language course requests with the same user and target language", async () => {
-    const uniqueId = randomUUID().slice(0, 8);
+  for (const [language, targetLanguage] of [
+    ["en", "en"],
+    ["ja-JP", "ja"],
+    ["zh-Hant-TW", "zh"],
+  ] as const) {
+    test(`rejects language course requests with matching ${language} and ${targetLanguage}`, async () => {
+      const uniqueId = randomUUID().slice(0, 8);
 
-    const startRequest = await coursePromptFixture({
-      canonicalTitle: `E2E Same Language Course ${uniqueId}`,
-      courseFormat: "language",
-      generationStatus: "completed",
-      language: "en",
-      targetLanguage: "en",
+      const startRequest = await coursePromptFixture({
+        canonicalTitle: `E2E Same Language Course ${uniqueId}`,
+        courseFormat: "language",
+        generationStatus: "completed",
+        language,
+        targetLanguage,
+      });
+
+      const { apiContext } = await createAuthenticatedApiContext({
+        baseURL: process.env.E2E_BASE_URL ?? "",
+        prefix: "course-same-language",
+      });
+
+      const response = await apiContext.post("/v1/generations", {
+        data: { target: { id: startRequest.id, type: "coursePrompt" } },
+      });
+
+      expect(response.status()).toBe(400);
+
+      const body = await response.json();
+
+      expect(body.error).toBeDefined();
+      expect(body.error.code).toBe("BAD_REQUEST");
+
+      await expect(
+        prisma.coursePrompt.findUniqueOrThrow({ where: { id: startRequest.id } }),
+      ).resolves.toMatchObject({ generationRunId: null, generationStatus: "completed" });
+
+      await apiContext.dispose();
     });
-
-    const { apiContext } = await createAuthenticatedApiContext({
-      baseURL,
-      prefix: "course-same-language",
-    });
-
-    const response = await apiContext.post("/v1/generations", {
-      data: { target: { id: startRequest.id, type: "coursePrompt" } },
-    });
-
-    expect(response.status()).toBe(400);
-
-    const body = await response.json();
-
-    expect(body.error).toBeDefined();
-    expect(body.error.code).toBe("BAD_REQUEST");
-
-    await apiContext.dispose();
-  });
+  }
 
   test("returns validation error when coursePromptId is missing", async () => {
     const { apiContext } = await createAuthenticatedApiContext({

--- a/apps/api/src/app/v1/courses/[courseId]/editions/route.ts
+++ b/apps/api/src/app/v1/courses/[courseId]/editions/route.ts
@@ -1,0 +1,68 @@
+import { errors } from "@/lib/api-errors";
+import { withApiErrorBoundary } from "@/lib/api-handler";
+import { parseBody } from "@/lib/body-parser";
+import { courseEditionRequestSchema } from "@/lib/openapi/schemas/course-editions";
+import { coursePathParamsSchema } from "@/lib/openapi/schemas/paths";
+import { parsePathParams } from "@/lib/path-params";
+import { parseQueryParams } from "@/lib/query-params";
+import { getCourseEdition, resolveCourseEdition } from "@zoonk/core/courses/editions";
+import { type NextRequest, NextResponse } from "next/server";
+
+function getEditionResponse(result: Awaited<ReturnType<typeof resolveCourseEdition>>) {
+  if (result.kind === "notFound") {
+    return errors.notFound("Course not found");
+  }
+
+  if (result.kind === "unauthorized") {
+    return errors.unauthorized();
+  }
+
+  if (result.kind === "course") {
+    return NextResponse.json({ courseId: result.course.id, kind: result.kind });
+  }
+
+  return NextResponse.json(result);
+}
+
+async function getEdition(
+  request: NextRequest,
+  context: RouteContext<"/v1/courses/[courseId]/editions">,
+) {
+  const path = parsePathParams({ params: await context.params, schema: coursePathParamsSchema });
+
+  if (!path.success) {
+    return errors.validation(path.error);
+  }
+
+  const query = parseQueryParams(request.nextUrl.searchParams, courseEditionRequestSchema);
+
+  if (!query.success) {
+    return errors.validation(query.error);
+  }
+
+  const result = await getCourseEdition({ ...path.data, ...query.data });
+  return getEditionResponse(result);
+}
+
+async function resolveEdition(
+  request: NextRequest,
+  context: RouteContext<"/v1/courses/[courseId]/editions">,
+) {
+  const path = parsePathParams({ params: await context.params, schema: coursePathParamsSchema });
+
+  if (!path.success) {
+    return errors.validation(path.error);
+  }
+
+  const body = await parseBody(request, courseEditionRequestSchema);
+
+  if (!body.success) {
+    return errors.validation(body.error);
+  }
+
+  const result = await resolveCourseEdition({ ...path.data, ...body.data });
+  return getEditionResponse(result);
+}
+
+export const GET = withApiErrorBoundary(getEdition);
+export const POST = withApiErrorBoundary(resolveEdition);

--- a/apps/api/src/lib/openapi/create-document.ts
+++ b/apps/api/src/lib/openapi/create-document.ts
@@ -9,6 +9,7 @@ import {
 import { accountPaths } from "./paths/account";
 import { catalogPaths } from "./paths/catalog";
 import { catalogResourcePaths } from "./paths/catalog-resources";
+import { courseEditionPaths } from "./paths/course-editions";
 import { coursePromptPaths } from "./paths/course-prompts";
 import { currentLearningPaths } from "./paths/current-learning";
 import { currentUserProgressPaths } from "./paths/current-user-progress";
@@ -70,6 +71,7 @@ const paths = withInternalErrorResponses({
   ...accountPaths,
   ...catalogPaths,
   ...catalogResourcePaths,
+  ...courseEditionPaths,
   ...coursePromptPaths,
   ...currentLearningPaths,
   ...generationPaths,

--- a/apps/api/src/lib/openapi/document.test.ts
+++ b/apps/api/src/lib/openapi/document.test.ts
@@ -35,6 +35,8 @@ const CANONICAL_OPERATIONS = [
   { method: "get", operationId: "searchCatalog", path: "/catalog/search" },
   { method: "get", operationId: "listCourses", path: "/courses" },
   { method: "get", operationId: "getCourse", path: "/courses/{courseId}" },
+  { method: "get", operationId: "getCourseEdition", path: "/courses/{courseId}/editions" },
+  { method: "post", operationId: "resolveCourseEdition", path: "/courses/{courseId}/editions" },
   { method: "get", operationId: "listCourseChapters", path: "/courses/{courseId}/chapters" },
   { method: "get", operationId: "getChapter", path: "/chapters/{chapterId}" },
   { method: "get", operationId: "listChapterLessons", path: "/chapters/{chapterId}/lessons" },

--- a/apps/api/src/lib/openapi/paths/course-editions.ts
+++ b/apps/api/src/lib/openapi/paths/course-editions.ts
@@ -1,0 +1,50 @@
+import {
+  courseEditionRequestSchema,
+  courseEditionResponseSchema,
+} from "../schemas/course-editions";
+import { coursePathParamsSchema } from "../schemas/paths";
+import {
+  forbiddenResponse,
+  notFoundResponse,
+  unauthorizedResponse,
+  validationErrorResponse,
+} from "../schemas/responses";
+import { OPTIONAL_AUTHENTICATION_SECURITY, PUBLIC_SECURITY } from "../security";
+
+const editionResponses = {
+  "200": {
+    content: { "application/json": { schema: courseEditionResponseSchema } },
+    description: "Available edition, existing generation, missing edition, or unsupported request",
+  },
+  "400": validationErrorResponse,
+  "404": notFoundResponse,
+};
+
+export const courseEditionPaths = {
+  "/courses/{courseId}/editions": {
+    get: {
+      description:
+        "Finds a course edition in the requested instructional language. Proven existing editions may be linked on demand; reading never runs identity models or creates generation requests.",
+      operationId: "getCourseEdition",
+      requestParams: { path: coursePathParamsSchema, query: courseEditionRequestSchema },
+      responses: editionResponses,
+      security: PUBLIC_SECURITY,
+      summary: "Find a course language edition",
+      tags: ["Courses"],
+    },
+    post: {
+      description:
+        "Reuses an existing edition publicly. If none exists, authentication is required to resolve the source title through normal course identity search and prepare generation. A generation result identifies the course prompt to submit to POST /generations.",
+      operationId: "resolveCourseEdition",
+      requestBody: {
+        content: { "application/json": { schema: courseEditionRequestSchema } },
+        required: true,
+      },
+      requestParams: { path: coursePathParamsSchema },
+      responses: { ...editionResponses, "401": unauthorizedResponse, "403": forbiddenResponse },
+      security: OPTIONAL_AUTHENTICATION_SECURITY,
+      summary: "Resolve a course language edition",
+      tags: ["Courses"],
+    },
+  },
+};

--- a/apps/api/src/lib/openapi/schemas/course-editions.ts
+++ b/apps/api/src/lib/openapi/schemas/course-editions.ts
@@ -1,0 +1,27 @@
+import { SUPPORTED_LOCALES } from "@zoonk/utils/locale";
+import { z } from "zod";
+import { generationStatusSchema } from "./curriculum";
+
+export const courseEditionRequestSchema = z
+  .object({
+    language: z
+      .enum(SUPPORTED_LOCALES)
+      .meta({ description: "Requested instructional language", examples: ["pt"] }),
+  })
+  .meta({ id: "CourseEditionRequest" });
+
+export const courseEditionResponseSchema = z
+  .discriminatedUnion("kind", [
+    z.object({ courseId: z.uuid(), kind: z.literal("course") }),
+    z.object({
+      coursePromptId: z.uuid(),
+      generationStatus: generationStatusSchema,
+      kind: z.literal("generation"),
+    }),
+    z.object({ kind: z.literal("missing") }),
+    z.object({
+      kind: z.literal("unsupported"),
+      reason: z.enum(["sameLanguage", "format", "language", "unavailable"]),
+    }),
+  ])
+  .meta({ id: "CourseEditionResponse" });

--- a/apps/api/src/lib/openapi/schemas/course-prompts.ts
+++ b/apps/api/src/lib/openapi/schemas/course-prompts.ts
@@ -3,22 +3,11 @@ import {
   COURSE_PROMPT_MAX_LENGTH,
 } from "@zoonk/core/courses/prompt-contract";
 import { TTS_SUPPORTED_LANGUAGE_CODES } from "@zoonk/utils/languages";
+import { getLanguageSubtag } from "@zoonk/utils/locale";
 import { z } from "zod";
 import { courseFormatSchema, generationStatusSchema } from "./curriculum";
 
 const unsupportedIntentSchema = z.enum(["ambiguous", "learn", "question"]);
-
-/**
- * Extracts the canonical language subtag from a BCP 47 locale so boundary
- * validation can reject malformed tags and compare regional variants safely.
- */
-function getLanguageSubtag(locale: string): string | null {
-  try {
-    return new Intl.Locale(locale).language;
-  } catch {
-    return null;
-  }
-}
 
 const sourceLanguageSchema = z
   .string()

--- a/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
+++ b/apps/api/src/workflows/course-generation/_internal/get-or-create-course.test.ts
@@ -73,6 +73,7 @@ describe(getOrCreateCourse, () => {
     const existingCourse = await courseFixture({
       generationRunId: winningWorkflowRunId,
       generationStatus: "running",
+      isPublished: true,
       language,
       organizationId,
       slug,
@@ -114,6 +115,7 @@ describe(getOrCreateCourse, () => {
       format: "core",
       generationRunId: winningWorkflowRunId,
       generationStatus: "running",
+      isPublished: true,
       language,
       organizationId,
       slug,
@@ -162,6 +164,7 @@ describe(getOrCreateCourse, () => {
     const existingCourse = await courseFixture({
       generationRunId: workflowRunId,
       generationStatus: "running",
+      isPublished: true,
       language,
       organizationId,
       slug,
@@ -213,6 +216,7 @@ describe(getOrCreateCourse, () => {
 
       await courseFixture({
         format: courseFormat,
+        isPublished: true,
         language: courseLanguage,
         organizationId,
         slug,
@@ -245,6 +249,7 @@ describe(getOrCreateCourse, () => {
       description: "Existing description",
       generationStatus: "failed",
       imageUrl: "https://example.com/img.webp",
+      isPublished: true,
       organizationId,
       title: `Existing Course ${randomUUID()}`,
     });
@@ -301,6 +306,7 @@ describe(getOrCreateCourse, () => {
       const course = await courseFixture({
         generationRunId: null,
         generationStatus,
+        isPublished: true,
         organizationId,
         title: `Concurrent Resume ${randomUUID()}`,
       });

--- a/apps/api/src/workflows/course-generation/_utils/course-identity-validation.ts
+++ b/apps/api/src/workflows/course-generation/_utils/course-identity-validation.ts
@@ -1,7 +1,24 @@
 import { getCompatibleCourseFormats } from "@zoonk/core/courses/prompt-generation";
 import { type Course } from "@zoonk/db";
+import { getContentLocale } from "@zoonk/utils/locale";
 import { FatalError } from "workflow";
 import { type GeneratableCoursePrompt } from "../steps/get-course-prompt-step";
+
+/** Unsupported or malformed languages may only match the same persisted value. */
+export function matchesCoursePromptLanguage({
+  courseLanguage,
+  promptLanguage,
+}: {
+  courseLanguage: string;
+  promptLanguage: string;
+}): boolean {
+  const courseLocale = getContentLocale(courseLanguage);
+  const promptLocale = getContentLocale(promptLanguage);
+
+  return (
+    courseLanguage === promptLanguage || (courseLocale !== null && courseLocale === promptLocale)
+  );
+}
 
 /**
  * Prevents cached, classified, or unique-conflict matches from linking a prompt
@@ -17,7 +34,10 @@ export function assertCourseMatchesPromptIdentity({
 }): void {
   const matchesPrompt =
     getCompatibleCourseFormats(prompt.courseFormat).includes(course.format) &&
-    course.language === prompt.language &&
+    matchesCoursePromptLanguage({
+      courseLanguage: course.language,
+      promptLanguage: prompt.language,
+    }) &&
     course.targetLanguage === prompt.targetLanguage;
 
   if (!matchesPrompt) {

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.test.ts
@@ -207,6 +207,7 @@ describe(courseGenerationWorkflow, () => {
       const course = await courseFixture({
         generationRunId: "test-run-id",
         generationStatus: "running",
+        isPublished: true,
         organizationId,
         slug: getCourseSlugForTitle({ language: "en", title }),
         title,
@@ -249,6 +250,7 @@ describe(courseGenerationWorkflow, () => {
       const course = await courseFixture({
         generationRunId: "completed-run-id",
         generationStatus: "completed",
+        isPublished: true,
         organizationId,
         slug: getCourseSlugForTitle({ language: "en", title }),
         title,
@@ -288,6 +290,7 @@ describe(courseGenerationWorkflow, () => {
       await courseFixture({
         generationRunId,
         generationStatus: "running",
+        isPublished: true,
         organizationId,
         slug,
         title,
@@ -318,7 +321,13 @@ describe(courseGenerationWorkflow, () => {
       const title = `Existing Completed Course ${randomUUID()}`;
       const slug = getCourseSlugForTitle({ language: "en", title });
 
-      await courseFixture({ generationStatus: "completed", organizationId, slug, title });
+      await courseFixture({
+        generationStatus: "completed",
+        isPublished: true,
+        organizationId,
+        slug,
+        title,
+      });
 
       const request = await coursePromptFixture({
         canonicalTitle: title,
@@ -352,6 +361,7 @@ describe(courseGenerationWorkflow, () => {
           format: "language",
           generationRunId: unrelatedGenerationRunId,
           generationStatus,
+          isPublished: true,
           language,
           organizationId,
           slug,
@@ -602,6 +612,7 @@ describe(courseGenerationWorkflow, () => {
       const existingCourse = await courseFixture({
         format: "language",
         generationStatus: "failed",
+        isPublished: true,
         organizationId,
         targetLanguage: "es",
         title,
@@ -645,6 +656,230 @@ describe(courseGenerationWorkflow, () => {
       expect(generateCourseIntroduction).not.toHaveBeenCalled();
 
       expect(startMock).toHaveBeenCalledExactlyOnceWith(chapterImagesWorkflow, [course.id]);
+    });
+  });
+
+  describe("language editions", () => {
+    it("fails a hidden target slug without completing the prompt or changing publication", async () => {
+      const title = `Hidden Edition ${randomUUID()}`;
+
+      const [source, hidden, request] = await Promise.all([
+        courseFixture({ isPublished: true, language: "en", organizationId }),
+        courseFixture({
+          generationStatus: "completed",
+          isPublished: false,
+          language: "pt",
+          organizationId,
+          slug: getCourseSlugForTitle({ language: "pt", title }),
+          title,
+        }),
+        coursePromptFixture({ canonicalTitle: title, language: "pt" }),
+      ]);
+
+      await prisma.courseEditionRequest.create({
+        data: { coursePromptId: request.id, language: "pt", sourceCourseId: source.id },
+      });
+
+      await expect(generateCourse(request.id)).rejects.toThrow("Course is not published");
+
+      const [persistedSource, persistedHidden, persistedPrompt] = await Promise.all([
+        prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+        prisma.course.findUniqueOrThrow({ where: { id: hidden.id } }),
+        prisma.coursePrompt.findUniqueOrThrow({ where: { id: request.id } }),
+      ]);
+
+      expect(persistedSource.familyId).toBeNull();
+      expect(persistedHidden.isPublished).toBe(false);
+      expect(persistedHidden.generationStatus).toBe("completed");
+      expect(persistedPrompt.courseId).toBeNull();
+      expect(persistedPrompt.generationStatus).toBe("failed");
+      expect(generateCourseDescription).not.toHaveBeenCalled();
+    });
+
+    it.each(["running", "completed"] as const)(
+      "links the source family before returning from %s course reuse",
+      async (generationStatus) => {
+        const title = `Ciência da Computação ${randomUUID()}`;
+        const targetFamily = await prisma.courseFamily.create({ data: {} });
+
+        const [source, target, request] = await Promise.all([
+          courseFixture({
+            isPublished: true,
+            language: "en",
+            organizationId,
+            title: `Computer Science ${randomUUID()}`,
+          }),
+          courseFixture({
+            familyId: targetFamily.id,
+            generationRunId: `existing-${randomUUID()}`,
+            generationStatus,
+            isPublished: true,
+            language: "pt",
+            organizationId,
+            slug: getCourseSlugForTitle({ language: "pt", title }),
+            title,
+          }),
+          coursePromptFixture({ canonicalTitle: title, language: "pt" }),
+        ]);
+
+        await prisma.courseEditionRequest.create({
+          data: { coursePromptId: request.id, language: "pt", sourceCourseId: source.id },
+        });
+
+        await generateCourse(request.id);
+
+        const [persistedSource, persistedTarget, persistedPrompt] = await Promise.all([
+          prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+          prisma.course.findUniqueOrThrow({ where: { id: target.id } }),
+          prisma.coursePrompt.findUniqueOrThrow({ where: { id: request.id } }),
+        ]);
+
+        expect(persistedSource.familyId).not.toBeNull();
+        expect(persistedSource.familyId).toBe(persistedTarget.familyId);
+        expect(persistedSource.slug).toBe(source.slug);
+        expect(persistedTarget.slug).toBe(target.slug);
+        expect(persistedPrompt.courseId).toBe(target.id);
+        expect(persistedPrompt.generationStatus).toBe(generationStatus);
+        expect(generateCourseDescription).not.toHaveBeenCalled();
+      },
+    );
+
+    it("links a newly generated edition without changing either localized slug", async () => {
+      const source = await courseFixture({
+        isPublished: true,
+        language: "en",
+        organizationId,
+        slug: `computer-science-${randomUUID()}`,
+        title: `Computer Science ${randomUUID()}`,
+      });
+
+      const title = `Ciência da Computação ${randomUUID()}`;
+
+      const request = await coursePromptFixture({
+        canonicalTitle: title,
+        language: "pt",
+        prompt: source.title,
+      });
+
+      await prisma.courseEditionRequest.create({
+        data: { coursePromptId: request.id, language: "pt", sourceCourseId: source.id },
+      });
+
+      await generateCourse(request.id);
+
+      const persistedPrompt = await prisma.coursePrompt.findUniqueOrThrow({
+        include: { course: true },
+        where: { id: request.id },
+      });
+
+      const persistedSource = await prisma.course.findUniqueOrThrow({ where: { id: source.id } });
+
+      expect(persistedSource.familyId).not.toBeNull();
+      expect(persistedPrompt.course?.familyId).toBe(persistedSource.familyId);
+      expect(persistedPrompt.course?.slug).toBe(getCourseSlugForTitle({ language: "pt", title }));
+      expect(persistedPrompt.course?.language).toBe("pt");
+      expect(persistedPrompt.generationStatus).toBe("completed");
+      expect(persistedSource.slug).toBe(source.slug);
+    });
+
+    it("links a semantically matched existing edition returned by identity search", async () => {
+      const title = `Ciência da Computação ${randomUUID()}`;
+
+      const [source, target, request] = await Promise.all([
+        courseFixture({
+          isPublished: true,
+          language: "en",
+          organizationId,
+          title: `Computer Science ${randomUUID()}`,
+        }),
+        courseFixture({
+          isPublished: true,
+          language: "pt",
+          normalizedTitle: normalizeString(title),
+          organizationId,
+          slug: getCourseSlugForTitle({ language: "pt", title }),
+          title,
+        }),
+        coursePromptFixture({ canonicalTitle: `Computação ${randomUUID()}`, language: "pt" }),
+      ]);
+
+      await prisma.courseEditionRequest.create({
+        data: { coursePromptId: request.id, language: "pt", sourceCourseId: source.id },
+      });
+
+      const usage = {
+        inputTokenDetails: {
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+          noCacheTokens: undefined,
+        },
+        inputTokens: 1,
+        outputTokenDetails: { reasoningTokens: undefined, textTokens: undefined },
+        outputTokens: 1,
+        totalTokens: 2,
+      };
+
+      vi.mocked(generateCourseIdentitySearchQueries).mockResolvedValueOnce({
+        data: { queries: [title] },
+        systemPrompt: "system",
+        usage,
+        userPrompt: "user",
+      });
+
+      vi.mocked(resolveCourseIdentity).mockResolvedValueOnce({
+        data: { courseSlug: target.slug, decision: "useExisting", reason: "same subject" },
+        systemPrompt: "system",
+        usage,
+        userPrompt: "user",
+      });
+
+      await generateCourse(request.id);
+
+      const [persistedSource, persistedTarget, persistedPrompt] = await Promise.all([
+        prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+        prisma.course.findUniqueOrThrow({ where: { id: target.id } }),
+        prisma.coursePrompt.findUniqueOrThrow({ where: { id: request.id } }),
+      ]);
+
+      expect(persistedSource.familyId).not.toBeNull();
+      expect(persistedSource.familyId).toBe(persistedTarget.familyId);
+      expect(persistedTarget.slug).toBe(target.slug);
+      expect(persistedPrompt.courseId).toBe(target.id);
+      expect(generateCourseDescription).not.toHaveBeenCalled();
+    });
+
+    it("fails an invalid edition request without creating a course or merging families", async () => {
+      const source = await courseFixture({
+        format: "language",
+        isPublished: true,
+        language: "en",
+        organizationId,
+        targetLanguage: "ja",
+      });
+
+      const request = await coursePromptFixture({
+        canonicalTitle: `Incorrect target ${randomUUID()}`,
+        courseFormat: "language",
+        language: "pt",
+        targetLanguage: "fr",
+      });
+
+      await prisma.courseEditionRequest.create({
+        data: { coursePromptId: request.id, language: "pt", sourceCourseId: source.id },
+      });
+
+      await expect(generateCourse(request.id)).rejects.toThrow();
+
+      const [persistedSource, persistedPrompt] = await Promise.all([
+        prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+        prisma.coursePrompt.findUniqueOrThrow({ where: { id: request.id } }),
+      ]);
+
+      expect(persistedSource.familyId).toBeNull();
+      expect(persistedPrompt.courseId).toBeNull();
+      expect(persistedPrompt.generationStatus).toBe("failed");
+      expect(generateCourseIdentitySearchQueries).not.toHaveBeenCalled();
+      expect(generateCourseDescription).not.toHaveBeenCalled();
     });
   });
 
@@ -697,6 +932,7 @@ describe(courseGenerationWorkflow, () => {
         description: "Existing description",
         generationStatus: "failed",
         imageUrl: "https://example.com/existing-image.webp",
+        isPublished: true,
         landingPage: {
           audience: ["Existing audience"],
           opportunities: ["Existing opportunity"],

--- a/apps/api/src/workflows/course-generation/course-generation-workflow.ts
+++ b/apps/api/src/workflows/course-generation/course-generation-workflow.ts
@@ -7,8 +7,13 @@ import { getOrCreateCourse } from "./_internal/get-or-create-course";
 import { setupCourse } from "./_internal/setup-course";
 import { completeCourseSetupStep } from "./steps/complete-course-setup-step";
 import { enrollCourseUserStep } from "./steps/enroll-course-user-step";
-import { assertGeneratableCoursePrompt, getCoursePromptStep } from "./steps/get-course-prompt-step";
+import {
+  type GeneratableCoursePrompt,
+  assertGeneratableCoursePrompt,
+  getCoursePromptStep,
+} from "./steps/get-course-prompt-step";
 import { handleCourseFailureStep } from "./steps/handle-failure-step";
+import { linkCourseEditionStep } from "./steps/link-course-edition-step";
 import { resolveCourseIdentityStep } from "./steps/resolve-course-identity-step";
 import { startChapterImagesWorkflowStep } from "./steps/start-chapter-images-workflow-step";
 
@@ -79,6 +84,20 @@ async function startChapterImagesAndGenerateFirstLanguageChapter({
   }
 }
 
+/** Keeps identity validation failures inside the same retryable initialization outcome. */
+async function prepareCourseForPrompt({
+  coursePromptId,
+  prompt,
+  workflowRunId,
+}: {
+  coursePromptId: string;
+  prompt: GeneratableCoursePrompt;
+  workflowRunId: string;
+}) {
+  const existingCourse = await resolveCourseIdentityStep(prompt);
+  return getOrCreateCourse({ coursePromptId, existingCourse, prompt, workflowRunId });
+}
+
 /**
  * Generates or resumes a course and enrolls the authenticated requester once
  * the workflow resolves the concrete course. Enrollment runs before completed
@@ -100,25 +119,35 @@ export async function courseGenerationWorkflow({
 
   assertGeneratableCoursePrompt(prompt);
 
-  const existingCourse = await resolveCourseIdentityStep(prompt);
+  const courseSetup = await prepareCourseForPrompt({ coursePromptId, prompt, workflowRunId }).catch(
+    async (error: unknown) => {
+      await handleCourseFailureStep({
+        courseId: null,
+        coursePromptId,
+        error: serializeWorkflowError(error),
+        workflowRunId,
+      });
 
-  const courseSetup = await getOrCreateCourse({
-    coursePromptId,
-    existingCourse,
-    prompt,
-    workflowRunId,
-  }).catch(async (error: unknown) => {
-    await handleCourseFailureStep({
-      courseId: null,
-      coursePromptId,
-      error: serializeWorkflowError(error),
-      workflowRunId,
-    });
+      logError(`[workflow ${workflowRunId}] Course initialization failed`, error);
 
-    logError(`[workflow ${workflowRunId}] Course initialization failed`, error);
+      throw error;
+    },
+  );
 
-    throw error;
-  });
+  await linkCourseEditionStep({ courseId: courseSetup.course.courseId, coursePromptId }).catch(
+    async (error: unknown) => {
+      await handleCourseFailureStep({
+        courseId: courseSetup.course.courseId,
+        coursePromptId,
+        error: serializeWorkflowError(error),
+        workflowRunId,
+      });
+
+      logError(`[workflow ${workflowRunId}] Course edition linking failed`, error);
+
+      throw error;
+    },
+  );
 
   if (userId) {
     await enrollCourseUserStep({ courseId: courseSetup.course.courseId, userId });

--- a/apps/api/src/workflows/course-generation/steps/get-course-prompt-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/get-course-prompt-step.test.ts
@@ -38,18 +38,25 @@ describe(getCoursePromptStep, () => {
     );
   });
 
-  it("throws FatalError when a language request uses the same user and target language", async () => {
-    const request = await coursePromptFixture({
-      canonicalTitle: `Same Language Request ${randomUUID()}`,
-      courseFormat: "language",
-      language: "en",
-      targetLanguage: "en",
-    });
+  it.each([
+    ["en", "en"],
+    ["ja-JP", "ja"],
+    ["zh-Hant-TW", "zh"],
+  ])(
+    "rejects a persisted %s prompt that teaches the same %s language",
+    async (language, targetLanguage) => {
+      const request = await coursePromptFixture({
+        canonicalTitle: `Same Language Request ${randomUUID()}`,
+        courseFormat: "language",
+        language,
+        targetLanguage,
+      });
 
-    await expect(getCoursePromptStep(request.id)).rejects.toThrow(
-      "Language course source and target languages must be different",
-    );
-  });
+      await expect(getCoursePromptStep(request.id)).rejects.toThrow(
+        "Language course source and target languages must be different",
+      );
+    },
+  );
 
   it.each(["", "es"])(
     "throws FatalError when a core request has target language %j",

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.test.ts
@@ -117,6 +117,7 @@ describe(initializeCourseStep, () => {
     const existingCourse = await courseFixture({
       generationRunId: winningWorkflowRunId,
       generationStatus: "running",
+      isPublished: true,
       language: request.language,
       organizationId: organization.id,
       slug: getCourseSlugForTitle({ language: request.language, title: canonicalTitle }),
@@ -134,5 +135,131 @@ describe(initializeCourseStep, () => {
     expect(persistedPrompt.courseId).toBeNull();
     expect(persistedPrompt.generationRunId).toBeNull();
     expect(persistedPrompt.generationStatus).toBe("pending");
+  });
+
+  it("creates only one family edition when equivalent prompts have different translated titles", async () => {
+    const organization = await aiOrganizationFixture();
+    const family = await prisma.courseFamily.create({ data: {} });
+
+    const [englishCourse, spanishCourse] = await Promise.all([
+      courseFixture({
+        familyId: family.id,
+        isPublished: true,
+        language: "en",
+        organizationId: organization.id,
+      }),
+      courseFixture({
+        familyId: family.id,
+        isPublished: true,
+        language: "es",
+        organizationId: organization.id,
+      }),
+    ]);
+
+    const [firstPrompt, secondPrompt] = await Promise.all([
+      generatableCoursePromptFixture({
+        canonicalTitle: `Computação ${randomUUID()}`,
+        language: "pt",
+      }),
+      generatableCoursePromptFixture({
+        canonicalTitle: `Ciência da Computação ${randomUUID()}`,
+        language: "pt",
+      }),
+    ]);
+
+    assertGeneratableCoursePrompt(firstPrompt);
+    assertGeneratableCoursePrompt(secondPrompt);
+
+    await prisma.courseEditionRequest.createMany({
+      data: [
+        { coursePromptId: firstPrompt.id, language: "pt", sourceCourseId: englishCourse.id },
+        { coursePromptId: secondPrompt.id, language: "pt", sourceCourseId: spanishCourse.id },
+      ],
+    });
+
+    const [first, second] = await Promise.all([
+      initializeCourseStep({ request: firstPrompt, workflowRunId: `first-${randomUUID()}` }),
+      initializeCourseStep({ request: secondPrompt, workflowRunId: `second-${randomUUID()}` }),
+    ]);
+
+    const editions = await prisma.course.findMany({
+      where: { familyId: family.id, language: "pt" },
+    });
+
+    expect(editions).toHaveLength(1);
+    expect(first.course.courseId).toBe(second.course.courseId);
+    expect([first, second].filter((result) => result.existing === null)).toHaveLength(1);
+    expect(editions[0]?.slug).toBe(first.course.courseSlug);
+    expect(editions[0]?.slug).toMatch(/-pt$/u);
+  });
+
+  it("rejects a hidden same-slug course without exposing it or linking the prompt", async () => {
+    const organization = await aiOrganizationFixture();
+    const title = `Hidden Slug ${randomUUID()}`;
+
+    const [hidden, request] = await Promise.all([
+      courseFixture({
+        generationStatus: "completed",
+        isPublished: false,
+        language: "pt",
+        organizationId: organization.id,
+        slug: getCourseSlugForTitle({ language: "pt", title }),
+        title,
+      }),
+      generatableCoursePromptFixture({ canonicalTitle: title, language: "pt" }),
+    ]);
+
+    assertGeneratableCoursePrompt(request);
+
+    await expect(
+      initializeCourseStep({ request, workflowRunId: `hidden-${randomUUID()}` }),
+    ).rejects.toThrow("Course is not published");
+
+    const [persistedCourse, persistedPrompt] = await Promise.all([
+      prisma.course.findUniqueOrThrow({ where: { id: hidden.id } }),
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: request.id } }),
+    ]);
+
+    expect(persistedCourse.isPublished).toBe(false);
+    expect(persistedCourse.generationStatus).toBe("completed");
+    expect(persistedPrompt.courseId).toBeNull();
+    expect(persistedPrompt.generationStatus).toBe("pending");
+  });
+
+  it("rejects an edition prompt that changes the language being learned before creating a course", async () => {
+    const organization = await aiOrganizationFixture();
+
+    const source = await courseFixture({
+      format: "language",
+      isPublished: true,
+      language: "en",
+      organizationId: organization.id,
+      targetLanguage: "ja",
+    });
+
+    const request = await generatableCoursePromptFixture({
+      canonicalTitle: `Different target ${randomUUID()}`,
+      courseFormat: "language",
+      language: "pt",
+      targetLanguage: "fr",
+    });
+
+    assertGeneratableCoursePrompt(request);
+
+    await prisma.courseEditionRequest.create({
+      data: { coursePromptId: request.id, language: "pt", sourceCourseId: source.id },
+    });
+
+    await expect(
+      initializeCourseStep({ request, workflowRunId: `invalid-${randomUUID()}` }),
+    ).rejects.toThrow();
+
+    const [persistedPrompt, courses] = await Promise.all([
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: request.id } }),
+      prisma.course.findMany({ where: { title: request.canonicalTitle } }),
+    ]);
+
+    expect(persistedPrompt.courseId).toBeNull();
+    expect(courses).toHaveLength(0);
   });
 });

--- a/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/initialize-course-step.ts
@@ -1,4 +1,5 @@
 import { createStepStream } from "@/workflows/_shared/stream-status";
+import { getCourseEditionForPrompt } from "@zoonk/core/courses/edition-link";
 import {
   type RegularCourseFormat,
   isRegularCourseFormat,
@@ -85,11 +86,13 @@ export function getCourseContext({
  * This is a pure save step — one DB operation.
  */
 async function createCourseEntity({
+  familyId,
   organizationId,
   prompt,
   transaction,
   workflowRunId,
 }: {
+  familyId: string | null;
   organizationId: string;
   prompt: GeneratableCoursePrompt;
   transaction: TransactionClient;
@@ -100,6 +103,7 @@ async function createCourseEntity({
 
   return transaction.course.create({
     data: {
+      familyId,
       format: prompt.courseFormat,
       generationRunId: workflowRunId,
       generationStatus: "running",
@@ -115,8 +119,9 @@ async function createCourseEntity({
 }
 
 /**
- * Runs course creation and prompt linking atomically so Workflow can safely
- * retry after a database or response failure without leaving partial state.
+ * Claims the family edition before creating a localized course. Titles can
+ * differ between equivalent requests, so the existing slug constraint alone
+ * cannot prevent two requests from generating different editions together.
  */
 async function createCourseAndLinkPrompt({
   organizationId,
@@ -126,16 +131,36 @@ async function createCourseAndLinkPrompt({
   organizationId: string;
   prompt: GeneratableCoursePrompt;
   workflowRunId: string;
-}): Promise<Course> {
+}): Promise<InitializedCourse> {
   return prisma.$transaction(async (transaction) => {
-    const course = await createCourseEntity({ organizationId, prompt, transaction, workflowRunId });
+    const edition = await getCourseEditionForPrompt({ coursePromptId: prompt.id, transaction });
+
+    if (edition?.course) {
+      const course = await transaction.course.findUniqueOrThrow({
+        include: courseContentInclude,
+        where: { id: edition.course.id },
+      });
+
+      return {
+        course: getCourseContext({ course, organizationId, prompt }),
+        existing: getExistingCourseContent(course),
+      };
+    }
+
+    const course = await createCourseEntity({
+      familyId: edition?.familyId ?? null,
+      organizationId,
+      prompt,
+      transaction,
+      workflowRunId,
+    });
 
     await transaction.coursePrompt.update({
       data: { courseId: course.id, generationRunId: workflowRunId, generationStatus: "running" },
       where: { id: prompt.id },
     });
 
-    return course;
+    return { course: getCourseContext({ course, organizationId, prompt }), existing: null };
   });
 }
 
@@ -168,6 +193,12 @@ async function getRecoveredCourse({
     throw error;
   }
 
+  // A hidden row can still reserve its slug. Do not expose it or publish it
+  // implicitly when the public identity search correctly ignored it.
+  if (!course.isPublished) {
+    throw new FatalError("Course is not published");
+  }
+
   assertCourseMatchesPromptIdentity({ course, prompt });
 
   return course;
@@ -191,9 +222,7 @@ async function createOrRecoverCourse({
   const slug = getCourseSlugForTitle({ language: prompt.language, title: prompt.canonicalTitle });
 
   try {
-    const course = await createCourseAndLinkPrompt({ organizationId, prompt, workflowRunId });
-
-    return { course: getCourseContext({ course, organizationId, prompt }), existing: null };
+    return await createCourseAndLinkPrompt({ organizationId, prompt, workflowRunId });
   } catch (error) {
     const course = await getRecoveredCourse({ error, organizationId, prompt, slug });
 

--- a/apps/api/src/workflows/course-generation/steps/link-course-edition-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/link-course-edition-step.ts
@@ -1,0 +1,17 @@
+import { linkCourseToEditionRequests } from "@zoonk/core/courses/edition-link";
+
+/**
+ * Links every requesting source after reuse or creation resolves the actual
+ * course, including workflows that immediately join an existing active run.
+ */
+export async function linkCourseEditionStep({
+  courseId,
+  coursePromptId,
+}: {
+  courseId: string;
+  coursePromptId: string;
+}): Promise<void> {
+  "use step";
+
+  await linkCourseToEditionRequests({ courseId, coursePromptId });
+}

--- a/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.test.ts
+++ b/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.test.ts
@@ -40,6 +40,8 @@ describe(resolveCourseIdentityStep, () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(generateCourseIdentitySearchQueries).mockReset();
+    vi.mocked(resolveCourseIdentity).mockReset();
 
     vi.mocked(generateCourseIdentitySearchQueries).mockResolvedValue({
       data: { queries: [] },
@@ -79,7 +81,7 @@ describe(resolveCourseIdentityStep, () => {
     const slug = getCourseSlugForTitle({ language: "en", title });
 
     const [course, request] = await Promise.all([
-      courseFixture({ organizationId, slug, title }),
+      courseFixture({ isPublished: true, organizationId, slug, title }),
       generatableCoursePromptFixture({ canonicalTitle: title, language: "en" }),
     ]);
 
@@ -96,12 +98,96 @@ describe(resolveCourseIdentityStep, () => {
     expect(resolveCourseIdentity).not.toHaveBeenCalled();
   });
 
+  it("skips a hidden cached slug match and uses the published course with the same title", async () => {
+    const title = `Published Identity ${randomUUID()}`;
+
+    const [hidden, published] = await Promise.all([
+      courseFixture({
+        isPublished: false,
+        language: "pt",
+        organizationId,
+        slug: getCourseSlugForTitle({ language: "pt", title }),
+        title,
+      }),
+      courseFixture({
+        isPublished: true,
+        language: "pt",
+        normalizedTitle: normalizeString(title),
+        organizationId,
+        title,
+      }),
+    ]);
+
+    const request = await generatableCoursePromptFixture({
+      canonicalTitle: title,
+      courseId: hidden.id,
+      language: "pt",
+    });
+
+    assertGeneratableCoursePrompt(request);
+
+    const result = await resolveCourseIdentityStep(request);
+    const persisted = await prisma.coursePrompt.findUniqueOrThrow({ where: { id: request.id } });
+
+    expect(result?.id).toBe(published.id);
+    expect(persisted.courseId).toBe(published.id);
+    expect(resolveCourseIdentity).not.toHaveBeenCalled();
+    expect(generateCourseIdentitySearchQueries).not.toHaveBeenCalled();
+  });
+
+  it.each(["pt", "pt-BR"])(
+    "uses a stored %s family edition before searching aliases",
+    async (language) => {
+      const family = await prisma.courseFamily.create({ data: {} });
+
+      const [source, edition, request] = await Promise.all([
+        courseFixture({
+          familyId: family.id,
+          isPublished: true,
+          language: "en",
+          organizationId,
+          title: `Computer Science ${randomUUID()}`,
+        }),
+        courseFixture({
+          familyId: family.id,
+          isPublished: true,
+          language,
+          organizationId,
+          slug: `ciencia-da-computacao-${randomUUID()}-pt`,
+          title: "Ciência da Computação",
+        }),
+        generatableCoursePromptFixture({
+          canonicalTitle: `Computação ${randomUUID()}`,
+          language: "pt",
+        }),
+      ]);
+
+      assertGeneratableCoursePrompt(request);
+
+      await prisma.courseEditionRequest.create({
+        data: { coursePromptId: request.id, language: "pt", sourceCourseId: source.id },
+      });
+
+      const result = await resolveCourseIdentityStep(request);
+
+      const persistedPrompt = await prisma.coursePrompt.findUniqueOrThrow({
+        where: { id: request.id },
+      });
+
+      expect(result?.id).toBe(edition.id);
+      expect(result?.slug).toBe(edition.slug);
+      expect(persistedPrompt.courseId).toBe(edition.id);
+      expect(generateCourseIdentitySearchQueries).not.toHaveBeenCalled();
+      expect(resolveCourseIdentity).not.toHaveBeenCalled();
+    },
+  );
+
   it("returns and stores an exact-slug course with a different regular format", async () => {
     const title = `Existing Cross Format Course ${randomUUID()}`;
     const slug = getCourseSlugForTitle({ language: "en", title });
 
     const [course, request] = await Promise.all([
-      courseFixture({ format: "core", organizationId, slug, title }),
+      courseFixture({ format: "core", isPublished: true, organizationId, slug, title }),
       generatableCoursePromptFixture({
         canonicalTitle: title,
         courseFormat: "coding",
@@ -127,6 +213,7 @@ describe(resolveCourseIdentityStep, () => {
   it("uses AI classification to link semantically equivalent course titles", async () => {
     const [course, request] = await Promise.all([
       courseFixture({
+        isPublished: true,
         normalizedTitle: normalizeString("Frontend Development"),
         organizationId,
         slug: `frontend-development-${randomUUID()}`,
@@ -170,10 +257,167 @@ describe(resolveCourseIdentityStep, () => {
     );
   });
 
+  it("preserves published source context when an older edition source was unpublished", async () => {
+    const title = `Bread Making ${randomUUID()}`;
+
+    const [source, course, request] = await Promise.all([
+      courseFixture({
+        description: "Préparer des pains avec de la farine, de l’eau et de la levure.",
+        isPublished: true,
+        language: "fr",
+        organizationId,
+        title: "Pain",
+      }),
+      courseFixture({
+        isPublished: true,
+        normalizedTitle: normalizeString(title),
+        organizationId,
+        title,
+      }),
+      generatableCoursePromptFixture({
+        canonicalTitle: `Bread Baking ${randomUUID()}`,
+        language: "en",
+      }),
+    ]);
+
+    assertGeneratableCoursePrompt(request);
+
+    const removedSource = await courseFixture({
+      description: "Physical discomfort and its treatment.",
+      isPublished: false,
+      language: "en",
+      organizationId,
+      title: "Pain",
+    });
+
+    await prisma.courseEditionRequest.create({
+      data: {
+        coursePromptId: request.id,
+        createdAt: new Date(0),
+        language: "en",
+        sourceCourseId: removedSource.id,
+      },
+    });
+
+    await prisma.courseEditionRequest.create({
+      data: { coursePromptId: request.id, language: "en", sourceCourseId: source.id },
+    });
+
+    vi.mocked(generateCourseIdentitySearchQueries).mockResolvedValueOnce({
+      data: { queries: [title] },
+      systemPrompt: "system",
+      usage,
+      userPrompt: "user",
+    });
+
+    vi.mocked(resolveCourseIdentity).mockResolvedValueOnce({
+      data: { courseSlug: course.slug, decision: "useExisting", reason: "same bread making topic" },
+      systemPrompt: "system",
+      usage,
+      userPrompt: "user",
+    });
+
+    const result = await resolveCourseIdentityStep(request);
+
+    const proposedCourse = {
+      description: JSON.stringify({
+        description: source.description,
+        instructionalLanguage: source.language,
+        title: source.title,
+      }),
+      language: "en",
+      targetLanguage: null,
+      title: request.canonicalTitle,
+    };
+
+    expect(result?.id).toBe(course.id);
+    expect(generateCourseIdentitySearchQueries).toHaveBeenCalledWith({ proposedCourse });
+    expect(resolveCourseIdentity).toHaveBeenCalledWith(expect.objectContaining({ proposedCourse }));
+  });
+
+  it.each(["pt-BR", "por"])(
+    "finds an ungrouped %s course for a Portuguese semantic identity request",
+    async (language) => {
+      const title = `Engenharia de Software ${randomUUID()}`;
+
+      const [course, request] = await Promise.all([
+        courseFixture({
+          isPublished: true,
+          language,
+          normalizedTitle: normalizeString(title),
+          organizationId,
+          title,
+        }),
+        generatableCoursePromptFixture({
+          canonicalTitle: `Desenvolvimento de Programas ${randomUUID()}`,
+          language: "pt",
+        }),
+      ]);
+
+      assertGeneratableCoursePrompt(request);
+
+      vi.mocked(generateCourseIdentitySearchQueries).mockResolvedValueOnce({
+        data: { queries: [title] },
+        systemPrompt: "system",
+        usage,
+        userPrompt: "user",
+      });
+
+      vi.mocked(resolveCourseIdentity).mockResolvedValueOnce({
+        data: { courseSlug: course.slug, decision: "useExisting", reason: "same discipline" },
+        systemPrompt: "system",
+        usage,
+        userPrompt: "user",
+      });
+
+      const result = await resolveCourseIdentityStep(request);
+
+      expect(result?.id).toBe(course.id);
+      expect(result?.slug).toBe(course.slug);
+
+      expect(resolveCourseIdentity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          candidates: expect.arrayContaining([
+            expect.objectContaining({ language, slug: course.slug }),
+          ]),
+        }),
+      );
+    },
+  );
+
+  it.each(["fr", "ja", "pt-??"])(
+    "does not reuse a cached or title-matched %s course as Portuguese",
+    async (language) => {
+      const title = `Different Content Language ${randomUUID()}`;
+
+      const course = await courseFixture({
+        isPublished: true,
+        language,
+        normalizedTitle: normalizeString(title),
+        organizationId,
+        title,
+      });
+
+      const request = await generatableCoursePromptFixture({
+        canonicalTitle: title,
+        courseId: course.id,
+        language: "pt",
+      });
+
+      assertGeneratableCoursePrompt(request);
+
+      const result = await resolveCourseIdentityStep(request);
+
+      expect(result).toBeNull();
+      expect(resolveCourseIdentity).not.toHaveBeenCalled();
+    },
+  );
+
   it("leaves the request unlinked when AI says the candidate is different", async () => {
     const [request] = await Promise.all([
       generatableCoursePromptFixture({ canonicalTitle: "Machine Learning", language: "en" }),
       courseFixture({
+        isPublished: true,
         normalizedTitle: normalizeString("Deep Learning"),
         organizationId,
         slug: `deep-learning-${randomUUID()}`,
@@ -211,6 +455,7 @@ describe(resolveCourseIdentityStep, () => {
     const [request] = await Promise.all([
       generatableCoursePromptFixture({ canonicalTitle: "Unique Topic", language: "en" }),
       courseFixture({
+        isPublished: true,
         normalizedTitle: normalizeString("Science"),
         organizationId,
         slug: `science-${randomUUID()}`,
@@ -237,6 +482,7 @@ describe(resolveCourseIdentityStep, () => {
     const [request] = await Promise.all([
       generatableCoursePromptFixture({ canonicalTitle: "Aprendizado de Máquina", language: "pt" }),
       courseFixture({
+        isPublished: true,
         language: "pt",
         normalizedTitle: normalizeString("Inteligência Artificial"),
         organizationId,
@@ -262,6 +508,7 @@ describe(resolveCourseIdentityStep, () => {
 
   it("uses the cached course link before querying AI again", async () => {
     const course = await courseFixture({
+      isPublished: true,
       organizationId,
       slug: `cached-course-${randomUUID()}`,
       title: "Cached Course",
@@ -288,6 +535,7 @@ describe(resolveCourseIdentityStep, () => {
 
     const course = await courseFixture({
       format: "language",
+      isPublished: true,
       language,
       organizationId,
       slug,
@@ -317,6 +565,7 @@ describe(resolveCourseIdentityStep, () => {
 
     const course = await courseFixture({
       format: "language",
+      isPublished: true,
       language,
       organizationId,
       slug: `spanish-language-${randomUUID()}`,
@@ -351,6 +600,7 @@ describe(resolveCourseIdentityStep, () => {
 
     await courseFixture({
       format: "core",
+      isPublished: true,
       language: "en",
       organizationId,
       slug,
@@ -377,6 +627,7 @@ describe(resolveCourseIdentityStep, () => {
   it("uses AI search queries before classifying cross-language title matches", async () => {
     const [course, request] = await Promise.all([
       courseFixture({
+        isPublished: true,
         language: "pt",
         normalizedTitle: normalizeString("Machine Learning"),
         organizationId,

--- a/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.ts
+++ b/apps/api/src/workflows/course-generation/steps/resolve-course-identity-step.ts
@@ -5,13 +5,20 @@ import {
   resolveCourseIdentity,
 } from "@zoonk/ai/tasks/courses/identity";
 import { generateCourseIdentitySearchQueries } from "@zoonk/ai/tasks/courses/identity-search";
+import {
+  getCourseEditionPrompt,
+  getExistingCourseEditionForPrompt,
+} from "@zoonk/core/courses/edition-link";
 import { getCompatibleCourseFormats } from "@zoonk/core/courses/prompt-generation";
 import { getCourseSlugForTitle } from "@zoonk/core/courses/slug";
 import { type CourseWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { type CourseGetPayload, getAiGenerationCourseWhere, prisma } from "@zoonk/db";
 import { normalizeString, toSlug } from "@zoonk/utils/string";
 import { courseContentInclude } from "../_internal/existing-course-content";
-import { assertCourseMatchesPromptIdentity } from "../_utils/course-identity-validation";
+import {
+  assertCourseMatchesPromptIdentity,
+  matchesCoursePromptLanguage,
+} from "../_utils/course-identity-validation";
 import { type GeneratableCoursePrompt } from "./get-course-prompt-step";
 
 const IDENTITY_SEARCH_STEP = "generateCourseIdentitySearchQueries";
@@ -58,12 +65,21 @@ function toIdentityCandidate(course: ExistingCourse): CourseIdentityCandidate {
 }
 
 /**
- * Converts a course prompt into the model input shape. Keeping this mapper
- * local to the workflow prevents the AI package from depending on Prisma types.
+ * An edition's source language and scope disambiguate translated titles. The
+ * request provenance is persisted by Core, and sources sharing a prompt belong
+ * to the same course family. Use one source context consistently for both calls.
  */
-function toIdentityRequest(request: GeneratableCoursePrompt): CourseIdentityProposedCourse {
+async function toIdentityRequest(
+  request: GeneratableCoursePrompt,
+): Promise<CourseIdentityProposedCourse> {
+  const editionRequest = await prisma.courseEditionRequest.findFirst({
+    include: { sourceCourse: true },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    where: { coursePromptId: request.id, sourceCourse: { isPublished: true } },
+  });
+
   return {
-    description: null,
+    description: editionRequest ? getCourseEditionPrompt(editionRequest.sourceCourse) : null,
     language: request.language,
     targetLanguage: request.targetLanguage,
     title: request.canonicalTitle,
@@ -120,14 +136,14 @@ function getCandidateWhereClauses({
 }
 
 /**
- * Builds the mandatory database identity shared by cached and searched course
- * lookups. Language targets are never an optional recall signal because two
- * learned languages cannot represent the same generated course.
+ * Builds the database constraints shared by cached and searched lookups.
+ * Instructional language is checked after retrieval so valid regional tags
+ * and aliases use the same locale policy as course routing and validation.
  */
 function getCourseIdentityWhere(request: GeneratableCoursePrompt): CourseWhereInput {
   return {
     format: { in: getCompatibleCourseFormats(request.courseFormat) },
-    language: request.language,
+    isPublished: true,
     targetLanguage: request.targetLanguage,
   };
 }
@@ -184,10 +200,17 @@ async function findCandidateCourses({
     return [];
   }
 
-  return prisma.course.findMany({
+  const courses = await prisma.course.findMany({
     include: courseContentInclude,
     where: getAiGenerationCourseWhere(where),
   });
+
+  return courses.filter((course) =>
+    matchesCoursePromptLanguage({
+      courseLanguage: course.language,
+      promptLanguage: request.language,
+    }),
+  );
 }
 
 /**
@@ -226,10 +249,46 @@ async function getCachedCourse(request: GeneratableCoursePrompt): Promise<Existi
     return null;
   }
 
-  return prisma.course.findFirst({
+  const course = await prisma.course.findFirst({
     include: courseContentInclude,
     where: getAiGenerationCourseWhere({ ...getCourseIdentityWhere(request), id: request.courseId }),
   });
+
+  return course &&
+    matchesCoursePromptLanguage({
+      courseLanguage: course.language,
+      promptLanguage: request.language,
+    })
+    ? course
+    : null;
+}
+
+/** Resolves editions through stored family identity before doing title-based model work. */
+async function getFamilyCourse(request: GeneratableCoursePrompt): Promise<ExistingCourse | null> {
+  const edition = await getExistingCourseEditionForPrompt({ coursePromptId: request.id });
+
+  if (!edition) {
+    return null;
+  }
+
+  assertCourseMatchesPromptIdentity({ course: edition, prompt: request });
+
+  return prisma.course.findFirst({
+    include: courseContentInclude,
+    where: getAiGenerationCourseWhere({ id: edition.id, isPublished: true }),
+  });
+}
+
+/** A family can acquire a winning edition after this prompt was first resolved. */
+async function getKnownCourse(request: GeneratableCoursePrompt): Promise<ExistingCourse | null> {
+  const course = await getFamilyCourse(request);
+
+  if (course) {
+    await linkRequestToCourse({ courseId: course.id, promptId: request.id });
+    return course;
+  }
+
+  return getCachedCourse(request);
 }
 
 /**
@@ -289,17 +348,15 @@ async function streamSkippedIdentityClassification(stream: CourseIdentityStream)
  * learner can see that duplicate-course search is doing model work.
  */
 async function generateSearchQueriesWithStatus({
-  request,
+  proposedCourse,
   stream,
 }: {
-  request: GeneratableCoursePrompt;
+  proposedCourse: CourseIdentityProposedCourse;
   stream: CourseIdentityStream;
 }): ReturnType<typeof generateCourseIdentitySearchQueries> {
   await stream.status({ status: "started", step: IDENTITY_SEARCH_STEP });
 
-  const search = await generateCourseIdentitySearchQueries({
-    proposedCourse: toIdentityRequest(request),
-  });
+  const search = await generateCourseIdentitySearchQueries({ proposedCourse });
 
   await stream.status({ status: "completed", step: IDENTITY_SEARCH_STEP });
 
@@ -313,18 +370,18 @@ async function generateSearchQueriesWithStatus({
  */
 async function resolveIdentityWithStatus({
   candidates,
-  request,
+  proposedCourse,
   stream,
 }: {
   candidates: ExistingCourse[];
-  request: GeneratableCoursePrompt;
+  proposedCourse: CourseIdentityProposedCourse;
   stream: CourseIdentityStream;
 }): ReturnType<typeof resolveCourseIdentity> {
   await stream.status({ status: "started", step: IDENTITY_CLASSIFICATION_STEP });
 
   const identity = await resolveCourseIdentity({
     candidates: candidates.map((course) => toIdentityCandidate(course)),
-    proposedCourse: toIdentityRequest(request),
+    proposedCourse,
   });
 
   await stream.status({ status: "completed", step: IDENTITY_CLASSIFICATION_STEP });
@@ -344,7 +401,7 @@ export async function resolveCourseIdentityStep(
 
   await using stream = createStepStream<CourseWorkflowStepName>();
 
-  const cachedCourse = await getCachedCourse(request);
+  const cachedCourse = await getKnownCourse(request);
 
   if (cachedCourse) {
     assertCourseMatchesPromptIdentity({ course: cachedCourse, prompt: request });
@@ -373,7 +430,8 @@ export async function resolveCourseIdentityStep(
     return null;
   }
 
-  const search = await generateSearchQueriesWithStatus({ request, stream });
+  const proposedCourse = await toIdentityRequest(request);
+  const search = await generateSearchQueriesWithStatus({ proposedCourse, stream });
 
   const aiCandidates = await findCandidateCourses({ request, searchTexts: search.data.queries });
 
@@ -384,7 +442,7 @@ export async function resolveCourseIdentityStep(
     return null;
   }
 
-  const identity = await resolveIdentityWithStatus({ candidates, request, stream });
+  const identity = await resolveIdentityWithStatus({ candidates, proposedCourse, stream });
 
   const selectedCourse =
     identity.data.decision === "useExisting"

--- a/apps/apple/Zoonk/openapi.json
+++ b/apps/apple/Zoonk/openapi.json
@@ -831,6 +831,194 @@
         }
       }
     },
+    "/courses/{courseId}/editions": {
+      "get": {
+        "description": "Finds a course edition in the requested instructional language. Proven existing editions may be linked on demand; reading never runs identity models or creates generation requests.",
+        "operationId": "getCourseEdition",
+        "security": [],
+        "summary": "Find a course language edition",
+        "tags": [
+          "Courses"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "courseId",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "description": "Course ID"
+            },
+            "required": true,
+            "description": "Course ID"
+          },
+          {
+            "in": "query",
+            "name": "language",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "en",
+                "es",
+                "pt",
+                "fr",
+                "de"
+              ],
+              "description": "Requested instructional language",
+              "example": "pt"
+            },
+            "required": true,
+            "description": "Requested instructional language"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Available edition, existing generation, missing edition, or unsupported request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseEditionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Reuses an existing edition publicly. If none exists, authentication is required to resolve the source title through normal course identity search and prepare generation. A generation result identifies the course prompt to submit to POST /generations.",
+        "operationId": "resolveCourseEdition",
+        "security": [
+          {},
+          {
+            "bearerAuth": []
+          },
+          {
+            "cookieAuth": []
+          }
+        ],
+        "summary": "Resolve a course language edition",
+        "tags": [
+          "Courses"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "courseId",
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$",
+              "description": "Course ID"
+            },
+            "required": true,
+            "description": "Course ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CourseEditionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Available edition, existing generation, missing edition, or unsupported request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseEditionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Request forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/course-prompts": {
       "post": {
         "description": "Classifies and stores topic prompts publicly, returning existing courses and unsupported outcomes without authentication. Authentication is required before a prompt can create a generation request.",
@@ -3930,6 +4118,26 @@
         "additionalProperties": false,
         "minProperties": 1
       },
+      "CourseEditionRequest": {
+        "type": "object",
+        "properties": {
+          "language": {
+            "type": "string",
+            "enum": [
+              "en",
+              "es",
+              "pt",
+              "fr",
+              "de"
+            ],
+            "description": "Requested instructional language",
+            "example": "pt"
+          }
+        },
+        "required": [
+          "language"
+        ]
+      },
       "ResolveCoursePromptRequest": {
         "oneOf": [
           {
@@ -5667,6 +5875,103 @@
           "title"
         ],
         "additionalProperties": false
+      },
+      "CourseEditionResponse": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "courseId": {
+                "type": "string",
+                "format": "uuid",
+                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "course"
+                ]
+              }
+            },
+            "required": [
+              "courseId",
+              "kind"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "coursePromptId": {
+                "type": "string",
+                "format": "uuid",
+                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+              },
+              "generationStatus": {
+                "type": "string",
+                "enum": [
+                  "completed",
+                  "failed",
+                  "pending",
+                  "running"
+                ]
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "generation"
+                ]
+              }
+            },
+            "required": [
+              "coursePromptId",
+              "generationStatus",
+              "kind"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "missing"
+                ]
+              }
+            },
+            "required": [
+              "kind"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "unsupported"
+                ]
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "sameLanguage",
+                  "format",
+                  "language",
+                  "unavailable"
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "reason"
+            ],
+            "additionalProperties": false
+          }
+        ],
+        "type": "object"
       },
       "ResolveCoursePromptResponse": {
         "oneOf": [

--- a/apps/main/e2e/canonical-url.test.ts
+++ b/apps/main/e2e/canonical-url.test.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
+import { setLocale } from "@zoonk/e2e/fixtures/locale";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { courseFixture } from "@zoonk/testing/fixtures/courses";
 import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { LOCALE_COOKIE } from "@zoonk/utils/locale";
 import { SITE_URL } from "@zoonk/utils/url";
 import { type Page, expect, test } from "./fixtures";
 
@@ -10,23 +12,27 @@ import { type Page, expect, test } from "./fixtures";
  * Course content can be opened through any UI locale, but search engines need
  * one stable URL based on the language of the content itself.
  */
-async function expectCanonicalUrl({
+async function expectCatalogMetadata({
   canonicalPath,
   page,
   path,
+  robots,
 }: {
   canonicalPath: string;
   page: Page;
   path: string;
+  robots: "index, follow" | "noindex, follow";
 }) {
   await page.goto(path);
-  await page.waitForLoadState("networkidle");
 
-  const canonicalUrl = await page.evaluate(
-    () => document.querySelector<HTMLLinkElement>("link[rel='canonical']")?.href ?? "",
-  );
-
-  expect(canonicalUrl).toBe(`${SITE_URL}${canonicalPath}`);
+  await expect
+    .poll(() =>
+      page.evaluate(() => ({
+        canonicalUrl: document.querySelector<HTMLLinkElement>("link[rel='canonical']")?.href,
+        robots: document.querySelector<HTMLMetaElement>("meta[name='robots']")?.content,
+      })),
+    )
+    .toStrictEqual({ canonicalUrl: `${SITE_URL}${canonicalPath}`, robots });
 }
 
 /**
@@ -50,9 +56,7 @@ test("marks course discovery pages as indexable", async ({ page }) => {
   await expectIndexable({ page, path: "/pt/courses/science" });
 });
 
-test("uses the course language for course, chapter, and lesson canonical URLs", async ({
-  page,
-}) => {
+test("indexes course, chapter, and lesson pages only in the course language", async ({ page }) => {
   const uniqueId = randomUUID().slice(0, 8);
   const organization = await getAiOrganization();
 
@@ -86,7 +90,137 @@ test("uses the course language for course, chapter, and lesson canonical URLs", 
   const chapterPath = `${coursePath}/ch/${chapter.slug}`;
   const lessonPath = `${chapterPath}/l/${lesson.slug}`;
 
-  await expectCanonicalUrl({ canonicalPath: `/pt${coursePath}`, page, path: coursePath });
-  await expectCanonicalUrl({ canonicalPath: `/pt${chapterPath}`, page, path: `/es${chapterPath}` });
-  await expectCanonicalUrl({ canonicalPath: `/pt${lessonPath}`, page, path: `/fr${lessonPath}` });
+  await expectCatalogMetadata({
+    canonicalPath: `/pt${coursePath}`,
+    page,
+    path: coursePath,
+    robots: "noindex, follow",
+  });
+
+  await expectCatalogMetadata({
+    canonicalPath: `/pt${chapterPath}`,
+    page,
+    path: `/es${chapterPath}`,
+    robots: "noindex, follow",
+  });
+
+  await expectCatalogMetadata({
+    canonicalPath: `/pt${lessonPath}`,
+    page,
+    path: `/fr${lessonPath}`,
+    robots: "noindex, follow",
+  });
+
+  await expectCatalogMetadata({
+    canonicalPath: `/pt${coursePath}`,
+    page,
+    path: `/pt${coursePath}`,
+    robots: "index, follow",
+  });
+
+  await expectCatalogMetadata({
+    canonicalPath: `/pt${chapterPath}`,
+    page,
+    path: `/pt${chapterPath}`,
+    robots: "index, follow",
+  });
+
+  await expectCatalogMetadata({
+    canonicalPath: `/pt${lessonPath}`,
+    page,
+    path: `/pt${lessonPath}`,
+    robots: "index, follow",
+  });
+});
+
+test("keeps unsupported instructional languages out of the English index", async ({ page }) => {
+  const organization = await getAiOrganization();
+
+  const course = await courseFixture({
+    isPublished: true,
+    language: "ja-JP",
+    organizationId: organization.id,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: organization.id,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    isPublished: true,
+    organizationId: organization.id,
+  });
+
+  const coursePath = `/b/${organization.slug}/c/${course.slug}`;
+  const chapterPath = `${coursePath}/ch/${chapter.slug}`;
+  const lessonPath = `${chapterPath}/l/${lesson.slug}`;
+
+  await expectCatalogMetadata({
+    canonicalPath: coursePath,
+    page,
+    path: coursePath,
+    robots: "noindex, follow",
+  });
+
+  await expectCatalogMetadata({
+    canonicalPath: chapterPath,
+    page,
+    path: chapterPath,
+    robots: "noindex, follow",
+  });
+
+  await expectCatalogMetadata({
+    canonicalPath: lessonPath,
+    page,
+    path: lessonPath,
+    robots: "noindex, follow",
+  });
+});
+
+test.describe("catalog URLs with another language preference", () => {
+  test.use({ locale: "pt-BR" });
+
+  test("keeps English canonicals stable while preserving the saved UI language", async ({
+    page,
+  }) => {
+    const organization = await getAiOrganization();
+
+    const course = await courseFixture({
+      isPublished: true,
+      language: "en",
+      organizationId: organization.id,
+    });
+
+    await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      language: course.language,
+      organizationId: organization.id,
+    });
+
+    const path = `/b/${organization.slug}/c/${course.slug}`;
+
+    await setLocale(page, "de");
+    await expectCatalogMetadata({ canonicalPath: path, page, path, robots: "index, follow" });
+    await expect(page.getByRole("heading", { level: 1, name: course.title })).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe(path);
+
+    await expectCatalogMetadata({
+      canonicalPath: path,
+      page,
+      path: `/pt${path}`,
+      robots: "noindex, follow",
+    });
+
+    expect(new URL(page.url()).pathname).toBe(`/pt${path}`);
+
+    const cookies = await page.context().cookies();
+    expect(cookies.find((cookie) => cookie.name === LOCALE_COOKIE)?.value).toBe("de");
+
+    await page.goto("/courses");
+    await expect(page).toHaveURL(/\/de\/courses$/u);
+  });
 });

--- a/apps/main/e2e/chapter-detail.test.ts
+++ b/apps/main/e2e/chapter-detail.test.ts
@@ -391,7 +391,7 @@ test.describe("Chapter Navbar - Mobile", () => {
 
     await expect(courseLink).toHaveCount(1);
     await expect(courseLink).toBeVisible();
-    await expect(courseLink).toHaveAttribute("href", courseUrl);
+    await expect(courseLink).toHaveAttribute("href", `${courseUrl}?edition=original`);
 
     await expect(homeLink).toHaveCount(1);
     await expect(homeLink).toBeVisible();
@@ -655,7 +655,7 @@ test.describe("Chapter - No Lessons", () => {
     await expect(courseLink).toBeVisible();
     await expect(courseLink.getByText(/^Esc$/u)).toBeVisible();
     await expect(courseLink).toHaveAttribute("aria-keyshortcuts", "Escape");
-    await expect(courseLink).toHaveAttribute("href", courseUrl);
+    await expect(courseLink).toHaveAttribute("href", `${courseUrl}?edition=original`);
 
     const actionsButton = page.getByRole("main").getByRole("button", { name: /more options/iu });
 
@@ -670,7 +670,11 @@ test.describe("Chapter - No Lessons", () => {
     await page.goto(noLessonsChapterUrl);
     await expect(page.getByRole("link", { name: /back to course/iu })).toBeVisible();
 
-    await pressShortcutAndWaitForUrl({ expectedUrl: courseUrl, key: "Escape", page });
+    await pressShortcutAndWaitForUrl({
+      expectedUrl: `${courseUrl}?edition=original`,
+      key: "Escape",
+      page,
+    });
   });
 
   test("non-AI chapters with no lessons stay on the chapter page", async ({ page }) => {

--- a/apps/main/e2e/continue-learning-revalidation.test.ts
+++ b/apps/main/e2e/continue-learning-revalidation.test.ts
@@ -117,6 +117,10 @@ async function completeStaticLesson({
   page: Page;
   userId: string;
 }) {
+  await expect(
+    page.getByRole("region", { name: "Lesson content" }).getByRole("button", { name: "Next step" }),
+  ).toBeEnabled();
+
   const serverActionResponse = page.waitForResponse(
     (resp) => resp.request().method() === "POST" && resp.ok(),
   );
@@ -166,7 +170,6 @@ test.describe("Continue Learning Revalidation", () => {
     // 2. Click the continue learning card link (client-side navigation)
     await nextLink.first().click();
     await page.waitForURL(new RegExp(`/l/e2e-cl-reval-current-${uniqueId}$`, "u"));
-    await page.waitForLoadState("networkidle");
 
     // 3. Complete the static lesson and wait for durable progress before navigating again.
     await completeStaticLesson({ lessonId: lesson1.id, page, userId: user.id });
@@ -178,7 +181,6 @@ test.describe("Continue Learning Revalidation", () => {
     // 5. Click the Home link in the navbar (client-side navigation — Router Cache)
     await page.getByRole("link", { name: /home page/iu }).click();
     await page.waitForURL(/\/$/u);
-    await page.waitForLoadState("networkidle");
 
     // 6. Continue learning should show the NEW next lesson, not the old one
     await expect(

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -139,7 +139,7 @@ test.beforeAll(async () => {
     }),
   ]);
 
-  ptCourseUrl = `/b/${AI_ORG_SLUG}/c/${ptCourse.slug}`;
+  ptCourseUrl = `/pt/b/${AI_ORG_SLUG}/c/${ptCourse.slug}`;
 });
 
 test.describe("Course Chapters List", () => {

--- a/apps/main/e2e/course-detail.test.ts
+++ b/apps/main/e2e/course-detail.test.ts
@@ -262,15 +262,17 @@ test.describe("Course Detail Page", () => {
       page.getByRole("heading", { level: 1, name: testData.regionalCourseTitle }),
     ).toBeVisible();
 
-    await expect(page).toHaveTitle(`Learn ${testData.regionalCourseTitle} | Zoonk`);
+    await expect(page).toHaveTitle(`Aprenda ${testData.regionalCourseTitle} | Zoonk`);
   });
 });
 
 test.describe("Course Detail Page - Locale", () => {
   test("course page renders in Portuguese locale", async ({ page }) => {
     await setLocale(page, "pt");
-    await page.goto(testData.ptCourseUrl);
+    await page.goto(`/pt${testData.ptCourseUrl}`);
 
-    await expect(page).toHaveURL(new RegExp(`/b/${AI_ORG_SLUG}/c/`, "u"));
+    await expect(page).toHaveURL(`/pt${testData.ptCourseUrl}`);
+    await expect(page.locator("html")).toHaveAttribute("lang", "pt");
+    await expect(page.getByRole("searchbox", { name: "Buscar capítulos…" })).toBeVisible();
   });
 });

--- a/apps/main/e2e/course-editions.test.ts
+++ b/apps/main/e2e/course-editions.test.ts
@@ -1,0 +1,613 @@
+import { randomUUID } from "node:crypto";
+import { type CourseFormat, prisma } from "@zoonk/db";
+import { setLocale } from "@zoonk/e2e/fixtures/locale";
+import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
+import { courseFixture, courseUserFixture } from "@zoonk/testing/fixtures/courses";
+import { LOCALE_COOKIE } from "@zoonk/utils/locale";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
+import { normalizeString } from "@zoonk/utils/string";
+import { getCourseEditionPrompt } from "../../../packages/core/src/courses/_utils/edition-prompt";
+import { expect, test } from "./fixtures";
+import {
+  getGenerationTriggerRequests,
+  isGenerationEvents,
+  isGenerationTrigger,
+  routeGenerationApis,
+} from "./generation-api";
+
+async function createCourse({
+  format = "core",
+  language = "pt",
+  targetLanguage,
+}: { format?: CourseFormat; language?: string; targetLanguage?: string } = {}) {
+  const organization = await getAiOrganization();
+  const id = randomUUID();
+  const title = language === "pt" ? `Ciência da Computação ${id}` : `Computer Science ${id}`;
+
+  const course = await courseFixture({
+    format,
+    isPublished: true,
+    language,
+    normalizedTitle: normalizeString(title),
+    organizationId: organization.id,
+    slug: language === "pt" ? `ciencia-da-computacao-${id}-pt` : `computer-science-${id}`,
+    targetLanguage: targetLanguage ?? null,
+    title,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    language,
+    organizationId: organization.id,
+    title: `Introduction ${id}`,
+  });
+
+  return { chapter, course, href: `/b/${AI_ORG_SLUG}/c/${course.slug}` };
+}
+
+async function connectKnownPrompt({
+  source,
+  target,
+}: {
+  source: Awaited<ReturnType<typeof createCourse>>;
+  target: Awaited<ReturnType<typeof createCourse>>;
+}) {
+  return coursePromptFixture({
+    canonicalTitle: target.course.title,
+    courseId: target.course.id,
+    generationStatus: "completed",
+    language: target.course.language,
+    prompt: getCourseEditionPrompt(source.course),
+  });
+}
+
+test.describe("Course language editions", () => {
+  test("links an existing local edition on demand and opens its own localized slug", async ({
+    page,
+  }) => {
+    const [source, target] = await Promise.all([createCourse(), createCourse({ language: "en" })]);
+    await connectKnownPrompt({ source, target });
+
+    await page.goto(source.href);
+
+    await expect(page).toHaveURL(target.href);
+    await expect(page.getByRole("heading", { level: 1, name: target.course.title })).toBeVisible();
+
+    await expect(async () => {
+      const [sourceCourse, targetCourse] = await Promise.all([
+        prisma.course.findUniqueOrThrow({ where: { id: source.course.id } }),
+        prisma.course.findUniqueOrThrow({ where: { id: target.course.id } }),
+      ]);
+
+      expect(sourceCourse.familyId).not.toBeNull();
+      expect(sourceCourse.familyId).toBe(targetCourse.familyId);
+    }).toPass();
+  });
+
+  test("offers a local course without generating on visit and keeps an explicit original choice", async ({
+    page,
+  }) => {
+    const source = await createCourse();
+    await page.setViewportSize({ height: 844, width: 390 });
+    await page.goto(source.href);
+
+    const languageChoice = page.getByRole("region", { name: "Course language" });
+    await expect(languageChoice.getByRole("button", { name: "Learn in English" })).toBeVisible();
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(source.chapter.title, "u") }),
+    ).toHaveCount(0);
+
+    await expect(
+      prisma.courseEditionRequest.count({ where: { sourceCourseId: source.course.id } }),
+    ).resolves.toBe(0);
+
+    await expect(
+      prisma.coursePrompt.count({
+        where: {
+          language: "en",
+          normalizedPrompt: normalizeString(getCourseEditionPrompt(source.course)),
+        },
+      }),
+    ).resolves.toBe(0);
+
+    await expect(
+      getGenerationTriggerRequests({ page, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(0);
+
+    await languageChoice.getByRole("link", { name: "Continue in Portuguese" }).click();
+
+    await expect(page).toHaveURL(`${source.href}?edition=original`);
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(source.chapter.title, "u") }),
+    ).toBeVisible();
+
+    await expect(
+      languageChoice.getByRole("heading", { name: "This course is in Portuguese" }),
+    ).toBeVisible();
+
+    await expect(
+      prisma.courseEditionRequest.count({ where: { sourceCourseId: source.course.id } }),
+    ).resolves.toBe(0);
+  });
+
+  test("requires sign-in before resolving an unknown edition", async ({ page }) => {
+    const source = await createCourse();
+
+    await page.route("**/auth/login**", async (route) => {
+      await route.fulfill({ body: "Auth app", contentType: "text/html", status: 200 });
+    });
+
+    const authRequest = page.waitForRequest("**/auth/login**");
+    await page.goto(source.href);
+    await page.getByRole("button", { name: "Learn in English" }).click();
+
+    const request = await authRequest;
+    const authUrl = new URL(request.url());
+    const callbackUrl = new URL(authUrl.searchParams.get("redirectTo") ?? "");
+
+    expect(authUrl.searchParams.get("locale")).toBe("en");
+    expect(callbackUrl.searchParams.get("next")).toBe(source.href);
+
+    await expect(
+      prisma.courseEditionRequest.count({ where: { sourceCourseId: source.course.id } }),
+    ).resolves.toBe(0);
+
+    await expect(
+      prisma.coursePrompt.count({
+        where: {
+          language: "en",
+          normalizedPrompt: normalizeString(getCourseEditionPrompt(source.course)),
+        },
+      }),
+    ).resolves.toBe(0);
+  });
+
+  test("reuses an edition that appears after the initial page visit", async ({
+    userWithoutProgress,
+  }) => {
+    const source = await createCourse();
+    await userWithoutProgress.goto(source.href);
+
+    await expect(
+      userWithoutProgress.getByRole("button", { name: "Learn in English" }),
+    ).toBeVisible();
+
+    const target = await createCourse({ language: "en" });
+    await connectKnownPrompt({ source, target });
+    await userWithoutProgress.getByRole("button", { name: "Learn in English" }).click();
+
+    await expect(userWithoutProgress).toHaveURL(target.href);
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { level: 1, name: target.course.title }),
+    ).toBeVisible();
+
+    await expect(
+      getGenerationTriggerRequests({ page: userWithoutProgress, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(0);
+  });
+
+  for (const language of ["pt", "pt-BR"]) {
+    test(`omits the language notice when Portuguese UI matches ${language} content`, async ({
+      page,
+    }) => {
+      const [source, target] = await Promise.all([
+        createCourse({ language }),
+        createCourse({ language: "en" }),
+      ]);
+
+      await connectKnownPrompt({ source, target });
+      await setLocale(page, "en");
+      await page.goto(`/pt${source.href}`);
+
+      await expect(page).toHaveURL(`/pt${source.href}`);
+
+      await expect(
+        page.getByRole("heading", { level: 1, name: source.course.title }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole("link", { name: new RegExp(source.chapter.title, "u") }),
+      ).toBeVisible();
+
+      await expect(page.getByRole("region", { name: "Idioma do curso" })).toHaveCount(0);
+    });
+  }
+
+  test("keeps the requested locale in the sign-in return URL", async ({ page }) => {
+    const source = await createCourse({ language: "en" });
+
+    await page.route("**/auth/login**", async (route) => {
+      await route.fulfill({ body: "Auth app", contentType: "text/html", status: 200 });
+    });
+
+    const authRequest = page.waitForRequest("**/auth/login**");
+    await setLocale(page, "de");
+    await page.goto(`/de${source.href}`);
+    await page.getByRole("button", { name: "Auf Deutsch lernen" }).click();
+
+    const request = await authRequest;
+    const authUrl = new URL(request.url());
+    const callbackUrl = new URL(authUrl.searchParams.get("redirectTo") ?? "");
+
+    expect(authUrl.searchParams.get("locale")).toBe("de");
+    expect(callbackUrl.searchParams.get("next")).toBe(`/de${source.href}`);
+
+    await expect(
+      prisma.courseEditionRequest.count({ where: { sourceCourseId: source.course.id } }),
+    ).resolves.toBe(0);
+  });
+
+  test("keeps the enrolled edition when opened from My Courses or a chapter", async ({
+    noProgressUser,
+    userWithoutProgress,
+  }) => {
+    const [source, target] = await Promise.all([createCourse(), createCourse({ language: "en" })]);
+
+    await Promise.all([
+      connectKnownPrompt({ source, target }),
+      courseUserFixture({ courseId: source.course.id, userId: noProgressUser.id }),
+    ]);
+
+    await userWithoutProgress.goto("/my");
+
+    await userWithoutProgress
+      .getByRole("link", { name: new RegExp(source.course.title, "u") })
+      .click();
+
+    await expect(userWithoutProgress).toHaveURL(`${source.href}?edition=original`);
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { level: 1, name: source.course.title }),
+    ).toBeVisible();
+
+    await userWithoutProgress
+      .getByRole("link", { name: new RegExp(source.chapter.title, "u") })
+      .click();
+
+    await expect(userWithoutProgress).toHaveURL(`${source.href}/ch/${source.chapter.slug}`);
+    await userWithoutProgress.getByRole("link", { exact: true, name: source.course.title }).click();
+
+    await expect(userWithoutProgress).toHaveURL(`${source.href}?edition=original`);
+
+    await userWithoutProgress
+      .getByRole("region", { name: "Course language" })
+      .getByRole("link", { name: "Learn in English" })
+      .click();
+
+    await expect(userWithoutProgress).toHaveURL(target.href);
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { level: 1, name: target.course.title }),
+    ).toBeVisible();
+  });
+
+  test("does not offer to teach a language through itself", async ({ page }) => {
+    const source = await createCourse({ format: "language", targetLanguage: "en" });
+    await page.goto(source.href);
+
+    const languageChoice = page.getByRole("region", { name: "Course language" });
+
+    await expect(languageChoice).toContainText(
+      "This course teaches English, with explanations in Portuguese.",
+    );
+
+    await expect(languageChoice.getByRole("button", { name: "Learn in English" })).toHaveCount(0);
+    await languageChoice.getByRole("link", { name: "Continue in Portuguese" }).click();
+    await expect(page).toHaveURL(`${source.href}?edition=original`);
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(source.chapter.title, "u") }),
+    ).toBeVisible();
+  });
+
+  test("recovers the original zero-chapter course in the current UI language", async ({
+    userWithoutProgress,
+  }) => {
+    const source = await createCourse({ language: "en" });
+
+    await Promise.all([
+      prisma.chapter.delete({ where: { id: source.chapter.id } }),
+      prisma.course.update({
+        data: { generationStatus: "running" },
+        where: { id: source.course.id },
+      }),
+    ]);
+
+    const prompt = await coursePromptFixture({
+      canonicalTitle: source.course.title,
+      courseId: source.course.id,
+      generationRunId: null,
+      generationStatus: "running",
+      language: "en",
+    });
+
+    // Exercise the real source-prompt lookup and recovery trigger while keeping
+    // the external generation service from producing content during E2E.
+    await routeGenerationApis({
+      handler: async (route) => {
+        if (isGenerationTrigger({ request: route.request(), targetType: "coursePrompt" })) {
+          await route.fulfill({
+            body: JSON.stringify({ id: `recovery-${prompt.id}`, status: "pending" }),
+            contentType: "application/json",
+            status: 202,
+          });
+
+          return;
+        }
+
+        if (isGenerationEvents(route.request().url())) {
+          await route.fulfill({
+            body: `data: ${JSON.stringify({ status: "started", step: "getCoursePrompt" })}\n\n`,
+            contentType: "text/event-stream",
+            status: 200,
+          });
+
+          return;
+        }
+
+        await route.continue();
+      },
+      page: userWithoutProgress,
+    });
+
+    await userWithoutProgress.goto(`/pt${source.href}?edition=original`);
+    await expect(userWithoutProgress).toHaveURL(`/pt/generate/course/${prompt.id}`);
+
+    await expect
+      .poll(() =>
+        getGenerationTriggerRequests({ page: userWithoutProgress, targetType: "coursePrompt" }),
+      )
+      .toHaveLength(1);
+
+    const [trigger] = await getGenerationTriggerRequests({
+      page: userWithoutProgress,
+      targetType: "coursePrompt",
+    });
+
+    expect(trigger?.postDataJSON()).toEqual({ target: { id: prompt.id, type: "coursePrompt" } });
+  });
+
+  test("follows a winning generation run and its real Portuguese slug without a completion event", async ({
+    userWithoutProgress,
+  }) => {
+    const target = await createCourse({ format: "language", targetLanguage: "ja" });
+    const originalRunId = `original-${randomUUID()}`;
+    const winningRunId = `winning-${randomUUID()}`;
+
+    await prisma.course.update({
+      data: { generationRunId: winningRunId, generationStatus: "running" },
+      where: { id: target.course.id },
+    });
+
+    const prompt = await coursePromptFixture({
+      canonicalTitle: `A different generated title ${randomUUID()}`,
+      courseFormat: "language",
+      generationRunId: originalRunId,
+      generationStatus: "running",
+      language: "pt",
+      targetLanguage: "ja",
+    });
+
+    // The workflow service is the external boundary; its durable handoff and
+    // completion are persisted exactly as the real workflow writes them.
+    await routeGenerationApis({
+      handler: async (route) => {
+        const url = new URL(route.request().url());
+
+        if (!isGenerationEvents(url.toString())) {
+          await route.continue();
+          return;
+        }
+
+        if (url.pathname.includes(originalRunId)) {
+          await prisma.coursePrompt.updateMany({
+            data: { courseId: target.course.id, generationRunId: winningRunId },
+            where: { generationRunId: originalRunId, id: prompt.id },
+          });
+        }
+
+        if (url.pathname.includes(winningRunId)) {
+          await Promise.all([
+            prisma.course.update({
+              data: { generationStatus: "completed" },
+              where: { id: target.course.id },
+            }),
+            prisma.coursePrompt.update({
+              data: { generationStatus: "completed" },
+              where: { id: prompt.id },
+            }),
+          ]);
+        }
+
+        await route.fulfill({
+          body: `data: ${JSON.stringify({ status: "started", step: "getCoursePrompt" })}\n\n`,
+          contentType: "text/event-stream",
+          status: 200,
+        });
+      },
+      page: userWithoutProgress,
+    });
+
+    await userWithoutProgress.goto(`/pt/generate/course/${prompt.id}`);
+
+    await expect(userWithoutProgress).toHaveURL(`/pt${target.href}?edition=original`, {
+      timeout: 20_000,
+    });
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { level: 1, name: target.course.title }),
+    ).toBeVisible();
+
+    await expect(
+      getGenerationTriggerRequests({ page: userWithoutProgress, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(0);
+  });
+
+  test("keeps a retry active while the old failure is stored and then follows the winning run", async ({
+    userWithoutProgress,
+  }) => {
+    const target = await createCourse();
+    const retryRunId = `retry-${randomUUID()}`;
+    const winningRunId = `winning-${randomUUID()}`;
+    const releaseRetryStream = Promise.withResolvers<null>();
+
+    await prisma.course.update({
+      data: { generationRunId: winningRunId, generationStatus: "running" },
+      where: { id: target.course.id },
+    });
+
+    const prompt = await coursePromptFixture({
+      canonicalTitle: `Retried course ${randomUUID()}`,
+      generationRunId: null,
+      generationStatus: "failed",
+      language: "pt",
+    });
+
+    // A retried workflow may still be resolving identity when the first real
+    // prompt poll sees the previous failure. Hold only the external event stream;
+    // the server action reads the actual database throughout this handoff.
+    await routeGenerationApis({
+      handler: async (route) => {
+        if (isGenerationTrigger({ request: route.request(), targetType: "coursePrompt" })) {
+          await route.fulfill({
+            body: JSON.stringify({ id: retryRunId, status: "pending" }),
+            contentType: "application/json",
+            status: 202,
+          });
+
+          return;
+        }
+
+        const url = new URL(route.request().url());
+
+        if (
+          route.request().method() === "GET" &&
+          url.pathname === `/v1/generations/${retryRunId}`
+        ) {
+          await route.fulfill({
+            body: JSON.stringify({ id: retryRunId, status: "running" }),
+            contentType: "application/json",
+            status: 200,
+          });
+
+          return;
+        }
+
+        if (!isGenerationEvents(url.toString())) {
+          await route.continue();
+          return;
+        }
+
+        if (url.pathname.includes(retryRunId)) {
+          await releaseRetryStream.promise;
+        }
+
+        if (url.pathname.includes(winningRunId)) {
+          await Promise.all([
+            prisma.course.update({
+              data: { generationStatus: "completed" },
+              where: { id: target.course.id },
+            }),
+            prisma.coursePrompt.update({
+              data: { generationStatus: "completed" },
+              where: { id: prompt.id },
+            }),
+          ]);
+        }
+
+        await route.fulfill({
+          body: `data: ${JSON.stringify({ status: "started", step: "getCoursePrompt" })}\n\n`,
+          contentType: "text/event-stream",
+          status: 200,
+        });
+      },
+      page: userWithoutProgress,
+    });
+
+    await userWithoutProgress.goto(`/pt/generate/course/${prompt.id}`);
+
+    await expect
+      .poll(
+        async () => {
+          const requests = await userWithoutProgress.requests();
+
+          return requests.filter(
+            (request) =>
+              request.method() === "POST" &&
+              Boolean(request.headers()["next-action"]) &&
+              new URL(request.url()).pathname === `/pt/generate/course/${prompt.id}`,
+          ).length;
+        },
+        { timeout: 15_000 },
+      )
+      .toBeGreaterThanOrEqual(2);
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: prompt.id } }),
+    ).resolves.toMatchObject({ generationStatus: "failed" });
+
+    await prisma.coursePrompt.update({
+      data: {
+        courseId: target.course.id,
+        generationRunId: winningRunId,
+        generationStatus: "running",
+      },
+      where: { id: prompt.id },
+    });
+
+    releaseRetryStream.resolve(null);
+
+    await expect(userWithoutProgress).toHaveURL(`/pt${target.href}?edition=original`, {
+      timeout: 20_000,
+    });
+
+    await expect(
+      userWithoutProgress.getByRole("heading", { level: 1, name: target.course.title }),
+    ).toBeVisible();
+
+    await expect(
+      getGenerationTriggerRequests({ page: userWithoutProgress, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(1);
+  });
+});
+
+test.describe("Browser language preferences for course editions", () => {
+  test.use({ locale: "de-DE" });
+
+  test("omits browser-language suggestions when the UI and course languages match", async ({
+    page,
+  }) => {
+    const [source, target] = await Promise.all([
+      createCourse({ language: "en" }),
+      createCourse({ language: "de" }),
+    ]);
+
+    await connectKnownPrompt({ source, target });
+    await page.goto("/courses");
+    await expect(page).toHaveURL("/de/courses");
+
+    const cookies = await page.context().cookies();
+    expect(cookies.some((cookie) => cookie.name === LOCALE_COOKIE)).toBe(false);
+
+    await page.goto(source.href);
+
+    await expect(page).toHaveURL(source.href);
+    await expect(page.getByRole("heading", { level: 1, name: source.course.title })).toBeVisible();
+
+    await expect(
+      page.getByRole("link", { name: new RegExp(source.chapter.title, "u") }),
+    ).toBeVisible();
+
+    await expect(page.getByRole("region", { name: "Course language" })).toHaveCount(0);
+
+    await expect(
+      getGenerationTriggerRequests({ page, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(0);
+  });
+});

--- a/apps/main/e2e/course-editions.test.ts
+++ b/apps/main/e2e/course-editions.test.ts
@@ -147,6 +147,8 @@ test.describe("Course language editions", () => {
     await page.getByRole("button", { name: "Learn in English" }).click();
 
     const request = await authRequest;
+    await expect(page.getByText("Auth app", { exact: true })).toBeVisible();
+
     const authUrl = new URL(request.url());
     const callbackUrl = new URL(authUrl.searchParams.get("redirectTo") ?? "");
 
@@ -232,6 +234,8 @@ test.describe("Course language editions", () => {
     await page.getByRole("button", { name: "Auf Deutsch lernen" }).click();
 
     const request = await authRequest;
+    await expect(page.getByText("Auth app", { exact: true })).toBeVisible();
+
     const authUrl = new URL(request.url());
     const callbackUrl = new URL(authUrl.searchParams.get("redirectTo") ?? "");
 

--- a/apps/main/e2e/generate-course.test.ts
+++ b/apps/main/e2e/generate-course.test.ts
@@ -3,7 +3,9 @@ import {
   COURSE_COMPLETION_STEP,
   INTRODUCTION_LESSON_COMPLETION_STEP,
 } from "@zoonk/core/workflows/steps";
+import { prisma } from "@zoonk/db";
 import { type Page, type Route } from "@zoonk/e2e/fixtures";
+import { setLocale } from "@zoonk/e2e/fixtures/locale";
 import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
 import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
 import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
@@ -164,12 +166,14 @@ async function setupMockApis(page: Page, options: MockApiOptions = {}): Promise<
 async function createPublishedCourseWithLesson({
   format,
   generationStatus,
+  language = "en",
   slug,
   targetLanguage,
   title,
 }: {
   format?: "core" | "language";
   generationStatus?: "completed" | "running";
+  language?: string;
   slug: string;
   targetLanguage?: string;
   title: string;
@@ -180,6 +184,7 @@ async function createPublishedCourseWithLesson({
     ...(format ? { format } : {}),
     ...(generationStatus ? { generationStatus } : {}),
     isPublished: true,
+    language,
     organizationId: org.id,
     slug,
     ...(targetLanguage ? { targetLanguage } : {}),
@@ -189,6 +194,7 @@ async function createPublishedCourseWithLesson({
   const chapter = await chapterFixture({
     courseId: course.id,
     isPublished: true,
+    language,
     organizationId: org.id,
     position: 0,
   });
@@ -196,6 +202,7 @@ async function createPublishedCourseWithLesson({
   const lesson = await lessonFixture({
     chapterId: chapter.id,
     isPublished: true,
+    language,
     organizationId: org.id,
     position: 0,
   });
@@ -216,7 +223,282 @@ function getIntroLessonCompletionTarget({
   return `${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`;
 }
 
+/** The workflow fails durably but its error event never reaches the browser. */
+async function setupFailedRunWithoutEvent({
+  beforeRunStatus,
+  page,
+  runStatus = "failed",
+}: {
+  beforeRunStatus?: (coursePromptId: string) => Promise<void>;
+  page: Page;
+  runStatus?: "completed" | "failed";
+}) {
+  const runId = `failed-progress-${randomUUID()}`;
+
+  const prompt = await coursePromptFixture({
+    canonicalTitle: `Failed course ${randomUUID()}`,
+    courseFormat: "language",
+    generationRunId: runId,
+    generationStatus: "running",
+    language: "en",
+    targetLanguage: "ja",
+  });
+
+  await routeGenerationApis({
+    handler: async (route) => {
+      const url = new URL(route.request().url());
+
+      if (isGenerationEvents(url.toString())) {
+        await prisma.coursePrompt.updateMany({
+          data: { generationRunId: null, generationStatus: "failed" },
+          where: { generationRunId: runId, id: prompt.id },
+        });
+
+        await route.abort("failed");
+        return;
+      }
+
+      if (url.pathname === `/v1/generations/${runId}`) {
+        await beforeRunStatus?.(prompt.id);
+
+        await route.fulfill({
+          body: JSON.stringify({ id: runId, status: runStatus }),
+          contentType: "application/json",
+          status: 200,
+        });
+
+        return;
+      }
+
+      await route.continue();
+    },
+    page,
+  });
+
+  return prompt;
+}
+
 test.describe("Generate Course Page", () => {
+  for (const language of ["en", "pt"] as const) {
+    test(`refreshes a warmed empty ${language} course after generation finishes`, async ({
+      authenticatedPage,
+    }) => {
+      const organization = await getAiOrganization();
+      const runId = `warm-course-${randomUUID()}`;
+      const releaseStream = Promise.withResolvers<null>();
+
+      const course = await courseFixture({
+        format: "language",
+        generationRunId: runId,
+        generationStatus: "running",
+        isPublished: true,
+        language,
+        organizationId: organization.id,
+        slug: `warm-course-${randomUUID()}-${language}`,
+        targetLanguage: "ja",
+        title: `Japanese ${randomUUID()}`,
+      });
+
+      const prompt = await coursePromptFixture({
+        canonicalTitle: course.title,
+        courseFormat: "language",
+        courseId: course.id,
+        generationRunId: runId,
+        generationStatus: "running",
+        language,
+        targetLanguage: "ja",
+      });
+
+      await routeGenerationApis({
+        handler: async (route) => {
+          if (!isGenerationEvents(route.request().url())) {
+            await route.continue();
+            return;
+          }
+
+          await releaseStream.promise;
+
+          await route.fulfill({
+            body: createSSEStream([
+              { entityId: course.slug, status: "completed", step: COURSE_COMPLETION_STEP },
+            ]),
+            contentType: "text/event-stream",
+            status: 200,
+          });
+        },
+        page: authenticatedPage,
+      });
+
+      const prefix = language === "en" ? "" : `/${language}`;
+      const courseHref = `${prefix}/b/ai/c/${course.slug}?edition=original`;
+      await setLocale(authenticatedPage, "de");
+
+      // Visiting the empty course first warms the exact cache entries that
+      // completion must expire before returning to the selected edition.
+      await authenticatedPage.goto(courseHref);
+      await expect(authenticatedPage).toHaveURL(`${prefix}/generate/course/${prompt.id}`);
+      await expect(authenticatedPage.getByRole("progressbar")).toBeVisible();
+
+      await expect(authenticatedPage.evaluate(() => document.documentElement.lang)).resolves.toBe(
+        language,
+      );
+
+      const chapter = await chapterFixture({
+        courseId: course.id,
+        isPublished: true,
+        language,
+        organizationId: organization.id,
+        title: `Completed curriculum ${randomUUID()}`,
+      });
+
+      await Promise.all([
+        prisma.course.update({ data: { generationStatus: "completed" }, where: { id: course.id } }),
+        prisma.coursePrompt.update({
+          data: { generationStatus: "completed" },
+          where: { id: prompt.id },
+        }),
+      ]);
+
+      releaseStream.resolve(null);
+
+      await expect(
+        authenticatedPage.getByRole("link", { name: new RegExp(chapter.title, "u") }),
+      ).toBeVisible({ timeout: 15_000 });
+
+      await expect(authenticatedPage).toHaveURL(courseHref);
+    });
+  }
+
+  test("keeps an English edition action in English despite a saved German preference", async ({
+    authenticatedPage,
+  }) => {
+    const { course } = await createPublishedCourseWithLesson({
+      language: "pt",
+      slug: `english-edition-action-${randomUUID()}-pt`,
+      title: `Portuguese course ${randomUUID()}`,
+    });
+
+    const prompt = await coursePromptFixture({
+      canonicalTitle: `English edition ${randomUUID()}`,
+      generationStatus: "pending",
+      language: "en",
+    });
+
+    await prisma.courseEditionRequest.create({
+      data: { coursePromptId: prompt.id, language: "en", sourceCourseId: course.id },
+    });
+
+    await setupMockApis(authenticatedPage, {
+      streamMessages: [{ status: "started", step: "getCoursePrompt" }],
+    });
+
+    await setLocale(authenticatedPage, "de");
+    await authenticatedPage.goto(`/b/ai/c/${course.slug}`);
+    await authenticatedPage.getByRole("button", { name: "Learn in English" }).click();
+
+    await expect(authenticatedPage).toHaveURL(`/generate/course/${prompt.id}`);
+
+    await expect(
+      authenticatedPage.getByRole("heading", {
+        name: `Creating the ${prompt.canonicalTitle} course`,
+      }),
+    ).toBeVisible();
+
+    await expect(authenticatedPage.evaluate(() => document.documentElement.lang)).resolves.toBe(
+      "en",
+    );
+  });
+
+  test("keeps English edition sign-in in English despite a saved German preference", async ({
+    page,
+  }) => {
+    const { course } = await createPublishedCourseWithLesson({
+      language: "pt",
+      slug: `english-edition-login-${randomUUID()}-pt`,
+      title: `Portuguese course ${randomUUID()}`,
+    });
+
+    const courseHref = `/b/ai/c/${course.slug}`;
+    const authUrls: URL[] = [];
+
+    await page.route("**/auth/login**", async (route) => {
+      authUrls.push(new URL(route.request().url()));
+      await route.fulfill({ body: "Auth app", contentType: "text/html", status: 200 });
+    });
+
+    await setLocale(page, "de");
+    await page.goto(courseHref);
+    await page.getByRole("button", { name: "Learn in English" }).click();
+    await expect.poll(() => authUrls.length).toBe(1);
+
+    const authUrl = authUrls.at(0);
+    expect(authUrl?.searchParams.get("locale")).toBe("en");
+
+    const callbackUrl = new URL(authUrl?.searchParams.get("redirectTo") ?? "");
+    expect(callbackUrl.searchParams.get("next")).toBe(courseHref);
+  });
+
+  test("lets guests follow an existing run without starting generation", async ({ page }) => {
+    const { course } = await createPublishedCourseWithLesson({
+      format: "language",
+      generationStatus: "running",
+      slug: `guest-progress-${randomUUID()}`,
+      targetLanguage: "ja",
+      title: `Japanese ${randomUUID()}`,
+    });
+
+    const runId = `guest-progress-${randomUUID()}`;
+
+    const prompt = await coursePromptFixture({
+      canonicalTitle: course.title,
+      courseFormat: "language",
+      courseId: course.id,
+      generationRunId: runId,
+      generationStatus: "running",
+      language: "en",
+      targetLanguage: "ja",
+    });
+
+    // Only the external workflow service is replaced. Readiness remains a real
+    // server-action read of the persisted course and prompt.
+    await routeGenerationApis({
+      handler: async (route) => {
+        if (!isGenerationEvents(route.request().url())) {
+          await route.continue();
+          return;
+        }
+
+        await Promise.all([
+          prisma.course.update({
+            data: { generationStatus: "completed" },
+            where: { id: course.id },
+          }),
+          prisma.coursePrompt.update({
+            data: { generationStatus: "completed" },
+            where: { id: prompt.id },
+          }),
+        ]);
+
+        await route.fulfill({
+          body: createSSEStream([{ status: "started", step: "getCoursePrompt" }]),
+          contentType: "text/event-stream",
+          status: 200,
+        });
+      },
+      page,
+    });
+
+    await page.goto(`/generate/course/${prompt.id}`);
+    await expect(page.getByRole("progressbar")).toBeVisible();
+
+    await expect(page).toHaveURL(`/b/ai/c/${course.slug}?edition=original`, { timeout: 15_000 });
+    await expect(page.getByRole("heading", { level: 1, name: course.title })).toBeVisible();
+
+    await expect(
+      getGenerationTriggerRequests({ page, targetType: "coursePrompt" }),
+    ).resolves.toHaveLength(0);
+  });
+
   test("asks unauthenticated users to log in without starting generation", async ({ page }) => {
     const coursePrompt = await coursePromptFixture({
       canonicalTitle: "E2E Unauth Course Generation",
@@ -518,7 +800,9 @@ test.describe("Generate Course Page", () => {
 
       await authenticatedPage.goto(`/generate/course/${request.id}`);
 
-      await authenticatedPage.waitForURL(`/b/ai/c/${courseSlug}`, { timeout: 10_000 });
+      await authenticatedPage.waitForURL(`/b/ai/c/${courseSlug}?edition=original`, {
+        timeout: 10_000,
+      });
     });
 
     test("shows completion state and redirects to the first intro lesson", async ({
@@ -634,7 +918,9 @@ test.describe("Generate Course Page", () => {
 
       await authenticatedPage.goto(`/generate/course/${request.id}`);
 
-      await authenticatedPage.waitForURL(`/b/ai/c/${courseSlug}`, { timeout: 10_000 });
+      await authenticatedPage.waitForURL(`/b/ai/c/${courseSlug}?edition=original`, {
+        timeout: 10_000,
+      });
     });
 
     test("redirects to suffixed slug intro lesson for non-English courses", async ({
@@ -671,6 +957,210 @@ test.describe("Generate Course Page", () => {
   });
 
   test.describe("Error handling", () => {
+    test("recovers the actual failed run when its error event is lost", async ({
+      authenticatedPage,
+    }) => {
+      const prompt = await setupFailedRunWithoutEvent({ page: authenticatedPage });
+      await authenticatedPage.goto(`/generate/course/${prompt.id}`);
+
+      await expect(authenticatedPage.getByRole("button", { name: "Try again" })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await expect(
+        prisma.coursePrompt.findUniqueOrThrow({ where: { id: prompt.id } }),
+      ).resolves.toMatchObject({ generationRunId: null, generationStatus: "failed" });
+
+      await expect(
+        getGenerationTriggerRequests({ page: authenticatedPage, targetType: "coursePrompt" }),
+      ).resolves.toHaveLength(0);
+    });
+
+    test("detects a failed joined winner after the initiating run already completed", async ({
+      authenticatedPage,
+    }) => {
+      // An identity handoff completes the initiating workflow before the first
+      // poll. Its winner then fails, clearing the prompt's winning run ID.
+      const prompt = await setupFailedRunWithoutEvent({
+        page: authenticatedPage,
+        runStatus: "completed",
+      });
+
+      await authenticatedPage.goto(`/generate/course/${prompt.id}`);
+
+      await expect(authenticatedPage.getByRole("button", { name: "Try again" })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await expect(
+        getGenerationTriggerRequests({ page: authenticatedPage, targetType: "coursePrompt" }),
+      ).resolves.toHaveLength(0);
+    });
+
+    test("rereads a failed prompt after its followed run finishes before showing an error", async ({
+      authenticatedPage,
+    }) => {
+      const { course } = await createPublishedCourseWithLesson({
+        format: "language",
+        slug: `completed-during-status-${randomUUID()}`,
+        targetLanguage: "ja",
+        title: `Japanese ${randomUUID()}`,
+      });
+
+      const prompt = await setupFailedRunWithoutEvent({
+        beforeRunStatus: async (coursePromptId) => {
+          await prisma.coursePrompt.update({
+            data: { courseId: course.id, generationStatus: "completed" },
+            where: { id: coursePromptId },
+          });
+        },
+        page: authenticatedPage,
+        runStatus: "completed",
+      });
+
+      await authenticatedPage.goto(`/generate/course/${prompt.id}`);
+
+      await expect(authenticatedPage.getByRole("button", { name: "Try again" })).toHaveCount(0);
+
+      await expect(authenticatedPage).toHaveURL(`/b/ai/c/${course.slug}?edition=original`, {
+        timeout: 15_000,
+      });
+
+      await expect(
+        authenticatedPage.getByRole("heading", { level: 1, name: course.title }),
+      ).toBeVisible();
+    });
+
+    test("requires guest sign-in before retrying a followed run that failed", async ({ page }) => {
+      const prompt = await setupFailedRunWithoutEvent({ page });
+      await page.goto(`/generate/course/${prompt.id}`);
+
+      await expect(page.getByRole("button", { name: "Try again" })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await page.getByRole("button", { name: "Try again" }).click();
+
+      await expect(page).toHaveURL(
+        `/login?next=${encodeURIComponent(`/en/generate/course/${prompt.id}`)}`,
+      );
+
+      await expect(
+        getGenerationTriggerRequests({ page, targetType: "coursePrompt" }),
+      ).resolves.toHaveLength(0);
+    });
+
+    test("accepts prompt readiness when a retry starts during an older run status read", async ({
+      authenticatedPage,
+    }) => {
+      const oldRunId = `older-status-${randomUUID()}`;
+      const retryRunId = `retry-status-${randomUUID()}`;
+      const oldStatusRequested = Promise.withResolvers<null>();
+      const releaseOldStatus = Promise.withResolvers<null>();
+      const retryStarted = Promise.withResolvers<null>();
+
+      const { course } = await createPublishedCourseWithLesson({
+        format: "language",
+        slug: `retry-during-status-${randomUUID()}`,
+        targetLanguage: "ja",
+        title: `Japanese ${randomUUID()}`,
+      });
+
+      const prompt = await coursePromptFixture({
+        canonicalTitle: course.title,
+        courseFormat: "language",
+        generationRunId: oldRunId,
+        generationStatus: "running",
+        language: "en",
+        targetLanguage: "ja",
+      });
+
+      // Hold only the external run resource. Prompt readiness stays a real
+      // server-action read, including the read that crosses a local retry.
+      await routeGenerationApis({
+        handler: async (route) => {
+          const request = route.request();
+          const pathname = new URL(request.url()).pathname;
+
+          if (isGenerationTrigger({ request, targetType: "coursePrompt" })) {
+            await route.fulfill({
+              body: JSON.stringify({ id: retryRunId, status: "pending" }),
+              contentType: "application/json",
+              status: 202,
+            });
+
+            return;
+          }
+
+          if (pathname === `/v1/generations/${oldRunId}/events`) {
+            await prisma.coursePrompt.updateMany({
+              data: { generationRunId: null, generationStatus: "failed" },
+              where: { generationRunId: oldRunId, id: prompt.id },
+            });
+
+            await oldStatusRequested.promise;
+
+            await route.fulfill({
+              body: createSSEStream([
+                { reason: "notFound", status: "error", step: "getCoursePrompt" },
+              ]),
+              contentType: "text/event-stream",
+              status: 200,
+            });
+
+            return;
+          }
+
+          if (pathname === `/v1/generations/${oldRunId}`) {
+            oldStatusRequested.resolve(null);
+            await releaseOldStatus.promise;
+
+            await route.fulfill({
+              body: JSON.stringify({ id: oldRunId, status: "completed" }),
+              contentType: "application/json",
+              status: 200,
+            });
+
+            return;
+          }
+
+          if (pathname === `/v1/generations/${retryRunId}/events`) {
+            await prisma.coursePrompt.update({
+              data: { courseId: course.id, generationStatus: "completed" },
+              where: { id: prompt.id },
+            });
+
+            retryStarted.resolve(null);
+
+            await route.fulfill({
+              body: createSSEStream([{ status: "started", step: "getCoursePrompt" }]),
+              contentType: "text/event-stream",
+              status: 200,
+            });
+
+            return;
+          }
+
+          await route.continue();
+        },
+        page: authenticatedPage,
+      });
+
+      await authenticatedPage.goto(`/generate/course/${prompt.id}`);
+      await oldStatusRequested.promise;
+      await authenticatedPage.getByRole("button", { name: "Try again" }).click();
+      await retryStarted.promise;
+      releaseOldStatus.resolve(null);
+
+      await expect(authenticatedPage).toHaveURL(`/b/ai/c/${course.slug}?edition=original`, {
+        timeout: 15_000,
+      });
+
+      await expect(
+        authenticatedPage.getByRole("heading", { level: 1, name: course.title }),
+      ).toBeVisible();
+    });
+
     test("shows error when stream returns error status", async ({ authenticatedPage }) => {
       const request = await coursePromptFixture({
         canonicalTitle: "E2E Error Handling Test",

--- a/apps/main/e2e/lesson-completion.test.ts
+++ b/apps/main/e2e/lesson-completion.test.ts
@@ -301,7 +301,6 @@ test.describe("Lesson Completion UX", () => {
     const { lessonUrl, lesson2, uniqueId } = await createLessonCompleteScenario("lnext");
 
     await page.goto(lessonUrl);
-    await page.waitForLoadState("networkidle");
     await expect(page.getByText("Lesson 1 of 2")).toBeVisible();
     await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
@@ -330,7 +329,6 @@ test.describe("Lesson Completion UX", () => {
     const { chapter, lessonUrl, uniqueId } = await createLessonCompleteScenario("lrev");
 
     await page.goto(lessonUrl);
-    await page.waitForLoadState("networkidle");
     await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
@@ -354,7 +352,6 @@ test.describe("Lesson Completion UX", () => {
       await createChapterCompleteScenario("chnext");
 
     await page.goto(lessonUrl);
-    await page.waitForLoadState("networkidle");
     await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
@@ -378,7 +375,6 @@ test.describe("Lesson Completion UX", () => {
     const { lessonUrl, chapter1, uniqueId } = await createChapterCompleteScenario("chrev");
 
     await page.goto(lessonUrl);
-    await page.waitForLoadState("networkidle");
     await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
@@ -395,7 +391,6 @@ test.describe("Lesson Completion UX", () => {
     const { lessonUrl, uniqueId } = await createChapterCompleteScenario("chrestart");
 
     await page.goto(lessonUrl);
-    await page.waitForLoadState("networkidle");
     await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     await page
@@ -421,7 +416,6 @@ test.describe("Lesson Completion UX", () => {
       await createChapterCompleteWithUngeneratedNextChapterScenario("chpending");
 
     await page.goto(lessonUrl);
-    await page.waitForLoadState("networkidle");
     await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
@@ -451,7 +445,6 @@ test.describe("Lesson Completion UX", () => {
     const { lessonUrl, course, uniqueId } = await createCourseCompleteScenario("crsrev");
 
     await page.goto(lessonUrl);
-    await page.waitForLoadState("networkidle");
     await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");
@@ -518,7 +511,6 @@ test.describe("Lesson Completion UX", () => {
     await createQuizLesson(lesson1.id, uniqueId);
 
     await page.goto(`/b/${AI_ORG_SLUG}/c/${course.slug}/ch/${chapter.slug}/l/${lesson1.slug}`);
-    await page.waitForLoadState("networkidle");
     await completeQuizAndShowCompletionSummary({ page, uniqueId });
 
     const completionScreen = page.getByRole("status");

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -739,7 +739,7 @@ test.describe("Lesson Player Page", () => {
     const chapterPath = `/b/ai/c/${course.slug}/ch/${chapter.slug}`;
 
     await setLocale(authenticatedPage, "pt");
-    await authenticatedPage.goto(`${chapterPath}/l/${lesson.slug}`);
+    await authenticatedPage.goto(`/pt${chapterPath}/l/${lesson.slug}`);
 
     await expect(authenticatedPage).toHaveURL(
       new RegExp(`/pt${chapterPath}/l/${lesson.slug}$`, "u"),
@@ -1005,12 +1005,14 @@ test.describe("Lesson Player Page", () => {
     await expect(page.getByText(/not found|404/iu)).toBeVisible();
   });
 
-  test("uses stored lesson metadata and permits indexing", async ({ page }) => {
+  test("uses stored lesson metadata and indexes only the content locale", async ({ page }) => {
     const { chapter, course, lesson, lessonTitle, uniqueId } = await createTestLesson({
       generationStatus: "completed",
     });
 
-    await page.goto(`/pt/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`);
+    const lessonPath = `/b/ai/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}`;
+
+    await page.goto(lessonPath);
 
     await expect(page).toHaveTitle(new RegExp(`${lessonTitle}.*:.*${course.title}`, "u"));
 
@@ -1025,6 +1027,11 @@ test.describe("Lesson Player Page", () => {
       );
 
     await expectRobotsMeta({ page, value: "index, follow" });
+
+    await page.goto(`/pt${lessonPath}`);
+
+    await expect(page).toHaveTitle(new RegExp(`${lessonTitle}.*:.*${course.title}`, "u"));
+    await expectRobotsMeta({ page, value: "noindex, follow" });
   });
 
   test("page title uses the source topic for an indexable companion lesson", async ({ page }) => {

--- a/apps/main/e2e/lesson-questions.test.ts
+++ b/apps/main/e2e/lesson-questions.test.ts
@@ -931,7 +931,7 @@ test("confirms external links in a localized accessible dialog", async ({
 
   await mockQuestionApi({ lessonId: scenario.lessonId, page: authenticatedPage });
 
-  await authenticatedPage.goto(scenario.url);
+  await authenticatedPage.goto(`/pt${scenario.url}`);
 
   await authenticatedPage.getByRole("button", { name: "Pergunte sobre esta aula" }).click();
 
@@ -1592,7 +1592,7 @@ test("announces the initial question history load", async ({
 
   await expect(loadingStatus).toBeVisible();
   await expect(loadingStatus).toHaveText("Loading questions…");
-  expect(api.getRequests).toBe(1);
+  await expect.poll(() => api.getRequests).toBe(1);
   api.releaseGetResponse(1);
   await expect(loadingStatus).toHaveCount(0);
   await expect(dialog.getByText("What would you like help with?")).toBeVisible();

--- a/apps/main/e2e/sitemap.test.ts
+++ b/apps/main/e2e/sitemap.test.ts
@@ -8,17 +8,25 @@ import { stepFixture } from "@zoonk/testing/fixtures/steps";
 import { expect, test } from "./fixtures";
 
 /**
- * Checks each generated lesson sitemap page because a new fixture may sort
- * after the first 5,000 lesson URLs in a long-lived E2E database.
+ * Checks every sitemap page because a new fixture may sort after the first
+ * 5,000 URLs in a long-lived E2E database. Next.js returns 404 for IDs beyond
+ * generateSitemaps(), while page zero must always exist.
  */
-async function lessonSitemapContainsUrl({
+async function sitemapContainsUrl({
   expectedUrl,
   page = 0,
+  resource,
 }: {
   expectedUrl: string;
   page?: number;
+  resource: "courses" | "chapters" | "lessons";
 }): Promise<boolean> {
-  const response = await fetch(`${getBaseURL()}/sitemaps/lessons/sitemap/${page}.xml`);
+  const response = await fetch(`${getBaseURL()}/sitemaps/${resource}/sitemap/${page}.xml`);
+
+  if (page > 0 && response.status === 404) {
+    return false;
+  }
+
   expect(response.status).toBe(200);
 
   const body = await response.text();
@@ -32,7 +40,22 @@ async function lessonSitemapContainsUrl({
     return false;
   }
 
-  return lessonSitemapContainsUrl({ expectedUrl, page: page + 1 });
+  return sitemapContainsUrl({ expectedUrl, page: page + 1, resource });
+}
+
+async function expectPortugueseSitemapUrl({
+  path,
+  resource,
+}: {
+  path: string;
+  resource: "courses" | "chapters" | "lessons";
+}) {
+  const matches = await Promise.all([
+    sitemapContainsUrl({ expectedUrl: `<loc>https://www.zoonk.com/pt${path}</loc>`, resource }),
+    sitemapContainsUrl({ expectedUrl: `<loc>https://www.zoonk.com${path}</loc>`, resource }),
+  ]);
+
+  expect(matches).toStrictEqual([true, false]);
 }
 
 test.describe("robots.txt", () => {
@@ -75,8 +98,8 @@ test.describe("course sitemaps", () => {
   });
 });
 
-test.describe("lesson sitemaps", () => {
-  test("returns canonical URLs for indexable lessons", async () => {
+test.describe("catalog sitemaps", () => {
+  test("returns only matching locale URLs for indexable course content", async () => {
     const uniqueId = randomUUID().slice(0, 8);
     const organization = await getAiOrganization();
 
@@ -108,7 +131,44 @@ test.describe("lesson sitemaps", () => {
 
     await stepFixture({ isPublished: true, lessonId: lesson.id });
 
-    const expectedUrl = `<loc>https://www.zoonk.com/pt/b/${organization.slug}/c/${course.slug}/ch/${chapter.slug}/l/${lesson.slug}</loc>`;
-    expect(await lessonSitemapContainsUrl({ expectedUrl })).toBe(true);
+    const coursePath = `/b/${organization.slug}/c/${course.slug}`;
+    const chapterPath = `${coursePath}/ch/${chapter.slug}`;
+    const lessonPath = `${chapterPath}/l/${lesson.slug}`;
+
+    await Promise.all([
+      expectPortugueseSitemapUrl({ path: coursePath, resource: "courses" }),
+      expectPortugueseSitemapUrl({ path: chapterPath, resource: "chapters" }),
+      expectPortugueseSitemapUrl({ path: lessonPath, resource: "lessons" }),
+    ]);
+  });
+
+  test("excludes unsupported course languages throughout the catalog", async () => {
+    const organization = await getAiOrganization();
+
+    const course = await courseFixture({
+      isPublished: true,
+      language: "ja-JP",
+      organizationId: organization.id,
+    });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    await lessonFixture({
+      chapterId: chapter.id,
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
+    const matches = await Promise.all(
+      (["courses", "chapters", "lessons"] as const).map((resource) =>
+        sitemapContainsUrl({ expectedUrl: course.slug, resource }),
+      ),
+    );
+
+    expect(matches).toStrictEqual([false, false, false]);
   });
 });

--- a/apps/main/e2e/workflow-generation-race.test.ts
+++ b/apps/main/e2e/workflow-generation-race.test.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from "node:crypto";
+import { prisma } from "@zoonk/db";
+import { getAiOrganization } from "@zoonk/e2e/fixtures/orgs";
+import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { type Page, expect, test } from "./fixtures";
+import {
+  getGenerationLimitResponse,
+  getGenerationTriggerRequests,
+  isGenerationEvents,
+  isGenerationTrigger,
+  routeGenerationApis,
+} from "./generation-api";
+
+function getLateTriggerResponse({
+  outcome,
+  runId,
+}: {
+  outcome: "success" | "failure" | "quota";
+  runId: string;
+}) {
+  if (outcome === "quota") {
+    return getGenerationLimitResponse({
+      period: "day",
+      resource: "course",
+      viewer: "authenticated",
+    });
+  }
+
+  if (outcome === "failure") {
+    return { body: { error: "Generation service unavailable" }, status: 503 };
+  }
+
+  return { body: { id: runId, status: "pending" }, status: 202 };
+}
+
+async function expectWinningRun({
+  outcome,
+  page,
+}: {
+  outcome: "success" | "failure" | "quota";
+  page: Page;
+}) {
+  const organization = await getAiOrganization();
+  const triggerRunId = `trigger-${randomUUID()}`;
+  const winningRunId = `winning-${randomUUID()}`;
+  const winningStreamRequested = Promise.withResolvers<null>();
+  const triggerDelivered = Promise.withResolvers<null>();
+
+  const course = await courseFixture({
+    format: "language",
+    generationRunId: winningRunId,
+    generationStatus: "running",
+    isPublished: true,
+    organizationId: organization.id,
+    targetLanguage: "ja",
+  });
+
+  const prompt = await coursePromptFixture({ courseFormat: "language", targetLanguage: "ja" });
+  const lateResponse = getLateTriggerResponse({ outcome, runId: triggerRunId });
+
+  // Hold the external generation response until the real prompt read has
+  // joined the persisted winner. The server action and session remain real.
+  await routeGenerationApis({
+    handler: async (route) => {
+      if (isGenerationTrigger({ request: route.request(), targetType: "coursePrompt" })) {
+        await prisma.coursePrompt.update({
+          data: { courseId: course.id, generationRunId: winningRunId, generationStatus: "running" },
+          where: { id: prompt.id },
+        });
+
+        await winningStreamRequested.promise;
+
+        await route.fulfill({
+          body: JSON.stringify(lateResponse.body),
+          contentType: "application/json",
+          status: lateResponse.status,
+        });
+
+        triggerDelivered.resolve(null);
+        return;
+      }
+
+      const url = new URL(route.request().url());
+
+      if (!isGenerationEvents(url.toString())) {
+        await route.continue();
+        return;
+      }
+
+      if (url.pathname.includes(winningRunId)) {
+        winningStreamRequested.resolve(null);
+        await triggerDelivered.promise;
+      }
+
+      await route.fulfill({
+        body: `data: ${JSON.stringify({ status: "started", step: "getCoursePrompt" })}\n\n`,
+        contentType: "text/event-stream",
+        status: 200,
+      });
+    },
+    page,
+  });
+
+  const nextOutcome = Promise.race([
+    page
+      .waitForRequest((request) => {
+        const url = new URL(request.url());
+
+        return (
+          isGenerationEvents(url.toString()) &&
+          url.pathname.includes(winningRunId) &&
+          url.searchParams.get("_rc") === "1"
+        );
+      })
+      .then(() => "winner"),
+    page
+      .waitForRequest((request) => request.url().includes(`/generations/${triggerRunId}/events`))
+      .then(() => "stale trigger"),
+    page
+      .getByRole("button", { name: "Try again" })
+      .waitFor({ state: "visible" })
+      .then(() => "error"),
+    page
+      .getByRole("heading", { name: "Daily course limit reached" })
+      .waitFor({ state: "visible" })
+      .then(() => "quota"),
+  ]);
+
+  await page.goto(`/generate/course/${prompt.id}`);
+
+  expect(await nextOutcome).toBe("winner");
+  await expect(page.getByRole("progressbar", { name: "Progress" })).toBeVisible();
+
+  await expect(
+    getGenerationTriggerRequests({ page, targetType: "coursePrompt" }),
+  ).resolves.toHaveLength(1);
+}
+
+test("keeps the joined workflow after a delayed trigger success", async ({
+  userWithoutProgress,
+}) => {
+  await expectWinningRun({ outcome: "success", page: userWithoutProgress });
+});
+
+test("keeps the joined workflow after a delayed trigger failure", async ({
+  userWithoutProgress,
+}) => {
+  await expectWinningRun({ outcome: "failure", page: userWithoutProgress });
+});
+
+test("keeps the joined workflow after a delayed trigger quota", async ({ userWithoutProgress }) => {
+  await expectWinningRun({ outcome: "quota", page: userWithoutProgress });
+});

--- a/apps/main/messages/de.po
+++ b/apps/main/messages/de.po
@@ -435,6 +435,84 @@ msgctxt "Pf4uqS"
 msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "Das Einführungskapitel ist fertig. Wir erstellen noch den kompletten Lehrplan, daher werden hier bald mehr Kapitel erscheinen."
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "qzAEFi"
+msgid "Finding your course…"
+msgstr "Wir suchen deinen Kurs…"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Erneut versuchen"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "o3ujZ5"
+msgid "Learn in {language}"
+msgstr "Auf {language} lernen"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "DLssby"
+msgid "This course isn't available in {language} yet."
+msgstr "Dieser Kurs ist noch nicht auf {language} verfügbar."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "fpKX8o"
+msgid "We couldn't prepare your course. Please try again."
+msgstr "Wir konnten deinen Kurs nicht vorbereiten. Bitte versuche es noch einmal."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "IPMgvJ"
+msgid "View progress"
+msgstr "Fortschritt ansehen"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "1eG4JB"
+msgid "This course teaches {language}, with explanations in {sourceLanguage}."
+msgstr "In diesem Kurs lernst du {language}, die Erklärungen sind auf {sourceLanguage}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "0G8GRg"
+msgid "This course is taught in {sourceLanguage}. It isn't available in {language} yet."
+msgstr "Dieser Kurs ist auf {sourceLanguage}. Auf {language} ist er noch nicht verfügbar."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KgG3PI"
+msgid "Your {language} course is being prepared. You can follow its progress."
+msgstr "Dein Kurs auf {language} wird gerade vorbereitet. Du kannst den Fortschritt verfolgen."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "rUYK7J"
+msgid "We couldn't finish preparing this course in {language}. You can try again."
+msgstr "Beim Vorbereiten dieses Kurses auf {language} ist etwas schiefgegangen. Du kannst es noch einmal versuchen."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "_LY-RG"
+msgid "Switching languages opens a separate course. Your progress stays here."
+msgstr "Wenn du die Sprache wechselst, öffnet sich ein separater Kurs. Dein Fortschritt bleibt hier."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "ALdIan"
+msgid "This course is taught in {sourceLanguage}. We'll find it in {language} or create it for you."
+msgstr "Dieser Kurs ist auf {sourceLanguage}. Wir finden eine Version auf {language} oder erstellen sie für dich."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KYeXR4"
+msgid "Course language"
+msgstr "Kurssprache"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "c5dUwC"
+msgid "This course is in {language}"
+msgstr "Dieser Kurs ist auf {language}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "QN-YqC"
+msgid "Continue in {language}"
+msgstr "Auf {language} weitermachen"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/not-found.tsx
 msgctxt "KjYOfT"
 msgid "You found a course that hasn't been written yet"
@@ -500,12 +578,6 @@ msgstr "Lade mehr Kurse…"
 msgctxt "W_5hwr"
 msgid "Something went wrong. Please try again."
 msgstr "Etwas ist schiefgelaufen. Bitte versuche es erneut."
-
-#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-#: src/components/generation/workflow-generation-error.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Erneut versuchen"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
 msgctxt "WgPMAP"
@@ -1826,6 +1898,16 @@ msgid "Back home"
 msgstr "Zurück zur Startseite"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
+msgstr "Wir leiten dich zu deinem Kurs weiter…"
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Deine erste Lektion wird gleich geöffnet…"
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "15FsdE"
 msgid "Your course is ready"
 msgstr "Dein Kurs ist bereit"
@@ -1835,16 +1917,6 @@ msgstr "Dein Kurs ist bereit"
 msgctxt "4Wktrz"
 msgid "Your lesson is ready"
 msgstr "Deine Lektion ist fertig"
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "0o41MR"
-msgid "Taking you to your course..."
-msgstr "Wir leiten dich zu deinem Kurs weiter…"
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "RMDr0s"
-msgid "Taking you to your first lesson…"
-msgstr "Deine erste Lektion wird gleich geöffnet…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"

--- a/apps/main/messages/en.po
+++ b/apps/main/messages/en.po
@@ -435,6 +435,84 @@ msgctxt "Pf4uqS"
 msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "qzAEFi"
+msgid "Finding your course…"
+msgstr "Finding your course…"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Try again"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "o3ujZ5"
+msgid "Learn in {language}"
+msgstr "Learn in {language}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "DLssby"
+msgid "This course isn't available in {language} yet."
+msgstr "This course isn't available in {language} yet."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "fpKX8o"
+msgid "We couldn't prepare your course. Please try again."
+msgstr "We couldn't prepare your course. Please try again."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "IPMgvJ"
+msgid "View progress"
+msgstr "View progress"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "1eG4JB"
+msgid "This course teaches {language}, with explanations in {sourceLanguage}."
+msgstr "This course teaches {language}, with explanations in {sourceLanguage}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "0G8GRg"
+msgid "This course is taught in {sourceLanguage}. It isn't available in {language} yet."
+msgstr "This course is taught in {sourceLanguage}. It isn't available in {language} yet."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KgG3PI"
+msgid "Your {language} course is being prepared. You can follow its progress."
+msgstr "Your {language} course is being prepared. You can follow its progress."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "rUYK7J"
+msgid "We couldn't finish preparing this course in {language}. You can try again."
+msgstr "We couldn't finish preparing this course in {language}. You can try again."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "_LY-RG"
+msgid "Switching languages opens a separate course. Your progress stays here."
+msgstr "Switching languages opens a separate course. Your progress stays here."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "ALdIan"
+msgid "This course is taught in {sourceLanguage}. We'll find it in {language} or create it for you."
+msgstr "This course is taught in {sourceLanguage}. We'll find it in {language} or create it for you."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KYeXR4"
+msgid "Course language"
+msgstr "Course language"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "c5dUwC"
+msgid "This course is in {language}"
+msgstr "This course is in {language}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "QN-YqC"
+msgid "Continue in {language}"
+msgstr "Continue in {language}"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/not-found.tsx
 msgctxt "KjYOfT"
 msgid "You found a course that hasn't been written yet"
@@ -500,12 +578,6 @@ msgstr "Loading more courses…"
 msgctxt "W_5hwr"
 msgid "Something went wrong. Please try again."
 msgstr "Something went wrong. Please try again."
-
-#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-#: src/components/generation/workflow-generation-error.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Try again"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
 msgctxt "WgPMAP"
@@ -1826,6 +1898,16 @@ msgid "Back home"
 msgstr "Back home"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
+msgstr "Taking you to your course..."
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Taking you to your first lesson…"
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "15FsdE"
 msgid "Your course is ready"
 msgstr "Your course is ready"
@@ -1835,16 +1917,6 @@ msgstr "Your course is ready"
 msgctxt "4Wktrz"
 msgid "Your lesson is ready"
 msgstr "Your lesson is ready"
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "0o41MR"
-msgid "Taking you to your course..."
-msgstr "Taking you to your course..."
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "RMDr0s"
-msgid "Taking you to your first lesson…"
-msgstr "Taking you to your first lesson…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"

--- a/apps/main/messages/es.po
+++ b/apps/main/messages/es.po
@@ -435,6 +435,84 @@ msgctxt "Pf4uqS"
 msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "El capítulo de introducción está listo. Aún estamos creando el plan completo, así que pronto aparecerán más capítulos aquí."
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "qzAEFi"
+msgid "Finding your course…"
+msgstr "Buscando tu curso…"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Inténtalo de nuevo"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "o3ujZ5"
+msgid "Learn in {language}"
+msgstr "Aprende en {language}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "DLssby"
+msgid "This course isn't available in {language} yet."
+msgstr "Este curso aún no está disponible en {language}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "fpKX8o"
+msgid "We couldn't prepare your course. Please try again."
+msgstr "No pudimos preparar tu curso. Inténtalo de nuevo."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "IPMgvJ"
+msgid "View progress"
+msgstr "Ver el progreso"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "1eG4JB"
+msgid "This course teaches {language}, with explanations in {sourceLanguage}."
+msgstr "Este curso enseña {language}, con explicaciones en {sourceLanguage}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "0G8GRg"
+msgid "This course is taught in {sourceLanguage}. It isn't available in {language} yet."
+msgstr "Este curso se imparte en {sourceLanguage}. Aún no está disponible en {language}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KgG3PI"
+msgid "Your {language} course is being prepared. You can follow its progress."
+msgstr "Estamos preparando tu curso en {language}. Puedes seguir su progreso."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "rUYK7J"
+msgid "We couldn't finish preparing this course in {language}. You can try again."
+msgstr "No pudimos terminar de preparar este curso en {language}. Puedes intentarlo de nuevo."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "_LY-RG"
+msgid "Switching languages opens a separate course. Your progress stays here."
+msgstr "Al cambiar de idioma, se abre otro curso. Tu progreso se queda aquí."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "ALdIan"
+msgid "This course is taught in {sourceLanguage}. We'll find it in {language} or create it for you."
+msgstr "Este curso se imparte en {sourceLanguage}. Lo buscaremos en {language} o lo crearemos para ti."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KYeXR4"
+msgid "Course language"
+msgstr "Idioma del curso"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "c5dUwC"
+msgid "This course is in {language}"
+msgstr "Este curso está en {language}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "QN-YqC"
+msgid "Continue in {language}"
+msgstr "Continuar en {language}"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/not-found.tsx
 msgctxt "KjYOfT"
 msgid "You found a course that hasn't been written yet"
@@ -500,12 +578,6 @@ msgstr "Cargando más cursos…"
 msgctxt "W_5hwr"
 msgid "Something went wrong. Please try again."
 msgstr "Algo salió mal. Inténtalo de nuevo."
-
-#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-#: src/components/generation/workflow-generation-error.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Inténtalo de nuevo"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
 msgctxt "WgPMAP"
@@ -1826,6 +1898,16 @@ msgid "Back home"
 msgstr "Volver al inicio"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
+msgstr "Te llevamos a tu curso…"
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Te llevamos a tu primera lección…"
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "15FsdE"
 msgid "Your course is ready"
 msgstr "Tu curso está listo"
@@ -1835,16 +1917,6 @@ msgstr "Tu curso está listo"
 msgctxt "4Wktrz"
 msgid "Your lesson is ready"
 msgstr "Tu lección está lista"
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "0o41MR"
-msgid "Taking you to your course..."
-msgstr "Te llevamos a tu curso…"
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "RMDr0s"
-msgid "Taking you to your first lesson…"
-msgstr "Te llevamos a tu primera lección…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"

--- a/apps/main/messages/fr.po
+++ b/apps/main/messages/fr.po
@@ -435,6 +435,84 @@ msgctxt "Pf4uqS"
 msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "Le chapitre d’introduction est prêt. Nous créons encore le programme complet, donc d’autres chapitres apparaîtront bientôt ici."
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "qzAEFi"
+msgid "Finding your course…"
+msgstr "Recherche de ton cours…"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Réessayer"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "o3ujZ5"
+msgid "Learn in {language}"
+msgstr "Apprendre en {language}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "DLssby"
+msgid "This course isn't available in {language} yet."
+msgstr "Ce cours n’est pas encore disponible en {language}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "fpKX8o"
+msgid "We couldn't prepare your course. Please try again."
+msgstr "Nous n’avons pas pu préparer ton cours. Réessaie."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "IPMgvJ"
+msgid "View progress"
+msgstr "Voir l’avancement"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "1eG4JB"
+msgid "This course teaches {language}, with explanations in {sourceLanguage}."
+msgstr "Ce cours enseigne {language}, avec des explications en {sourceLanguage}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "0G8GRg"
+msgid "This course is taught in {sourceLanguage}. It isn't available in {language} yet."
+msgstr "Ce cours est en {sourceLanguage}. Il n’est pas encore disponible en {language}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KgG3PI"
+msgid "Your {language} course is being prepared. You can follow its progress."
+msgstr "Ton cours en {language} est en cours de préparation. Tu peux suivre son avancement."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "rUYK7J"
+msgid "We couldn't finish preparing this course in {language}. You can try again."
+msgstr "Nous n’avons pas pu terminer la préparation de ce cours en {language}. Tu peux réessayer."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "_LY-RG"
+msgid "Switching languages opens a separate course. Your progress stays here."
+msgstr "Changer de langue ouvre un cours distinct. Ta progression reste ici."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "ALdIan"
+msgid "This course is taught in {sourceLanguage}. We'll find it in {language} or create it for you."
+msgstr "Ce cours est en {sourceLanguage}. Nous allons le chercher en {language} ou le créer pour toi."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KYeXR4"
+msgid "Course language"
+msgstr "Langue du cours"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "c5dUwC"
+msgid "This course is in {language}"
+msgstr "Ce cours est en {language}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "QN-YqC"
+msgid "Continue in {language}"
+msgstr "Continuer en {language}"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/not-found.tsx
 msgctxt "KjYOfT"
 msgid "You found a course that hasn't been written yet"
@@ -500,12 +578,6 @@ msgstr "Chargement d'autres cours…"
 msgctxt "W_5hwr"
 msgid "Something went wrong. Please try again."
 msgstr "Une erreur est survenue. Réessaie."
-
-#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-#: src/components/generation/workflow-generation-error.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Réessayer"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
 msgctxt "WgPMAP"
@@ -1826,6 +1898,16 @@ msgid "Back home"
 msgstr "Retour à l’accueil"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
+msgstr "On t’emmène vers ton cours…"
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Direction ta première leçon…"
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "15FsdE"
 msgid "Your course is ready"
 msgstr "Ton cours est prêt"
@@ -1835,16 +1917,6 @@ msgstr "Ton cours est prêt"
 msgctxt "4Wktrz"
 msgid "Your lesson is ready"
 msgstr "Ta leçon est prête"
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "0o41MR"
-msgid "Taking you to your course..."
-msgstr "On t’emmène vers ton cours…"
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "RMDr0s"
-msgid "Taking you to your first lesson…"
-msgstr "Direction ta première leçon…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"

--- a/apps/main/messages/pt.po
+++ b/apps/main/messages/pt.po
@@ -435,6 +435,84 @@ msgctxt "Pf4uqS"
 msgid "The intro chapter is ready. We're still creating the full curriculum, so more chapters will appear here soon."
 msgstr "O capítulo de introdução está pronto. A gente ainda está criando o currículo completo, então mais capítulos vão aparecer aqui em breve."
 
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "qzAEFi"
+msgid "Finding your course…"
+msgstr "Procurando seu curso…"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
+#: src/components/generation/workflow-generation-error.tsx
+msgctxt "FazwRl"
+msgid "Try again"
+msgstr "Tentar de novo"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "o3ujZ5"
+msgid "Learn in {language}"
+msgstr "Aprenda em {language}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "DLssby"
+msgid "This course isn't available in {language} yet."
+msgstr "Este curso ainda não está disponível em {language}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+msgctxt "fpKX8o"
+msgid "We couldn't prepare your course. Please try again."
+msgstr "Não conseguimos preparar seu curso. Tente novamente."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "IPMgvJ"
+msgid "View progress"
+msgstr "Ver progresso"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "1eG4JB"
+msgid "This course teaches {language}, with explanations in {sourceLanguage}."
+msgstr "Este curso ensina {language}, com explicações em {sourceLanguage}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "0G8GRg"
+msgid "This course is taught in {sourceLanguage}. It isn't available in {language} yet."
+msgstr "Este curso é dado em {sourceLanguage}. Ele ainda não está disponível em {language}."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KgG3PI"
+msgid "Your {language} course is being prepared. You can follow its progress."
+msgstr "Seu curso em {language} está sendo preparado. Você pode acompanhar o progresso."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "rUYK7J"
+msgid "We couldn't finish preparing this course in {language}. You can try again."
+msgstr "Não conseguimos terminar de preparar este curso em {language}. Você pode tentar novamente."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "_LY-RG"
+msgid "Switching languages opens a separate course. Your progress stays here."
+msgstr "Ao trocar de idioma, você abre um curso separado. Seu progresso continua aqui."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "ALdIan"
+msgid "This course is taught in {sourceLanguage}. We'll find it in {language} or create it for you."
+msgstr "Este curso é dado em {sourceLanguage}. A gente vai procurar ele em {language} ou criar um para você."
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "KYeXR4"
+msgid "Course language"
+msgstr "Idioma do curso"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "c5dUwC"
+msgid "This course is in {language}"
+msgstr "Este curso está em {language}"
+
+#: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+msgctxt "QN-YqC"
+msgid "Continue in {language}"
+msgstr "Continuar em {language}"
+
 #: src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/not-found.tsx
 msgctxt "KjYOfT"
 msgid "You found a course that hasn't been written yet"
@@ -500,12 +578,6 @@ msgstr "Carregando mais cursos…"
 msgctxt "W_5hwr"
 msgid "Something went wrong. Please try again."
 msgstr "Algo deu errado. Tente de novo."
-
-#: src/app/[lang]/(catalog)/courses/course-list-client.tsx
-#: src/components/generation/workflow-generation-error.tsx
-msgctxt "FazwRl"
-msgid "Try again"
-msgstr "Tentar de novo"
 
 #: src/app/[lang]/(catalog)/courses/page.tsx
 msgctxt "WgPMAP"
@@ -1826,6 +1898,16 @@ msgid "Back home"
 msgstr "Voltar para o início"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "0o41MR"
+msgid "Taking you to your course..."
+msgstr "Te levando para o seu curso…"
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
+msgctxt "RMDr0s"
+msgid "Taking you to your first lesson…"
+msgstr "Te levando para sua primeira aula…"
+
+#: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "15FsdE"
 msgid "Your course is ready"
 msgstr "Seu curso está pronto"
@@ -1835,16 +1917,6 @@ msgstr "Seu curso está pronto"
 msgctxt "4Wktrz"
 msgid "Your lesson is ready"
 msgstr "Sua aula está pronta"
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "0o41MR"
-msgid "Taking you to your course..."
-msgstr "Te levando para o seu curso…"
-
-#: src/app/[lang]/generate/course/[id]/generation-client.tsx
-msgctxt "RMDr0s"
-msgid "Taking you to your first lesson…"
-msgstr "Te levando para sua primeira aula…"
 
 #: src/app/[lang]/generate/course/[id]/generation-client.tsx
 msgctxt "u6ROZF"

--- a/apps/main/src/app/[lang]/(catalog)/(home)/continue-learning-card.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/(home)/continue-learning-card.tsx
@@ -1,3 +1,4 @@
+import { getOriginalCourseHref } from "@/data/courses/course-href";
 import { Link } from "@/i18n/navigation";
 import { getLessonDisplayMeta } from "@/lib/lessons";
 import { type ContinueLearningItem } from "@zoonk/core/courses/list-current-user-continue-learning";
@@ -40,7 +41,11 @@ function getHrefs(item: ContinueLearningItem) {
     return { chapterHref: href, courseHref: href, headerHref: href, prefetch: true };
   }
 
-  const courseHref = `/b/${course.organization.slug}/c/${course.slug}` as const;
+  const courseHref = getOriginalCourseHref({
+    brandSlug: course.organization.slug,
+    courseSlug: course.slug,
+  });
+
   const chapterHref = `/b/${course.organization.slug}/c/${course.slug}/ch/${chapter.slug}` as const;
 
   const lessonHref = lesson

--- a/apps/main/src/app/[lang]/(catalog)/_components/mobile-chapter-nav-target.ts
+++ b/apps/main/src/app/[lang]/(catalog)/_components/mobile-chapter-nav-target.ts
@@ -1,3 +1,5 @@
+import { getOriginalCourseHref } from "@/data/courses/course-href";
+
 export type MobileChapterNavTarget = { courseHref: `/b/${string}/c/${string}` };
 
 const CHAPTER_PAGE_PATH_PATTERN = /^\/b\/(?<brandSlug>[^/]+)\/c\/(?<courseSlug>[^/]+)\/ch\/[^/]+$/u;
@@ -15,5 +17,10 @@ export function getMobileChapterNavTarget(pathname: string): MobileChapterNavTar
     return null;
   }
 
-  return { courseHref: `/b/${groups.brandSlug}/c/${groups.courseSlug}` as const };
+  return {
+    courseHref: getOriginalCourseHref({
+      brandSlug: groups.brandSlug,
+      courseSlug: groups.courseSlug,
+    }),
+  };
 }

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-header.tsx
@@ -1,5 +1,6 @@
 import { AIWarning } from "@/components/catalog/ai-warning";
 import { CatalogHeaderImage } from "@/components/catalog/catalog-header-image";
+import { getOriginalCourseHref } from "@/data/courses/course-href";
 import { Link } from "@/i18n/navigation";
 import { getDefaultChapterImage } from "@/lib/catalog/default-images";
 import { type ChapterWithDetails } from "@zoonk/core/chapters/get-by-slug";
@@ -40,7 +41,7 @@ export function ChapterHeader({
         <MediaCardBreadcrumb className="hidden sm:block">
           <Link
             className="hover:text-foreground block truncate transition-colors"
-            href={`/b/${brandSlug}/c/${courseSlug}`}
+            href={getOriginalCourseHref({ brandSlug, courseSlug })}
             prefetch
           >
             {chapter.course.title}

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-lesson-grid.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/chapter-lesson-grid.tsx
@@ -1,3 +1,4 @@
+import { getOriginalCourseHref } from "@/data/courses/course-href";
 import { getChapter } from "@zoonk/core/chapters/get-by-slug";
 import { listChapterLessons } from "@zoonk/core/lessons/list-by-chapter";
 import { getLessonVisibility } from "@zoonk/core/users/lesson-visibility";
@@ -30,7 +31,10 @@ export async function ChapterLessonGrid({
 
   if (brandSlug === AI_ORG_SLUG && lessons.length === 0) {
     return (
-      <ChapterNotGenerated chapterId={chapter.id} courseHref={`/b/${brandSlug}/c/${courseSlug}`} />
+      <ChapterNotGenerated
+        chapterId={chapter.id}
+        courseHref={getOriginalCourseHref({ brandSlug, courseSlug })}
+      />
     );
   }
 

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/page.tsx
@@ -6,6 +6,7 @@ import {
 import { getLocalizedUrl } from "@/lib/metadata/localized-url";
 import { getChapter } from "@zoonk/core/chapters/get-by-slug";
 import { Grid } from "@zoonk/ui/components/grid";
+import { getContentLocale } from "@zoonk/utils/locale";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
 import { Suspense } from "react";
@@ -15,7 +16,7 @@ import { ChapterSidebar } from "./chapter-sidebar";
 export async function generateMetadata({
   params,
 }: PageProps<"/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]">): Promise<Metadata> {
-  const { brandSlug, chapterSlug, courseSlug } = await params;
+  const { brandSlug, chapterSlug, courseSlug, lang: locale } = await params;
 
   const chapter = await getChapter({ brandSlug, chapterSlug, courseSlug });
 
@@ -23,7 +24,8 @@ export async function generateMetadata({
     return {};
   }
 
-  const t = await getExtracted({ locale: chapter.course.language });
+  const contentLocale = getContentLocale(chapter.course.language);
+  const t = await getExtracted({ locale: contentLocale ?? locale });
 
   return {
     alternates: {
@@ -37,7 +39,7 @@ export async function generateMetadata({
       course: chapter.course.title,
       description: chapter.description,
     }),
-    robots: { follow: true, index: true },
+    robots: { follow: true, index: contentLocale === locale },
     title: t("{chapter}: {course} course", {
       chapter: chapter.title,
       course: chapter.course.title,

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-chapter-grid.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-chapter-grid.tsx
@@ -3,6 +3,7 @@ import { redirect } from "@/i18n/navigation";
 import { getDefaultChapterImage } from "@/lib/catalog/default-images";
 import { type CourseChapter, listCourseChapters } from "@zoonk/core/chapters/list-by-course";
 import { type CourseWithDetails, getCourse } from "@zoonk/core/courses/get-by-slug";
+import { getCoursePromptByCourseSlug } from "@zoonk/core/courses/get-prompt-by-course";
 import { getLessonVisibility } from "@zoonk/core/users/lesson-visibility";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { notFound } from "next/navigation";
@@ -54,7 +55,16 @@ export async function CourseChapterGrid({
   const chapters = await listCourseChapters({ courseId: course.id });
 
   if (brandSlug === AI_ORG_SLUG && chapters.length === 0) {
-    return redirect({ href: `/generate/c/${course.slug}`, locale });
+    const request = await getCoursePromptByCourseSlug({
+      language: course.language,
+      slug: course.slug,
+    });
+
+    if (!request) {
+      notFound();
+    }
+
+    return redirect({ forcePrefix: true, href: `/generate/course/${request.id}`, locale });
   }
 
   const isCurriculumPending = isCurriculumStillGenerating({ brandSlug, chapters, course });

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-content.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-content.tsx
@@ -1,0 +1,113 @@
+import { CatalogDetailLayout } from "@/components/catalog/catalog-detail-layout";
+import {
+  CatalogGridSkeleton,
+  CatalogSidebarSkeleton,
+} from "@/components/catalog/catalog-skeletons";
+import { redirect } from "@/i18n/navigation";
+import { getCourseEdition } from "@zoonk/core/courses/editions";
+import { getCourse } from "@zoonk/core/courses/get-by-slug";
+import { Grid } from "@zoonk/ui/components/grid";
+import { getContentLocale } from "@zoonk/utils/locale";
+import { notFound } from "next/navigation";
+import { type ReactNode, Suspense } from "react";
+import { CourseChapterGrid } from "./course-chapter-grid";
+import { CourseEditionNotice } from "./course-edition-notice";
+import { CourseHeader } from "./course-header";
+import { CourseSidebar } from "./course-sidebar";
+
+function CourseCatalog({
+  notice,
+  params,
+}: Pick<PageProps<"/[lang]/b/[brandSlug]/c/[courseSlug]">, "params"> & { notice?: ReactNode }) {
+  return (
+    <CatalogDetailLayout
+      sidebar={
+        <>
+          <Suspense fallback={<CatalogSidebarSkeleton />}>
+            <CourseSidebar params={params} />
+          </Suspense>
+          {notice}
+        </>
+      }
+    >
+      <Grid variant="pane">
+        <Suspense fallback={<CatalogGridSkeleton count={5} groupVariant="pane" search />}>
+          <CourseChapterGrid params={params} />
+        </Suspense>
+      </Grid>
+    </CatalogDetailLayout>
+  );
+}
+
+/**
+ * Keep exact lesson/course choices stable while adapting discovery to the UI
+ * locale. Ordinary visits can reuse known editions but never start generation.
+ */
+export async function CourseContent({
+  params,
+  searchParams,
+}: PageProps<"/[lang]/b/[brandSlug]/c/[courseSlug]">) {
+  const { brandSlug, courseSlug, lang: locale } = await params;
+  const course = await getCourse({ brandSlug, courseSlug });
+
+  if (!course) {
+    notFound();
+  }
+
+  if (getContentLocale(course.language) === locale) {
+    return <CourseCatalog params={params} />;
+  }
+
+  const [edition, query] = await Promise.all([
+    getCourseEdition({ courseId: course.id, language: locale }),
+    searchParams,
+  ]);
+
+  if (edition.kind === "notFound") {
+    notFound();
+  }
+
+  if (query.edition === "original") {
+    return (
+      <CourseCatalog
+        notice={
+          <CourseEditionNotice
+            brandSlug={brandSlug}
+            compact
+            course={course}
+            edition={edition}
+            targetLocale={locale}
+          />
+        }
+        params={params}
+      />
+    );
+  }
+
+  if (edition.kind === "course") {
+    return redirect({ href: `/b/${brandSlug}/c/${edition.course.slug}`, locale });
+  }
+
+  return (
+    <CatalogDetailLayout
+      sidebar={<CourseHeader brandSlug={brandSlug} course={course} variant="sidebar" />}
+    >
+      <CourseEditionNotice
+        brandSlug={brandSlug}
+        course={course}
+        edition={edition}
+        targetLocale={locale}
+      />
+    </CatalogDetailLayout>
+  );
+}
+
+export function CourseContentSkeleton() {
+  return (
+    <CatalogDetailLayout sidebar={<CatalogSidebarSkeleton />}>
+      <Grid variant="pane">
+        <CatalogGridSkeleton count={5} groupVariant="pane" search />
+      </Grid>
+    </CatalogDetailLayout>
+  );
+}

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-action.ts
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-action.ts
@@ -1,0 +1,94 @@
+"use server";
+
+import { getPathname } from "@/i18n/navigation";
+import { resolveCourseEdition } from "@zoonk/core/courses/editions";
+import { getCourse } from "@zoonk/core/courses/get-by-slug";
+import { safeAsync } from "@zoonk/utils/error";
+import { parseFormField } from "@zoonk/utils/form";
+import { isValidLocale } from "@zoonk/utils/locale";
+import { logError } from "@zoonk/utils/logger";
+import { isUuid } from "@zoonk/utils/uuid";
+
+export type CourseEditionActionState =
+  | { status: "error" | "idle" | "unsupported" }
+  | { href: string; status: "redirect" };
+
+/**
+ * Only an explicit form submission may resolve an unknown edition through AI.
+ * Resolve the return route from the public source course before redirecting.
+ */
+export async function resolveCourseEditionAction(
+  _previousState: CourseEditionActionState,
+  formData: FormData,
+): Promise<CourseEditionActionState> {
+  const courseId = parseFormField(formData, "courseId");
+  const brandSlug = parseFormField(formData, "brandSlug");
+  const courseSlug = parseFormField(formData, "courseSlug");
+  const locale = parseFormField(formData, "language");
+
+  if (
+    !courseId ||
+    !isUuid(courseId) ||
+    !brandSlug ||
+    !courseSlug ||
+    !locale ||
+    !isValidLocale(locale)
+  ) {
+    return { status: "error" };
+  }
+
+  const { data: course, error: sourceError } = await safeAsync(() =>
+    getCourse({ brandSlug, courseSlug }),
+  );
+
+  if (sourceError) {
+    logError("Error loading source course for edition:", sourceError);
+    return { status: "error" };
+  }
+
+  if (!course || course.id !== courseId || !course.organization) {
+    return { status: "error" };
+  }
+
+  const { data: result, error } = await safeAsync(() =>
+    resolveCourseEdition({ courseId, language: locale }),
+  );
+
+  if (error || !result) {
+    logError("Error resolving course edition:", error);
+    return { status: "error" };
+  }
+
+  if (result.kind === "unauthorized") {
+    const next = getPathname({ href: `/b/${course.organization.slug}/c/${course.slug}`, locale });
+
+    return {
+      href: getPathname({
+        forcePrefix: true,
+        href: `/login?next=${encodeURIComponent(next)}`,
+        locale,
+      }),
+      status: "redirect",
+    };
+  }
+
+  if (result.kind === "course") {
+    return {
+      href: getPathname({ href: `/b/${course.organization.slug}/c/${result.course.slug}`, locale }),
+      status: "redirect",
+    };
+  }
+
+  if (result.kind === "generation") {
+    return {
+      href: getPathname({
+        forcePrefix: true,
+        href: `/generate/course/${result.coursePromptId}`,
+        locale,
+      }),
+      status: "redirect",
+    };
+  }
+
+  return { status: result.kind === "unsupported" ? "unsupported" : "error" };
+}

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-form.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Button } from "@zoonk/ui/components/button";
+import { Spinner } from "@zoonk/ui/components/spinner";
+import { getLanguageName } from "@zoonk/utils/languages";
+import { useExtracted, useLocale } from "next-intl";
+import { useActionState } from "react";
+import { type CourseEditionActionState, resolveCourseEditionAction } from "./course-edition-action";
+
+const INITIAL_STATE: CourseEditionActionState = { status: "idle" };
+
+/**
+ * A document navigation lets the proxy persist the explicit language before
+ * canonicalizing English, without retaining the server action's old locale.
+ */
+async function submitCourseEdition(previousState: CourseEditionActionState, formData: FormData) {
+  const result = await resolveCourseEditionAction(previousState, formData);
+
+  if (result.status === "redirect") {
+    globalThis.location.assign(result.href);
+  }
+
+  return result;
+}
+
+function CourseEditionSubmitLabel({
+  failed,
+  language,
+  pending,
+}: {
+  failed: boolean;
+  language: string;
+  pending: boolean;
+}) {
+  const t = useExtracted();
+
+  if (pending) {
+    return t("Finding your course…");
+  }
+
+  if (failed) {
+    return t("Try again");
+  }
+
+  return t("Learn in {language}", { language });
+}
+
+export function CourseEditionForm({
+  brandSlug,
+  compact,
+  courseId,
+  courseSlug,
+  failed,
+  targetLocale,
+}: {
+  brandSlug: string;
+  compact: boolean;
+  courseId: string;
+  courseSlug: string;
+  failed: boolean;
+  targetLocale: string;
+}) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const language = getLanguageName({ targetLanguage: targetLocale, userLanguage: locale });
+  const [state, formAction, isPending] = useActionState(submitCourseEdition, INITIAL_STATE);
+  const pending = isPending || state.status === "redirect";
+
+  if (state.status === "unsupported") {
+    return (
+      <p className="text-muted-foreground text-sm" role="status">
+        {t("This course isn't available in {language} yet.", { language })}
+      </p>
+    );
+  }
+
+  return (
+    <form action={formAction} aria-busy={pending} className="flex w-full flex-col gap-3">
+      <input name="brandSlug" type="hidden" value={brandSlug} />
+      <input name="courseId" type="hidden" value={courseId} />
+      <input name="courseSlug" type="hidden" value={courseSlug} />
+      <input name="language" type="hidden" value={targetLocale} />
+
+      {state.status === "error" && (
+        <p className="text-destructive text-sm" role="alert">
+          {t("We couldn't prepare your course. Please try again.")}
+        </p>
+      )}
+
+      <Button
+        className="h-auto min-h-11 w-full whitespace-normal"
+        disabled={pending}
+        type="submit"
+        variant={compact ? "outline" : "default"}
+      >
+        {pending && <Spinner />}
+        <CourseEditionSubmitLabel
+          failed={failed || state.status === "error"}
+          language={language}
+          pending={pending}
+        />
+      </Button>
+    </form>
+  );
+}

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-edition-notice.tsx
@@ -1,0 +1,194 @@
+import { getOriginalCourseHref } from "@/data/courses/course-href";
+import { Link } from "@/i18n/navigation";
+import { type CourseEditionResult } from "@zoonk/core/courses/editions";
+import { type CourseWithDetails } from "@zoonk/core/courses/get-by-slug";
+import { buttonVariants } from "@zoonk/ui/components/button";
+import { cn } from "@zoonk/ui/lib/utils";
+import { getLanguageName } from "@zoonk/utils/languages";
+import { LanguagesIcon } from "lucide-react";
+import { getExtracted, getLocale } from "next-intl/server";
+import { CourseEditionForm } from "./course-edition-form";
+
+type CourseEditionNoticeProps = {
+  brandSlug: string;
+  compact?: boolean;
+  course: CourseWithDetails;
+  edition: CourseEditionResult;
+  targetLocale: string;
+};
+
+async function CourseEditionAction({
+  brandSlug,
+  compact = false,
+  course,
+  edition,
+  targetLocale,
+}: CourseEditionNoticeProps) {
+  const [t, locale] = await Promise.all([getExtracted(), getLocale()]);
+  const language = getLanguageName({ targetLanguage: targetLocale, userLanguage: locale });
+
+  if (edition.kind === "course") {
+    return (
+      <Link
+        className={buttonVariants({
+          className: "h-auto min-h-11 whitespace-normal",
+          variant: "outline",
+        })}
+        href={`/b/${brandSlug}/c/${edition.course.slug}`}
+        locale={targetLocale}
+      >
+        {t("Learn in {language}", { language })}
+      </Link>
+    );
+  }
+
+  if (edition.kind === "generation" && edition.generationStatus === "running") {
+    return (
+      <Link
+        className={buttonVariants({
+          className: "h-auto min-h-11 whitespace-normal",
+          variant: compact ? "outline" : "default",
+        })}
+        href={`/generate/course/${edition.coursePromptId}`}
+        locale={targetLocale}
+        prefetch={false}
+      >
+        {t("View progress")}
+      </Link>
+    );
+  }
+
+  if (edition.kind === "unsupported" || edition.kind === "notFound") {
+    return null;
+  }
+
+  return (
+    <CourseEditionForm
+      brandSlug={brandSlug}
+      compact={compact}
+      courseId={course.id}
+      courseSlug={course.slug}
+      failed={edition.kind === "generation" && edition.generationStatus === "failed"}
+      targetLocale={targetLocale}
+    />
+  );
+}
+
+async function CourseEditionDescription({
+  compact,
+  course,
+  edition,
+  targetLocale,
+}: {
+  compact: boolean;
+  course: CourseWithDetails;
+  edition: CourseEditionResult;
+  targetLocale: string;
+}) {
+  const [t, locale] = await Promise.all([getExtracted(), getLocale()]);
+  const language = getLanguageName({ targetLanguage: targetLocale, userLanguage: locale });
+  const sourceLanguage = getLanguageName({ targetLanguage: course.language, userLanguage: locale });
+
+  if (edition.kind === "unsupported" && edition.reason === "sameLanguage") {
+    return t("This course teaches {language}, with explanations in {sourceLanguage}.", {
+      language,
+      sourceLanguage,
+    });
+  }
+
+  if (edition.kind === "unsupported") {
+    return t("This course is taught in {sourceLanguage}. It isn't available in {language} yet.", {
+      language,
+      sourceLanguage,
+    });
+  }
+
+  if (edition.kind === "generation" && edition.generationStatus === "running") {
+    return t("Your {language} course is being prepared. You can follow its progress.", {
+      language,
+    });
+  }
+
+  if (edition.kind === "generation" && edition.generationStatus === "failed") {
+    return t("We couldn't finish preparing this course in {language}. You can try again.", {
+      language,
+    });
+  }
+
+  if (compact) {
+    return t("Switching languages opens a separate course. Your progress stays here.");
+  }
+
+  return t(
+    "This course is taught in {sourceLanguage}. We'll find it in {language} or create it for you.",
+    { language, sourceLanguage },
+  );
+}
+
+/**
+ * Discovery gives the local language one clear primary action. An explicitly
+ * selected edition keeps its curriculum and offers switching as a secondary action.
+ */
+export async function CourseEditionNotice({
+  brandSlug,
+  compact = false,
+  course,
+  edition,
+  targetLocale,
+}: CourseEditionNoticeProps) {
+  const [t, locale] = await Promise.all([getExtracted(), getLocale()]);
+  const language = getLanguageName({ targetLanguage: targetLocale, userLanguage: locale });
+  const sourceLanguage = getLanguageName({ targetLanguage: course.language, userLanguage: locale });
+  const unsupported = edition.kind === "unsupported";
+  const originalHref = getOriginalCourseHref({ brandSlug, courseSlug: course.slug });
+
+  return (
+    <section
+      aria-label={t("Course language")}
+      className={cn(
+        "flex flex-col gap-4",
+        compact ? "bg-muted/50 rounded-2xl p-4" : "mx-auto max-w-lg px-2 py-6 sm:px-8 sm:py-12",
+      )}
+    >
+      {!compact && <LanguagesIcon aria-hidden="true" className="text-muted-foreground size-8" />}
+
+      <div className="space-y-2">
+        <h2
+          className={cn("font-semibold text-balance", compact ? "text-sm" : "text-xl sm:text-2xl")}
+        >
+          {compact || unsupported
+            ? t("This course is in {language}", { language: sourceLanguage })
+            : t("Learn in {language}", { language })}
+        </h2>
+        <p className="text-muted-foreground text-sm leading-relaxed">
+          <CourseEditionDescription
+            compact={compact}
+            course={course}
+            edition={edition}
+            targetLocale={targetLocale}
+          />
+        </p>
+      </div>
+
+      <CourseEditionAction
+        brandSlug={brandSlug}
+        compact={compact}
+        course={course}
+        edition={edition}
+        targetLocale={targetLocale}
+      />
+
+      {!compact && (
+        <Link
+          className={buttonVariants({
+            className: "h-auto min-h-11 whitespace-normal",
+            variant: unsupported ? "default" : "outline",
+          })}
+          href={originalHref}
+        >
+          {t("Continue in {language}", { language: sourceLanguage })}
+        </Link>
+      )}
+    </section>
+  );
+}

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/course-header.tsx
@@ -48,15 +48,21 @@ export async function CourseHeader({
       <MediaCardContent>
         <MediaCardTrigger>
           <MediaCardHeader>
-            <MediaCardTitle>{course.title}</MediaCardTitle>
+            <MediaCardTitle>
+              <span lang={course.language}>{course.title}</span>
+            </MediaCardTitle>
             <MediaCardIndicator />
           </MediaCardHeader>
-          <MediaCardDescription>{course.description}</MediaCardDescription>
+          <MediaCardDescription>
+            <span lang={course.language}>{course.description}</span>
+          </MediaCardDescription>
         </MediaCardTrigger>
       </MediaCardContent>
 
       <MediaCardPopover>
-        <MediaCardPopoverText>{course.description}</MediaCardPopoverText>
+        <MediaCardPopoverText>
+          <span lang={course.language}>{course.description}</span>
+        </MediaCardPopoverText>
 
         <MediaCardPopoverMeta>
           <MediaCardPopoverSource>

--- a/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/b/[brandSlug]/c/[courseSlug]/page.tsx
@@ -1,28 +1,23 @@
-import { CatalogDetailLayout } from "@/components/catalog/catalog-detail-layout";
-import {
-  CatalogGridSkeleton,
-  CatalogSidebarSkeleton,
-} from "@/components/catalog/catalog-skeletons";
 import { getLocalizedUrl } from "@/lib/metadata/localized-url";
 import { getCourse } from "@zoonk/core/courses/get-by-slug";
-import { Grid } from "@zoonk/ui/components/grid";
+import { getContentLocale } from "@zoonk/utils/locale";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
 import { Suspense } from "react";
-import { CourseChapterGrid } from "./course-chapter-grid";
-import { CourseSidebar } from "./course-sidebar";
+import { CourseContent, CourseContentSkeleton } from "./course-content";
 
 export async function generateMetadata({
   params,
 }: PageProps<"/[lang]/b/[brandSlug]/c/[courseSlug]">): Promise<Metadata> {
-  const { brandSlug, courseSlug } = await params;
+  const { brandSlug, courseSlug, lang: locale } = await params;
   const course = await getCourse({ brandSlug, courseSlug });
 
   if (!course) {
     return {};
   }
 
-  const t = await getExtracted({ locale: course.language });
+  const contentLocale = getContentLocale(course.language);
+  const t = await getExtracted({ locale: contentLocale ?? locale });
 
   return {
     alternates: {
@@ -35,24 +30,15 @@ export async function generateMetadata({
       "Learn {course} online with practical examples and everyday language. {description}",
       { course: course.title, description: course.description ?? "" },
     ),
+    robots: { follow: true, index: contentLocale === locale },
     title: t("Learn {course}", { course: course.title }),
   };
 }
 
-export default function CoursePage({ params }: PageProps<"/[lang]/b/[brandSlug]/c/[courseSlug]">) {
+export default function CoursePage(props: PageProps<"/[lang]/b/[brandSlug]/c/[courseSlug]">) {
   return (
-    <CatalogDetailLayout
-      sidebar={
-        <Suspense fallback={<CatalogSidebarSkeleton />}>
-          <CourseSidebar params={params} />
-        </Suspense>
-      }
-    >
-      <Grid variant="pane">
-        <Suspense fallback={<CatalogGridSkeleton count={5} groupVariant="pane" search />}>
-          <CourseChapterGrid params={params} />
-        </Suspense>
-      </Grid>
-    </CatalogDetailLayout>
+    <Suspense fallback={<CourseContentSkeleton />}>
+      <CourseContent {...props} />
+    </Suspense>
   );
 }

--- a/apps/main/src/app/[lang]/(catalog)/my/user-course-list.tsx
+++ b/apps/main/src/app/[lang]/(catalog)/my/user-course-list.tsx
@@ -1,3 +1,4 @@
+import { getOriginalCourseHref } from "@/data/courses/course-href";
 import { Link } from "@/i18n/navigation";
 import { listCurrentUserCourses } from "@zoonk/core/courses/list-current-user";
 import { buttonVariants } from "@zoonk/ui/components/button";
@@ -55,7 +56,14 @@ export async function UserCourseList() {
         <ListItem className="gap-0 p-0" key={course.id}>
           <Link
             className="focus-visible:ring-ring/50 hover:bg-muted flex min-w-0 flex-1 items-center gap-3.5 rounded-2xl px-4 py-2.5 transition-colors outline-none focus-visible:ring-[3px]"
-            href={`/b/${course.organization?.slug}/c/${course.slug}`}
+            href={
+              course.organization
+                ? getOriginalCourseHref({
+                    brandSlug: course.organization.slug,
+                    courseSlug: course.slug,
+                  })
+                : `/p/${course.id}`
+            }
             prefetch
           >
             {course.imageUrl ? (

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.test.ts
@@ -124,7 +124,7 @@ describe(buildLessonPlayerModel, () => {
 
     expect(model.milestone).toStrictEqual({
       chapterHref: "/b/brand/c/course/ch/chapter-1",
-      courseHref: "/b/brand/c/course",
+      courseHref: "/b/brand/c/course?edition=original",
       kind: "course",
     });
 

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/lesson-player-model.ts
@@ -1,3 +1,5 @@
+import { getOriginalCourseHref } from "@/data/courses/course-href";
+
 type NextLesson = { chapterSlug: string; lessonSlug: string; lessonTitle: string | null };
 type OrderedItem = { id: string };
 type OrderedChapter = OrderedItem & { slug: string };
@@ -224,7 +226,7 @@ export function buildLessonPlayerModel({
   nextLesson: NextLesson | null;
 }) {
   const chapterHref = `/b/${brandSlug}/c/${courseSlug}/ch/${chapterSlug}` as const;
-  const courseHref = `/b/${brandSlug}/c/${courseSlug}` as const;
+  const courseHref = getOriginalCourseHref({ brandSlug, courseSlug });
 
   const currentLessonHref = getCurrentLessonHref({
     brandSlug,

--- a/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
+++ b/apps/main/src/app/[lang]/b/[brandSlug]/c/[courseSlug]/ch/[chapterSlug]/l/[lessonSlug]/page.tsx
@@ -19,6 +19,7 @@ import { getPlayerProgressSnapshot } from "@zoonk/core/player/queries/get-player
 import { getSession } from "@zoonk/core/users/session";
 import { Container, ContainerBody } from "@zoonk/ui/components/container";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { getContentLocale } from "@zoonk/utils/locale";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { type Metadata } from "next";
 import { getExtracted } from "next-intl/server";
@@ -100,7 +101,7 @@ async function getSubscriptionRequiredContent({
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { brandSlug, chapterSlug, courseSlug, lessonSlug } = await params;
+  const { brandSlug, chapterSlug, courseSlug, lang: locale, lessonSlug } = await params;
   const lessonShell = await getCatalogLesson({ brandSlug, chapterSlug, courseSlug, lessonSlug });
 
   if (!lessonShell) {
@@ -120,13 +121,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     },
     robots: {
       follow: true,
-      index: isLessonSeoIndexable({
-        description: lessonShell.description,
-        kind: lessonShell.kind,
-        slug: lessonShell.slug,
-        sourceTitle,
-        title: lessonShell.title,
-      }),
+      index:
+        getContentLocale(lessonShell.chapter.course.language) === locale &&
+        isLessonSeoIndexable({
+          description: lessonShell.description,
+          kind: lessonShell.kind,
+          slug: lessonShell.slug,
+          sourceTitle,
+          title: lessonShell.title,
+        }),
     },
   };
 }

--- a/apps/main/src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
+++ b/apps/main/src/app/[lang]/generate/ch/[id]/generate-chapter-content.tsx
@@ -1,6 +1,7 @@
 import { GenerationAuthenticationCTA } from "@/components/generation/generation-authentication-cta";
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
 import { SubscriptionGate } from "@/components/subscription/subscription-gate";
+import { getOriginalCourseHref } from "@/data/courses/course-href";
 import { getInitialGenerationPageStatus } from "@/lib/workflow/get-initial-generation-page-status";
 import {
   getChapterCacheTag,
@@ -47,7 +48,11 @@ export async function GenerateChapterContent({ params }: { params: Promise<{ id:
   const { chapter } = access;
   const t = await getExtracted();
 
-  const backHref = `/b/${AI_ORG_SLUG}/c/${chapter.course.slug}` as const;
+  const backHref = getOriginalCourseHref({
+    brandSlug: AI_ORG_SLUG,
+    courseSlug: chapter.course.slug,
+  });
+
   const backLabel = t("Back to course");
 
   const initialStatus = getInitialGenerationPageStatus({

--- a/apps/main/src/app/[lang]/generate/ch/[id]/generation-client.tsx
+++ b/apps/main/src/app/[lang]/generate/ch/[id]/generation-client.tsx
@@ -12,6 +12,8 @@ import {
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import { WorkflowGenerationError } from "@/components/generation/workflow-generation-error";
+import { getOriginalCourseHref } from "@/data/courses/course-href";
+import { getPathname } from "@/i18n/navigation";
 import { type GenerationStatus, isGenerationInProgress } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
@@ -19,7 +21,7 @@ import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
 import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { CHAPTER_COMPLETION_STEP, type ChapterWorkflowStepName } from "@zoonk/core/workflows/steps";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
-import { useExtracted } from "next-intl";
+import { useExtracted, useLocale } from "next-intl";
 import { type ReactNode } from "react";
 import { useGenerationPhases } from "./use-generation-phases";
 
@@ -43,7 +45,8 @@ export function GenerationClient({
   invalidateContent: () => Promise<void>;
 }) {
   const t = useExtracted();
-  const backHref = `/b/${AI_ORG_SLUG}/c/${courseSlug}` as const;
+  const locale = useLocale();
+  const backHref = getOriginalCourseHref({ brandSlug: AI_ORG_SLUG, courseSlug });
   const loginHref = `/login?next=${encodeURIComponent(`/generate/ch/${chapterId}`)}` as const;
 
   const generation = useWorkflowGeneration<ChapterWorkflowStepName>({
@@ -83,7 +86,7 @@ export function GenerationClient({
   useCompletionRedirect({
     beforeRedirect: invalidateContent,
     status: generation.status,
-    url: `/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}`,
+    url: getPathname({ href: `/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}`, locale }),
   });
 
   if (isActive) {

--- a/apps/main/src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
+++ b/apps/main/src/app/[lang]/generate/course/[id]/generate-course-prompt-content.tsx
@@ -1,5 +1,6 @@
 import { GenerationAuthenticationCTA } from "@/components/generation/generation-authentication-cta";
 import { GenerationExitLink } from "@/components/generation/generation-exit-link";
+import { getOriginalCourseHref } from "@/data/courses/course-href";
 import { redirect } from "@/i18n/navigation";
 import { getCoursePromptGeneration } from "@zoonk/core/courses/get-prompt-generation";
 import { getSession } from "@zoonk/core/users/session";
@@ -29,7 +30,13 @@ export async function GenerateCoursePromptContent({
 
   if (generation.status === "redirect") {
     if (generation.target.kind === "course") {
-      return redirect({ href: `/b/${AI_ORG_SLUG}/c/${generation.target.courseSlug}`, locale });
+      return redirect({
+        href: getOriginalCourseHref({
+          brandSlug: AI_ORG_SLUG,
+          courseSlug: generation.target.courseSlug,
+        }),
+        locale,
+      });
     }
 
     return redirect({
@@ -38,7 +45,9 @@ export async function GenerateCoursePromptContent({
     });
   }
 
-  if (!session) {
+  const canFollowRun = generation.generationStatus === "running" && generation.generationRunId;
+
+  if (!session && !canFollowRun) {
     const loginHref = `/login?next=${encodeURIComponent(`/generate/course/${id}`)}` as const;
 
     return (
@@ -59,6 +68,7 @@ export async function GenerateCoursePromptContent({
     <Container variant="narrow">
       <ContainerBody>
         <GenerationClient
+          canGenerate={Boolean(session)}
           completionKind={generation.completionKind}
           courseSlug={generation.courseSlug}
           courseTitle={generation.courseTitle}

--- a/apps/main/src/app/[lang]/generate/course/[id]/generation-client.tsx
+++ b/apps/main/src/app/[lang]/generate/course/[id]/generation-client.tsx
@@ -12,7 +12,8 @@ import {
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import { WorkflowGenerationError } from "@/components/generation/workflow-generation-error";
-import { isGenerationInProgress } from "@/lib/workflow/generation-store";
+import { getPathname } from "@/i18n/navigation";
+import { type GenerationErrorKind, isGenerationInProgress } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
 import { useThinkingMessages } from "@/lib/workflow/use-thinking-messages";
@@ -25,9 +26,10 @@ import {
 } from "@zoonk/core/workflows/steps";
 import { type GenerationStatus } from "@zoonk/db";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
-import { useExtracted } from "next-intl";
+import { useExtracted, useLocale } from "next-intl";
 import { type ReactNode } from "react";
 import { invalidateGeneratedCourse } from "./invalidate-generated-course";
+import { useCoursePromptReconciliation } from "./use-course-prompt-reconciliation";
 import { useGenerationPhases } from "./use-generation-phases";
 
 /**
@@ -46,7 +48,81 @@ function getCourseGenerationCompletionStep({
   return INTRODUCTION_LESSON_COMPLETION_STEP;
 }
 
+function getReadyTargetPath(target: ReturnType<typeof useCoursePromptReconciliation>["target"]) {
+  if (!target) {
+    return null;
+  }
+
+  if (target.kind === "course") {
+    return `${target.courseSlug}?edition=original`;
+  }
+
+  return `${target.courseSlug}/ch/${target.chapterSlug}/l/${target.lessonSlug}`;
+}
+
+function getCompletionTargetPath({
+  completionEntityId,
+  completionKind,
+  courseSlug,
+  linkedCourseSlug,
+}: {
+  completionEntityId: string | null;
+  completionKind: CoursePromptGenerationCompletionKind;
+  courseSlug: string;
+  linkedCourseSlug: string | null;
+}) {
+  const target = completionEntityId ?? linkedCourseSlug ?? courseSlug;
+
+  if (completionKind === "course" || !completionEntityId) {
+    return `${target}?edition=original`;
+  }
+
+  return target;
+}
+
+/** Viewing an existing run is public; retrying generation requires a session. */
+function retryCourseGeneration({
+  canGenerate,
+  errorKind,
+  loginHref,
+  onRetry,
+  reload,
+}: {
+  canGenerate: boolean;
+  errorKind: GenerationErrorKind | null;
+  loginHref: string;
+  onRetry: () => void;
+  reload: boolean;
+}) {
+  if (!canGenerate && errorKind !== "connection") {
+    globalThis.location.href = loginHref;
+    return;
+  }
+
+  if (reload) {
+    globalThis.location.reload();
+    return;
+  }
+
+  onRetry();
+}
+
+function CourseGenerationCompleted({ isLanguageCourse }: { isLanguageCourse: boolean }) {
+  const t = useExtracted();
+
+  return (
+    <GenerationProgressCompleted
+      subtitle={
+        isLanguageCourse ? t("Taking you to your course...") : t("Taking you to your first lesson…")
+      }
+    >
+      {isLanguageCourse ? t("Your course is ready") : t("Your lesson is ready")}
+    </GenerationProgressCompleted>
+  );
+}
+
 export function GenerationClient({
+  canGenerate,
   children,
   completionKind,
   courseSlug,
@@ -57,6 +133,7 @@ export function GenerationClient({
   linkedCourseSlug,
   requestId,
 }: {
+  canGenerate: boolean;
   children: ReactNode;
   completionKind: CoursePromptGenerationCompletionKind;
   courseSlug: string;
@@ -68,14 +145,25 @@ export function GenerationClient({
   requestId: string;
 }) {
   const t = useExtracted();
+  const locale = useLocale();
   const completionStep = getCourseGenerationCompletionStep({ completionKind });
 
   const generation = useWorkflowGeneration<CourseWorkflowStepName>({
+    autoTrigger: canGenerate,
     completionStep,
     initialRunId: generationRunId,
-    initialStatus: generationStatus === "running" ? "streaming" : "idle",
+    initialStatus: generationStatus === "running" && generationRunId ? "streaming" : "idle",
     target: { id: requestId, type: "coursePrompt" },
   });
+
+  const reconciliation = useCoursePromptReconciliation({
+    onResume: generation.resume,
+    requestId,
+    runId: generation.runId,
+    status: generation.status,
+  });
+
+  const status = reconciliation.target ? "completed" : generation.status;
 
   const {
     activePhaseDurationMs,
@@ -91,7 +179,7 @@ export function GenerationClient({
     isLanguageCourse,
   );
 
-  const isActive = isGenerationInProgress(generation.status);
+  const isActive = isGenerationInProgress(status) && !reconciliation.hasError;
 
   const displayProgress = useAnimatedProgress({
     estimatedDurationMs: activePhaseDurationMs,
@@ -105,20 +193,28 @@ export function GenerationClient({
     isActive ? activePhaseNames : [],
   );
 
-  const destinationTarget = generation.completionEntityId ?? linkedCourseSlug ?? courseSlug;
-  const redirectHref = `/b/${AI_ORG_SLUG}/c/${destinationTarget}`;
+  const completionPath = getCompletionTargetPath({
+    completionEntityId: generation.completionEntityId,
+    completionKind,
+    courseSlug,
+    linkedCourseSlug,
+  });
 
-  const completedTitle = isLanguageCourse ? t("Your course is ready") : t("Your lesson is ready");
+  const destinationTarget = getReadyTargetPath(reconciliation.target) ?? completionPath;
 
-  const completedSubtitle = isLanguageCourse
-    ? t("Taking you to your course...")
-    : t("Taking you to your first lesson…");
+  const redirectHref = getPathname({ href: `/b/${AI_ORG_SLUG}/c/${destinationTarget}`, locale });
 
-  const loginHref = `/login?next=${encodeURIComponent(`/generate/course/${requestId}`)}` as const;
+  const returnHref = getPathname({
+    forcePrefix: true,
+    href: `/generate/course/${requestId}`,
+    locale,
+  });
+
+  const loginHref = `/login?next=${encodeURIComponent(returnHref)}` as const;
 
   useCompletionRedirect({
     beforeRedirect: () => invalidateGeneratedCourse(redirectHref),
-    status: generation.status,
+    status,
     url: redirectHref,
   });
 
@@ -155,15 +251,11 @@ export function GenerationClient({
     );
   }
 
-  if (generation.status === "completed") {
-    return (
-      <GenerationProgressCompleted subtitle={completedSubtitle}>
-        {completedTitle}
-      </GenerationProgressCompleted>
-    );
+  if (status === "completed") {
+    return <CourseGenerationCompleted isLanguageCourse={isLanguageCourse} />;
   }
 
-  if (generation.status === "limitReached" && generation.limit) {
+  if (status === "limitReached" && generation.limit) {
     return (
       <GenerationLimitCTA
         backHref="/"
@@ -174,13 +266,21 @@ export function GenerationClient({
     );
   }
 
-  if (generation.status === "error") {
+  if (status === "error" || reconciliation.hasError) {
     return (
       <>
         <WorkflowGenerationError
-          error={generation.error}
-          errorKind={generation.errorKind}
-          onRetry={generation.retry}
+          error={reconciliation.hasError ? null : generation.error}
+          errorKind={reconciliation.errorKind ?? generation.errorKind}
+          onRetry={() =>
+            retryCourseGeneration({
+              canGenerate,
+              errorKind: reconciliation.errorKind ?? generation.errorKind,
+              loginHref: getPathname({ forcePrefix: true, href: loginHref, locale }),
+              onRetry: generation.retry,
+              reload: reconciliation.hasError,
+            })
+          }
         />
         {children}
       </>

--- a/apps/main/src/app/[lang]/generate/course/[id]/invalidate-generated-course.ts
+++ b/apps/main/src/app/[lang]/generate/course/[id]/invalidate-generated-course.ts
@@ -1,10 +1,19 @@
 "use server";
 
 import { COURSE_LIST_CACHE_TAG, LANGUAGE_COURSE_LIST_CACHE_TAG } from "@zoonk/core/cache-tags";
+import { DEFAULT_LOCALE, isValidLocale } from "@zoonk/utils/locale";
+import { SITE_URL } from "@zoonk/utils/url";
 import { revalidatePath, updateTag } from "next/cache";
 
 export async function invalidateGeneratedCourse(destinationHref: string): Promise<void> {
-  revalidatePath(destinationHref);
+  const pathname = new URL(destinationHref, SITE_URL).pathname;
+  revalidatePath(pathname);
+
+  // Cache tags use the internal locale route, including English's rewrite.
+  if (!isValidLocale(pathname.split("/")[1] ?? "")) {
+    revalidatePath(`/${DEFAULT_LOCALE}${pathname}`);
+  }
+
   updateTag(COURSE_LIST_CACHE_TAG);
   updateTag(LANGUAGE_COURSE_LIST_CACHE_TAG);
 }

--- a/apps/main/src/app/[lang]/generate/course/[id]/read-course-prompt-generation.ts
+++ b/apps/main/src/app/[lang]/generate/course/[id]/read-course-prompt-generation.ts
@@ -1,0 +1,8 @@
+"use server";
+
+import { getCoursePromptGeneration } from "@zoonk/core/courses/get-prompt-generation";
+
+/** Reads durable readiness when an identity match hands generation to another run. */
+export async function readCoursePromptGeneration(coursePromptId: string) {
+  return getCoursePromptGeneration({ coursePromptId });
+}

--- a/apps/main/src/app/[lang]/generate/course/[id]/use-course-prompt-reconciliation.ts
+++ b/apps/main/src/app/[lang]/generate/course/[id]/use-course-prompt-reconciliation.ts
@@ -1,0 +1,169 @@
+"use client";
+
+import { type GenerationErrorKind, type GenerationStatus } from "@/lib/workflow/generation-store";
+import { getString } from "@zoonk/utils/json";
+import { API_URL } from "@zoonk/utils/url";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { readCoursePromptGeneration } from "./read-course-prompt-generation";
+
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLL_ATTEMPTS = 120;
+const MAX_READ_FAILURES = 5;
+
+type PromptGeneration = Awaited<ReturnType<typeof readCoursePromptGeneration>>;
+type ReadyTarget = Extract<PromptGeneration, { status: "redirect" }>["target"];
+
+/** A terminal run can have handed ownership to another run before that winner failed. */
+async function readTerminalGenerationId({ runId, signal }: { runId: string; signal: AbortSignal }) {
+  const response = await fetch(`${API_URL}/v1/generations/${encodeURIComponent(runId)}`, {
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error("Could not read generation status");
+  }
+
+  const data: unknown = await response.json();
+  const status = getString(data, "status");
+
+  if (
+    getString(data, "id") !== runId ||
+    !["pending", "running", "completed", "failed", "cancelled"].includes(status ?? "")
+  ) {
+    throw new Error("Invalid generation status");
+  }
+
+  return status === "pending" || status === "running" ? null : runId;
+}
+
+/**
+ * Identity search can join an existing workflow after the browser starts
+ * listening to a new run. The durable prompt owns both the winning run and the
+ * real course/lesson destination, so reconcile it alongside streaming progress.
+ */
+export function useCoursePromptReconciliation({
+  onResume,
+  requestId,
+  runId,
+  status,
+}: {
+  onResume: (generationRunId: string) => void;
+  requestId: string;
+  runId: string | null;
+  status: GenerationStatus;
+}) {
+  const [target, setTarget] = useState<ReadyTarget | null>(null);
+  const [errorKind, setErrorKind] = useState<GenerationErrorKind | null>(null);
+  const hasError = errorKind !== null;
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const active = status !== "completed" && status !== "limitReached" && !target && !hasError;
+
+  const readLatestGeneration = useEffectEvent(
+    async (result: PromptGeneration, signal: AbortSignal) => {
+      if (result.status !== "pending" || result.generationStatus !== "failed" || !runId) {
+        return { generation: result, terminalRunId: null };
+      }
+
+      const terminalRunId = await readTerminalGenerationId({ runId, signal });
+
+      if (!terminalRunId || signal.aborted) {
+        return { generation: result, terminalRunId: null };
+      }
+
+      // The initial failed snapshot can predate a retry's completion. Read
+      // readiness again after the followed run is known to have finished.
+      const generation = await readCoursePromptGeneration(requestId);
+      return { generation, terminalRunId };
+    },
+  );
+
+  const reconcile = useEffectEvent((result: PromptGeneration, terminalRunId: string | null) => {
+    if (result.status === "redirect") {
+      setTarget(result.target);
+      return;
+    }
+
+    if (result.status === "notFound") {
+      setErrorKind("connection");
+      return;
+    }
+
+    /**
+     * A retry can still be resolving identity while the prompt retains its old
+     * failed state. Stop only after that retry has finished and the prompt still
+     * reports failure, including a joined winner that failed before polling.
+     */
+    if (terminalRunId && terminalRunId === runId && result.generationStatus === "failed") {
+      setErrorKind("generation");
+      return;
+    }
+
+    if (
+      result.generationStatus === "running" &&
+      result.generationRunId &&
+      result.generationRunId !== runId
+    ) {
+      onResume(result.generationRunId);
+    }
+  });
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    async function poll(attempt: number, failures: number): Promise<void> {
+      try {
+        const result = await readCoursePromptGeneration(requestId);
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const { generation, terminalRunId } = await readLatestGeneration(result, controller.signal);
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        reconcile(generation, terminalRunId);
+
+        if (generation.status !== "pending") {
+          return;
+        }
+
+        if (attempt >= MAX_POLL_ATTEMPTS) {
+          setErrorKind("connection");
+          return;
+        }
+
+        timer.current = setTimeout(() => void poll(attempt + 1, 0), POLL_INTERVAL_MS);
+      } catch {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        if (failures + 1 >= MAX_READ_FAILURES || attempt >= MAX_POLL_ATTEMPTS) {
+          setErrorKind("connection");
+          return;
+        }
+
+        timer.current = setTimeout(() => void poll(attempt + 1, failures + 1), POLL_INTERVAL_MS);
+      }
+    }
+
+    timer.current = setTimeout(() => void poll(1, 0), POLL_INTERVAL_MS);
+
+    return () => {
+      controller.abort();
+
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+    };
+  }, [active, requestId]);
+
+  return { errorKind, hasError, target };
+}

--- a/apps/main/src/app/[lang]/generate/l/[id]/generation-client.tsx
+++ b/apps/main/src/app/[lang]/generate/l/[id]/generation-client.tsx
@@ -12,6 +12,7 @@ import {
   GenerationTimelineTitle,
 } from "@/components/generation/generation-progress";
 import { WorkflowGenerationError } from "@/components/generation/workflow-generation-error";
+import { getPathname } from "@/i18n/navigation";
 import { type GenerationStatus, isGenerationInProgress } from "@/lib/workflow/generation-store";
 import { useAnimatedProgress } from "@/lib/workflow/use-animated-progress";
 import { useCompletionRedirect } from "@/lib/workflow/use-completion-redirect";
@@ -20,7 +21,7 @@ import { useWorkflowGeneration } from "@/lib/workflow/use-workflow-generation";
 import { type GeneratedLessonKind } from "@zoonk/core/lessons/generated-companion-kinds";
 import { LESSON_COMPLETION_STEP, type LessonStepName } from "@zoonk/core/workflows/steps";
 import { AI_ORG_SLUG } from "@zoonk/utils/org";
-import { useExtracted } from "next-intl";
+import { useExtracted, useLocale } from "next-intl";
 import { type ReactNode } from "react";
 import { useGenerationPhases } from "./use-generation-phases";
 
@@ -48,6 +49,7 @@ export function GenerationClient({
   lessonTitle: string;
 }) {
   const t = useExtracted();
+  const locale = useLocale();
   const backHref = `/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}` as const;
   const loginHref = `/login?next=${encodeURIComponent(`/generate/l/${lessonId}`)}` as const;
 
@@ -89,7 +91,10 @@ export function GenerationClient({
   useCompletionRedirect({
     beforeRedirect: invalidateContent,
     status: generation.status,
-    url: `/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
+    url: getPathname({
+      href: `/b/${AI_ORG_SLUG}/c/${courseSlug}/ch/${chapterSlug}/l/${lessonSlug}`,
+      locale,
+    }),
   });
 
   if (isActive) {

--- a/apps/main/src/data/courses/course-href.ts
+++ b/apps/main/src/data/courses/course-href.ts
@@ -11,3 +11,14 @@ export type AiCourseHref = `/b/${typeof AI_ORG_SLUG}/c/${string}`;
 export function getAiCourseHref(course: Pick<Course, "slug">): AiCourseHref {
   return `/b/${AI_ORG_SLUG}/c/${course.slug}`;
 }
+
+/** Learning history and parent navigation must keep the selected course edition. */
+export function getOriginalCourseHref({
+  brandSlug,
+  courseSlug,
+}: {
+  brandSlug: string;
+  courseSlug: string;
+}) {
+  return `/b/${brandSlug}/c/${courseSlug}?edition=original` as const;
+}

--- a/apps/main/src/data/sitemaps/chapters.ts
+++ b/apps/main/src/data/sitemaps/chapters.ts
@@ -1,17 +1,18 @@
 import "server-only";
 import { getPublishedChapterWhere, prisma } from "@zoonk/db";
+import { getSitemapCourseWhere } from "./course-where";
 import { SITEMAP_BATCH_SIZE } from "./courses";
 
 /**
  * Every published brand chapter is a public catalog page worth discovering,
  * including chapters whose lesson generation has not completed yet.
  */
-const sitemapChapterWhere = getPublishedChapterWhere({
-  courseWhere: { organization: { kind: "brand" } },
-});
+async function getSitemapChapterWhere() {
+  return getPublishedChapterWhere({ courseWhere: await getSitemapCourseWhere() });
+}
 
 export async function countSitemapChapters(): Promise<number> {
-  return prisma.chapter.count({ where: sitemapChapterWhere });
+  return prisma.chapter.count({ where: await getSitemapChapterWhere() });
 }
 
 export async function listSitemapChapters(
@@ -30,7 +31,7 @@ export async function listSitemapChapters(
     orderBy: { id: "asc" },
     skip: page * SITEMAP_BATCH_SIZE,
     take: SITEMAP_BATCH_SIZE,
-    where: sitemapChapterWhere,
+    where: await getSitemapChapterWhere(),
   });
 
   return chapters.map((chapter) => ({

--- a/apps/main/src/data/sitemaps/course-where.ts
+++ b/apps/main/src/data/sitemaps/course-where.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import { getPublishedCourseWhere, prisma } from "@zoonk/db";
+import { getContentLocale } from "@zoonk/utils/locale";
+
+/**
+ * Resolve the small set of stored language tags with the same strict locale
+ * parser as page metadata. Filtering in the database keeps sitemap counts and
+ * pagination correct without treating unsupported languages as English.
+ */
+export async function getSitemapCourseWhere() {
+  const languages = await prisma.course.groupBy({
+    by: ["language"],
+    where: getPublishedCourseWhere({ organization: { kind: "brand" } }),
+  });
+
+  const supportedLanguages = languages
+    .filter(({ language }) => getContentLocale(language) !== null)
+    .map(({ language }) => language);
+
+  return getPublishedCourseWhere({
+    language: { in: supportedLanguages },
+    organization: { kind: "brand" },
+  });
+}

--- a/apps/main/src/data/sitemaps/courses.ts
+++ b/apps/main/src/data/sitemaps/courses.ts
@@ -1,12 +1,11 @@
 import "server-only";
-import { getPublishedCourseWhere, prisma } from "@zoonk/db";
+import { prisma } from "@zoonk/db";
+import { getSitemapCourseWhere } from "./course-where";
 
 export const SITEMAP_BATCH_SIZE = 5000;
 
 export async function countSitemapCourses(): Promise<number> {
-  return prisma.course.count({
-    where: getPublishedCourseWhere({ organization: { kind: "brand" } }),
-  });
+  return prisma.course.count({ where: await getSitemapCourseWhere() });
 }
 
 export async function listSitemapCourses(
@@ -17,7 +16,7 @@ export async function listSitemapCourses(
     orderBy: { id: "asc" },
     skip: page * SITEMAP_BATCH_SIZE,
     take: SITEMAP_BATCH_SIZE,
-    where: getPublishedCourseWhere({ organization: { kind: "brand" } }),
+    where: await getSitemapCourseWhere(),
   });
 
   return courses.map((course) => ({

--- a/apps/main/src/data/sitemaps/languages.test.ts
+++ b/apps/main/src/data/sitemaps/languages.test.ts
@@ -1,0 +1,78 @@
+import { chapterFixture } from "@zoonk/testing/fixtures/chapters";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { lessonFixture } from "@zoonk/testing/fixtures/lessons";
+import { organizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, it } from "vitest";
+import { countSitemapChapters, listSitemapChapters } from "./chapters";
+import { SITEMAP_BATCH_SIZE, countSitemapCourses, listSitemapCourses } from "./courses";
+import { countSitemapLessons, listSitemapLessons } from "./lessons";
+
+/**
+ * Read every sitemap page so excluded fixtures cannot appear to pass simply
+ * because their IDs sort outside the final page in a shared test database.
+ */
+async function listSitemapPages<T>({
+  count,
+  list,
+}: {
+  count: () => Promise<number>;
+  list: (page: number) => Promise<T[]>;
+}): Promise<T[]> {
+  const pages = Math.max(Math.ceil((await count()) / SITEMAP_BATCH_SIZE), 1);
+  const rows = await Promise.all(Array.from({ length: pages }, (_, page) => list(page)));
+  return rows.flat();
+}
+
+async function createLocalizedCatalog(language: string) {
+  const organization = await organizationFixture({ kind: "brand" });
+
+  const course = await courseFixture({
+    isPublished: true,
+    language,
+    organizationId: organization.id,
+  });
+
+  const chapter = await chapterFixture({
+    courseId: course.id,
+    isPublished: true,
+    organizationId: organization.id,
+  });
+
+  const lesson = await lessonFixture({
+    chapterId: chapter.id,
+    isPublished: true,
+    organizationId: organization.id,
+  });
+
+  return { chapter, course, lesson };
+}
+
+describe("sitemap content languages", () => {
+  it("includes regional teaching languages and excludes unsupported or malformed languages throughout the catalog", async () => {
+    const [regional, unsupported, malformed] = await Promise.all([
+      createLocalizedCatalog("pt-BR"),
+      createLocalizedCatalog("ja-JP"),
+      createLocalizedCatalog("en_US"),
+    ]);
+
+    const [courses, chapters, lessons] = await Promise.all([
+      listSitemapPages({ count: countSitemapCourses, list: listSitemapCourses }),
+      listSitemapPages({ count: countSitemapChapters, list: listSitemapChapters }),
+      listSitemapPages({ count: countSitemapLessons, list: listSitemapLessons }),
+    ]);
+
+    const courseSlugs = courses.map((course) => course.courseSlug);
+    const chapterSlugs = chapters.map((chapter) => chapter.chapterSlug);
+    const lessonSlugs = lessons.map((lesson) => lesson.lessonSlug);
+
+    expect(courseSlugs).toContain(regional.course.slug);
+    expect(chapterSlugs).toContain(regional.chapter.slug);
+    expect(lessonSlugs).toContain(regional.lesson.slug);
+
+    for (const excluded of [unsupported, malformed]) {
+      expect(courseSlugs).not.toContain(excluded.course.slug);
+      expect(chapterSlugs).not.toContain(excluded.chapter.slug);
+      expect(lessonSlugs).not.toContain(excluded.lesson.slug);
+    }
+  });
+});

--- a/apps/main/src/data/sitemaps/lessons.ts
+++ b/apps/main/src/data/sitemaps/lessons.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/lessons/seo";
 import { SPLIT_LESSON_SLUG_MARKER } from "@zoonk/core/lessons/split-lessons";
 import { getPublishedLessonWhere, prisma } from "@zoonk/db";
+import { getSitemapCourseWhere } from "./course-where";
 import { SITEMAP_BATCH_SIZE } from "./courses";
 
 /**
@@ -15,10 +16,10 @@ import { SITEMAP_BATCH_SIZE } from "./courses";
  * chapter title. Reading and listening stay excluded because they span several
  * topics without standalone metadata.
  */
-function getSitemapLessonWhere() {
+async function getSitemapLessonWhere() {
   return {
     AND: [
-      getPublishedLessonWhere({ courseWhere: { organization: { kind: "brand" } } }),
+      getPublishedLessonWhere({ courseWhere: await getSitemapCourseWhere() }),
       { NOT: { slug: { contains: SPLIT_LESSON_SLUG_MARKER } } },
       {
         OR: [
@@ -55,7 +56,7 @@ function getSitemapLessonWhere() {
  * lesson page's robots metadata.
  */
 export async function countSitemapLessons(): Promise<number> {
-  return prisma.lesson.count({ where: getSitemapLessonWhere() });
+  return prisma.lesson.count({ where: await getSitemapLessonWhere() });
 }
 
 /**
@@ -79,7 +80,7 @@ export async function listSitemapLessons(
     orderBy: { id: "asc" },
     skip: page * SITEMAP_BATCH_SIZE,
     take: SITEMAP_BATCH_SIZE,
-    where: getSitemapLessonWhere(),
+    where: await getSitemapLessonWhere(),
   });
 
   return lessons.map((lesson) => ({

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -208,6 +208,17 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
     dispatch({ type: "reset" });
   }, [resetIndex, state.errorKind]);
 
+  /** An identity match can transfer the requested content to an already-running workflow. */
+  const resume = useCallback(
+    (runId: string) => {
+      hasTriggeredRef.current = true;
+      resetIndex();
+      dispatch({ type: "reset" });
+      dispatch({ runId, type: "triggerSuccess" });
+    },
+    [resetIndex],
+  );
+
   return {
     completedSteps: state.completedSteps,
     completionEntityId: state.completionEntityId,
@@ -215,7 +226,9 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
     error: state.error,
     errorKind: state.errorKind,
     limit: state.limit,
+    resume,
     retry,
+    runId: state.runId,
     startedSteps: state.startedSteps,
     status: state.status,
   };

--- a/apps/main/src/lib/workflow/use-workflow-generation.ts
+++ b/apps/main/src/lib/workflow/use-workflow-generation.ts
@@ -58,6 +58,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   const { autoTrigger = true, completionStep, entityId, target } = config;
 
   const hasTriggeredRef = useRef(false);
+  const triggerAttemptRef = useRef(0);
 
   // Wrapper preserves the TStep generic that useReducer would otherwise widen to string.
   const resolvedStatus = config.initialStatus ?? "idle";
@@ -150,10 +151,24 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   });
 
   const startTrigger = useEffectEvent(async () => {
+    triggerAttemptRef.current += 1;
+    const attempt = triggerAttemptRef.current;
+
+    /** Resuming another run supersedes every outcome of the pending trigger. */
+    function dispatchTriggerResult(action: GenerationAction<TStep>) {
+      if (triggerAttemptRef.current === attempt) {
+        dispatch(action);
+      }
+    }
+
     dispatch({ type: "triggerStart" });
 
     try {
       const authHeaders = await getWorkflowAuthHeaders();
+
+      if (triggerAttemptRef.current !== attempt) {
+        return;
+      }
 
       const response = await fetch(
         `${API_URL}/v1/generations`,
@@ -165,7 +180,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
         const limit = getGenerationLimit(data);
 
         if (limit) {
-          dispatch({ limit, type: "limitReached" });
+          dispatchTriggerResult({ limit, type: "limitReached" });
           return;
         }
 
@@ -179,9 +194,9 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
         throw new Error("Invalid response: missing generation ID");
       }
 
-      dispatch({ runId: generationId, type: "triggerSuccess" });
+      dispatchTriggerResult({ runId: generationId, type: "triggerSuccess" });
     } catch (error) {
-      dispatch({
+      dispatchTriggerResult({
         error: error instanceof Error ? error.message : "Failed to start",
         type: "setError",
       });
@@ -198,6 +213,8 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   }, [autoTrigger, state.status]);
 
   const retry = useCallback(() => {
+    triggerAttemptRef.current += 1;
+
     if (state.errorKind === "connection") {
       globalThis.location.reload();
       return;
@@ -211,6 +228,7 @@ export function useWorkflowGeneration<TStep extends string = string>(config: {
   /** An identity match can transfer the requested content to an already-running workflow. */
   const resume = useCallback(
     (runId: string) => {
+      triggerAttemptRef.current += 1;
       hasTriggeredRef.current = true;
       resetIndex();
       dispatch({ type: "reset" });

--- a/apps/main/src/proxy.test.ts
+++ b/apps/main/src/proxy.test.ts
@@ -1,6 +1,54 @@
 import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
+import { NextRequest } from "next/server";
 import { describe, expect, it } from "vitest";
-import { config } from "./proxy";
+import proxy, { config } from "./proxy";
+
+describe("catalog locale routing", () => {
+  it.each([
+    "/b/zoonk/c/computer-science",
+    "/b/zoonk/c/computer-science/ch/basics",
+    "/b/zoonk/c/computer-science/ch/basics/l/intro",
+  ])("keeps the unprefixed English canonical stable at %s", (path) => {
+    const request = new NextRequest(`https://www.zoonk.com${path}?edition=original`, {
+      headers: { "accept-language": "pt-BR", cookie: "ZOONK_LOCALE=de" },
+    });
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      `https://www.zoonk.com/en${path}?edition=original`,
+    );
+
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("link")).toBeNull();
+  });
+
+  it("honors an explicit course locale without overwriting the saved preference", () => {
+    const response = proxy(
+      new NextRequest("https://www.zoonk.com/pt/b/zoonk/c/ciencia-da-computacao-pt", {
+        headers: { "accept-language": "fr-FR", cookie: "ZOONK_LOCALE=de" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-request-x-next-intl-locale")).toBe("pt");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get("link")).toBeNull();
+  });
+
+  it("continues applying the saved preference outside course routes", () => {
+    const response = proxy(
+      new NextRequest("https://www.zoonk.com/courses", {
+        headers: { "accept-language": "pt-BR", cookie: "ZOONK_LOCALE=de" },
+      }),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://www.zoonk.com/de/courses");
+  });
+});
 
 describe("proxy matcher", () => {
   it.each([

--- a/apps/main/src/proxy.ts
+++ b/apps/main/src/proxy.ts
@@ -1,7 +1,32 @@
+import { SUPPORTED_LOCALES } from "@zoonk/utils/locale";
 import createMiddleware from "next-intl/middleware";
+import { type NextRequest } from "next/server";
 import { routing } from "./i18n/routing";
 
-export default createMiddleware(routing);
+const localizedMiddleware = createMiddleware(routing);
+
+const catalogMiddleware = createMiddleware({
+  ...routing,
+  alternateLinks: false,
+  localeCookie: false,
+  localeDetection: false,
+});
+
+const CATALOG_PATH = new RegExp(
+  `^/(?:(?:${SUPPORTED_LOCALES.join("|")})/)?b/[^/]+/c/[^/]+(?:/|$)`,
+  "u",
+);
+
+/**
+ * Catalog canonicals identify an edition through the URL, including unprefixed
+ * English URLs. Opening one must not rewrite the visitor's saved preference or
+ * advertise the same course slug as an alternate in every UI language.
+ */
+export default function proxy(request: NextRequest) {
+  return CATALOG_PATH.test(request.nextUrl.pathname)
+    ? catalogMiddleware(request)
+    : localizedMiddleware(request);
+}
 
 export const config = {
   matcher: [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,8 @@
     "./chapters/search": "./src/chapters/search-chapters.ts",
     "./courses/continue-learning-contract": "./src/courses/continue-learning-contract.ts",
     "./courses/generation-access": "./src/courses/course-generation-access.ts",
+    "./courses/editions": "./src/courses/course-editions.ts",
+    "./courses/edition-link": "./src/courses/course-edition-link.ts",
     "./courses/get-by-id": "./src/courses/get-course-by-id.ts",
     "./courses/get-by-slug": "./src/courses/get-course-by-slug.ts",
     "./courses/get-first-lesson": "./src/courses/get-first-course-lesson.ts",

--- a/packages/core/src/courses/_utils/edition-discovery.ts
+++ b/packages/core/src/courses/_utils/edition-discovery.ts
@@ -1,0 +1,199 @@
+import "server-only";
+import { type Course, prisma } from "@zoonk/db";
+import { isTTSSupportedLanguage } from "@zoonk/utils/languages";
+import { getContentLocale } from "@zoonk/utils/locale";
+import { normalizeString } from "@zoonk/utils/string";
+import { type CourseEditionResult } from "../course-editions";
+import { isRegularCourseFormat } from "../course-prompt-generation";
+import {
+  chooseCourseEdition,
+  findFamilyCourse,
+  haveCompatibleEditionIdentity,
+  linkCourseEditions,
+  lockCourseFamilies,
+} from "./edition-family";
+import { getCourseEditionPrompt } from "./edition-prompt";
+
+export async function getSourceCourse(courseId: string) {
+  return prisma.course.findFirst({
+    include: { organization: true },
+    where: { id: courseId, isPublished: true, organization: { kind: "brand" } },
+  });
+}
+
+export function getEditionRestriction({
+  source,
+  language,
+}: {
+  source: Course;
+  language: string;
+}): CourseEditionResult | null {
+  if (source.format === "language") {
+    if (!isTTSSupportedLanguage(source.targetLanguage)) {
+      return { kind: "unsupported", reason: "format" };
+    }
+
+    return getContentLocale(source.targetLanguage ?? "") === language
+      ? { kind: "unsupported", reason: "sameLanguage" }
+      : null;
+  }
+
+  return isRegularCourseFormat(source.format) && source.targetLanguage === null
+    ? null
+    : { kind: "unsupported", reason: "format" };
+}
+
+export async function getStoredEditionRequest({
+  source,
+  language,
+}: {
+  source: Course;
+  language: string;
+}) {
+  return prisma.courseEditionRequest.findFirst({
+    include: { coursePrompt: { include: { course: true } } },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    where: {
+      language,
+      sourceCourse: {
+        isPublished: true,
+        ...(source.familyId ? { familyId: source.familyId } : { id: source.id }),
+      },
+    },
+  });
+}
+
+/**
+ * Legacy courses become related only when a visitor encounters them. Cached
+ * prompt identities and finite language targets are safe to reuse here without
+ * running a model or starting generation on a GET or a prefetch.
+ */
+export async function findKnownEdition({
+  source,
+  language,
+}: {
+  source: Course;
+  language: string;
+}): Promise<Course | null> {
+  if (source.familyId) {
+    const course = await findFamilyCourse({
+      familyId: source.familyId,
+      language,
+      transaction: prisma,
+    });
+
+    if (course && haveCompatibleEditionIdentity({ course, source })) {
+      return course;
+    }
+  }
+
+  if (source.format === "language") {
+    const courses = await prisma.course.findMany({
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      where: {
+        format: "language",
+        isPublished: true,
+        organizationId: source.organizationId,
+        targetLanguage: source.targetLanguage,
+      },
+    });
+
+    return chooseCourseEdition(
+      courses.filter((course) => getContentLocale(course.language) === language),
+    );
+  }
+
+  const prompt = await prisma.coursePrompt.findUnique({
+    include: { course: true },
+    where: {
+      languageNormalizedPrompt: {
+        language,
+        normalizedPrompt: normalizeString(getCourseEditionPrompt(source)),
+      },
+    },
+  });
+
+  const course = prompt?.course;
+
+  return course?.isPublished &&
+    getContentLocale(course.language) === language &&
+    haveCompatibleEditionIdentity({ course, source })
+    ? course
+    : null;
+}
+
+async function attachKnownEdition({
+  source,
+  course,
+  language,
+}: {
+  source: Course;
+  course: Course;
+  language: string;
+}) {
+  if (!source.familyId || source.familyId !== course.familyId) {
+    await prisma.$transaction(async (transaction) => {
+      await lockCourseFamilies(transaction);
+
+      await linkCourseEditions({
+        courseId: course.id,
+        language,
+        sourceCourseId: source.id,
+        transaction,
+      });
+    });
+  }
+}
+
+export async function getCourseEditionOutcome({
+  course,
+  source,
+  language,
+}: {
+  course: Course;
+  source: Course;
+  language: string;
+}): Promise<CourseEditionResult> {
+  if (!course.isPublished) {
+    return { kind: "unsupported", reason: "unavailable" };
+  }
+
+  if (
+    getContentLocale(course.language) !== language ||
+    !haveCompatibleEditionIdentity({ course, source })
+  ) {
+    return { kind: "unsupported", reason: "format" };
+  }
+
+  await attachKnownEdition({ course, language, source });
+
+  if (course.generationStatus === "completed") {
+    return { course, kind: "course" };
+  }
+
+  const prompts = await prisma.coursePrompt.findMany({
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    where: { courseId: course.id, generationStatus: { not: null } },
+  });
+
+  const compatiblePrompts = prompts.filter(
+    (prompt) => getContentLocale(prompt.language) === language,
+  );
+
+  const prompt =
+    compatiblePrompts.find(
+      (item) =>
+        item.generationRunId === course.generationRunId &&
+        item.generationStatus === course.generationStatus,
+    ) ?? compatiblePrompts[0];
+
+  if (prompt?.generationStatus) {
+    return {
+      coursePromptId: prompt.id,
+      generationStatus: prompt.generationStatus,
+      kind: "generation",
+    };
+  }
+
+  return { kind: "missing" };
+}

--- a/packages/core/src/courses/_utils/edition-family.ts
+++ b/packages/core/src/courses/_utils/edition-family.ts
@@ -1,0 +1,151 @@
+import { type Course, type TransactionClient, sql } from "@zoonk/db";
+import { getContentLocale } from "@zoonk/utils/locale";
+import { getCompatibleCourseFormats } from "../course-prompt-generation";
+
+/**
+ * Family membership can merge while another language request is being saved.
+ * Serialize only this short bookkeeping transaction, never model calls or
+ * generation, so requests continue following their source course after merges.
+ */
+export async function lockCourseFamilies(transaction: TransactionClient): Promise<void> {
+  await transaction.$queryRaw(sql`SELECT pg_advisory_xact_lock(92741, 1)::text`);
+}
+
+export function haveCompatibleEditionIdentity({
+  source,
+  course,
+}: {
+  source: Course;
+  course: Course;
+}): boolean {
+  return (
+    source.organizationId === course.organizationId &&
+    getCompatibleCourseFormats(source.format).includes(course.format) &&
+    source.targetLanguage === course.targetLanguage
+  );
+}
+
+export async function ensureCourseFamily({
+  course,
+  transaction,
+}: {
+  course: Course;
+  transaction: TransactionClient;
+}): Promise<string> {
+  if (course.familyId) {
+    return course.familyId;
+  }
+
+  const family = await transaction.courseFamily.create({ data: {} });
+  await transaction.course.update({ data: { familyId: family.id }, where: { id: course.id } });
+  return family.id;
+}
+
+/**
+ * Old editions may already contain duplicate courses in one language. Preserve
+ * their IDs and progress, preferring usable content before an unfinished row.
+ */
+export function chooseCourseEdition(courses: Course[]): Course | null {
+  return (
+    courses.find((course) => course.generationStatus === "completed") ??
+    courses.find((course) => course.generationStatus === "running") ??
+    courses[0] ??
+    null
+  );
+}
+
+export async function findFamilyCourse({
+  familyId,
+  language,
+  transaction,
+}: {
+  familyId: string;
+  language: string;
+  transaction: TransactionClient;
+}): Promise<Course | null> {
+  const courses = await transaction.course.findMany({
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    where: { familyId, isPublished: true },
+  });
+
+  return chooseCourseEdition(
+    courses.filter((course) => getContentLocale(course.language) === language),
+  );
+}
+
+/**
+ * Membership is evidence from the existing identity resolver, not a translated
+ * slug guess. Keep request provenance on its source course so no pending request
+ * is lost when two already-populated families meet.
+ */
+export async function linkCourseEditions({
+  courseId,
+  language,
+  sourceCourseId,
+  transaction,
+}: {
+  courseId: string;
+  language: string;
+  sourceCourseId: string;
+  transaction: TransactionClient;
+}): Promise<void> {
+  const [source, course] = await Promise.all([
+    transaction.course.findUniqueOrThrow({ where: { id: sourceCourseId } }),
+    transaction.course.findUniqueOrThrow({ where: { id: courseId } }),
+  ]);
+
+  if (
+    !source.isPublished ||
+    !course.isPublished ||
+    getContentLocale(course.language) !== language ||
+    !haveCompatibleEditionIdentity({ course, source })
+  ) {
+    throw new Error("Course edition does not match its source course");
+  }
+
+  if (source.id === course.id) {
+    return;
+  }
+
+  await mergeCourseFamilies({ course, source, transaction });
+}
+
+export async function mergeCourseFamilies({
+  course,
+  source,
+  transaction,
+}: {
+  course: Course;
+  source: Course;
+  transaction: TransactionClient;
+}): Promise<void> {
+  if (
+    !source.isPublished ||
+    !course.isPublished ||
+    !haveCompatibleEditionIdentity({ course, source })
+  ) {
+    throw new Error("Course families contain incompatible editions");
+  }
+
+  const sourceFamilyId = await ensureCourseFamily({ course: source, transaction });
+
+  const familyIds = [
+    ...new Set([sourceFamilyId, course.familyId].filter((id): id is string => Boolean(id))),
+  ].toSorted();
+
+  const familyId = familyIds[0] ?? sourceFamilyId;
+  const members = await transaction.course.findMany({ where: { familyId: { in: familyIds } } });
+
+  if (members.some((member) => !haveCompatibleEditionIdentity({ course: member, source }))) {
+    throw new Error("Course families contain incompatible editions");
+  }
+
+  await transaction.course.updateMany({
+    data: { familyId },
+    where: { OR: [{ familyId: { in: familyIds } }, { id: course.id }] },
+  });
+
+  await transaction.courseFamily.deleteMany({
+    where: { id: { in: familyIds.filter((id) => id !== familyId) } },
+  });
+}

--- a/packages/core/src/courses/_utils/edition-prompt.ts
+++ b/packages/core/src/courses/_utils/edition-prompt.ts
@@ -1,0 +1,15 @@
+import { type Course } from "@zoonk/db";
+
+/**
+ * A title alone is ambiguous across languages: French "Pain" is bread, not
+ * English pain. Keep source meaning in both the model input and prompt cache.
+ */
+export function getCourseEditionPrompt(
+  source: Pick<Course, "title" | "language" | "description">,
+): string {
+  return JSON.stringify({
+    description: source.description,
+    instructionalLanguage: source.language,
+    title: source.title,
+  });
+}

--- a/packages/core/src/courses/_utils/edition-request.ts
+++ b/packages/core/src/courses/_utils/edition-request.ts
@@ -6,24 +6,26 @@ import { normalizeString } from "@zoonk/utils/string";
 import { type CourseEditionResult } from "../course-editions";
 import { getCompatibleCourseFormats } from "../course-prompt-generation";
 import { resolveLanguageCourse } from "../language-course";
-import { getCourseEditionOutcome, getEditionRestriction } from "./edition-discovery";
+import {
+  getCourseEditionOutcome,
+  getEditionRestriction,
+  getSourceCourse,
+} from "./edition-discovery";
 import { ensureCourseFamily, linkCourseEditions, lockCourseFamilies } from "./edition-family";
 import { getCourseEditionPrompt } from "./edition-prompt";
+
+type EditionRequestInput = { sourceCourseId: string; language: string; coursePromptId: string };
 
 /**
  * Classification is outside the lock. Concurrent callers can classify the same
  * topic, but only the winning request is returned to start a workflow. Request
  * ownership follows the source course through subsequent family merges.
  */
-export async function saveEditionRequest({
+async function persistEditionRequest({
   sourceCourseId,
   language,
   coursePromptId,
-}: {
-  sourceCourseId: string;
-  language: string;
-  coursePromptId: string;
-}): Promise<CourseEditionResult> {
+}: EditionRequestInput): Promise<CourseEditionResult> {
   return prisma.$transaction(async (transaction) => {
     await lockCourseFamilies(transaction);
     const source = await transaction.course.findUniqueOrThrow({ where: { id: sourceCourseId } });
@@ -88,6 +90,38 @@ export async function saveEditionRequest({
       kind: "generation",
     };
   });
+}
+
+/**
+ * Ordinary initialization can finish before its first edition request commits.
+ * Recheck after commit: either this read sees that course, or the workflow's
+ * later linking step sees this request. No prompt lock can invert the existing
+ * course-before-prompt lock order used by workflow claims and completion.
+ */
+export async function saveEditionRequest(input: EditionRequestInput): Promise<CourseEditionResult> {
+  const result = await persistEditionRequest(input);
+
+  if (result.kind !== "generation") {
+    return result;
+  }
+
+  const [prompt, source] = await Promise.all([
+    prisma.coursePrompt.findUniqueOrThrow({
+      include: { course: true },
+      where: { id: result.coursePromptId },
+    }),
+    getSourceCourse(input.sourceCourseId),
+  ]);
+
+  if (!source) {
+    return { kind: "notFound" };
+  }
+
+  if (prompt.course) {
+    return getCourseEditionOutcome({ course: prompt.course, language: input.language, source });
+  }
+
+  return result;
 }
 
 /**

--- a/packages/core/src/courses/_utils/edition-request.ts
+++ b/packages/core/src/courses/_utils/edition-request.ts
@@ -1,0 +1,165 @@
+import "server-only";
+import { generateCanonicalCourseTitle } from "@zoonk/ai/tasks/courses/canonical-title";
+import { type Course, prisma } from "@zoonk/db";
+import { getContentLocale } from "@zoonk/utils/locale";
+import { normalizeString } from "@zoonk/utils/string";
+import { type CourseEditionResult } from "../course-editions";
+import { getCompatibleCourseFormats } from "../course-prompt-generation";
+import { resolveLanguageCourse } from "../language-course";
+import { getCourseEditionOutcome, getEditionRestriction } from "./edition-discovery";
+import { ensureCourseFamily, linkCourseEditions, lockCourseFamilies } from "./edition-family";
+import { getCourseEditionPrompt } from "./edition-prompt";
+
+/**
+ * Classification is outside the lock. Concurrent callers can classify the same
+ * topic, but only the winning request is returned to start a workflow. Request
+ * ownership follows the source course through subsequent family merges.
+ */
+export async function saveEditionRequest({
+  sourceCourseId,
+  language,
+  coursePromptId,
+}: {
+  sourceCourseId: string;
+  language: string;
+  coursePromptId: string;
+}): Promise<CourseEditionResult> {
+  return prisma.$transaction(async (transaction) => {
+    await lockCourseFamilies(transaction);
+    const source = await transaction.course.findUniqueOrThrow({ where: { id: sourceCourseId } });
+
+    if (!source.isPublished) {
+      return { kind: "notFound" };
+    }
+
+    const familyId = await ensureCourseFamily({ course: source, transaction });
+
+    const existing = await transaction.courseEditionRequest.findFirst({
+      include: { coursePrompt: { include: { course: true } } },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      where: { language, sourceCourse: { familyId, isPublished: true } },
+    });
+
+    const selectedPrompt =
+      existing?.coursePrompt ??
+      (await transaction.coursePrompt.findUniqueOrThrow({
+        include: { course: true },
+        where: { id: coursePromptId },
+      }));
+
+    if (selectedPrompt.course?.isPublished === false) {
+      return { kind: "unsupported", reason: "unavailable" };
+    }
+
+    if (
+      !selectedPrompt.generationStatus ||
+      selectedPrompt.intent !== "learn" ||
+      !selectedPrompt.courseFormat ||
+      !getCompatibleCourseFormats(source.format).includes(selectedPrompt.courseFormat) ||
+      source.targetLanguage !== selectedPrompt.targetLanguage ||
+      getContentLocale(selectedPrompt.language) !== language ||
+      getEditionRestriction({ language, source })
+    ) {
+      return { kind: "unsupported", reason: "format" };
+    }
+
+    await transaction.courseEditionRequest.upsert({
+      create: { coursePromptId: selectedPrompt.id, language, sourceCourseId },
+      update: {},
+      where: { sourceLanguage: { language, sourceCourseId } },
+    });
+
+    if (selectedPrompt.course?.isPublished) {
+      await linkCourseEditions({
+        courseId: selectedPrompt.course.id,
+        language,
+        sourceCourseId,
+        transaction,
+      });
+
+      if (selectedPrompt.course.generationStatus === "completed") {
+        return { course: selectedPrompt.course, kind: "course" };
+      }
+    }
+
+    return {
+      coursePromptId: selectedPrompt.id,
+      generationStatus: selectedPrompt.generationStatus,
+      kind: "generation",
+    };
+  });
+}
+
+/**
+ * Published courses already have an intent and format. Translate their identity
+ * with source context, then reuse normal course matching and generation. Running
+ * free-text personalization again would mistake a catalog description for a
+ * request for a personalized course.
+ */
+export async function resolveRegularEditionPrompt({
+  source,
+  language,
+}: {
+  source: Course;
+  language: string;
+}) {
+  const prompt = getCourseEditionPrompt(source);
+  const normalizedPrompt = normalizeString(prompt);
+  const where = { languageNormalizedPrompt: { language, normalizedPrompt } };
+  const cached = await prisma.coursePrompt.findUnique({ include: { course: true }, where });
+
+  if (cached) {
+    return cached;
+  }
+
+  const result = await generateCanonicalCourseTitle({ language, prompt });
+  const title = result.data.title.trim();
+
+  if (!title) {
+    throw new Error("Could not resolve a localized course title");
+  }
+
+  await prisma.coursePrompt.createMany({
+    data: {
+      canonicalTitle: title,
+      courseFormat: source.format,
+      generationStatus: "pending",
+      intent: "learn",
+      language,
+      normalizedPrompt,
+      prompt,
+      targetLanguage: null,
+    },
+    skipDuplicates: true,
+  });
+
+  return prisma.coursePrompt.findUniqueOrThrow({ include: { course: true }, where });
+}
+
+export async function resolveLanguageEdition({
+  source,
+  language,
+}: {
+  source: Course;
+  language: string;
+}): Promise<CourseEditionResult | { kind: "unauthorized" }> {
+  if (!source.targetLanguage) {
+    return { kind: "unsupported", reason: "format" };
+  }
+
+  const result = await resolveLanguageCourse({ language, targetLanguage: source.targetLanguage });
+
+  if (result.kind === "unauthorized") {
+    return result;
+  }
+
+  if (result.kind === "course") {
+    return getCourseEditionOutcome({ course: result.course, language, source });
+  }
+
+  return saveEditionRequest({
+    coursePromptId: result.coursePrompt.id,
+    language,
+    sourceCourseId: source.id,
+  });
+}

--- a/packages/core/src/courses/course-edition-link.test.ts
+++ b/packages/core/src/courses/course-edition-link.test.ts
@@ -1,0 +1,113 @@
+import { prisma, sql } from "@zoonk/db";
+import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { describe, expect, it } from "vitest";
+import { saveEditionRequest } from "./_utils/edition-request";
+import { getCourseEditionForPrompt } from "./course-edition-link";
+
+describe("course edition transaction coordination", () => {
+  it("does not hold the global family lock during ordinary course initialization", async () => {
+    const prompt = await coursePromptFixture();
+
+    await prisma.$transaction(async (transaction) => {
+      await expect(
+        getCourseEditionForPrompt({ coursePromptId: prompt.id, transaction }),
+      ).resolves.toBeNull();
+
+      const locks = await transaction.$queryRaw<{ held: boolean }[]>(sql`
+        SELECT EXISTS (
+          SELECT FROM pg_locks
+          WHERE pid = pg_backend_pid() AND locktype = 'advisory'
+            AND classid = 92741 AND objid = 1 AND granted
+        ) AS held
+      `);
+
+      expect(locks[0]?.held).toBe(false);
+    });
+  });
+
+  it.each(["unlinked", "linked"])(
+    "reconciles a %s prompt completing while an edition request is saved",
+    async (state) => {
+      const organization = await aiOrganizationFixture();
+
+      const [source, target] = await Promise.all([
+        courseFixture({ isPublished: true, organizationId: organization.id }),
+        courseFixture({
+          generationStatus: "completed",
+          isPublished: true,
+          language: "pt",
+          organizationId: organization.id,
+        }),
+      ]);
+
+      const prompt = await coursePromptFixture({
+        courseId: state === "linked" ? target.id : null,
+        language: "pt",
+      });
+
+      const locked = Promise.withResolvers<null>();
+
+      const [, result] = await Promise.all([
+        prisma.$transaction(async (transaction) => {
+          // Existing-course claims lock the course before updating their prompt.
+          // An unlinked prompt models initialization publishing its first target.
+          if (state === "linked") {
+            await transaction.$queryRaw(sql`
+            SELECT id FROM courses WHERE id = ${target.id}::uuid FOR UPDATE
+          `);
+          } else {
+            await transaction.$queryRaw(sql`
+            SELECT id FROM course_prompts WHERE id = ${prompt.id}::uuid FOR UPDATE
+          `);
+          }
+
+          const backend = await transaction.$queryRaw<{ pid: number }[]>(sql`
+          SELECT pg_backend_pid() AS pid
+        `);
+
+          const pid = backend[0]?.pid;
+          expect(pid).toBeDefined();
+          locked.resolve(null);
+
+          // Wait for the actual database conflict instead of scheduling with a sleep.
+          await expect
+            .poll(async () => {
+              const waiters = await prisma.$queryRaw<{ waiting: boolean }[]>(sql`
+            SELECT EXISTS (
+              SELECT FROM pg_stat_activity
+              WHERE ${pid}::int = ANY(pg_blocking_pids(pid))
+            ) AS waiting
+          `);
+
+              return waiters[0]?.waiting;
+            })
+            .toBe(true);
+
+          await transaction.coursePrompt.update({
+            data: { courseId: target.id, generationStatus: "completed" },
+            where: { id: prompt.id },
+          });
+        }),
+        locked.promise.then(() =>
+          saveEditionRequest({
+            coursePromptId: prompt.id,
+            language: "pt",
+            sourceCourseId: source.id,
+          }),
+        ),
+      ]);
+
+      expect(result).toMatchObject({ course: { id: target.id }, kind: "course" });
+
+      const [persistedSource, persistedTarget] = await Promise.all([
+        prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+        prisma.course.findUniqueOrThrow({ where: { id: target.id } }),
+      ]);
+
+      expect(persistedSource.familyId).toBeTruthy();
+      expect(persistedTarget.familyId).toBe(persistedSource.familyId);
+    },
+  );
+});

--- a/packages/core/src/courses/course-edition-link.ts
+++ b/packages/core/src/courses/course-edition-link.ts
@@ -53,6 +53,28 @@ async function getEditionRequests({
 }
 
 /**
+ * Ordinary prompts do not need family serialization. Once provenance exists,
+ * reload it after locking because other edition requests can merge families.
+ * Requests added later reconcile the prompt's course after they commit.
+ */
+async function getLockedEditionRequests({
+  coursePromptId,
+  transaction,
+}: {
+  coursePromptId: string;
+  transaction: TransactionClient;
+}) {
+  const request = await transaction.courseEditionRequest.findFirst({ where: { coursePromptId } });
+
+  if (!request) {
+    return [];
+  }
+
+  await lockCourseFamilies(transaction);
+  return getEditionRequests({ coursePromptId, transaction });
+}
+
+/**
  * Called inside initialization's transaction. The lock remains held until the
  * row is saved, preventing different translated slugs from creating two new
  * editions after independently discovered families have merged.
@@ -64,8 +86,7 @@ export async function getCourseEditionForPrompt({
   coursePromptId: string;
   transaction: TransactionClient;
 }): Promise<{ familyId: string; course: Course | null } | null> {
-  await lockCourseFamilies(transaction);
-  const requests = await getEditionRequests({ coursePromptId, transaction });
+  const requests = await getLockedEditionRequests({ coursePromptId, transaction });
   const first = requests[0];
 
   if (!first) {
@@ -138,8 +159,7 @@ export async function linkCourseToEditionRequests({
   coursePromptId: string;
 }): Promise<void> {
   await prisma.$transaction(async (transaction) => {
-    await lockCourseFamilies(transaction);
-    const requests = await getEditionRequests({ coursePromptId, transaction });
+    const requests = await getLockedEditionRequests({ coursePromptId, transaction });
 
     for (const request of requests) {
       // eslint-disable-next-line no-await-in-loop -- Each attachment can merge the next source's family.

--- a/packages/core/src/courses/course-edition-link.ts
+++ b/packages/core/src/courses/course-edition-link.ts
@@ -1,0 +1,154 @@
+import "server-only";
+import { type Course, type TransactionClient, prisma } from "@zoonk/db";
+import { getContentLocale } from "@zoonk/utils/locale";
+import {
+  chooseCourseEdition,
+  ensureCourseFamily,
+  findFamilyCourse,
+  haveCompatibleEditionIdentity,
+  linkCourseEditions,
+  lockCourseFamilies,
+  mergeCourseFamilies,
+} from "./_utils/edition-family";
+import { getCompatibleCourseFormats } from "./course-prompt-generation";
+
+export { getCourseEditionPrompt } from "./_utils/edition-prompt";
+
+/** Workflow provenance always comes from persisted requests, never client input. */
+async function getEditionRequests({
+  coursePromptId,
+  transaction,
+}: {
+  coursePromptId: string;
+  transaction: TransactionClient;
+}) {
+  const requests = await transaction.courseEditionRequest.findMany({
+    include: { coursePrompt: true, sourceCourse: true },
+    orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+    where: { coursePromptId },
+  });
+
+  const publishedRequests = requests.filter((request) => request.sourceCourse.isPublished);
+
+  if (requests.length > 0 && publishedRequests.length === 0) {
+    throw new Error("Course edition request has no published source course");
+  }
+
+  for (const request of publishedRequests) {
+    const { coursePrompt, sourceCourse } = request;
+
+    if (
+      getContentLocale(coursePrompt.language) !== request.language ||
+      !coursePrompt.courseFormat ||
+      !getCompatibleCourseFormats(sourceCourse.format).includes(coursePrompt.courseFormat) ||
+      sourceCourse.targetLanguage !== coursePrompt.targetLanguage ||
+      (sourceCourse.format === "language" &&
+        getContentLocale(sourceCourse.targetLanguage ?? "") === request.language)
+    ) {
+      throw new Error("Course edition request does not match its source course");
+    }
+  }
+
+  return publishedRequests;
+}
+
+/**
+ * Called inside initialization's transaction. The lock remains held until the
+ * row is saved, preventing different translated slugs from creating two new
+ * editions after independently discovered families have merged.
+ */
+export async function getCourseEditionForPrompt({
+  coursePromptId,
+  transaction,
+}: {
+  coursePromptId: string;
+  transaction: TransactionClient;
+}): Promise<{ familyId: string; course: Course | null } | null> {
+  await lockCourseFamilies(transaction);
+  const requests = await getEditionRequests({ coursePromptId, transaction });
+  const first = requests[0];
+
+  if (!first) {
+    return null;
+  }
+
+  for (const request of requests.slice(1)) {
+    // Each merge changes family IDs, so later merges must read the updated rows.
+    // eslint-disable-next-line no-await-in-loop
+    const [source, course] = await Promise.all([
+      transaction.course.findUniqueOrThrow({ where: { id: first.sourceCourseId } }),
+      transaction.course.findUniqueOrThrow({ where: { id: request.sourceCourseId } }),
+    ]);
+
+    // eslint-disable-next-line no-await-in-loop -- Family mutations must be sequential.
+    await mergeCourseFamilies({ course, source, transaction });
+  }
+
+  const source = await transaction.course.findUniqueOrThrow({
+    where: { id: first.sourceCourseId },
+  });
+
+  const familyId = await ensureCourseFamily({ course: source, transaction });
+  const course = await findFamilyCourse({ familyId, language: first.language, transaction });
+
+  if (course && !haveCompatibleEditionIdentity({ course, source })) {
+    throw new Error("Course edition does not match its source course");
+  }
+
+  return { course, familyId };
+}
+
+/** Checks every source family because a reused prompt can acquire more than one. */
+export async function getExistingCourseEditionForPrompt({
+  coursePromptId,
+}: {
+  coursePromptId: string;
+}): Promise<Course | null> {
+  const requests = await getEditionRequests({ coursePromptId, transaction: prisma });
+
+  const courses = await Promise.all(
+    requests.map(async (request) => {
+      if (!request.sourceCourse.familyId) {
+        return null;
+      }
+
+      const course = await findFamilyCourse({
+        familyId: request.sourceCourse.familyId,
+        language: request.language,
+        transaction: prisma,
+      });
+
+      if (course && !haveCompatibleEditionIdentity({ course, source: request.sourceCourse })) {
+        throw new Error("Course edition does not match its source course");
+      }
+
+      return course;
+    }),
+  );
+
+  return chooseCourseEdition(courses.filter((course): course is Course => Boolean(course)));
+}
+
+/** Attaches every source that reused a prompt, including sources merged mid-run. */
+export async function linkCourseToEditionRequests({
+  courseId,
+  coursePromptId,
+}: {
+  courseId: string;
+  coursePromptId: string;
+}): Promise<void> {
+  await prisma.$transaction(async (transaction) => {
+    await lockCourseFamilies(transaction);
+    const requests = await getEditionRequests({ coursePromptId, transaction });
+
+    for (const request of requests) {
+      // eslint-disable-next-line no-await-in-loop -- Each attachment can merge the next source's family.
+      await linkCourseEditions({
+        courseId,
+        language: request.language,
+        sourceCourseId: request.sourceCourseId,
+        transaction,
+      });
+    }
+  });
+}

--- a/packages/core/src/courses/course-editions.test.ts
+++ b/packages/core/src/courses/course-editions.test.ts
@@ -1,0 +1,509 @@
+import { randomUUID } from "node:crypto";
+import * as canonicalTitleTask from "@zoonk/ai/tasks/courses/canonical-title";
+import * as formatTask from "@zoonk/ai/tasks/courses/format";
+import * as intentTask from "@zoonk/ai/tasks/courses/intent";
+import * as personalizationTask from "@zoonk/ai/tasks/courses/personalization";
+import { prisma } from "@zoonk/db";
+import { signInAs } from "@zoonk/testing/fixtures/auth";
+import { coursePromptFixture } from "@zoonk/testing/fixtures/course-prompts";
+import { courseFixture } from "@zoonk/testing/fixtures/courses";
+import { aiOrganizationFixture } from "@zoonk/testing/fixtures/orgs";
+import { userFixture } from "@zoonk/testing/fixtures/users";
+import { normalizeString } from "@zoonk/utils/string";
+import { headers } from "next/headers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getCourseEditionPrompt } from "./_utils/edition-prompt";
+import { getCourseEditionForPrompt, linkCourseToEditionRequests } from "./course-edition-link";
+import { getCourseEdition, resolveCourseEdition } from "./course-editions";
+import { getCourseSlugForTitle } from "./course-slug";
+
+// Next request headers are the platform boundary; sessions and persistence are real.
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
+
+async function sourceFixture(attrs: Parameters<typeof courseFixture>[0] = {}) {
+  const organization = await aiOrganizationFixture();
+  const title = attrs?.title ?? `Course editions ${randomUUID()}`;
+
+  return courseFixture({
+    isPublished: true,
+    normalizedTitle: normalizeString(title),
+    organizationId: organization.id,
+    title,
+    ...attrs,
+  });
+}
+
+async function authenticate() {
+  const user = await userFixture();
+  vi.mocked(headers).mockResolvedValue(await signInAs(user.email, user.password));
+  return user;
+}
+
+/** Only model responses are substituted; the normal resolver and database run. */
+function mockClassification(title: string) {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- external AI response fixture
+  vi.spyOn(canonicalTitleTask, "generateCanonicalCourseTitle").mockResolvedValue({
+    data: { title },
+  } as never);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- external AI response fixture
+  vi.spyOn(formatTask, "classifyCourseFormat").mockResolvedValue({
+    data: { courseFormat: "core" },
+  } as never);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- external AI response fixture
+  vi.spyOn(intentTask, "classifyCourseIntent").mockResolvedValue({
+    data: { intent: "learn" },
+  } as never);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- external AI response fixture
+  vi.spyOn(personalizationTask, "classifyCoursePersonalization").mockResolvedValue({
+    data: { requiresPersonalization: false },
+  } as never);
+}
+
+describe("course editions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(headers).mockResolvedValue(new Headers());
+  });
+
+  it("leaves a matching course and unrelated legacy data untouched", async () => {
+    const source = await sourceFixture();
+
+    await expect(getCourseEdition({ courseId: source.id, language: "en" })).resolves.toMatchObject({
+      course: { id: source.id, slug: source.slug },
+      kind: "course",
+    });
+
+    await expect(
+      prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+    ).resolves.toMatchObject({ familyId: null });
+  });
+
+  it("does not classify, create a family, or prepare generation on a missing public read", async () => {
+    const source = await sourceFixture();
+    const classify = vi.spyOn(canonicalTitleTask, "generateCanonicalCourseTitle");
+
+    await expect(getCourseEdition({ courseId: source.id, language: "pt" })).resolves.toStrictEqual({
+      kind: "missing",
+    });
+
+    expect(classify).not.toHaveBeenCalled();
+
+    await expect(
+      prisma.courseEditionRequest.count({ where: { sourceCourseId: source.id } }),
+    ).resolves.toBe(0);
+
+    await expect(
+      prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+    ).resolves.toMatchObject({ familyId: null });
+
+    await expect(
+      resolveCourseEdition({ courseId: source.id, language: "pt" }),
+    ).resolves.toStrictEqual({ kind: "unauthorized" });
+
+    expect(classify).not.toHaveBeenCalled();
+  });
+
+  it("links a previously resolved translated prompt on demand and keeps both slugs", async () => {
+    const [source, target, untouched] = await Promise.all([
+      sourceFixture(),
+      sourceFixture({ language: "pt", slug: `ciencia-da-computacao-${randomUUID()}-pt` }),
+      sourceFixture(),
+    ]);
+
+    await coursePromptFixture({
+      courseId: target.id,
+      generationStatus: "completed",
+      language: "pt",
+      prompt: getCourseEditionPrompt(source),
+    });
+
+    await expect(getCourseEdition({ courseId: source.id, language: "pt" })).resolves.toMatchObject({
+      course: { id: target.id, slug: target.slug },
+      kind: "course",
+    });
+
+    const rows = await prisma.course.findMany({
+      where: { id: { in: [source.id, target.id, untouched.id] } },
+    });
+
+    const original = rows.find((row) => row.id === source.id);
+    expect(original?.familyId).toBeTruthy();
+    expect(rows.find((row) => row.id === target.id)?.familyId).toBe(original?.familyId);
+    expect(rows.find((row) => row.id === untouched.id)?.familyId).toBeNull();
+    expect(original?.slug).toBe(source.slug);
+  });
+
+  it("preserves source meaning and uses the actual localized slug without reclassifying the course", async () => {
+    await authenticate();
+    const source = await sourceFixture();
+    const title = `Ciência da Computação ${randomUUID()}`;
+    const slug = getCourseSlugForTitle({ language: "pt", title });
+    const target = await sourceFixture({ language: "pt", slug, title });
+    mockClassification(title);
+    const result = await resolveCourseEdition({ courseId: source.id, language: "pt" });
+    expect(result).toMatchObject({ course: { id: target.id, slug }, kind: "course" });
+
+    expect(canonicalTitleTask.generateCanonicalCourseTitle).toHaveBeenCalledWith({
+      language: "pt",
+      prompt: getCourseEditionPrompt(source),
+    });
+
+    const original = await prisma.course.findUniqueOrThrow({ where: { id: source.id } });
+
+    await expect(
+      prisma.course.findUniqueOrThrow({ where: { id: target.id } }),
+    ).resolves.toMatchObject({ familyId: original.familyId });
+
+    expect(original.familyId).toBeTruthy();
+  });
+
+  it("shares one pending prompt across concurrent requests from different source editions", async () => {
+    await authenticate();
+    const family = await prisma.courseFamily.create({ data: {} });
+
+    const [english, german] = await Promise.all([
+      sourceFixture({ familyId: family.id }),
+      sourceFixture({ familyId: family.id, language: "de" }),
+    ]);
+
+    mockClassification(`Novo curso ${randomUUID()}`);
+
+    const results = await Promise.all(
+      [english, german, english, german].map((source) =>
+        resolveCourseEdition({ courseId: source.id, language: "pt" }),
+      ),
+    );
+
+    expect(results.every((result) => result.kind === "generation")).toBe(true);
+
+    const requests = await prisma.courseEditionRequest.findMany({
+      where: { language: "pt", sourceCourse: { familyId: family.id } },
+    });
+
+    expect(new Set(requests.map((request) => request.coursePromptId)).size).toBe(1);
+    expect(requests).toHaveLength(2);
+
+    expect(
+      new Set(
+        results.flatMap((result) => (result.kind === "generation" ? [result.coursePromptId] : [])),
+      ).size,
+    ).toBe(1);
+
+    await expect(
+      prisma.course.count({ where: { familyId: family.id, language: "pt" } }),
+    ).resolves.toBe(0);
+  });
+
+  it("does not mistake a foreign title for an identically spelled English topic", async () => {
+    await authenticate();
+
+    const source = await sourceFixture({
+      description: "La fabrication du pain, la farine et la fermentation.",
+      language: "fr",
+      title: `Pain ${randomUUID()}`,
+    });
+
+    const wrong = await sourceFixture({
+      description: "Understanding physical pain.",
+      title: "Pain",
+    });
+
+    const title = `Bread ${randomUUID()}`;
+
+    const target = await sourceFixture({
+      slug: getCourseSlugForTitle({ language: "en", title }),
+      title,
+    });
+
+    const unrelatedPrompt = await coursePromptFixture({
+      courseId: wrong.id,
+      generationStatus: "completed",
+      language: "en",
+      prompt: source.title,
+    });
+
+    await expect(getCourseEdition({ courseId: source.id, language: "en" })).resolves.toStrictEqual({
+      kind: "missing",
+    });
+
+    mockClassification(title);
+
+    await expect(
+      resolveCourseEdition({ courseId: source.id, language: "en" }),
+    ).resolves.toMatchObject({ course: { id: target.id }, kind: "course" });
+
+    await expect(
+      prisma.coursePrompt.findUniqueOrThrow({ where: { id: unrelatedPrompt.id } }),
+    ).resolves.toMatchObject({ courseId: wrong.id });
+
+    await expect(
+      prisma.course.findUniqueOrThrow({ where: { id: wrong.id } }),
+    ).resolves.toMatchObject({ familyId: null });
+
+    expect(formatTask.classifyCourseFormat).not.toHaveBeenCalled();
+    expect(intentTask.classifyCourseIntent).not.toHaveBeenCalled();
+    expect(personalizationTask.classifyCoursePersonalization).not.toHaveBeenCalled();
+  });
+
+  it("joins an existing regional edition using its original running prompt", async () => {
+    const family = await prisma.courseFamily.create({ data: {} });
+
+    const [source, target] = await Promise.all([
+      sourceFixture({ familyId: family.id }),
+      sourceFixture({
+        familyId: family.id,
+        generationRunId: "regional-edition-run",
+        generationStatus: "running",
+        language: "pt-BR",
+      }),
+    ]);
+
+    const prompt = await coursePromptFixture({
+      courseId: target.id,
+      generationRunId: target.generationRunId,
+      generationStatus: "running",
+      language: "pt-BR",
+    });
+
+    await expect(getCourseEdition({ courseId: source.id, language: "pt" })).resolves.toStrictEqual({
+      coursePromptId: prompt.id,
+      generationStatus: "running",
+      kind: "generation",
+    });
+  });
+
+  it.each(["en", "en-US"])(
+    "never prepares an English-through-English edition for %s",
+    async (language) => {
+      await authenticate();
+
+      const source = await sourceFixture({
+        format: "language",
+        language: "de",
+        targetLanguage: "en",
+      });
+
+      await expect(resolveCourseEdition({ courseId: source.id, language })).resolves.toStrictEqual({
+        kind: "unsupported",
+        reason: "sameLanguage",
+      });
+
+      await expect(
+        prisma.courseEditionRequest.count({ where: { sourceCourseId: source.id } }),
+      ).resolves.toBe(0);
+    },
+  );
+
+  it("stops offering a linked edition after it is unpublished", async () => {
+    const [source, target] = await Promise.all([
+      sourceFixture(),
+      sourceFixture({ isPublished: false, language: "pt" }),
+    ]);
+
+    const prompt = await coursePromptFixture({
+      courseId: target.id,
+      generationStatus: "completed",
+      language: "pt",
+    });
+
+    await prisma.courseEditionRequest.create({
+      data: { coursePromptId: prompt.id, language: "pt", sourceCourseId: source.id },
+    });
+
+    await expect(getCourseEdition({ courseId: source.id, language: "pt" })).resolves.toStrictEqual({
+      kind: "unsupported",
+      reason: "unavailable",
+    });
+  });
+
+  it("rejects unavailable sources and unsupported locales", async () => {
+    const source = await sourceFixture({ isPublished: false });
+
+    await expect(getCourseEdition({ courseId: source.id, language: "pt" })).resolves.toStrictEqual({
+      kind: "notFound",
+    });
+
+    await expect(
+      getCourseEdition({ courseId: source.id, language: "xx-invalid" }),
+    ).resolves.toStrictEqual({ kind: "unsupported", reason: "language" });
+  });
+
+  it("merges discovered families without dropping duplicate course IDs or pending provenance", async () => {
+    const [leftFamily, rightFamily] = await Promise.all([
+      prisma.courseFamily.create({ data: {} }),
+      prisma.courseFamily.create({ data: {} }),
+    ]);
+
+    const [source, duplicate, target] = await Promise.all([
+      sourceFixture({ familyId: leftFamily.id }),
+      sourceFixture({ familyId: rightFamily.id }),
+      sourceFixture({ familyId: rightFamily.id, language: "pt" }),
+    ]);
+
+    const [prompt, pending] = await Promise.all([
+      coursePromptFixture({ courseId: target.id, language: "pt" }),
+      coursePromptFixture({ language: "de" }),
+    ]);
+
+    await prisma.courseEditionRequest.createMany({
+      data: [
+        { coursePromptId: prompt.id, language: "pt", sourceCourseId: source.id },
+        { coursePromptId: pending.id, language: "de", sourceCourseId: duplicate.id },
+      ],
+    });
+
+    await linkCourseToEditionRequests({ courseId: target.id, coursePromptId: prompt.id });
+
+    const rows = await prisma.course.findMany({
+      where: { id: { in: [source.id, duplicate.id, target.id] } },
+    });
+
+    expect(rows).toHaveLength(3);
+    expect(new Set(rows.map((row) => row.familyId)).size).toBe(1);
+
+    await expect(
+      prisma.courseEditionRequest.count({ where: { coursePromptId: pending.id } }),
+    ).resolves.toBe(1);
+  });
+
+  it("uses remaining published sources when an older request source is unpublished", async () => {
+    const [removed, source, target] = await Promise.all([
+      sourceFixture({ isPublished: false }),
+      sourceFixture(),
+      sourceFixture({ language: "pt" }),
+    ]);
+
+    const prompt = await coursePromptFixture({ language: "pt" });
+
+    await prisma.courseEditionRequest.createMany({
+      data: [removed, source].map((course) => ({
+        coursePromptId: prompt.id,
+        language: "pt",
+        sourceCourseId: course.id,
+      })),
+    });
+
+    const edition = await prisma.$transaction((transaction) =>
+      getCourseEditionForPrompt({ coursePromptId: prompt.id, transaction }),
+    );
+
+    expect(edition).toMatchObject({ course: null, familyId: expect.any(String) });
+
+    await linkCourseToEditionRequests({ courseId: target.id, coursePromptId: prompt.id });
+
+    const [linked, removedSource] = await Promise.all([
+      prisma.course.findUniqueOrThrow({ where: { id: target.id } }),
+      prisma.course.findUniqueOrThrow({ where: { id: removed.id } }),
+    ]);
+
+    expect(linked.familyId).toBe(edition?.familyId);
+    expect(removedSource.familyId).toBeNull();
+  });
+
+  it("refuses to initialize an edition after every request source is unpublished", async () => {
+    const source = await sourceFixture({ isPublished: false });
+    const prompt = await coursePromptFixture({ language: "pt" });
+
+    await prisma.courseEditionRequest.create({
+      data: { coursePromptId: prompt.id, language: "pt", sourceCourseId: source.id },
+    });
+
+    await expect(
+      prisma.$transaction((transaction) =>
+        getCourseEditionForPrompt({ coursePromptId: prompt.id, transaction }),
+      ),
+    ).rejects.toThrow("source course");
+
+    await expect(
+      prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+    ).resolves.toMatchObject({ familyId: null });
+  });
+
+  it("prepares live provenance when the only family request came from an unpublished source", async () => {
+    await authenticate();
+    mockClassification(`Published edition ${randomUUID()}`);
+    const family = await prisma.courseFamily.create({ data: {} });
+
+    const [removed, source] = await Promise.all([
+      sourceFixture({ familyId: family.id, isPublished: false, language: "de" }),
+      sourceFixture({ familyId: family.id }),
+    ]);
+
+    const stalePrompt = await coursePromptFixture({ language: "pt" });
+
+    await prisma.courseEditionRequest.create({
+      data: { coursePromptId: stalePrompt.id, language: "pt", sourceCourseId: removed.id },
+    });
+
+    await expect(getCourseEdition({ courseId: source.id, language: "pt" })).resolves.toStrictEqual({
+      kind: "missing",
+    });
+
+    const result = await resolveCourseEdition({ courseId: source.id, language: "pt" });
+
+    expect(result).toMatchObject({ kind: "generation" });
+
+    const request = await prisma.courseEditionRequest.findUniqueOrThrow({
+      where: { sourceLanguage: { language: "pt", sourceCourseId: source.id } },
+    });
+
+    expect(request.coursePromptId).not.toBe(stalePrompt.id);
+    expect(result).toMatchObject({ coursePromptId: request.coursePromptId });
+  });
+
+  it("validates every source sharing a prompt and rolls back incompatible family links", async () => {
+    const [source, invalid, target] = await Promise.all([
+      sourceFixture(),
+      sourceFixture({ format: "language", targetLanguage: "ja" }),
+      sourceFixture({ language: "pt" }),
+    ]);
+
+    const prompt = await coursePromptFixture({ courseId: target.id, language: "pt" });
+
+    await prisma.courseEditionRequest.createMany({
+      data: [source, invalid].map((course) => ({
+        coursePromptId: prompt.id,
+        language: "pt",
+        sourceCourseId: course.id,
+      })),
+    });
+
+    await expect(
+      linkCourseToEditionRequests({ courseId: target.id, coursePromptId: prompt.id }),
+    ).rejects.toThrow("does not match");
+
+    await expect(
+      prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+    ).resolves.toMatchObject({ familyId: null });
+  });
+
+  it("finds a target attached to a later source of a shared prompt before initializing another course", async () => {
+    const family = await prisma.courseFamily.create({ data: {} });
+
+    const [source, other, target] = await Promise.all([
+      sourceFixture(),
+      sourceFixture({ familyId: family.id, language: "de" }),
+      sourceFixture({ familyId: family.id, language: "pt" }),
+    ]);
+
+    const prompt = await coursePromptFixture({ language: "pt" });
+
+    await prisma.courseEditionRequest.createMany({
+      data: [source, other].map((course) => ({
+        coursePromptId: prompt.id,
+        language: "pt",
+        sourceCourseId: course.id,
+      })),
+    });
+
+    const result = await prisma.$transaction((transaction) =>
+      getCourseEditionForPrompt({ coursePromptId: prompt.id, transaction }),
+    );
+
+    expect(result).toMatchObject({ course: { id: target.id } });
+
+    await expect(
+      prisma.course.findUniqueOrThrow({ where: { id: source.id } }),
+    ).resolves.toMatchObject({ familyId: result?.familyId });
+  });
+});

--- a/packages/core/src/courses/course-editions.ts
+++ b/packages/core/src/courses/course-editions.ts
@@ -1,0 +1,158 @@
+import "server-only";
+import { type Course, type GenerationStatus, prisma } from "@zoonk/db";
+import { getContentLocale } from "@zoonk/utils/locale";
+import { AI_ORG_SLUG } from "@zoonk/utils/org";
+import { getSession } from "../users/get-session";
+import { getReusableCourseForCoursePrompt } from "./_utils/course-prompt-reusable-course";
+import {
+  findKnownEdition,
+  getCourseEditionOutcome,
+  getEditionRestriction,
+  getSourceCourse,
+  getStoredEditionRequest,
+} from "./_utils/edition-discovery";
+import {
+  resolveLanguageEdition,
+  resolveRegularEditionPrompt,
+  saveEditionRequest,
+} from "./_utils/edition-request";
+
+export type CourseEditionResult =
+  | { kind: "course"; course: Course }
+  | { kind: "generation"; coursePromptId: string; generationStatus: GenerationStatus }
+  | { kind: "missing" }
+  | { kind: "notFound" }
+  | { kind: "unsupported"; reason: "sameLanguage" | "format" | "language" | "unavailable" };
+
+type CourseEditionInput = { courseId: string; language: string };
+
+/**
+ * Discovers available editions and existing work. This may persist a proven
+ * legacy association, but cannot classify prompts, enroll users or generate
+ * content. Missing results stay uncached so newly resolved editions appear.
+ */
+export async function getCourseEdition({
+  courseId,
+  language,
+}: CourseEditionInput): Promise<CourseEditionResult> {
+  const locale = getContentLocale(language);
+
+  if (!locale) {
+    return { kind: "unsupported", reason: "language" };
+  }
+
+  const source = await getSourceCourse(courseId);
+
+  if (!source) {
+    return { kind: "notFound" };
+  }
+
+  if (getContentLocale(source.language) === locale) {
+    return { course: source, kind: "course" };
+  }
+
+  if (source.organization?.slug !== AI_ORG_SLUG) {
+    return { kind: "unsupported", reason: "format" };
+  }
+
+  const restriction = getEditionRestriction({ language: locale, source });
+
+  if (restriction) {
+    return restriction;
+  }
+
+  const [course, request] = await Promise.all([
+    findKnownEdition({ language: locale, source }),
+    getStoredEditionRequest({ language: locale, source }),
+  ]);
+
+  if (course) {
+    return getCourseEditionOutcome({ course, language: locale, source });
+  }
+
+  if (request?.coursePrompt.course?.isPublished === false) {
+    return { kind: "unsupported", reason: "unavailable" };
+  }
+
+  if (request?.coursePrompt.course?.isPublished) {
+    return getCourseEditionOutcome({
+      course: request.coursePrompt.course,
+      language: locale,
+      source,
+    });
+  }
+
+  if (request?.coursePrompt.generationStatus) {
+    return {
+      coursePromptId: request.coursePromptId,
+      generationStatus: request.coursePrompt.generationStatus,
+      kind: "generation",
+    };
+  }
+
+  return { kind: "missing" };
+}
+
+/** Only an authenticated, explicit action can prepare a new course edition. */
+export async function resolveCourseEdition(
+  input: CourseEditionInput,
+): Promise<CourseEditionResult | { kind: "unauthorized" }> {
+  const known = await getCourseEdition(input);
+
+  if (known.kind !== "missing") {
+    return known;
+  }
+
+  const session = await getSession();
+
+  if (!session) {
+    return { kind: "unauthorized" };
+  }
+
+  const source = await getSourceCourse(input.courseId);
+  const language = getContentLocale(input.language);
+
+  if (!source) {
+    return { kind: "notFound" };
+  }
+
+  if (!language) {
+    return { kind: "unsupported", reason: "language" };
+  }
+
+  const restriction = getEditionRestriction({ language, source });
+
+  if (restriction) {
+    return restriction;
+  }
+
+  if (source.format === "language") {
+    return resolveLanguageEdition({ language, source });
+  }
+
+  const prompt = await resolveRegularEditionPrompt({ language, source });
+
+  const saved = await saveEditionRequest({
+    coursePromptId: prompt.id,
+    language,
+    sourceCourseId: source.id,
+  });
+
+  if (saved.kind !== "generation") {
+    return saved;
+  }
+
+  const selected = await prisma.coursePrompt.findUniqueOrThrow({
+    include: { course: true },
+    where: { id: saved.coursePromptId },
+  });
+
+  const reusable = await getReusableCourseForCoursePrompt(selected);
+
+  if (reusable) {
+    const course = await prisma.course.findUniqueOrThrow({ where: { id: reusable.id } });
+    return getCourseEditionOutcome({ course, language, source });
+  }
+
+  return saved;
+}

--- a/packages/core/src/courses/course-prompt-generation.test.ts
+++ b/packages/core/src/courses/course-prompt-generation.test.ts
@@ -31,19 +31,37 @@ describe(getCoursePromptGenerationError, () => {
     expect(getCoursePromptGenerationError(prompt)).toBe("Course prompt is not generatable");
   });
 
-  it.each(["en", "en-US", "EN"])(
-    "rejects a language prompt whose %s source matches its target",
-    (language) => {
-      const prompt = {
-        ...generatableCorePrompt,
-        courseFormat: "language" as const,
-        language,
-        targetLanguage: "en",
-      };
+  it.each([
+    ["en", "en"],
+    ["en-US", "en"],
+    ["EN", "en"],
+    ["ja-JP", "ja"],
+    ["zh-Hant-TW", "zh"],
+    ["JA-jp", "ja"],
+  ])("rejects a language prompt whose %s source matches its target", (language, targetLanguage) => {
+    const prompt = {
+      ...generatableCorePrompt,
+      courseFormat: "language" as const,
+      language,
+      targetLanguage,
+    };
 
-      expect(getCoursePromptGenerationError(prompt)).toBe(
-        "Language course source and target languages must be different",
-      );
-    },
-  );
+    expect(getCoursePromptGenerationError(prompt)).toBe(
+      "Language course source and target languages must be different",
+    );
+  });
+
+  it.each([
+    ["ja-JP", "ko"],
+    ["zh-Hant-TW", "ja"],
+  ])("accepts %s language courses with a different %s target", (language, targetLanguage) => {
+    expect(
+      getCoursePromptGenerationError({
+        ...generatableCorePrompt,
+        courseFormat: "language",
+        language,
+        targetLanguage,
+      }),
+    ).toBeNull();
+  });
 });

--- a/packages/core/src/courses/course-prompt-generation.test.ts
+++ b/packages/core/src/courses/course-prompt-generation.test.ts
@@ -31,15 +31,19 @@ describe(getCoursePromptGenerationError, () => {
     expect(getCoursePromptGenerationError(prompt)).toBe("Course prompt is not generatable");
   });
 
-  it("rejects a language prompt whose source and target languages match", () => {
-    const prompt = {
-      ...generatableCorePrompt,
-      courseFormat: "language" as const,
-      targetLanguage: "en",
-    };
+  it.each(["en", "en-US", "EN"])(
+    "rejects a language prompt whose %s source matches its target",
+    (language) => {
+      const prompt = {
+        ...generatableCorePrompt,
+        courseFormat: "language" as const,
+        language,
+        targetLanguage: "en",
+      };
 
-    expect(getCoursePromptGenerationError(prompt)).toBe(
-      "Language course source and target languages must be different",
-    );
-  });
+      expect(getCoursePromptGenerationError(prompt)).toBe(
+        "Language course source and target languages must be different",
+      );
+    },
+  );
 });

--- a/packages/core/src/courses/course-prompt-generation.ts
+++ b/packages/core/src/courses/course-prompt-generation.ts
@@ -1,5 +1,5 @@
 import { type CourseFormat, type CoursePrompt } from "@zoonk/db";
-import { getContentLocale } from "@zoonk/utils/locale";
+import { getLanguageSubtag } from "@zoonk/utils/locale";
 
 const SAME_LANGUAGE_COURSE_ERROR = "Language course source and target languages must be different";
 const UNSUPPORTED_COURSE_PROMPT_ERROR = "Course prompt is not generatable";
@@ -49,11 +49,12 @@ export function getCompatibleCourseFormats(courseFormat: CourseFormat): CourseFo
 function isSameLanguageCourseRequest(
   prompt: Pick<CoursePromptGenerationInput, "courseFormat" | "language" | "targetLanguage">,
 ): boolean {
+  const language = getLanguageSubtag(prompt.language);
+
   return (
     prompt.courseFormat === "language" &&
     (prompt.targetLanguage === prompt.language ||
-      (getContentLocale(prompt.language) !== null &&
-        getContentLocale(prompt.language) === getContentLocale(prompt.targetLanguage ?? "")))
+      (language !== null && language === getLanguageSubtag(prompt.targetLanguage ?? "")))
   );
 }
 

--- a/packages/core/src/courses/course-prompt-generation.ts
+++ b/packages/core/src/courses/course-prompt-generation.ts
@@ -1,4 +1,5 @@
 import { type CourseFormat, type CoursePrompt } from "@zoonk/db";
+import { getContentLocale } from "@zoonk/utils/locale";
 
 const SAME_LANGUAGE_COURSE_ERROR = "Language course source and target languages must be different";
 const UNSUPPORTED_COURSE_PROMPT_ERROR = "Course prompt is not generatable";
@@ -48,7 +49,12 @@ export function getCompatibleCourseFormats(courseFormat: CourseFormat): CourseFo
 function isSameLanguageCourseRequest(
   prompt: Pick<CoursePromptGenerationInput, "courseFormat" | "language" | "targetLanguage">,
 ): boolean {
-  return prompt.courseFormat === "language" && prompt.targetLanguage === prompt.language;
+  return (
+    prompt.courseFormat === "language" &&
+    (prompt.targetLanguage === prompt.language ||
+      (getContentLocale(prompt.language) !== null &&
+        getContentLocale(prompt.language) === getContentLocale(prompt.targetLanguage ?? "")))
+  );
 }
 
 /**

--- a/packages/core/src/courses/get-course-prompt-generation.test.ts
+++ b/packages/core/src/courses/get-course-prompt-generation.test.ts
@@ -37,6 +37,7 @@ describe(getCoursePromptGeneration, () => {
   it("targets the first published lesson as soon as a core course becomes useful", async () => {
     const course = await courseFixture({
       generationStatus: "running",
+      isPublished: true,
       organizationId,
       title: `Core generation ${randomUUID()}`,
     });
@@ -73,6 +74,7 @@ describe(getCoursePromptGeneration, () => {
   it("falls back to a completed core course when no intro lesson exists", async () => {
     const course = await courseFixture({
       generationStatus: "completed",
+      isPublished: true,
       organizationId,
       title: `Completed core generation ${randomUUID()}`,
     });
@@ -89,6 +91,7 @@ describe(getCoursePromptGeneration, () => {
     const course = await courseFixture({
       format: "language",
       generationStatus: "running",
+      isPublished: true,
       organizationId,
       title: `Language generation ${randomUUID()}`,
     });
@@ -108,6 +111,7 @@ describe(getCoursePromptGeneration, () => {
     const course = await courseFixture({
       format: "language",
       generationStatus: "completed",
+      isPublished: true,
       organizationId,
       title: `Completed language generation ${randomUUID()}`,
     });
@@ -118,6 +122,36 @@ describe(getCoursePromptGeneration, () => {
       status: "redirect",
       target: { courseSlug: course.slug, kind: "course" },
     });
+  });
+
+  it.each([
+    { format: "core", generationStatus: "running" },
+    { format: "core", generationStatus: "completed" },
+    { format: "language", generationStatus: "completed" },
+  ] as const)("hides an unpublished $format course while $generationStatus", async (attrs) => {
+    const course = await courseFixture({ ...attrs, isPublished: false, organizationId });
+
+    const chapter = await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId,
+      position: 0,
+    });
+
+    await lessonFixture({ chapterId: chapter.id, isPublished: true, organizationId, position: 0 });
+
+    const prompt = await coursePromptFixture({
+      courseFormat: attrs.format,
+      courseId: course.id,
+      generationStatus: attrs.generationStatus,
+    });
+
+    const resources = await Promise.all([
+      getCoursePromptGeneration({ coursePromptId: prompt.id }),
+      getCoursePromptGenerationResource({ coursePromptId: prompt.id }),
+    ]);
+
+    expect(resources).toStrictEqual([{ status: "notFound" }, { status: "notFound" }]);
   });
 
   it("hides malformed and incomplete prompt resources", async () => {

--- a/packages/core/src/courses/get-course-prompt-generation.ts
+++ b/packages/core/src/courses/get-course-prompt-generation.ts
@@ -52,7 +52,8 @@ export async function getCoursePromptGeneration({ coursePromptId }: { courseProm
   if (
     !coursePrompt?.canonicalTitle ||
     !coursePrompt.courseFormat ||
-    !coursePrompt.generationStatus
+    !coursePrompt.generationStatus ||
+    coursePrompt.course?.isPublished === false
   ) {
     return { status: "notFound" as const };
   }
@@ -102,7 +103,8 @@ export async function getCoursePromptGenerationResource({
   if (
     !coursePrompt?.canonicalTitle ||
     !coursePrompt.courseFormat ||
-    !coursePrompt.generationStatus
+    !coursePrompt.generationStatus ||
+    coursePrompt.course?.isPublished === false
   ) {
     return { status: "notFound" as const };
   }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -27,6 +27,8 @@ export type {
   Course,
   CourseCategory,
   CourseCompletion,
+  CourseEditionRequest,
+  CourseFamily,
   CoursePrompt,
   CourseUser,
   GenerationStatus,

--- a/packages/db/src/prisma/migrations/20260911182030_course_language_editions/migration.sql
+++ b/packages/db/src/prisma/migrations/20260911182030_course_language_editions/migration.sql
@@ -1,0 +1,39 @@
+-- AlterTable
+ALTER TABLE "courses" ADD COLUMN     "family_id" UUID;
+
+-- CreateTable
+CREATE TABLE "course_families" (
+    "id" UUID NOT NULL DEFAULT uuidv7(),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "course_families_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "course_edition_requests" (
+    "id" UUID NOT NULL DEFAULT uuidv7(),
+    "source_course_id" UUID NOT NULL,
+    "language" VARCHAR(10) NOT NULL,
+    "course_prompt_id" UUID NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "course_edition_requests_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "course_edition_requests_course_prompt_id_idx" ON "course_edition_requests"("course_prompt_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "course_edition_requests_source_course_id_language_key" ON "course_edition_requests"("source_course_id", "language");
+
+-- CreateIndex
+CREATE INDEX "courses_family_id_language_idx" ON "courses"("family_id", "language");
+
+-- AddForeignKey
+ALTER TABLE "courses" ADD CONSTRAINT "courses_family_id_fkey" FOREIGN KEY ("family_id") REFERENCES "course_families"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_edition_requests" ADD CONSTRAINT "course_edition_requests_source_course_id_fkey" FOREIGN KEY ("source_course_id") REFERENCES "courses"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "course_edition_requests" ADD CONSTRAINT "course_edition_requests_course_prompt_id_fkey" FOREIGN KEY ("course_prompt_id") REFERENCES "course_prompts"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/src/prisma/models/courses.prisma
+++ b/packages/db/src/prisma/models/courses.prisma
@@ -1,30 +1,33 @@
 model Course {
-  id               String             @id @default(dbgenerated("uuidv7()")) @db.Uuid
-  organizationId   String?            @map("organization_id") @db.Uuid
-  organization     Organization?      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  userId           String?            @map("user_id") @db.Uuid
-  user             User?              @relation(fields: [userId], references: [id], onDelete: Cascade)
-  format           CourseFormat       @default(core)
-  completedAt      DateTime?          @map("completed_at")
-  isPublished      Boolean            @default(false) @map("is_published")
-  language         String             @db.VarChar(10)
+  id               String                 @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  familyId         String?                @map("family_id") @db.Uuid
+  family           CourseFamily?          @relation(fields: [familyId], references: [id], onDelete: SetNull)
+  organizationId   String?                @map("organization_id") @db.Uuid
+  organization     Organization?          @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  userId           String?                @map("user_id") @db.Uuid
+  user             User?                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  format           CourseFormat           @default(core)
+  completedAt      DateTime?              @map("completed_at")
+  isPublished      Boolean                @default(false) @map("is_published")
+  language         String                 @db.VarChar(10)
   slug             String
   title            String
-  normalizedTitle  String             @map("normalized_title")
+  normalizedTitle  String                 @map("normalized_title")
   description      String?
-  landingPage      Json?              @map("landing_page")
-  targetLanguage   String?            @map("target_language") @db.VarChar(10)
-  generationStatus GenerationStatus   @default(completed) @map("generation_status")
-  generationRunId  String?            @map("generation_run_id")
-  imageUrl         String?            @map("image_url")
-  userCount        Int                @default(0) @map("user_count")
-  createdAt        DateTime           @default(now()) @map("created_at")
-  updatedAt        DateTime           @default(now()) @updatedAt @map("updated_at")
+  landingPage      Json?                  @map("landing_page")
+  targetLanguage   String?                @map("target_language") @db.VarChar(10)
+  generationStatus GenerationStatus       @default(completed) @map("generation_status")
+  generationRunId  String?                @map("generation_run_id")
+  imageUrl         String?                @map("image_url")
+  userCount        Int                    @default(0) @map("user_count")
+  createdAt        DateTime               @default(now()) @map("created_at")
+  updatedAt        DateTime               @default(now()) @updatedAt @map("updated_at")
   categories       CourseCategory[]
   chapters         Chapter[]
   completions      CourseCompletion[]
   prompts          CoursePrompt[]
   users            CourseUser[]
+  editionRequests  CourseEditionRequest[]
 
   @@unique([organizationId, slug], name: "orgSlug")
   @@unique([userId, slug], name: "userSlug")
@@ -33,24 +36,48 @@ model Course {
   @@index([isPublished, normalizedTitle])
   @@index([isPublished, language, userCount, id])
   @@index([userId, format])
+  @@index([familyId, language])
   @@map("courses")
 }
 
+model CourseFamily {
+  id        String   @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  courses   Course[]
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@map("course_families")
+}
+
+model CourseEditionRequest {
+  id             String       @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  sourceCourseId String       @map("source_course_id") @db.Uuid
+  sourceCourse   Course       @relation(fields: [sourceCourseId], references: [id], onDelete: Cascade)
+  language       String       @db.VarChar(10)
+  coursePromptId String       @map("course_prompt_id") @db.Uuid
+  coursePrompt   CoursePrompt @relation(fields: [coursePromptId], references: [id], onDelete: Cascade)
+  createdAt      DateTime     @default(now()) @map("created_at")
+
+  @@unique([sourceCourseId, language], name: "sourceLanguage")
+  @@index([coursePromptId])
+  @@map("course_edition_requests")
+}
+
 model CoursePrompt {
-  id               String             @id @default(dbgenerated("uuidv7()")) @db.Uuid
-  courseId         String?            @map("course_id") @db.Uuid
-  course           Course?            @relation(fields: [courseId], references: [id], onDelete: SetNull)
-  language         String             @db.VarChar(10)
+  id               String                 @id @default(dbgenerated("uuidv7()")) @db.Uuid
+  courseId         String?                @map("course_id") @db.Uuid
+  course           Course?                @relation(fields: [courseId], references: [id], onDelete: SetNull)
+  language         String                 @db.VarChar(10)
   prompt           String
-  normalizedPrompt String             @map("normalized_prompt")
+  normalizedPrompt String                 @map("normalized_prompt")
   intent           CoursePromptIntent
-  courseFormat     CourseFormat?      @map("course_format")
-  canonicalTitle   String?            @map("canonical_title")
-  targetLanguage   String?            @map("target_language") @db.VarChar(10)
-  generationStatus GenerationStatus?  @map("generation_status")
-  generationRunId  String?            @map("generation_run_id")
-  createdAt        DateTime           @default(now()) @map("created_at")
-  updatedAt        DateTime           @default(now()) @updatedAt @map("updated_at")
+  courseFormat     CourseFormat?          @map("course_format")
+  canonicalTitle   String?                @map("canonical_title")
+  targetLanguage   String?                @map("target_language") @db.VarChar(10)
+  generationStatus GenerationStatus?      @map("generation_status")
+  generationRunId  String?                @map("generation_run_id")
+  createdAt        DateTime               @default(now()) @map("created_at")
+  updatedAt        DateTime               @default(now()) @updatedAt @map("updated_at")
+  editionRequests  CourseEditionRequest[]
 
   @@unique([language, normalizedPrompt], name: "languageNormalizedPrompt")
   @@index([courseId])

--- a/packages/utils/src/locale.test.ts
+++ b/packages/utils/src/locale.test.ts
@@ -2,10 +2,29 @@ import { describe, expect, it } from "vitest";
 import {
   getContentLocale,
   getCountryFromAcceptLanguage,
+  getLanguageSubtag,
   getLocaleFromRequest,
   getSupportedLocaleFromLanguage,
   isValidLocale,
 } from "./locale";
+
+describe(getLanguageSubtag, () => {
+  it.each([
+    ["ja-JP", "ja"],
+    ["JA-jp", "ja"],
+    ["zh-Hant-TW", "zh"],
+    ["iw-IL", "he"],
+  ])("preserves language identity outside supported UI locales for %s", (language, subtag) => {
+    expect(getLanguageSubtag(language)).toBe(subtag);
+  });
+
+  it.each(["", "en_US", "invalid_language", "und", "und-Latn"])(
+    "returns no language identity for %s",
+    (language) => {
+      expect(getLanguageSubtag(language)).toBeNull();
+    },
+  );
+});
 
 describe(getContentLocale, () => {
   it.each([
@@ -19,7 +38,7 @@ describe(getContentLocale, () => {
     expect(getContentLocale(language)).toBe(locale);
   });
 
-  it.each(["it", "ja-JP", "", "en_US", "pt-invalid_tag"])(
+  it.each(["it", "ja-JP", "", "en_US", "pt-invalid_tag", "und", "und-Latn"])(
     "does not invent an English content locale for %s",
     (language) => {
       expect(getContentLocale(language)).toBeNull();

--- a/packages/utils/src/locale.test.ts
+++ b/packages/utils/src/locale.test.ts
@@ -1,10 +1,31 @@
 import { describe, expect, it } from "vitest";
 import {
+  getContentLocale,
   getCountryFromAcceptLanguage,
   getLocaleFromRequest,
   getSupportedLocaleFromLanguage,
   isValidLocale,
 } from "./locale";
+
+describe(getContentLocale, () => {
+  it.each([
+    ["en", "en"],
+    ["es-419", "es"],
+    ["pt-BR", "pt"],
+    ["PT-pt", "pt"],
+    ["fr-Latn-CA", "fr"],
+    ["de-DE", "de"],
+  ])("matches the supported route locale for %s", (language, locale) => {
+    expect(getContentLocale(language)).toBe(locale);
+  });
+
+  it.each(["it", "ja-JP", "", "en_US", "pt-invalid_tag"])(
+    "does not invent an English content locale for %s",
+    (language) => {
+      expect(getContentLocale(language)).toBeNull();
+    },
+  );
+});
 
 describe(isValidLocale, () => {
   it("accepts every app locale", () => {

--- a/packages/utils/src/locale.ts
+++ b/packages/utils/src/locale.ts
@@ -14,18 +14,26 @@ export function isValidLocale(value: string): value is SupportedLocale {
 }
 
 /**
+ * Content matching and indexing need a real supported language. A navigation
+ * fallback would incorrectly identify unsupported content as English.
+ */
+export function getContentLocale(language: string): SupportedLocale | null {
+  try {
+    const locale = new Intl.Locale(language).language;
+    return isValidLocale(locale) ? locale : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Stored content languages can include regional tags such as `pt-BR`, while
  * app routes only support base locales such as `pt`. Falling back to English
  * keeps unsupported content languages on a real route instead of inventing an
  * invalid locale prefix.
  */
 export function getSupportedLocaleFromLanguage(language: string): SupportedLocale {
-  try {
-    const locale = new Intl.Locale(language).language;
-    return isValidLocale(locale) ? locale : DEFAULT_LOCALE;
-  } catch {
-    return DEFAULT_LOCALE;
-  }
+  return getContentLocale(language) ?? DEFAULT_LOCALE;
 }
 
 /**

--- a/packages/utils/src/locale.ts
+++ b/packages/utils/src/locale.ts
@@ -13,17 +13,22 @@ export function isValidLocale(value: string): value is SupportedLocale {
   return SUPPORTED_LOCALES.some((locale) => locale === value);
 }
 
+/** Canonical language identity must also support languages outside the UI catalog. */
+export function getLanguageSubtag(language: string): string | null {
+  try {
+    return new Intl.Locale(language).language ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Content matching and indexing need a real supported language. A navigation
  * fallback would incorrectly identify unsupported content as English.
  */
 export function getContentLocale(language: string): SupportedLocale | null {
-  try {
-    const locale = new Intl.Locale(language).language;
-    return isValidLocale(locale) ? locale : null;
-  } catch {
-    return null;
-  }
+  const locale = getLanguageSubtag(language);
+  return locale && isValidLocale(locale) ? locale : null;
 }
 
 /**


### PR DESCRIPTION
Course links can open content in a different language from the UI. Resolve existing localized editions on demand, or offer to find or generate one through the existing course workflow, while preserving localized slugs and progress in the original course.

Add course families without backfilling existing data, public API support, and generation handoff/retry recovery. Keep mismatched language URLs out of indexing and sitemaps, and prevent language courses taught through the language being learned.
