### PR TITLE
chore(ci): speed up main e2e and retain timing reports

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -14,7 +14,7 @@ on:
         default: "4"
         options: ["3", "4", "6"]
       rebuild:
-        description: Rebuild instead of restoring Turbo build outputs
+        description: Build without Turbo or Next.js caches
         type: boolean
         default: false
 
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Restore Next.js build cache
+        if: ${{ !inputs.rebuild }}
         id: nextjs-cache
         uses: actions/cache/restore@v6
         with:
@@ -101,7 +102,7 @@ jobs:
           retention-days: 7
 
       - name: Save Next.js build cache
-        if: ${{ matrix.shard == 1 && steps.nextjs-cache.outputs.cache-hit != 'true' }}
+        if: ${{ !inputs.rebuild && matrix.shard == 1 && steps.nextjs-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v6
         with:
           path: apps/main/.next-e2e/cache

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      shards:
+        description: Number of test shards
+        type: choice
+        default: "4"
+        options: ["3", "4", "6"]
+      rebuild:
+        description: Rebuild instead of restoring Turbo build outputs
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: ${{ fromJSON(inputs.shards == '3' && '[1, 2, 3]' || inputs.shards == '6' && '[1, 2, 3, 4, 5, 6]' || '[1, 2, 3, 4]') }}
     env:
       BETTER_AUTH_SECRET: test-secret-for-ci
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/zoonk_e2e
@@ -49,17 +60,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
 
-      - name: Cache turbo build setup
-        uses: actions/cache@v6
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-${{ hashFiles('**/pnpm-lock.yaml') }}-
-            ${{ runner.os }}-turbo-
-
-      - name: Cache Next.js build
-        uses: actions/cache@v6
+      - name: Restore Next.js build cache
+        id: nextjs-cache
+        uses: actions/cache/restore@v6
         with:
           path: apps/main/.next-e2e/cache
           key: ${{ runner.os }}-nextjs-main-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('apps/main/**/*.ts', 'apps/main/**/*.tsx', 'packages/**/*.ts', 'packages/**/*.tsx') }}
@@ -76,5 +79,30 @@ jobs:
       - name: Setup database
         run: pnpm --filter @zoonk/db db:setup:e2e
 
+      # Keep shard arguments out of Turbo's build cache keys.
+      - name: Build E2E app
+        run: pnpm build:e2e --filter main ${{ inputs.rebuild && '--force' || '' }}
+
+      # Run Playwright directly so every CI run executes the tests.
       - name: Run E2E tests
-        run: pnpm e2e --filter main -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        env:
+          PLAYWRIGHT_HTML_OPEN: never
+          PLAYWRIGHT_JSON_OUTPUT_NAME: test-results/results.json
+        run: pnpm --filter main e2e --shard=${{ matrix.shard }}/${{ strategy.job-total }} --workers=2 --reporter=github,html,json
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-main-${{ matrix.shard }}
+          path: |
+            apps/main/playwright-report/
+            apps/main/test-results/results.json
+          retention-days: 7
+
+      - name: Save Next.js build cache
+        if: ${{ matrix.shard == 1 && steps.nextjs-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6
+        with:
+          path: apps/main/.next-e2e/cache
+          key: ${{ steps.nextjs-cache.outputs.cache-primary-key }}

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -991,10 +991,11 @@ test.describe("Lesson Player Page", () => {
 
     await expectGuestProgressWarning(page);
 
-    await page.waitForLoadState("networkidle");
-    await page.keyboard.press("Escape");
-
-    await expect(page).toHaveURL(new RegExp(`/b/ai/c/${course.slug}/ch/${chapter.slug}$`, "u"));
+    await pressShortcutAndWaitForUrl({
+      expectedUrl: new RegExp(`/b/ai/c/${course.slug}/ch/${chapter.slug}$`, "u"),
+      key: "Escape",
+      page,
+    });
   });
 
   test("non-existent lesson shows 404 page", async ({ page }) => {

--- a/apps/main/e2e/lesson-questions.test.ts
+++ b/apps/main/e2e/lesson-questions.test.ts
@@ -1619,6 +1619,8 @@ test("keeps saved history visible but blocks sending during a reopen refresh", a
   });
 
   await authenticatedPage.goto(scenario.url);
+  // The held second request must belong to the reopen, after the initial preload.
+  await expect.poll(() => api.completedGetRequests).toBe(1);
   await authenticatedPage.getByRole("button", { name: "Ask about this lesson" }).click();
   const dialog = authenticatedPage.getByRole("dialog");
   await expect(dialog.getByText(savedQuestion.question)).toBeVisible();
@@ -1668,6 +1670,7 @@ test("ignores an older reopen response that arrives after a newer refresh", asyn
   });
 
   await authenticatedPage.goto(scenario.url);
+  await expect.poll(() => api.completedGetRequests).toBe(1);
   await authenticatedPage.getByRole("button", { name: "Ask about this lesson" }).click();
   const dialog = authenticatedPage.getByRole("dialog");
   await expect(dialog.getByText(firstQuestion.question)).toBeVisible();
@@ -1762,6 +1765,7 @@ test("ignores an earlier page that finishes after the latest page refreshes", as
   });
 
   await authenticatedPage.goto(scenario.url);
+  await expect.poll(() => api.completedGetRequests).toBe(1);
 
   const openQuestions = authenticatedPage.getByRole("button", { name: "Ask about this lesson" });
 

--- a/apps/main/e2e/lesson-questions.test.ts
+++ b/apps/main/e2e/lesson-questions.test.ts
@@ -1619,8 +1619,6 @@ test("keeps saved history visible but blocks sending during a reopen refresh", a
   });
 
   await authenticatedPage.goto(scenario.url);
-  // The held second request must belong to the reopen, after the initial preload.
-  await expect.poll(() => api.completedGetRequests).toBe(1);
   await authenticatedPage.getByRole("button", { name: "Ask about this lesson" }).click();
   const dialog = authenticatedPage.getByRole("dialog");
   await expect(dialog.getByText(savedQuestion.question)).toBeVisible();
@@ -1670,7 +1668,6 @@ test("ignores an older reopen response that arrives after a newer refresh", asyn
   });
 
   await authenticatedPage.goto(scenario.url);
-  await expect.poll(() => api.completedGetRequests).toBe(1);
   await authenticatedPage.getByRole("button", { name: "Ask about this lesson" }).click();
   const dialog = authenticatedPage.getByRole("dialog");
   await expect(dialog.getByText(firstQuestion.question)).toBeVisible();
@@ -1765,7 +1762,6 @@ test("ignores an earlier page that finishes after the latest page refreshes", as
   });
 
   await authenticatedPage.goto(scenario.url);
-  await expect.poll(() => api.completedGetRequests).toBe(1);
 
   const openQuestions = authenticatedPage.getByRole("button", { name: "Ask about this lesson" });
 

--- a/apps/main/src/data/sitemaps/chapters.test.ts
+++ b/apps/main/src/data/sitemaps/chapters.test.ts
@@ -32,6 +32,15 @@ function lastPage(count: number): number {
 
 describe(countSitemapChapters, () => {
   it("returns a positive count", async () => {
+    const organization = await organizationFixture({ kind: "brand" });
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
+    await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
     const count = await countSitemapChapters();
     expect(count).toBeGreaterThan(0);
   });

--- a/apps/main/src/data/sitemaps/courses.test.ts
+++ b/apps/main/src/data/sitemaps/courses.test.ts
@@ -9,6 +9,9 @@ function lastPage(count: number): number {
 
 describe(countSitemapCourses, () => {
   it("returns a positive count", async () => {
+    const organization = await organizationFixture({ kind: "brand" });
+    await courseFixture({ isPublished: true, organizationId: organization.id });
+
     const count = await countSitemapCourses();
     expect(count).toBeGreaterThan(0);
   });

--- a/packages/player/src/questions/use-lesson-questions.ts
+++ b/packages/player/src/questions/use-lesson-questions.ts
@@ -83,6 +83,8 @@ export function useLessonQuestions({
       openedScopes.current.add(scope);
 
       if (canAskQuestions && needsRefresh) {
+        /** An early open performs the preload before the effect can run. */
+        preloadedScopes.current.add(scope);
         void loadThread(context);
       }
     },


### PR DESCRIPTION
Main E2E now uses four shards, shares build cache keys across shards, always executes tests fresh, and saves the Next.js cache from one runner. Per-shard Playwright reports and manual cold-build/shard controls make future comparisons measurable.

Fixes duplicate question-history preloads, uses the existing Escape helper, and gives sitemap count tests independent fixtures after CI exposed those races.

Measured cold runs improved from 5m28s to [4m06s](https://github.com/zoonk/zoonk/actions/runs/34655773913); the [warm run took 3m24s](https://github.com/zoonk/zoonk/actions/runs/34656063228), with all 425 tests freshly executed. Four shards trade additional runner time versus the optimized three-shard control for lower latency. Isolated language, auth teardown, and chapter-search retries remain documented in the benchmark results.
