### PR TITLE
fix(main): prevent input and question loading races

### DIFF
--- a/apps/main/e2e/auth-callback.test.ts
+++ b/apps/main/e2e/auth-callback.test.ts
@@ -87,6 +87,7 @@ test.describe("Auth Callback", () => {
     });
 
     await page.goto("/pt/login");
+    await expect(page.getByText("Auth app", { exact: true })).toBeVisible();
     await expect.poll(() => authUrls.length).toBe(1);
 
     const authUrl = getInterceptedAuthUrl(authUrls);
@@ -108,6 +109,7 @@ test.describe("Auth Callback", () => {
     });
 
     await page.goto("/login");
+    await expect(page.getByText("Auth app", { exact: true })).toBeVisible();
     await expect.poll(() => authUrls.length).toBe(1);
 
     const authUrl = getInterceptedAuthUrl(authUrls);
@@ -130,6 +132,7 @@ test.describe("Auth Callback", () => {
     });
 
     await page.goto(`/login?next=${encodeURIComponent(nextPath)}`);
+    await expect(page.getByText("Auth app", { exact: true })).toBeVisible();
     await expect.poll(() => authUrls.length).toBe(1);
 
     const authUrl = getInterceptedAuthUrl(authUrls);
@@ -156,6 +159,7 @@ test.describe("Auth Callback", () => {
     });
 
     await page.goto(`/login?next=${encodeURIComponent(unsafeNextPath)}`);
+    await expect(page.getByText("Auth app", { exact: true })).toBeVisible();
     await expect.poll(() => authUrls.length).toBe(1);
 
     const authUrl = getInterceptedAuthUrl(authUrls);

--- a/apps/main/e2e/course-chapters.test.ts
+++ b/apps/main/e2e/course-chapters.test.ts
@@ -9,6 +9,7 @@ import { AI_ORG_SLUG } from "@zoonk/utils/org";
 import { normalizeString } from "@zoonk/utils/string";
 import { getSearchInputTop, scrollSearchInputToTop } from "./catalog-search";
 import { expect, test } from "./fixtures";
+import { holdHydration } from "./hydration";
 
 const SEARCH_CHAPTERS_LABEL = /search chapters/iu;
 let courseUrl: string;
@@ -247,6 +248,34 @@ test.describe("Course Chapters - Locale", () => {
 });
 
 test.describe("Course Chapter Search", () => {
+  test("waits for hydration before accepting a chapter search", async ({ page }) => {
+    /** Keep the streaming shell available while delaying the catalog's own client bundle. */
+    const releaseHydration = await holdHydration({ page, scriptText: "catalog-grid-search" });
+
+    try {
+      await page.goto(courseUrl, { waitUntil: "commit" });
+
+      const search = page.getByLabel(SEARCH_CHAPTERS_LABEL);
+      await expect(search).toBeVisible();
+      await expect(search).toBeDisabled();
+      releaseHydration();
+
+      await search.fill("Gamma");
+      await expect(page).toHaveURL(/\?q=Gamma/u);
+
+      await expect(
+        page.getByRole("link", { name: new RegExp(chapterNames.third, "u") }),
+      ).toBeVisible();
+
+      await expect(
+        page.getByRole("link", { name: new RegExp(chapterNames.first, "u") }),
+      ).not.toBeVisible();
+    } finally {
+      releaseHydration();
+      await page.unrouteAll({ behavior: "wait" });
+    }
+  });
+
   test("filters chapters by title", async ({ page }) => {
     await page.goto(courseUrl);
 

--- a/apps/main/e2e/hydration.ts
+++ b/apps/main/e2e/hydration.ts
@@ -1,0 +1,25 @@
+import { type Page } from "./fixtures";
+
+/** Holds client scripts so tests can exercise controls while only their HTML is available. */
+export async function holdHydration({
+  page,
+  scriptText,
+}: {
+  page: Page;
+  scriptText?: string;
+}): Promise<() => void> {
+  const scripts = Promise.withResolvers<null>();
+
+  await page.route("**/_next/static/chunks/**", async (route) => {
+    const response = await route.fetch();
+    const script = await response.text();
+
+    if (!scriptText || script.includes(scriptText)) {
+      await scripts.promise;
+    }
+
+    await route.fulfill({ response });
+  });
+
+  return () => scripts.resolve(null);
+}

--- a/apps/main/e2e/language.test.ts
+++ b/apps/main/e2e/language.test.ts
@@ -2,6 +2,7 @@ import { type Locator, type Page } from "@playwright/test";
 import { setLocale } from "@zoonk/e2e/fixtures/locale";
 import { type SupportedLocale } from "@zoonk/utils/locale";
 import { expect, test } from "./fixtures";
+import { holdHydration } from "./hydration";
 
 /**
  * Change the language and wait for the proxy to finish canonicalizing the
@@ -23,6 +24,25 @@ async function selectLanguage({
 }
 
 test.describe("Language settings page", () => {
+  test("waits for hydration before accepting a language change", async ({ page }) => {
+    const releaseHydration = await holdHydration({ page });
+
+    try {
+      await page.goto("/language", { waitUntil: "commit" });
+
+      const selector = page.getByRole("combobox", { name: /update language/iu });
+      await expect(selector).toBeVisible();
+      await expect(selector).toBeDisabled();
+      releaseHydration();
+
+      await selectLanguage({ expectedPath: "/es/language", locale: "es", page, selector });
+      await expect(page.getByRole("heading", { level: 1, name: /^idioma$/iu })).toBeVisible();
+    } finally {
+      releaseHydration();
+      await page.unrouteAll({ behavior: "wait" });
+    }
+  });
+
   test("displays language selector with current locale", async ({ page }) => {
     await page.goto("/language");
 

--- a/apps/main/e2e/lesson-detail.test.ts
+++ b/apps/main/e2e/lesson-detail.test.ts
@@ -991,10 +991,11 @@ test.describe("Lesson Player Page", () => {
 
     await expectGuestProgressWarning(page);
 
-    await page.waitForLoadState("networkidle");
-    await page.keyboard.press("Escape");
-
-    await expect(page).toHaveURL(new RegExp(`/b/ai/c/${course.slug}/ch/${chapter.slug}$`, "u"));
+    await pressShortcutAndWaitForUrl({
+      expectedUrl: new RegExp(`/b/ai/c/${course.slug}/ch/${chapter.slug}$`, "u"),
+      key: "Escape",
+      page,
+    });
   });
 
   test("non-existent lesson shows 404 page", async ({ page }) => {

--- a/apps/main/e2e/lesson-questions.test.ts
+++ b/apps/main/e2e/lesson-questions.test.ts
@@ -2127,22 +2127,26 @@ async function expectReopenedSavedExplanation({
   expect(api.questions).toHaveLength(7);
   expect(api.answerRequests).toBe(1);
 
+  /** The saved explanation is visible before the refreshed thread has arrived. */
+  await expect(dialog.getByText("Follow-up question 5", { exact: true })).toBeVisible();
+
   const loadEarlier = dialog.getByRole("button", { name: "Load earlier questions" });
+  const turns = dialog.getByRole("article", { name: "Your question" });
 
   async function loadAllEarlierQuestions() {
-    if (!(await loadEarlier.isVisible())) {
+    const loadedCount = await turns.count();
+
+    if (loadedCount >= 7) {
       return;
     }
 
-    const completedRequests = api.completedGetRequests;
     await loadEarlier.click();
-    await expect.poll(() => api.completedGetRequests).toBeGreaterThan(completedRequests);
+    await expect.poll(() => turns.count()).toBeGreaterThan(loadedCount);
     await loadAllEarlierQuestions();
   }
 
   await loadAllEarlierQuestions();
 
-  const turns = dialog.getByRole("article", { name: "Your question" });
   await expect(turns).toHaveCount(7);
   await expect(turns.nth(0)).toContainText(ANSWER_TEXT);
 

--- a/apps/main/e2e/profile.test.ts
+++ b/apps/main/e2e/profile.test.ts
@@ -1,6 +1,30 @@
 import { expect, test } from "./fixtures";
+import { holdHydration } from "./hydration";
 
 test.describe("Profile settings page", () => {
+  test("waits for hydration before accepting a username change", async ({
+    authenticatedPage: page,
+  }) => {
+    const releaseHydration = await holdHydration({ page, scriptText: "defaultUsername" });
+
+    try {
+      await page.goto("/profile", { waitUntil: "commit" });
+
+      const usernameInput = page.getByRole("textbox", { name: /username/iu });
+      await expect(usernameInput).toBeVisible();
+      await expect(usernameInput).toBeDisabled();
+      await expect(page.getByRole("button", { name: /save changes/iu })).toBeDisabled();
+      releaseHydration();
+
+      await usernameInput.fill("AB!@#");
+      await expect(usernameInput).toHaveValue("ab!@#");
+      await expect(page.getByRole("button", { name: /save changes/iu })).toBeDisabled();
+    } finally {
+      releaseHydration();
+      await page.unrouteAll({ behavior: "wait" });
+    }
+  });
+
   test("shows login prompt for unauthenticated users", async ({ page }) => {
     await page.goto("/profile");
 

--- a/apps/main/src/app/[lang]/(settings)/_components/locale-switcher.tsx
+++ b/apps/main/src/app/[lang]/(settings)/_components/locale-switcher.tsx
@@ -4,6 +4,7 @@ import { getPathname, usePathname } from "@/i18n/navigation";
 import { Field, FieldContent, FieldLabel } from "@zoonk/ui/components/field";
 import { NativeSelect, NativeSelectOption } from "@zoonk/ui/components/native-select";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
+import { useIsMounted } from "@zoonk/ui/hooks/is-mounted";
 import { LOCALE_LABELS, SUPPORTED_LOCALES, isValidLocale } from "@zoonk/utils/locale";
 import { useExtracted, useLocale } from "next-intl";
 
@@ -11,6 +12,7 @@ export function LocaleSwitcher() {
   const t = useExtracted();
   const locale = useLocale();
   const pathname = usePathname();
+  const isMounted = useIsMounted();
 
   /**
    * Use a document navigation because changing the root language through the
@@ -37,6 +39,7 @@ export function LocaleSwitcher() {
           aria-label={t("Update language")}
           className="w-full sm:w-70"
           defaultValue={locale}
+          disabled={!isMounted}
           id="language"
           onChange={onSelectChange}
         >

--- a/apps/main/src/app/[lang]/(settings)/profile/profile-form.tsx
+++ b/apps/main/src/app/[lang]/(settings)/profile/profile-form.tsx
@@ -17,6 +17,7 @@ import { Input } from "@zoonk/ui/components/input";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@zoonk/ui/components/input-group";
 import { Skeleton } from "@zoonk/ui/components/skeleton";
 import { Spinner } from "@zoonk/ui/components/spinner";
+import { useIsMounted } from "@zoonk/ui/hooks/is-mounted";
 import { cn } from "@zoonk/ui/lib/utils";
 import { SubmitButton } from "@zoonk/ui/patterns/buttons/submit";
 import { useExtracted } from "next-intl";
@@ -71,6 +72,7 @@ export function ProfileForm({
 }) {
   const t = useExtracted();
 
+  const isMounted = useIsMounted();
   const { setUsername, status, username } = useUsernameAvailability(defaultUsername);
 
   const [state, formAction] = useActionState(profileFormAction, initialState);
@@ -78,7 +80,7 @@ export function ProfileForm({
   const currentName = state.name || defaultName;
 
   const hasError = state.status === "error";
-  const isSubmitDisabled = status !== "idle" && status !== "available";
+  const isSubmitDisabled = !isMounted || (status !== "idle" && status !== "available");
 
   return (
     <form action={formAction} className="flex flex-col gap-6 lg:max-w-md">
@@ -123,6 +125,7 @@ export function ProfileForm({
               autoCapitalize="none"
               autoComplete="username"
               autoCorrect="off"
+              disabled={!isMounted}
               id="username"
               maxLength={USERNAME_MAX_LENGTH}
               minLength={USERNAME_MIN_LENGTH}

--- a/apps/main/src/components/catalog/catalog-grid.tsx
+++ b/apps/main/src/components/catalog/catalog-grid.tsx
@@ -3,6 +3,7 @@
 import { type AppRoute, Link } from "@/i18n/navigation";
 import { GridContent, GridEmpty, GridGroupItem, GridItem } from "@zoonk/ui/components/grid";
 import { Input } from "@zoonk/ui/components/input";
+import { useIsMounted } from "@zoonk/ui/hooks/is-mounted";
 import { cn } from "@zoonk/ui/lib/utils";
 import { SEARCH_QUERY_THROTTLE_MS } from "@zoonk/utils/search";
 import { normalizeString } from "@zoonk/utils/string";
@@ -129,6 +130,8 @@ export function CatalogGridSearchField({
   placeholder: string;
   search: string;
 }) {
+  const isMounted = useIsMounted();
+
   return (
     <div
       className={cn("flex w-full min-w-0 items-center gap-2", className)}
@@ -139,6 +142,7 @@ export function CatalogGridSearchField({
         <Input
           aria-label={placeholder}
           className="border-border/40 placeholder:text-muted-foreground/50 focus-visible:border-border h-10 bg-transparent pl-9 focus-visible:ring-0"
+          disabled={!isMounted}
           onChange={(event) => onSearchChange(event.target.value)}
           placeholder={placeholder}
           type="search"

--- a/apps/main/src/data/sitemaps/chapters.test.ts
+++ b/apps/main/src/data/sitemaps/chapters.test.ts
@@ -32,6 +32,15 @@ function lastPage(count: number): number {
 
 describe(countSitemapChapters, () => {
   it("returns a positive count", async () => {
+    const organization = await organizationFixture({ kind: "brand" });
+    const course = await courseFixture({ isPublished: true, organizationId: organization.id });
+
+    await chapterFixture({
+      courseId: course.id,
+      isPublished: true,
+      organizationId: organization.id,
+    });
+
     const count = await countSitemapChapters();
     expect(count).toBeGreaterThan(0);
   });

--- a/apps/main/src/data/sitemaps/courses.test.ts
+++ b/apps/main/src/data/sitemaps/courses.test.ts
@@ -9,6 +9,9 @@ function lastPage(count: number): number {
 
 describe(countSitemapCourses, () => {
   it("returns a positive count", async () => {
+    const organization = await organizationFixture({ kind: "brand" });
+    await courseFixture({ isPublished: true, organizationId: organization.id });
+
     const count = await countSitemapCourses();
     expect(count).toBeGreaterThan(0);
   });

--- a/packages/player/src/questions/use-lesson-questions.ts
+++ b/packages/player/src/questions/use-lesson-questions.ts
@@ -83,6 +83,8 @@ export function useLessonQuestions({
       openedScopes.current.add(scope);
 
       if (canAskQuestions && needsRefresh) {
+        /** An early open performs the preload before the effect can run. */
+        preloadedScopes.current.add(scope);
         void loadThread(context);
       }
     },


### PR DESCRIPTION
Prevent duplicate lesson-question history loads when the panel opens before preloading, and keep language, catalog search, and username controls disabled until their handlers are ready. Adds browser regressions for input lost during hydration.

Stabilizes auth navigation teardown, Escape navigation, question pagination waits, and sitemap counts with test-owned published fixtures. CI configuration is separate in #1871.
